### PR TITLE
Add explicit cd step to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Here is the **[FAQ](https://github.com/Pita/etherpad-lite/wiki/FAQ)**
 
 <ol start="3">
   <li>Move to a folder where you want to install Etherpad Lite. Clone the git repository <code>git clone 'git://github.com/Pita/etherpad-lite.git'</code><br>&nbsp;</li>
+  <li>Change into the newly cloned folder with <code>cd etherpad-line</code><br> </li>
   <li>Install the dependencies with <code>bin/installDeps.sh</code><br>&nbsp;</li>
   <li>Start it with <code>bin/run.sh</code><br>&nbsp;</li>
   <li>Open your web browser and visit <a href="http://localhost:9001">http://localhost:9001</a>. You like it? Look at the 'Next Steps' section below</li>


### PR DESCRIPTION
Its pretty obvious that you should change into the directory after the clone, but if you're just cut-n-pasting steps, it doesn't quite work as written.
