### PR TITLE
adding basic numbered list support to dokuwiki export

### DIFF
--- a/src/node/utils/ExportDokuWiki.js
+++ b/src/node/utils/ExportDokuWiki.js
@@ -252,7 +252,12 @@ function getDokuWikiFromAtext(pad, atext)
 
     if (line.listLevel && lineContent)
     {
-      pieces.push(new Array(line.listLevel + 1).join('  ') + '* ');
+      if (line.listTypeName == "number")
+      {
+        pieces.push(new Array(line.listLevel + 1).join('  ') + ' - ');
+      } else {
+        pieces.push(new Array(line.listLevel + 1).join('  ') + '* ');
+      }
     }
     pieces.push(lineContent);
   }


### PR DESCRIPTION
Think I finally fixed the pull request, thanks for your patience.

This adds basic support for numbered lists in addition to bulleted lists in Dokuwiki export. 
