### PR TITLE
Fix + New Hook

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -167,7 +167,13 @@ require.setGlobalKeyPath("require");\n\
       buffer.push(Ace2Editor.EMBEDED[KERNEL_SOURCE]);
       buffer.push(KERNEL_BOOT);
       buffer.push('<\/script>');
-    }
+    } else {
+      file = KERNEL_SOURCE;
+      buffer.push('<script type="application/javascript" src="' + KERNEL_SOURCE + '"><\/script>');
+      buffer.push('<script type="text/javascript">');
+      buffer.push(KERNEL_BOOT);
+      buffer.push('<\/script>');
+    } 
   }
   function pushScriptsTo(buffer) {
     /* Folling is for packaging regular expression. */

--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -229,6 +229,10 @@ domline.createDomLine = function(nonEmpty, doesWrap, optBrowser, optDocument)
       result.node.innerHTML = curHTML;
     }
     if (lineClass !== null) result.node.className = lineClass;
+	
+	hooks.callAll("acePostWriteDomLineHTML", {
+        node: result.node
+	});
   }
   result.prepareForAdd = writeHTML;
   result.finishUpdate = writeHTML;


### PR DESCRIPTION
Adds a new hook post-createdomline after the line has been added to the page.

Fixes ReferenceErrors I've been getting because require-kernel.js wasn't being sent to the iframe.
