### PR TITLE
Userlists now scrolls if there are too many users

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -18,6 +18,12 @@ iframe {position:absolute;}
   border-radius: 6px; 
 }
 
+#otherusers
+{
+  max-height: 400px;
+  overflow: auto;
+}
+
 a img
 {
   border: 0;


### PR DESCRIPTION
The max height of the #otherusers container in the userlist is set to 400px so that the user list begins scrolling if there are more users.
