### PR TITLE
Allow location of settings.json to be overridden through cli arg

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -44,8 +44,7 @@ fi
 settings="settings.json"
 a='';
 for arg in $*; do
-  if [ "$a" = "--settings" ]; then settings=$arg; fi
-  if [ "$a" = "-s" ]; then settings=$arg; fi
+  if [ "$a" = "--settings" ] || [ "$a" = "-s" ]; then settings=$arg; fi
   a=$arg
 done
 #Does a $settings exist? if no copy the template

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -20,10 +20,18 @@ if [ "$(id -u)" -eq 0 ]; then
    fi
 fi
 
+prep=1
+#If merely looking for help, don't prep the environment
+for arg in $*; do
+  if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then prep=0; fi
+done
+
 #prepare the enviroment
-bin/installDeps.sh $* || exit 1
+if [ $prep -eq 1 ]; then
+  bin/installDeps.sh $* || exit 1
+  echo "start..."
+fi
 
 #Move to the node folder and start
-echo "start..."
 cd "node"
 node server.js $*

--- a/node/server.js
+++ b/node/server.js
@@ -20,6 +20,7 @@
  * limitations under the License.
  */
 
+var cli = require('./utils/Cli');
 var ERR = require("async-stacktrace");
 var log4js = require('log4js');
 var os = require("os");

--- a/node/utils/Cli.js
+++ b/node/utils/Cli.js
@@ -1,0 +1,53 @@
+/**
+ * The CLI module handles command line parameters
+ */
+
+/*
+ * 2012 Jordan Hollinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+  "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The help text
+exports.helpText = '\
+run.sh [OPTIONS]                                        \n\
+                                                        \n\
+OPTIONS                                                 \n\
+ -s|--settings FILE     Specifies the settings.json file\n\
+ -h|--help              Print this message and exit     \n\
+';
+
+// An object containing the parsed command-line options
+exports.argv = {};
+
+var argv = process.argv.slice(2);
+var arg, prevArg;
+
+// Loop through args
+for ( var i = 0; i < argv.length; i++ ) {
+  arg = argv[i];
+
+  // Override location of settings.json file
+  if ( prevArg == '--settings' || prevArg == '-s' ) {
+    exports.argv.settings = arg;
+  }
+
+  // Print help and exit
+  else if ( arg == '--help' || arg == '-h' ) {
+    console.log(exports.helpText);
+    process.exit(0);
+  }
+
+  prevArg = arg;
+}

--- a/node/utils/Settings.js
+++ b/node/utils/Settings.js
@@ -22,11 +22,7 @@
 var fs = require("fs");
 var os = require("os");
 var path = require('path');
-
-/**
- * Read in cli args
- */
-exports.argv = require('optimist').argv;
+var cli = require('./Cli');
 
 /**
  * The IP ep-lite should listen to
@@ -94,7 +90,7 @@ exports.abiwordAvailable = function()
 }
 
 // Discover where the settings file lives
-var settingsFilename = exports.argv.settings || exports.argv.s || "settings.json";
+var settingsFilename = cli.argv.settings || "settings.json";
 var settingsPath = settingsFilename.charAt(0) == '/' ? '' : path.normalize(__dirname + "/../../");
 
 //read the settings sync

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
                       "formidable"          : "1.0.7",
                       "log4js"              : "0.4.1",
                       "jsdom-nocontextifiy" : "0.2.10",
-                      "async-stacktrace"    : "0.0.2",
-                      "optimist"            : "0.3.1"
+                      "async-stacktrace"    : "0.0.2"
                      },
   "devDependencies": {
                       "jshint"  : "*"


### PR DESCRIPTION
Resolves issue #195, allowing the location of the settings file to passed as a parameter. The following should all work:

```
bin/run.sh --settings settings2.json
bin/run.sh --settings /abs/path/to/settings.json
node server.js --settings my_settings.json
...
```

Unfortunately this adds a dependency (optimist) that converts cli args into a hash object. However that should make adding other options quite simple in the future.
