### PR TITLE
Don't require http auth for static paths

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -28,6 +28,11 @@ exports.basicAuth = function (req, res, next) {
       return next();
     }
   }
+  // Do not require auth for static paths...this could be a bit brittle
+  else if (req.path.match(/^\/(static|javascripts|pluginfw)/)) {
+    return next();
+  }
+
 
   // Otherwise return Auth required Headers, delayed for 1 second, if auth failed.
   res.header('WWW-Authenticate', 'Basic realm="Protected Area"');


### PR DESCRIPTION
Fixes issue #628, where static paths are blocked by http auth and the edit screen hangs on "Loading...".

In the future we may need to make this more flexible, but I think it's reasonable for now.
