### PR TITLE
Fix pad.js' customStart.

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -319,6 +319,8 @@
         <script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define"></script>
         <script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define"></script>
 
+        <script type="text/javascript" src="../static/custom/pad.js"></script>
+
         <!-- Bootstrap page -->
         <script type="text/javascript">
             var clientVars = {};


### PR DESCRIPTION
Appears that sourcing of static/custom/pad.js was removed from
templates/pad.html. This prevented static/custom/pad.js:customStart
from running. Add it back to get customStart working again.
