### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here is the **[FAQ](https://github.com/Pita/etherpad-lite/wiki/FAQ)**
   </li><br>
   <li>Install node.js 
     <ol type="a">
-      <li>Download the latest <b>0.6.x</b> node.js release from <a href="http://nodejs.org/#download">http://nodejs.org/#download</a></li>
+      <li>Download the latest <b>0.6.x</b> node.js release from <a href="http://nodejs.org/dist/">http://nodejs.org</a></li>
       <li>Extract it with <code>tar xf node-v0.6*</code></li>
       <li>Move into the node folder <code>cd node-v0.6*</code> and build node with <code>./configure && make && make install</code></li>
     </ol>


### PR DESCRIPTION
corrected node.js link to point to 0.6.x versions (and not to 0.8.x on nodejs.org homepage)
