### PR TITLE
handle shift+tab, trivial fix

### DIFF
--- a/static/js/ace2_inner.js
+++ b/static/js/ace2_inner.js
@@ -3580,15 +3580,9 @@ function OUTER(gscope)
 
   function doTabKey(shiftDown)
   {
-    if (shiftDown === true){
-       doDeleteKey();
-    }
-    else
+    if (!doIndentOutdent(shiftDown))
     {
-      if (!doIndentOutdent(shiftDown))
-      {
-        performDocumentReplaceSelection(THE_TAB);
-      }
+      performDocumentReplaceSelection(THE_TAB);
     }
   }
 


### PR DESCRIPTION
Here is the promised help to fix the "shit+tab" issue. It appeared to be much easier than I initially thought. Many thanks to johnyma22 for giving me the idea to look here !

I still need to bring back the "backspace" behavior when already to the higher indentation level.

Nota: the first attempt to fix it was here: https://github.com/Pita/etherpad-lite/commit/697201b3def7cb7173dfebac50624dc694e34fd6
