### PR TITLE
make PadMessageHandler more robust against timing issues

### DIFF
--- a/node/handler/PadMessageHandler.js
+++ b/node/handler/PadMessageHandler.js
@@ -516,7 +516,12 @@ exports.updatePadClients = function(pad, callback)
         ], function(err)
         {
           if(ERR(err, callback)) return;
-            
+          // next if session has not been deleted
+          if(sessioninfos[session] == null)
+          {
+            callback(null);
+            return;
+          }
           if(author == sessioninfos[session].author)
           {
             socketio.sockets.sockets[session].json.send({"type":"COLLABROOM","data":{type:"ACCEPT_COMMIT", newRev:r}});
@@ -538,7 +543,10 @@ exports.updatePadClients = function(pad, callback)
       callback
     );
       
-    sessioninfos[session].rev = pad.getHeadRevisionNumber();
+    if(sessioninfos[session] != null)
+    {
+      sessioninfos[session].rev = pad.getHeadRevisionNumber();
+    }
   },callback);  
 }
 


### PR DESCRIPTION
I'm using etherpad on top of a remote connection so database access is way slower than usual - also i was not using caching at that time.
What I observed was the server crashing during text updates because the sessioninfos[session] was null.
It had been deleted by another user who left in the meantime. I guess this is really rare with other databases - in particular with caching but I think it's a race condition never the less.
