### PR TITLE
Update jQuery to 1.7.1

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -54,7 +54,7 @@ npm install || {
 
 echo "Ensure jQuery is downloaded and up to date..."
 DOWNLOAD_JQUERY="true"
-NEEDED_VERSION="1.7"
+NEEDED_VERSION="1.7.1"
 if [ -f "static/js/jquery.js" ]; then
   VERSION=$(cat static/js/jquery.js | head -n 3 | grep -o "v[0-9].[0-9]");
   


### PR DESCRIPTION
removes "event.layerX/layerY are broken and deprecated" message
