### PR TITLE
Sanitize pad names

### DIFF
--- a/node/handler/APIHandler.js
+++ b/node/handler/APIHandler.js
@@ -21,6 +21,7 @@
 var ERR = require("async-stacktrace");
 var fs = require("fs");
 var api = require("../db/API");
+var padManager = require("../db/PadManager");
 
 //ensure we have an apikey
 var apikey = null;
@@ -95,7 +96,33 @@ exports.handle = function(functionName, fields, req, res)
     res.send({code: 3, message: "no such function", data: null});
     return;
   }
-  
+
+  //sanitize any pad id's before continuing
+  if(fields["padID"])
+  {
+    padManager.sanitizePadId(fields["padID"], function(padId)
+    {
+      fields["padID"] = padId;
+      callAPI(functionName, fields, req, res);
+    });
+  }
+  else if(fields["padName"])
+  {
+    padManager.sanitizePadId(fields["padName"], function(padId)
+    {
+      fields["padName"] = padId;
+      callAPI(functionName, fields, req, res);
+    });
+  }
+  else
+  {
+    callAPI(functionName, fields, req, res);
+  }
+}
+
+//calls the api function
+function callAPI(functionName, fields, req, res)
+{
   //put the function parameters in an array
   var functionParams = [];
   for(var i=0;i<functions[functionName].length;i++)

--- a/node/server.js
+++ b/node/server.js
@@ -232,101 +232,108 @@ async.waterfall([
           res.send(html);
       });
     });
-        
-    //serve pad.html under /p
-    app.get('/p/:pad', function(req, res, next)
-    {    
+    
+    //redirects browser to the pad's sanitized url if needed. otherwise, renders the html
+    function goToPad(req, res, render) {
       //ensure the padname is valid and the url doesn't end with a /
       if(!padManager.isValidPadId(req.params.pad) || /\/$/.test(req.url))
       {
         res.send('Such a padname is forbidden', 404);
-        return;
       }
-      
-      res.header("Server", serverName);
-      var filePath = path.normalize(__dirname + "/../static/pad.html");
-      res.sendfile(filePath, { maxAge: exports.maxAge });
+      else
+      {
+        padManager.sanitizePadId(req.params.pad, function(padId) {
+          //the pad id was sanitized, so we redirect to the sanitized version
+          if(padId != req.params.pad)
+          {
+            var real_path = req.path.replace(/^\/p\/[^\/]+/, '/p/' + padId);
+            res.header('Location', real_path);
+            res.send('You should be redirected to <a href="' + real_path + '">' + real_path + '</a>', 302);
+          }
+          //the pad id was fine, so just render it
+          else
+          {
+            render();
+          }
+        });
+      }
+    }
+    
+    //serve pad.html under /p
+    app.get('/p/:pad', function(req, res, next)
+    {    
+      goToPad(req, res, function() {
+        res.header("Server", serverName);
+        var filePath = path.normalize(__dirname + "/../static/pad.html");
+        res.sendfile(filePath, { maxAge: exports.maxAge });
+      });
     });
     
     //serve timeslider.html under /p/$padname/timeslider
     app.get('/p/:pad/timeslider', function(req, res, next)
     {
-      //ensure the padname is valid and the url doesn't end with a /
-      if(!padManager.isValidPadId(req.params.pad) || /\/$/.test(req.url))
-      {
-        res.send('Such a padname is forbidden', 404);
-        return;
-      }
-      
-      res.header("Server", serverName);
-      var filePath = path.normalize(__dirname + "/../static/timeslider.html");
-      res.sendfile(filePath, { maxAge: exports.maxAge });
+      goToPad(req, res, function() {
+        res.header("Server", serverName);
+        var filePath = path.normalize(__dirname + "/../static/timeslider.html");
+        res.sendfile(filePath, { maxAge: exports.maxAge });
+      });
     });
     
     //serve timeslider.html under /p/$padname/timeslider
     app.get('/p/:pad/export/:type', function(req, res, next)
     {
-      //ensure the padname is valid and the url doesn't end with a /
-      if(!padManager.isValidPadId(req.params.pad) || /\/$/.test(req.url))
-      {
-        res.send('Such a padname is forbidden', 404);
-        return;
-      }
-    
-      var types = ["pdf", "doc", "txt", "html", "odt", "dokuwiki"];
-      //send a 404 if we don't support this filetype
-      if(types.indexOf(req.params.type) == -1)
-      {
-        next();
-        return;
-      }
-      
-      //if abiword is disabled, and this is a format we only support with abiword, output a message
-      if(settings.abiword == null &&
-         ["odt", "pdf", "doc"].indexOf(req.params.type) !== -1)
-      {
-        res.send("Abiword is not enabled at this Etherpad Lite instance. Set the path to Abiword in settings.json to enable this feature");
-        return;
-      }
-      
-      res.header("Access-Control-Allow-Origin", "*");
-      res.header("Server", serverName);
-      
-      hasPadAccess(req, res, function()
-      {
-        exportHandler.doExport(req, res, req.params.pad, req.params.type);
+      goToPad(req, res, function() {
+        var types = ["pdf", "doc", "txt", "html", "odt", "dokuwiki"];
+        //send a 404 if we don't support this filetype
+        if(types.indexOf(req.params.type) == -1)
+        {
+          next();
+          return;
+        }
+        
+        //if abiword is disabled, and this is a format we only support with abiword, output a message
+        if(settings.abiword == null &&
+           ["odt", "pdf", "doc"].indexOf(req.params.type) !== -1)
+        {
+          res.send("Abiword is not enabled at this Etherpad Lite instance. Set the path to Abiword in settings.json to enable this feature");
+          return;
+        }
+        
+        res.header("Access-Control-Allow-Origin", "*");
+        res.header("Server", serverName);
+        
+        hasPadAccess(req, res, function()
+        {
+          exportHandler.doExport(req, res, req.params.pad, req.params.type);
+        });
       });
     });
     
     //handle import requests
     app.post('/p/:pad/import', function(req, res, next)
     {
-      //ensure the padname is valid and the url doesn't end with a /
-      if(!padManager.isValidPadId(req.params.pad) || /\/$/.test(req.url))
-      {
-        res.send('Such a padname is forbidden', 404);
-        return;
-      }
-    
-      //if abiword is disabled, skip handling this request
-      if(settings.abiword == null)
-      {
-        next();
-        return; 
-      }
+      goToPad(req, res, function() {
+        //if abiword is disabled, skip handling this request
+        if(settings.abiword == null)
+        {
+          next();
+          return; 
+        }
       
-      res.header("Server", serverName);
-      
-      hasPadAccess(req, res, function()
-      {
-        importHandler.doImport(req, res, req.params.pad);
+        res.header("Server", serverName);
+        
+        hasPadAccess(req, res, function()
+        {
+          importHandler.doImport(req, res, req.params.pad);
+        });
       });
     });
     
     var apiLogger = log4js.getLogger("API");
 
     //This is for making an api call, collecting all post information and passing it to the apiHandler
-    var apiCaller = function(req, res, fields) {
+    var apiCaller = function(req, res, fields)
+    {
       res.header("Server", serverName);
       res.header("Content-Type", "application/json; charset=utf-8");
     

--- a/static/js/pad2.js
+++ b/static/js/pad2.js
@@ -194,7 +194,7 @@ function handshake()
     padId = decodeURIComponent(padId); // unescape neccesary due to Safari and Opera interpretation of spaces
 
     if(!isReconnect)
-      document.title = document.title + " | " + padId;
+      document.title = document.title + " | " + padId.replace(/_+/g, ' ');
 
     var token = readCookie("token");
     if (token == null)

--- a/static/timeslider.html
+++ b/static/timeslider.html
@@ -65,7 +65,7 @@
     padId = decodeURIComponent(urlParts[urlParts.length-2]);
         
     //set the title
-    document.title = document.title + " | " + padId;
+    document.title = document.title + " | " + padId.replace(/_+/g, ' ');
         
     //ensure we have a token
     token = readCookie("token");


### PR DESCRIPTION
(Resubmission of https://github.com/Pita/etherpad-lite/pull/288 after reforking)

Per issue #215, the Web front-end converts "a pad name" to "a_pad_name". This is accomplished using a redirect, which seemed the cleanest way to do it (particularly if legacy pad names were to be supported). "Legacy" pads with spaces are still accessible, and any future changes in pad name policies should be easy to incorporate.

The API obviously doesn't use redirects, but simply resolves "a pad name" to "a_pad_name".
