### PR TITLE
use relative path for redirects avoiding problems with reverse proxies

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -98,7 +98,7 @@ async.waterfall([
           //the pad id was sanitized, so we redirect to the sanitized version
           if(sanitizedPadId != padId)
           {
-            var real_path = req.path.replace(/^\/p\/[^\/]+/, '/p/' + sanitizedPadId);
+            var real_path = req.path.replace(/^\/p\/[^\/]+/, './' + sanitizedPadId);
             res.header('Location', real_path);
             res.send('You should be redirected to <a href="' + real_path + '">' + real_path + '</a>', 302);
           }


### PR DESCRIPTION
Since nginx doesn't rewrite `Location: ...` headers typing a padname like 'hello world' will result in a redirect to /p/hello_world instead of /pad/p/hello_world

You can reproduce this bug on factor.cc/pad:

`curl -v "https://factor.cc/pad/p/Hello%20World"`

Redirecting to `./sanetized_pad_name` instead of `/p/sanetized_pad_name` should fix this
