### PR TITLE
Notify the user if Javascript is disabled

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -148,7 +148,10 @@
 
         <div id="editorcontainerbox">
             <div id="editorcontainer"></div>
-            <div id="editorloadingbox">Loading...</div>
+            <div id="editorloadingbox">
+              <p>Loading...</p>
+              <noscript><strong>Sorry, you have to enable Javascript in order to use this.</strong></noscript>
+            </div>
         </div>
 
         <div id="settings" class="popup">


### PR DESCRIPTION
Currently, users see `Loading...` although nothing is loading, when JavaScript is disabled.

This adds a `<noscript>` tag, notifying the user, that they need Javascript for Etherpad to work.
