### PR TITLE
Don't rewrite in a stupid way

### DIFF
--- a/src/node/hooks/express/padurlsanitize.js
+++ b/src/node/hooks/express/padurlsanitize.js
@@ -15,7 +15,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 	//the pad id was sanitized, so we redirect to the sanitized version
 	if(sanitizedPadId != padId)
 	{
-          var real_url = req.url.replace(/^\/p\/[^\/]+/, '/p/' + sanitizedPadId);
+          var real_url = sanitizedPadId;
           var query = url.parse(req.url).query;
           if ( query ) real_url += '?' + query;
 	  res.header('Location', real_url);


### PR DESCRIPTION
This patch fixes reverse-proxy setups where URL rewrites (i.e., 302 responses) may be happening due to invalid characters (':' and ' ') in the pad name.
