### PR TITLE
Get the HTML of a Pad via the API

### DIFF
--- a/node/db/API.js
+++ b/node/db/API.js
@@ -25,6 +25,7 @@ var groupManager = require("./GroupManager");
 var authorManager = require("./AuthorManager");
 var sessionManager = require("./SessionManager");
 var async = require("async");
+var exportHtml = require("../utils/ExportHtml");
 
 /**********************/
 /**GROUP FUNCTIONS*****/
@@ -166,6 +167,90 @@ exports.setText = function(padID, text, callback)
     
     //update the clients on the pad
     padMessageHandler.updatePadClients(pad, callback);
+  });
+}
+
+/**
+getHTML(padID, [rev]) returns the html of a pad 
+
+Example returns:
+
+{code: 0, message:"ok", data: {text:"Welcome <strong>Text</strong>"}}
+{code: 1, message:"padID does not exist", data: null}
+*/
+exports.getHTML = function(padID, rev, callback)
+{
+  if(typeof rev == "function")
+  {
+    callback = rev;
+    rev = undefined; 
+  }
+
+  if (rev !== undefined && typeof rev != "number")
+  {
+    if (!isNaN(parseInt(rev)))
+    {
+      rev = parseInt(rev);
+    }
+    else
+    {
+      callback({stop: "rev is not a number"});
+      return;
+    }
+  }
+
+  if(rev !== undefined && rev < 0)
+  {
+     callback({stop: "rev is a negative number"});
+     return;
+  }
+
+  if(rev !== undefined && !is_int(rev))
+  {
+    callback({stop: "rev is a float value"});
+    return;
+  }
+
+  getPadSafe(padID, true, function(err, pad)
+  {
+    if(err)
+    {
+      callback(err);
+      return;
+    }
+    
+    //the client asked for a special revision
+    if(rev !== undefined)
+    {
+      //check if this is a valid revision
+      if(rev > pad.getHeadRevisionNumber())
+      {
+        callback({stop: "rev is higher than the head revision of the pad"});
+        return;
+      }
+     
+      //get the html of this revision 
+      exportHtml.getPadHTML(pad, rev, function(err, html)
+      {
+          if(!err)
+          {
+            data = {html: html};
+          }
+          callback(err, data);
+      });
+    }
+    //the client wants the latest text, lets return it to him
+    else
+    {
+      exportHtml.getPadHTML(pad, undefined, function (err, html)
+      {
+        if(!err)
+        {
+          data = {html: html};
+        }
+        callback(err, data);
+      });
+    }
   });
 }
 

--- a/node/handler/APIHandler.js
+++ b/node/handler/APIHandler.js
@@ -50,6 +50,7 @@ var functions = {
   "listSessionsOfAuthor"      : ["authorID"], 
   "getText"                   : ["padID", "rev"],
   "setText"                   : ["padID", "text"],
+  "getHTML"                   : ["padID", "rev"],
   "getRevisionsCount"         : ["padID"], 
   "deletePad"                 : ["padID"], 
   "getReadOnlyID"             : ["padID"],

--- a/node/utils/ExportHtml.js
+++ b/node/utils/ExportHtml.js
@@ -85,6 +85,8 @@ function getPadHTML(pad, revNum, callback)
   });
 }
 
+exports.getPadHTML = getPadHTML;
+
 function getHTMLFromAtext(pad, atext)
 {
   var apool = pad.apool();


### PR DESCRIPTION
I'm integrating Etherpad Lite with Foswiki and we found convenient to use HTML as the intermediate format for connecting both sides.

This pull request covers the case of sending HTML from Etherpad Lite to Foswiki by adding a new API: getHTML. I'm going to try implementing the opposite case, e.g, the API setHTML.

By the way, thanks for making Etherpad Lite such an awesome software.
