### PR TITLE
Fix #769 - wonky bug with pasted lists

### DIFF
--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -258,7 +258,8 @@ function makeContentCollector(collectStyles, browser, apool, domInterface, class
     {
       state.listNesting--;
     }
-    if(oldListType) state.lineAttributes['list'] = oldListType;
+    if (oldListType && oldListType != 'none') { state.lineAttributes['list'] = oldListType; }
+    else { delete state.lineAttributes['list']; }
     _recalcAttribString(state);
   }
 


### PR DESCRIPTION
After 6507614e459dac868d3c76355ca013d13132bc79 the contentcollector does not properly "exit" lists back to the `none` listType anymore.
The repro steps on #769 seem to pass correctly after this change.
