### PR TITLE
Fixes plugin architecture on the client side when used from inside IFrames (e.g. from linestylefilter.js)

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -261,6 +261,11 @@ require.setGlobalKeyPath("require");\n\
       // Inject my plugins into my child.
       iframeHTML.push('\
 <script type="text/javascript">\
+  parent_req = require("./pluginfw/parent_require.js");\
+  parent_req.getRequirementFromParent(require, "ep_etherpad-lite/static/js/pluginfw/hooks");\
+  parent_req.getRequirementFromParent(require, "ep_etherpad-lite/static/js/pluginfw/plugins");\
+  parent_req.getRequirementFromParent(require, "./pluginfw/hooks");\
+  parent_req.getRequirementFromParent(require, "./pluginfw/plugins");\
   require.define("/plugins", null);\n\
   require.define("/plugins.js", function (require, exports, module) {\
     module.exports = require("ep_etherpad-lite/static/js/plugins");\

--- a/src/static/js/pluginfw/parent_require.js
+++ b/src/static/js/pluginfw/parent_require.js
@@ -1,0 +1,37 @@
+/**
+ * This module allows passing require modules instances to
+ * embedded iframes in a page. 
+ * For example, if a page has the "plugins" module initialized,
+ * it is important to use exactly the same "plugins" instance 
+ * inside iframes as well. Otherwise, plugins cannot save any 
+ * state.
+ */
+
+
+/**
+ * Instructs the require object that when a reqModuleName module
+ * needs to be loaded, that it iterates through the parents of the 
+ * current window until it finds one who can execute "require" 
+ * statements and asks it to perform require on reqModuleName.
+ *
+ * @params requireDefObj Require object which supports define 
+ * statements. This object is accessible after loading require-kernel.
+ * @params reqModuleName Module name e.g. (ep_etherpad-lite/static/js/plugins)
+ */
+exports.getRequirementFromParent = function(requireDefObj, reqModuleName) {
+    requireDefObj.define(reqModuleName, function(require, exports, module) {
+	var t = parent;
+	var max = 0;  // make sure I don't go up more than 10 times
+	while (typeof(t) != "undefined") {
+	    max++;
+	    if (max==10)
+		break;
+	    if (typeof(t.require) != "undefined") {
+		module.exports = t.require(reqModuleName);
+		return;
+	    }
+	    t = t.parent;
+	}
+    }); 
+
+}


### PR DESCRIPTION
file linestylefilter.js:32 requires the "hooks" module in order to notify client plugins of "aceAttribsToClasses" event. This does not work because the: plugin architecture is not initialized in the current IFrame. To test it, put a console.log(require("./pluginfw/plugins")) statement in linestylefilter.js and you'll see that it does not know of any plugins.

This patch makes the plugin architecture available from the first parent supporting require statements.
