### PR TITLE
Fix npm version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -25,7 +25,7 @@
                       "log4js"              : "0.4.1",
                       "jsdom-nocontextifiy" : "0.2.10",
                       "async-stacktrace"    : "0.0.2",
-                      "npm"                 : "1.1",
+                      "npm"                 : "1.1.24",
                       "ejs"                 : "0.6.1",
                       "graceful-fs"         : "1.1.5",
                       "slide"               : "1.1.3",


### PR DESCRIPTION
npm version 1.1.25 appears to have a bug which crashes the server on boot. I've fixed the npm version at 1.1.24. This is in regard to issue #771.

While things are fine for existing checkouts, new ones will be broken.
