### PR TITLE
Add a hook for utils/ExportHtml.js

### DIFF
--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -403,19 +403,20 @@ function getHTMLFromAtext(pad, atext)
         lists.length--;
       }   
       var lineContentFromHook = hooks.callAllStr("getLineHTMLForExport", 
-        {
-	 line: line,
-	 apool: apool,
-	 attribLine: attribLines[i],
-	 text: textLines[i]
-        }, " ", " ", "");
-	if (lineContentFromHook)
-	{
-	 pieces.push(lineContentFromHook, '');
-	} else 
-	{
-	 pieces.push(lineContent, '<br>');
-	}		  
+      {
+        line: line,
+        apool: apool,
+        attribLine: attribLines[i],
+        text: textLines[i]
+      }, " ", " ", "");
+	  if (lineContentFromHook)
+	  {
+	    pieces.push(lineContentFromHook, '');
+	  } 
+	  else 
+	 {
+	   pieces.push(lineContent, '<br>');
+	 }		  
     }
   }
   


### PR DESCRIPTION
This hook will allow a plug-in developer to re-write each line when exporting to HTML.

See ep_headings as an example.
