### PR TITLE
Stuff I came across while reading the code: Spelling fixes and two small code patches.

### DIFF
--- a/node/handler/ExportHandler.js
+++ b/node/handler/ExportHandler.js
@@ -81,10 +81,9 @@ exports.doExport = function(req, res, padId, type)
           res.send(html);
           callback("stop");  
         }
-        //write the html export to a file
-        else
+        else //write the html export to a file
         {
-          randNum = Math.floor(Math.random()*new Date().getTime());
+          randNum = Math.floor(Math.random()*0xFFFFFFFF);
           srcFile = tempDirectory + "/eplite_export_" + randNum + ".html";
           fs.writeFile(srcFile, html, callback); 
         }
@@ -114,10 +113,13 @@ exports.doExport = function(req, res, padId, type)
           function(callback)
           {
             //100ms delay to accomidate for slow windows fs
-            setTimeout(function() 
-            {
-              fs.unlink(destFile, callback);
-            }, 100);
+			if(os.type().indexOf("Windows") > -1)
+			{
+			  setTimeout(function() 
+			  {
+			    fs.unlink(destFile, callback);
+			  }, 100);
+			}
           }
         ], callback);
       }

--- a/node/handler/PadMessageHandler.js
+++ b/node/handler/PadMessageHandler.js
@@ -193,7 +193,7 @@ exports.handleMessage = function(client, message)
   //if the message type is unkown, throw an exception
   else
   {
-    messageLogger.warn("Droped message, unkown Message Type " + message.type);
+    messageLogger.warn("Dropped message, unkown Message Type " + message.type);
   }
 }
 
@@ -272,12 +272,12 @@ function handleSuggestUserName(client, message)
   //check if all ok
   if(message.data.payload.newName == null)
   {
-    messageLogger.warn("Droped message, suggestUserName Message has no newName!");
+    messageLogger.warn("Dropped message, suggestUserName Message has no newName!");
     return;
   }
   if(message.data.payload.unnamedId == null)
   {
-    messageLogger.warn("Droped message, suggestUserName Message has no unnamedId!");
+    messageLogger.warn("Dropped message, suggestUserName Message has no unnamedId!");
     return;
   }
   
@@ -304,7 +304,7 @@ function handleUserInfoUpdate(client, message)
   //check if all ok
   if(message.data.userInfo.colorId == null)
   {
-    messageLogger.warn("Droped message, USERINFO_UPDATE Message has no colorId!");
+    messageLogger.warn("Dropped message, USERINFO_UPDATE Message has no colorId!");
     return;
   }
   
@@ -348,17 +348,17 @@ function handleUserChanges(client, message)
   //check if all ok
   if(message.data.baseRev == null)
   {
-    messageLogger.warn("Droped message, USER_CHANGES Message has no baseRev!");
+    messageLogger.warn("Dropped message, USER_CHANGES Message has no baseRev!");
     return;
   }
   if(message.data.apool == null)
   {
-    messageLogger.warn("Droped message, USER_CHANGES Message has no apool!");
+    messageLogger.warn("Dropped message, USER_CHANGES Message has no apool!");
     return;
   }
   if(message.data.changeset == null)
   {
-    messageLogger.warn("Droped message, USER_CHANGES Message has no changeset!");
+    messageLogger.warn("Dropped message, USER_CHANGES Message has no changeset!");
     return;
   }
   
@@ -600,22 +600,22 @@ function handleClientReady(client, message)
   //check if all ok
   if(!message.token)
   {
-    messageLogger.warn("Droped message, CLIENT_READY Message has no token!");
+    messageLogger.warn("Dropped message, CLIENT_READY message has no token!");
     return;
   }
   if(!message.padId)
   {
-    messageLogger.warn("Droped message, CLIENT_READY Message has no padId!");
+    messageLogger.warn("Dropped message, CLIENT_READY message has no padId!");
     return;
   }
   if(!message.protocolVersion)
   {
-    messageLogger.warn("Droped message, CLIENT_READY Message has no protocolVersion!");
+    messageLogger.warn("Dropped message, CLIENT_READY message has no protocolVersion!");
     return;
   }
   if(message.protocolVersion != 2)
   {
-    messageLogger.warn("Droped message, CLIENT_READY Message has a unkown protocolVersion '" + message.protocolVersion + "'!");
+    messageLogger.warn("Dropped message, CLIENT_READY message has an unkown protocolVersion '" + message.protocolVersion + "'!");
     return;
   }
 

--- a/node/handler/TimesliderMessageHandler.js
+++ b/node/handler/TimesliderMessageHandler.js
@@ -77,7 +77,7 @@ exports.handleMessage = function(client, message)
   //if the message type is unkown, throw an exception
   else
   {
-    messageLogger.warn("Droped message, unkown Message Type: '" + message.type + "'");
+    messageLogger.warn("Dropped message, unkown Message Type: '" + message.type + "'");
   }
 }
 
@@ -85,7 +85,7 @@ function handleClientReady(client, message)
 {
   if(message.padId == null)
   {
-    messageLogger.warn("Droped message, changeset request has no padId!");
+    messageLogger.warn("Dropped message, changeset request has no padId!");
     return;
   }
   
@@ -106,27 +106,27 @@ function handleChangesetRequest(client, message)
   //check if all ok
   if(message.data == null)
   {
-    messageLogger.warn("Droped message, changeset request has no data!");
+    messageLogger.warn("Dropped message, changeset request has no data!");
     return;
   }
   if(message.padId == null)
   {
-    messageLogger.warn("Droped message, changeset request has no padId!");
+    messageLogger.warn("Dropped message, changeset request has no padId!");
     return;
   }
   if(message.data.granularity == null)
   {
-    messageLogger.warn("Droped message, changeset request has no granularity!");
+    messageLogger.warn("Dropped message, changeset request has no granularity!");
     return;
   }
   if(message.data.start == null)
   {
-    messageLogger.warn("Droped message, changeset request has no start!");
+    messageLogger.warn("Dropped message, changeset request has no start!");
     return;
   }
   if(message.data.requestID == null)
   {
-    messageLogger.warn("Droped message, changeset request has no requestID!");
+    messageLogger.warn("Dropped message, changeset request has no requestID!");
     return;
   }
   


### PR DESCRIPTION
Spelling fixes in log messages, made a delay windows-only which according to a comment should be windows-only, fixed a random filename generator.
Concerning the delay: I do not know if it is also required on unix, so use with care (tm).
Concerning the filename generation: The old code actually had a collision probability which lowered since 1970-01-01 00:00, now it is a constant 1 in 2^32 chance.
