### PR TITLE
Create group2sessions.sessionIDs if it doesn't exist yet.

### DIFF
--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -162,7 +162,7 @@ exports.createSession = function(groupID, authorID, validUntil, callback)
         if(ERR(err, callback)) return;
         
         //the entry doesn't exist so far, let's create it
-        if(author2sessions == null)
+        if(author2sessions == null || author2sessions.sessionIDs == null)
         {
           author2sessions = {sessionIDs : {}};
         }


### PR DESCRIPTION
This attempts to fix a bug, that caused a server shutdown in [#787](https://github.com/Pita/etherpad-lite/issues/787#issuecomment-7597618).
