### PR TITLE
Change pad name spaces to underscores

### DIFF
--- a/node/handler/APIHandler.js
+++ b/node/handler/APIHandler.js
@@ -21,6 +21,7 @@
 var ERR = require("async-stacktrace");
 var fs = require("fs");
 var api = require("../db/API");
+var padManager = require("../db/PadManager");
 
 //ensure we have an apikey
 var apikey = null;
@@ -95,7 +96,33 @@ exports.handle = function(functionName, fields, req, res)
     res.send({code: 3, message: "no such function", data: null});
     return;
   }
-  
+
+  //sanitize any pad id's before continuing
+  if(fields["padID"])
+  {
+    padManager.sanitizePadId(fields["padID"], function(padId)
+    {
+      fields["padID"] = padId;
+      callAPI(functionName, fields, req, res);
+    });
+  }
+  else if(fields["padName"])
+  {
+    padManager.sanitizePadId(fields["padName"], function(padId)
+    {
+      fields["padName"] = padId;
+      callAPI(functionName, fields, req, res);
+    });
+  }
+  else
+  {
+    callAPI(functionName, fields, req, res);
+  }
+}
+
+//calls the api function
+function callAPI(functionName, fields, req, res)
+{
   //put the function parameters in an array
   var functionParams = [];
   for(var i=0;i<functions[functionName].length;i++)

--- a/static/js/pad2.js
+++ b/static/js/pad2.js
@@ -194,7 +194,7 @@ function handshake()
     padId = decodeURIComponent(padId); // unescape neccesary due to Safari and Opera interpretation of spaces
 
     if(!isReconnect)
-      document.title = document.title + " | " + padId;
+      document.title = document.title + " | " + padId.replace(/_+/g, ' ');
 
     var token = readCookie("token");
     if (token == null)

--- a/static/timeslider.html
+++ b/static/timeslider.html
@@ -65,7 +65,7 @@
     padId = decodeURIComponent(urlParts[urlParts.length-2]);
         
     //set the title
-    document.title = document.title + " | " + padId;
+    document.title = document.title + " | " + padId.replace(/_+/g, ' ');
         
     //ensure we have a token
     token = readCookie("token");


### PR DESCRIPTION
Per issue #215, the Web front-end converts "a pad name" to "a_pad_name". This is accomplished using a redirect, which seemed the cleanest way to do it (particularly if legacy pad names were to be supported). "Legacy" pads with spaces are still accessible, and any future changes in pad name policies should be easy to incorporate.

The API obviously doesn't use redirects, but simply resolves "a pad name" to "a_pad_name".

I've been testing this for a few days and I can't find any odd behavior. But admittedly I've been the sole tester.
