### PR TITLE
Promote proper use of css specificity

### DIFF
--- a/static/custom/css.template
+++ b/static/custom/css.template
@@ -1,5 +1,8 @@
 /*
-  You may have to use !important to override css attributs, for example:
-  
-  * {color: blue !important;}
+  custom css files are loaded after core css files. Simply use the same selector to override a style.
+  Example:
+      #editbar LI {border:1px solid #000;}
+    overrides
+      #editbar LI {border:1px solid #d5d5d5;}
+    from pad.css
 */


### PR DESCRIPTION
Using !important is bad practice and by no means required
