### PR TITLE
Fix the noColor embed param

### DIFF
--- a/static/js/pad_editor.js
+++ b/static/js/pad_editor.js
@@ -87,8 +87,6 @@ var padeditor = (function()
         return defaultValue;
       }
 
-      self.ace.setProperty("showsauthorcolors", !settings.noColors);
-
       self.ace.setProperty("rtlIsTrue", settings.rtlIsTrue);
 
       var v;
@@ -100,6 +98,8 @@ var padeditor = (function()
       v = getOption('showAuthorColors', true);
       self.ace.setProperty("showsauthorcolors", v);
       padutils.setCheckbox($("#options-colorscheck"), v);
+      // Override from parameters
+      self.ace.setProperty("showsauthorcolors", !settings.noColors);
 
       v = getOption('useMonospaceFont', false);
       self.ace.setProperty("textface", (v ? "monospace" : "Arial, sans-serif"));


### PR DESCRIPTION
This commit fixes the noColor embed parameter, which is presently broken in master again. 

I previously opened pull request 554 for this also, but closed it when I realised I could not commit to my master branch ion my fork without adding commits to that pull request.
