### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Here is the **[FAQ](https://github.com/Pita/etherpad-lite/wiki/FAQ)**
   </li><br>
   <li>Install node.js 
     <ol type="a">
-      <li>Download the latest <b>0.6.x</b> node.js release from <a href="http://nodejs.org/#download">http://nodejs.org/#download</a></li>
-      <li>Extract it with <code>tar xf node-v0.6*</code></li>
-      <li>Move into the node folder <code>cd node-v0.6*</code> and build node with <code>./configure && make && make install</code></li>
+      <li>Download the latest node.js release (both 0.6 and 0.8 are supported, recommended is stable 0.8.8) from <a href="http://nodejs.org/download">http://nodejs.org</a></li>
+      <li>Extract it with <code>tar xf node-v0.8.8</code></li>
+      <li>Move into the node folder <code>cd node-v0.8.8</code> and build node with <code>./configure && make && make install</code></li>
     </ol>
   </li>
 </ol>


### PR DESCRIPTION
npm cache clean jshint was the only way to get jshint installed correctly again after an upgrade.
