### PR TITLE
Fix cursor jump in IE when clicking edit buttons

### DIFF
--- a/static/js/ace2_inner.js
+++ b/static/js/ace2_inner.js
@@ -4050,8 +4050,6 @@ function OUTER(gscope)
     catch (e)
     {}
     if (!origSelectionRange) return false;
-    var selectionParent = origSelectionRange.parentElement();
-    if (selectionParent.ownerDocument != doc) return false;
     return true;
   }
 


### PR DESCRIPTION
This fixes issue #292, where clicking any of the edit buttons on the left (bold, bullets, undo, etc.) resets the cursor position to the first char in the first line in IE8. (FYI, I was only able to test this change in IE8.)

Note that this does _not_ fix the similar buggy behavior in IE8 of the buttons on the right (import/export, embed, etc). Those clicks are handled quite differently, and probably require some heavier refactoring. And since they aren't edit buttons, the problem isn't as noticeable.
