### PR TITLE
basic support for cloudfoundry.

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -419,6 +419,8 @@ async.waterfall([
     //this is only a workaround to ensure it works with all browers behind a proxy
     //we should remove this when the new socket.io version is more stable
     io.set('transports', ['xhr-polling']);
+
+    io.set('polling duration', settings.pollingDuration)
     
     var socketIOLogger = log4js.getLogger("socket.io");
     io.set('logger', {

--- a/node/utils/Settings.js
+++ b/node/utils/Settings.js
@@ -57,6 +57,11 @@ exports.abiword = null;
  */
 exports.loglevel = "INFO";
 
+/**
+ * xhr-polling duration
+ */
+exports.pollingDuration = 20;
+
 //read the settings sync
 var settingsStr = fs.readFileSync("../settings.json").toString();
 
@@ -95,5 +100,33 @@ for(var i in settings)
   {
     console.warn("Unkown Setting: '" + i + "'");
     console.warn("This setting doesn't exist or it was removed");
+  }
+}
+
+// If deployed in CloudFoundry
+if(process.env.VCAP_APP_PORT) {
+  exports.port = process.env.VCAP_APP_PORT
+}
+
+
+// use mysql if provided.
+var vcap_services = process.env.VCAP_SERVICES;
+
+if(vcap_services) {
+  var svcs = JSON.parse(vcap_services)
+  for(var key in svcs ) {
+    var svc = svcs[key]
+    console.log("service:" + svc)
+    if( key.match(/^mysql/) ) {
+      exports.dbType= "mysql";
+      var cred = svc[0].credentials
+      exports.dbSettings = {
+        "user" : cred.user ,
+        "host" : cred.host ,
+        "password" : cred.password ,
+        "database" : cred.name ,
+      };
+    }
+    console.debug("database setup:" + console.dir(exports.dbSettings))
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,5 @@
+// Entry point for etherpad running on cloudfoundry
+var path = require('path')
+process.chdir( path.join( process.cwd(), 'node'))
+
+var s = require("./node/server")

--- a/settings.json.template
+++ b/settings.json.template
@@ -37,5 +37,8 @@
   "abiword" : null,
   
   /* The log level we are using, can be: DEBUG, INFO, WARN, ERROR */
-  "loglevel": "INFO"
+  "loglevel": "INFO",
+
+  /* The xhr-polling duration, default value is 20. */
+  "pollingDuration" : 20
 }


### PR DESCRIPTION
Add
- Entry point server.js
- Load port and mysql configuraion from env variable
- Tunable polling duration as the default 20 seconds is too long for cloudfoundry.com
