### PR TITLE
basic support for numbered lists in docuwiki export

### DIFF
--- a/src/node/utils/ExportDokuWiki.js
+++ b/src/node/utils/ExportDokuWiki.js
@@ -252,12 +252,12 @@ function getDokuWikiFromAtext(pad, atext)
 
     if (line.listLevel && lineContent)
     {
-	  if (line.listTypeName == "number")
-		{
-          pieces.push(new Array(line.listLevel + 1).join('  ') + ' - ');
-	    } else {
-          pieces.push(new Array(line.listLevel + 1).join('  ') + '* ');
-		}
+      if (line.listTypeName == "number")
+      {
+        pieces.push(new Array(line.listLevel + 1).join('  ') + ' - ');
+      } else {
+        pieces.push(new Array(line.listLevel + 1).join('  ') + '* ');
+      }
     }
     pieces.push(lineContent);
   }


### PR DESCRIPTION
See subject. Known issues:

1) Some inconsistencies when mixing numbered and ordered lists

It does support nested ordered lists.
