### PR TITLE
Add in an HTTP API call to send a custom message type.

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -512,6 +512,39 @@ exports.listAuthorsOfPad = function(padID, callback)
   });
 }
 
+/**
+sendClientsMessage(padID, msg) sends a message to all clients connected to the
+pad, possibly for the purpose of signalling a plugin.
+
+Note, this will only accept strings from the HTTP API, so sending bogus changes
+or chat messages will probably not be possible.
+
+The resulting message will be structured like so:
+
+{
+  type: 'COLLABROOM',
+  data: {
+    type: <msg>,
+    time: <time the message was sent>
+  }
+}
+
+Example returns:
+
+{code: 0, message:"ok"}
+{code: 1, message:"padID does not exist"}
+*/
+
+exports.sendClientsMessage = function (padID, msg, callback) {
+  getPadSafe(padID, true, function (err, pad) {
+    if (ERR(err, callback)) {
+      return;
+    } else {
+      padMessageHandler.handleCustomMessage(padID, msg, callback);
+    }
+  } );
+}
+
 
 /******************************/
 /** INTERNAL HELPER FUNCTIONS */

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -66,7 +66,8 @@ var functions = {
   "setPassword"               : ["padID", "password"], 
   "isPasswordProtected"       : ["padID"], 
   "listAuthorsOfPad"          : ["padID"],
-  "padUsersCount"             : ["padID"]
+  "padUsersCount"             : ["padID"],
+  "sendClientsMessage"        : ["padID", "msg"]
 };
 
 /**

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -273,6 +273,28 @@ function handleSaveRevisionMessage(client, message){
 }
 
 /**
+ * Handles a custom message (sent via HTTP API request)
+ *
+ * @param padID {Pad} the pad to which we're sending this message
+ * @param msg {String} the message we're sending
+ */
+exports.handleCustomMessage = function (padID, msg, cb) {
+  var time = new Date().getTime();
+  var msg = {
+    type: 'COLLABROOM',
+    data: {
+      type: msg,
+      time: time
+    }
+  };
+  for (var i in pad2sessions[padID]) {
+    socketio.sockets.sockets[pad2sessions[padID][i]].json.send(msg);
+  }
+
+  cb(null, {});
+}
+
+/**
  * Handles a Chat Message
  * @param client the client that send this message
  * @param message the message from the client


### PR DESCRIPTION
You cannot currently send any data with your custom message, but
this patch is just begging for a second one that will allow that.
