### PR TITLE
fix the url encoding in timeslider & return to pad link

### DIFF
--- a/static/timeslider.html
+++ b/static/timeslider.html
@@ -272,7 +272,11 @@
               <!-- termporary place holder--> 
               <a id = "returnbutton">Return to pad</a>
               <script>
-                $("#returnbutton").attr("href", document.location.href.substring(0,document.location.href.lastIndexOf("/")));
+              	if(document.referrer.length > 0 && document.referrer.substring(document.referrer.lastIndexOf("/")-1,document.referrer.lastIndexOf("/")) === "p") {
+                  $("#returnbutton").attr("href", document.referrer);
+              	} else {
+                  $("#returnbutton").attr("href", document.location.href.substring(0,document.location.href.lastIndexOf("/")));
+              	}
               </script>
             </div>
 


### PR DESCRIPTION
This fixes the broken url ecoding in the timeslider if a pad with spaces in its name is opened,
The second commit fixes the behavior of the "Return to pad" link if the page is reloaded. This was broken because after a reload document.referrer points to timeslider, not to the original pad.
