### PR TITLE
Add in a plugin hook "handleClientMessage_<MSG_NAME>"

### DIFF
--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -21,6 +21,7 @@
  */
 
 var chat = require('./chat').chat;
+var hooks = require('./pluginfw/hooks');
 
 // Dependency fill on init. This exists for `pad.socket` only.
 // TODO: bind directly to the socket.
@@ -337,6 +338,7 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
     {
       callbacks.onServerMessage(msg.payload);
     }
+    hooks.callAll('handleClientMessage_' + msg.type, {payload: msg.payload});
   }
 
   function updateUserInfo(userInfo)


### PR DESCRIPTION
The new hook will accept only the message named in the hook call.
It will be used primarily for adding new message handlers, but it
can alse be used to handle existing message types.
