### PR TITLE
Exported HTML ist not W3C valid (has no title tag)

### DIFF
--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -469,7 +469,7 @@ exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
     var head = 
       (noDocType ? '' : '<!doctype html>\n') + 
       '<html lang="en">\n' + (noDocType ? '' : '<head>\n' + 
-	'<title>' + padId + '</title>\n' +
+	'<title>' + Security.escapeHTML(padId) + '</title>\n' +
         '<meta charset="utf-8">\n' + 
         '<style> * { font-family: arial, sans-serif;\n' + 
           'font-size: 13px;\n' + 


### PR DESCRIPTION
Currently, the HTML code generated by the HTML exporter is not valid (I'm using http://validator.w3.org to test) because the title tag inside the HTML head is missing.

I fixed this by adding the pad ID being exported as title tag.

With my fix, the exported HTML is valid.
