### PR TITLE
Display errors occuring on page load to the user.

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -320,12 +320,17 @@
             /* Display errors on page load to the user 
                (Gets overridden by padutils.setupGlobalExceptionHandler)
             */
-            window.onerror = function(msg, url, line) {
-              var box   = document.getElementById('editorloadingbox');
-              box.innerHTML = '<p><b>An error occured while loading the pad</b></p>'
-                            + '<p><b>'+msg+'</b> '
-                            + '<small>in '+ url +' (line '+ line +')</small></p>'
-            };
+            (function() {
+              var originalHandler = window.onerror;
+              window.onerror = function(msg, url, line) {
+                var box   = document.getElementById('editorloadingbox');
+                box.innerHTML = '<p><b>An error occured while loading the pad</b></p>'
+                              + '<p><b>'+msg+'</b> '
+                              + '<small>in '+ url +' (line '+ line +')</small></p>';
+                // call original error handler
+                if(typeof(originalHandler) == 'function') originalHandler.call(null, arguments);
+              };
+            })();
         </script>
 
         <script type="text/javascript" src="../static/js/require-kernel.js"></script>


### PR DESCRIPTION
This registers a `window.onerror` handler that will display all uncaught errors to the user.
Once the pad is fully loaded, padutils.setupGlobalExceptionHandler will override the `window.onerror` handler.

Read more on the 'Why?' about this in #879
