### PR TITLE
Fix for issue #406 (avoid check ssl certificate in curl with prefixfree)

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -79,7 +79,7 @@ if [ -f "static/js/prefixfree.js" ]; then
 fi
 
 if [ $DOWNLOAD_PREFIXFREE = "true" ]; then
-  curl -lo static/js/prefixfree.js https://raw.github.com/LeaVerou/prefixfree/master/prefixfree.js || exit 1
+  curl -lo static/js/prefixfree.js -k https://raw.github.com/LeaVerou/prefixfree/master/prefixfree.js || exit 1
 fi
 
 #Remove all minified data to force node creating it new


### PR DESCRIPTION
I really don't know if it's better this way but if you can't fix the proxy that you're behind then this check can't be performed.
