### PR TITLE
HTTP API listPads should return an array

### DIFF
--- a/node/db/GroupManager.js
+++ b/node/db/GroupManager.js
@@ -248,9 +248,13 @@ exports.listPads = function(groupID, callback)
     //group exists, let's get the pads
     else
     {
-      db.getSub("group:" + groupID, ["pads"], function(err, pads)
+      db.getSub("group:" + groupID, ["pads"], function(err, result)
       {
         if(ERR(err, callback)) return;
+        var pads = [];
+        for ( var padId in result ) {
+          pads.push(padId);
+        }
         callback(null, {padIDs: pads});
       });
     }


### PR DESCRIPTION
Bugfix for issue #307. HTTP API listPads function is returning an object, but should be returning an array.
