### PR TITLE
Fix users popup for mobile devices

### DIFF
--- a/static/css/pad.css
+++ b/static/css/pad.css
@@ -1189,13 +1189,6 @@ label[for=readonlyinput] {
   #chaticon {
     opacity: .8;
   }
-  /*
-  #users {
-    right: none;
-    left: 30px;
-  }
-  */
-  
   #users {
 	top: 42px;
 	bottom: 40px;


### PR DESCRIPTION
This fixes the CSS for the users popup for mobile devices (https://github.com/Pita/etherpad-lite/issues/304). I've only been able to test it on an iPod running iOS 5.0.1.
