### PR TITLE
Fix version check for jQuery 1.7.1 download.

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -56,7 +56,7 @@ echo "Ensure jQuery is downloaded and up to date..."
 DOWNLOAD_JQUERY="true"
 NEEDED_VERSION="1.7.1"
 if [ -f "static/js/jquery.js" ]; then
-  VERSION=$(cat static/js/jquery.js | head -n 3 | grep -o "v[0-9].[0-9]");
+  VERSION=$(cat static/js/jquery.js | head -n 3 | grep -o "v[0-9].[0-9].[0-9]");
   
   if [ ${VERSION#v} = $NEEDED_VERSION ]; then
     DOWNLOAD_JQUERY="false"


### PR DESCRIPTION
This corrects 3d108d6dceaac78e2e8395620d80b10f88b766d5, which caused jQuery's version to mismatch and installDeps to download a new version every run.
