### PR TITLE
Add in padUsersCount method and API call

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -48,6 +48,7 @@ exports.createGroupPad = groupManager.createGroupPad;
 exports.createAuthor = authorManager.createAuthor;
 exports.createAuthorIfNotExistsFor = authorManager.createAuthorIfNotExistsFor;
 exports.listPadsOfAuthor = authorManager.listPadsOfAuthor;
+exports.padUsersCount = padMessageHandler.padUsersCount;
 
 /**********************/
 /**SESSION FUNCTIONS***/

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -65,7 +65,8 @@ var functions = {
   "getPublicStatus"           : ["padID"], 
   "setPassword"               : ["padID", "password"], 
   "isPasswordProtected"       : ["padID"], 
-  "listAuthorsOfPad"          : ["padID"]
+  "listAuthorsOfPad"          : ["padID"],
+  "padUsersCount"             : ["padID"]
 };
 
 /**

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1348,3 +1348,14 @@ function composePadChangesets(padId, startNum, endNum, callback)
     callback(null, changeset);
   });
 }
+
+/**
+ * Get the number of users in a pad
+ */
+exports.padUsersCount = function (padID, callback) {
+  if (!pad2sessions[padID] || typeof pad2sessions[padID] != typeof []) {
+    callback(null, {padUsersCount: 0});
+  } else {
+    callback(null, {padUsersCount: pad2sessions[padID].length});
+  }
+}


### PR DESCRIPTION
This API call is for checking how many users are currently connected to the pad. See commit message for more.
