### PR TITLE
Implement HTTP API calls through POST

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -316,6 +316,35 @@ async.waterfall([
       //call the api handler
       apiHandler.handle(req.params.func, req.query, req, res);
     });
+
+    //This is a api call, collect all post informations and pass it to the apiHandler
+    app.post('/api/1/:func', function(req, res)
+    {
+      res.header("Server", serverName);
+      res.header("Content-Type", "application/json; charset=utf-8");
+
+      new formidable.IncomingForm().parse(req, function(err, fields, files) 
+      {
+        apiLogger.info("REQUEST, " + req.params.func + ", " + JSON.stringify(fields));
+
+        //wrap the send function so we can log the response
+        res._send = res.send;
+        res.send = function(response)
+        {
+          response = JSON.stringify(response);
+          apiLogger.info("RESPONSE, " + req.params.func + ", " + response);
+          
+          //is this a jsonp call, if yes, add the function call
+          if(req.query.jsonp)
+            response = req.query.jsonp + "(" + response + ")";
+          
+          res._send(response);
+        }
+      
+        //call the api handler
+        apiHandler.handle(req.params.func, fields, req, res);
+      });
+    });
     
     //The Etherpad client side sends information about how a disconnect happen
     app.post('/ep/pad/connection-diagnostic-info', function(req, res)


### PR DESCRIPTION
Per issue #175.

This implements _all_ API calls though POST, even read-only ones. Ideally I suppose read and write calls should be separated into GET and POST, respectively. But seeing as how that would break compatibility, I didn't do it here.

This is my first time coding node.js, so it might be awful and unacceptable.
