### PR TITLE
update log4js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
                       "clean-css"           : "0.2.4",
                       "uglify-js"           : "1.1.1",
                       "formidable"          : "1.0.7",
-                      "log4js"              : "0.3.9",
+                      "log4js"              : "0.4.1",
                       "jsdom-nocontextifiy" : "0.2.10",
                       "async-stacktrace"    : "0.0.2"
                      },


### PR DESCRIPTION
Should remove the deprecation warning caused by the 'sys' module and a warning caused by the package.json file.
