### PR TITLE
Eliminate the loopback that has been causing so much trouble.

### DIFF
--- a/src/node/hooks/express/static.js
+++ b/src/node/hooks/express/static.js
@@ -7,8 +7,75 @@ var Yajsml = require('yajsml');
 var fs = require("fs");
 var ERR = require("async-stacktrace");
 var _ = require("underscore");
+var urlutil = require('url');
 
 exports.expressCreateServer = function (hook_name, args, cb) {
+  // What follows is a terrible hack to avoid loop-back within the server.
+  // TODO: Serve files from another service, or directly from the file system.
+  function requestURI(url, method, headers, callback, redirectCount) {
+    var parsedURL = urlutil.parse(url);
+
+    var status = 500, headers = {}, content = [];
+
+    var mockRequest = {
+      url: url
+    , method: method
+    , params: {filename: parsedURL.path.replace(/^\/static\//, '')}
+    , headers: headers
+    };
+    var mockResponse = {
+      writeHead: function (_status, _headers) {
+        status = _status;
+        for (var header in _headers) {
+          if (Object.prototype.hasOwnProperty.call(_headers, header)) {
+            headers[header] = _headers[header];
+          }
+        }
+      }
+    , setHeader: function (header, value) {
+        headers[header.toLowerCase()] = value.toString();
+      }
+    , header: function (header, value) {
+        headers[header.toLowerCase()] = value.toString();
+      }
+    , write: function (_content) {
+      _content && content.push(_content);
+      }
+    , end: function (_content) {
+        _content && content.push(_content);
+        callback(status, headers, content.join(''));
+      }
+    };
+
+    minify.minify(mockRequest, mockResponse);
+  }
+  function requestURIs(locations, method, headers, callback) {
+    var pendingRequests = locations.length;
+    var responses = [];
+
+    function respondFor(i) {
+      return function (status, headers, content) {
+        responses[i] = [status, headers, content];
+        if (--pendingRequests == 0) {
+          completed();
+        }
+      };
+    }
+
+    for (var i = 0, ii = locations.length; i < ii; i++) {
+      requestURI(locations[i], method, headers, respondFor(i));
+    }
+
+    function completed() {
+      var statuss = responses.map(function (x) {return x[0]});
+      var headerss = responses.map(function (x) {return x[1]});
+      var contentss = responses.map(function (x) {return x[2]});
+      callback(statuss, headerss, contentss);
+    };
+  }
+
+
+
   // Cache both minified and static.
   var assetCache = new CachingMiddleware;
   args.app.all('/(javascripts|static)/*', assetCache.handle);
@@ -24,6 +91,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   , rootURI: 'http://localhost:' + settings.port + '/static/js/'
   , libraryPath: 'javascripts/lib/'
   , libraryURI: 'http://localhost:' + settings.port + '/static/plugins/'
+  , requestURIs: requestURIs // Loop-back is causing problems, this is a workaround.
   });
 
   var StaticAssociator = Yajsml.associators.StaticAssociator;

--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
                         "name": "Robin Buse" }
                      ],
   "dependencies"   : {
-                      "yajsml"              : "1.1.3",
+                      "yajsml"              : "1.1.4",
                       "request"             : "2.9.100",
                       "require-kernel"      : "1.0.5",
                       "resolve"             : "0.2.1",


### PR DESCRIPTION
`localhost`, `0.0.0.0`, `127.0.0.1` each works only in some places some of the time, this works around the problem by overriding Yajsml's built-in request mechanism in favor of a hacked together one. TODO: Serve files from another service, or directly from the file system in order to make this unnecessary.

Fixes #747
