### PR TITLE
Allow settings filename to be passed as a cli option

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -40,10 +40,18 @@ if [ ! $(echo $NODE_VERSION | cut -d "." -f 1-2) = "v0.6" ]; then
   exit 1 
 fi
 
-#Does a settings.json exist? if no copy the template
-if [ ! -f "settings.json" ]; then
-  echo "Copy the settings template to settings.json..."
-  cp -v settings.json.template settings.json || exit 1
+#Get the name of the settings file
+settings="settings.json"
+a='';
+for arg in $*; do
+  if [ "$a" = "--settings" ] || [ "$a" = "-s" ]; then settings=$arg; fi
+  a=$arg
+done
+
+#Does a $settings exist? if no copy the template
+if [ ! -f $settings ]; then
+  echo "Copy the settings template to $settings..."
+  cp -v settings.json.template $settings || exit 1
 fi
 
 echo "Ensure that all dependencies are up to date..."

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -21,9 +21,9 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 #prepare the enviroment
-bin/installDeps.sh || exit 1
+bin/installDeps.sh $* || exit 1
 
 #Move to the node folder and start
 echo "start..."
 cd "node"
-node server.js
+node server.js $*

--- a/node/utils/Cli.js
+++ b/node/utils/Cli.js
@@ -1,0 +1,38 @@
+/**
+ * The CLI module handles command line parameters
+ */
+
+/*
+ * 2012 Jordan Hollinger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+  "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// An object containing the parsed command-line options
+exports.argv = {};
+
+var argv = process.argv.slice(2);
+var arg, prevArg;
+
+// Loop through args
+for ( var i = 0; i < argv.length; i++ ) {
+  arg = argv[i];
+
+  // Override location of settings.json file
+  if ( prevArg == '--settings' || prevArg == '-s' ) {
+    exports.argv.settings = arg;
+  }
+
+  prevArg = arg;
+}

--- a/node/utils/Settings.js
+++ b/node/utils/Settings.js
@@ -22,6 +22,7 @@
 var fs = require("fs");
 var os = require("os");
 var path = require('path');
+var argv = require('./Cli').argv;
 
 /**
  * The IP ep-lite should listen to
@@ -88,9 +89,12 @@ exports.abiwordAvailable = function()
   }
 }
 
+// Discover where the settings file lives
+var settingsFilename = argv.settings || "settings.json";
+var settingsPath = settingsFilename.charAt(0) == '/' ? '' : path.normalize(__dirname + "/../../");
+
 //read the settings sync
-var settingsPath = path.normalize(__dirname + "/../../");
-var settingsStr = fs.readFileSync(settingsPath + "settings.json").toString();
+var settingsStr = fs.readFileSync(settingsPath + settingsFilename).toString();
 
 //remove all comments
 settingsStr = settingsStr.replace(/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/gm,"").replace(/#.*/g,"").replace(/\/\/.*/g,"");


### PR DESCRIPTION
This resolved issue #195, allowing for `bin/run.sh --settings settings.a.json`. As suggested by @fourplusone, cli args are parsed in their own module, allowing them to be cleanly expanded upon in the future.

Since `-s|--settings` is currently the only option, a `--help` flag is not provided.

(This is a cleaner implementation of pull #455, which I have closed.)
