### PR TITLE
fix #890 test if console is available before writing to console.log

### DIFF
--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -310,7 +310,7 @@ function makeContentCollector(collectStyles, browser, apool, domInterface, class
       ['insertorder', 'first']
     ].concat(
       _.map(state.lineAttributes,function(value,key){
-        console.log([key, value])
+        if (window.console) console.log([key, value])
         return [key, value];
       })
     );


### PR DESCRIPTION
(my first pull request. Bear with me, and let me know if I did it correctly.)

https://github.com/Wikinaut/etherpad-lite/compare/Pita:develop...Wikinaut:fix-for-issue-890

Fix for #890 https://github.com/Pita/etherpad-lite/issues/890 "ordered and unordered lists are not working ('console' is not defined in line 45 character 1606...)"

i.e. all these problems with Internet Explorer and Firefox without Firebug and so, where "console" is not available.

Tested with node v0.8.4
- IE 8.0 
- FF 14.0.1
- Chrome
