### PR TITLE
add vagrant(+puppet) support to etherpad-lite

### DIFF
--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,20 @@
+Vagrant::Config.run do |config|
+  config.vm.box = "lucid32"
+  config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
+  config.vm.customize ["modifyvm", :id, "--memory", "512"]
+  config.vm.network :hostonly, "33.33.33.10"
+
+  # enable this to see the GUI if vagrant cannot connect
+  #config.vm.boot_mode = :gui
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "puppet/manifests"
+    puppet.manifest_file = "init.pp"
+    # enable this to see verbose and debug puppet output
+    #puppet.options = "--verbose --debug"
+  end
+  Vagrant::Config.run do |config|
+    config.vm.share_folder("etherpad-code", "/home/etherpad/dev/etherpad", "../", :nfs => true)
+  end
+
+end

--- a/vagrant/puppet/manifests/classes/etherpad-lite.pp
+++ b/vagrant/puppet/manifests/classes/etherpad-lite.pp
@@ -1,0 +1,53 @@
+class etherpad-lite {
+    package { "curl":
+        ensure => latest,
+        require => Exec["apt-get-update"];
+    }
+
+    file { "/home/etherpad":
+        require => User[etherpad],
+        owner => etherpad,
+        group => etherpad,
+        mode  => 775,
+        recurse=> false,
+        ensure => directory;
+    }
+
+    file { "/home/etherpad/dev":
+        require => File["/home/etherpad"],
+        owner => etherpad,
+        group => etherpad,
+        mode  => 775,
+        recurse=> false,
+        ensure => directory;
+    }
+
+    user { "etherpad":
+        ensure => "present",
+        uid => "10000",
+        shell => "/bin/bash",
+        managehome => true;
+    }
+
+    exec { "/bin/bash bin/installDeps.sh":
+        alias => "install-etherpad-deps",
+        require => Exec["install-npm"],
+        environment => "HOME=/home/etherpad",
+        cwd => "/home/etherpad/dev/etherpad",
+        logoutput => on_failure,
+        user => "etherpad";
+    }
+
+    exec { "/bin/bash bin/run.sh &":
+        alias => "run-etherpad-lite",
+        require => Exec["install-etherpad-deps"],
+        environment => "HOME=/home/etherpad",
+        cwd => "/home/etherpad/dev/etherpad",
+        logoutput => on_failure,
+        user => "etherpad";
+    }
+
+    group { "puppet":
+        ensure => "present",
+    }
+}

--- a/vagrant/puppet/manifests/classes/node-js.pp
+++ b/vagrant/puppet/manifests/classes/node-js.pp
@@ -1,0 +1,54 @@
+class node-js {
+    package { ["build-essential"]:
+        ensure => latest,
+        require => Exec["apt-get-update"];
+    }
+
+    exec { "/usr/bin/apt-get update":
+        alias => "apt-get-update";
+    }
+
+    exec {
+        "/usr/bin/wget -N http://nodejs.org/dist/${node_version}/node-${node_version}.tar.gz":
+            alias => "download-node",
+            user => "etherpad",
+            cwd => "/home/etherpad/dev/",
+            require => File["/home/etherpad/dev"];
+
+        "/bin/tar zxf node-${node_version}.tar.gz":
+            alias => "unpack-node",
+            user => "etherpad",
+            cwd => "/home/etherpad/dev/",
+            creates => "/home/etherpad/dev/etherpad/node-${node_version}",
+            require => Exec["download-node"];
+
+        "/home/etherpad/dev/node-${node_version}/configure --prefix=/home/etherpad/node-${node_version} && /usr/bin/make install":
+            alias => "install-node",
+            environment => "HOME=/home/etherpad",
+            user => "etherpad",
+            cwd => "/home/etherpad/dev/node-${node_version}",
+            creates => "/home/etherpad/node-${node_version}",
+            timeout => 0,
+            require => [Exec["unpack-node"], Package["build-essential"]];
+
+        "/usr/bin/wget -N http://registry.npmjs.org/npm/-/npm-${npm_version}.tgz":
+            alias => "download-npm",
+            user => "etherpad",
+            cwd => "/home/etherpad/dev/",
+            require => Exec["install-node"];
+
+        "/bin/mkdir npm-${npm_version} && /bin/tar -C npm-${npm_version} -xf npm-${npm_version}.tgz":
+            alias => "unpack-npm",
+            user => "etherpad",
+            cwd => "/home/etherpad/dev/",
+            creates => "/home/etherpad/dev/npm-${npm_version}",
+            require => Exec["download-npm"];
+
+        "/usr/bin/make install":
+            alias => "install-npm",
+            environment => ["HOME=/home/etherpad", "UID=10000"],
+            user => "etherpad",
+            cwd => "/home/etherpad/dev/npm-${npm_version}/package",
+            require => Exec["unpack-npm"];
+    }
+}

--- a/vagrant/puppet/manifests/init.pp
+++ b/vagrant/puppet/manifests/init.pp
@@ -1,0 +1,11 @@
+$node_version = "v0.6.14"
+$npm_version = "1.1.12"
+
+Exec { 
+  logoutput => on_failure,
+  path => "/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/opt/ruby/bin/:/home/etherpad/node-${node_version}/bin",
+
+}
+
+import "classes/*"
+import "nodes/*"

--- a/vagrant/puppet/manifests/nodes/nodes.pp
+++ b/vagrant/puppet/manifests/nodes/nodes.pp
@@ -1,0 +1,4 @@
+node default {
+    include node-js
+    include etherpad-lite
+}

--- a/vagrant/puppet/ubuntu-bootstrap.sh
+++ b/vagrant/puppet/ubuntu-bootstrap.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Quick bootstrap script for an Ubuntu Lucid host
+#
+# This allows you to bootstrap any Lucid box (VM, physical hardware, etc)
+# using Puppet and automatically install a full Etherpad environment on it.
+#
+
+apt-get install git-core puppet rsync
+
+GIT_REPO_URL="git://github.com/rhelmer/etherpad.git"
+
+mkdir /puppet
+
+# Clone the project from github
+useradd etherpad
+su - etherpad
+mkdir dev
+cd dev
+git clone $GIT_REPO_URL etherpad
+
+# copy the files from the git checkout to /puppet
+rsync -a ./etherpad/puppet/ /puppet/
+exit
+
+# Let puppet take it from here...
+puppet /home/etherpad/dev/puppet/manifests/*.pp
+


### PR DESCRIPTION
- basic puppet manifests for installing node.js and etherpad-lite
- Vagrantfile that can run these puppet manifests - http://vagrantup.com/ 

This allows you to create and provision a new etherpad-lite dev VM by running "vagrant up", build a new one by running "vagrant destroy && vagrant up" etc. The dev environment from your host is shared, so changes are reflected without having the ssh in to the VM.

After installing virtualbox+vagrant and running "vagrant up", etherpad-lite is available on http://33.33.33.10:9001/
