### PR TITLE
Add support for multiple api versions

### DIFF
--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -38,38 +38,40 @@ catch(e)
 }
 
 //a list of all functions
-var functions = {
-  "createGroup"               : [],
-  "createGroupIfNotExistsFor" : ["groupMapper"], 
-  "deleteGroup"               : ["groupID"], 
-  "listPads"                  : ["groupID"], 
-  "createPad"                 : ["padID", "text"], 
-  "createGroupPad"            : ["groupID", "padName", "text"],
-  "createAuthor"              : ["name"], 
-  "createAuthorIfNotExistsFor": ["authorMapper" , "name"], 
-  "listPadsOfAuthor"          : ["authorID"], 
-  "createSession"             : ["groupID", "authorID", "validUntil"], 
-  "deleteSession"             : ["sessionID"], 
-  "getSessionInfo"            : ["sessionID"], 
-  "listSessionsOfGroup"       : ["groupID"], 
-  "listSessionsOfAuthor"      : ["authorID"], 
-  "getText"                   : ["padID", "rev"],
-  "setText"                   : ["padID", "text"],
-  "getHTML"                   : ["padID", "rev"],
-  "setHTML"                   : ["padID", "html"],
-  "getRevisionsCount"         : ["padID"], 
-  "getLastEdited"             : ["padID"],
-  "deletePad"                 : ["padID"], 
-  "getReadOnlyID"             : ["padID"],
-  "setPublicStatus"           : ["padID", "publicStatus"], 
-  "getPublicStatus"           : ["padID"], 
-  "setPassword"               : ["padID", "password"], 
-  "isPasswordProtected"       : ["padID"], 
-  "listAuthorsOfPad"          : ["padID"],
-  "padUsersCount"             : ["padID"],
-  "getAuthorName"             : ["authorID"],
-  "padUsers"                  : ["padID"],
-  "sendClientsMessage"        : ["padID", "msg"]
+var version =
+{ "1":
+  { "createGroup"               : []
+  , "createGroupIfNotExistsFor" : ["groupMapper"]
+  , "deleteGroup"               : ["groupID"]
+  , "listPads"                  : ["groupID"]
+  , "createPad"                 : ["padID", "text"]
+  , "createGroupPad"            : ["groupID", "padName", "text"]
+  , "createAuthor"              : ["name"]
+  , "createAuthorIfNotExistsFor": ["authorMapper" , "name"]
+  , "listPadsOfAuthor"          : ["authorID"]
+  , "createSession"             : ["groupID", "authorID", "validUntil"]
+  , "deleteSession"             : ["sessionID"]
+  , "getSessionInfo"            : ["sessionID"]
+  , "listSessionsOfGroup"       : ["groupID"]
+  , "listSessionsOfAuthor"      : ["authorID"]
+  , "getText"                   : ["padID", "rev"]
+  , "setText"                   : ["padID", "text"]
+  , "getHTML"                   : ["padID", "rev"]
+  , "setHTML"                   : ["padID", "html"]
+  , "getRevisionsCount"         : ["padID"]
+  , "getLastEdited"             : ["padID"]
+  , "deletePad"                 : ["padID"]
+  , "getReadOnlyID"             : ["padID"]
+  , "setPublicStatus"           : ["padID", "publicStatus"]
+  , "getPublicStatus"           : ["padID"]
+  , "setPassword"               : ["padID", "password"]
+  , "isPasswordProtected"       : ["padID"]
+  , "listAuthorsOfPad"          : ["padID"]
+  , "padUsersCount"             : ["padID"]
+  , "getAuthorName"             : ["authorID"]
+  , "padUsers"                  : ["padID"]
+  , "sendClientsMessage"        : ["padID", "msg"]
+  }
 };
 
 /**
@@ -79,18 +81,30 @@ var functions = {
  * @req express request object
  * @res express response object
  */
-exports.handle = function(functionName, fields, req, res)
+exports.handle = function(apiVersion, functionName, fields, req, res)
 {
-  //check the api key!
-  if(fields["apikey"] != apikey.trim())
+  //check if this is a valid apiversion
+  var isKnownApiVersion = false;
+  for(var knownApiVersion in version)
   {
-    res.send({code: 4, message: "no or wrong API Key", data: null});
+    if(knownApiVersion == apiVersion)
+    {
+      isKnownApiVersion = true;
+      break;
+    }
+  }
+  
+  //say goodbye if this is an unkown API version
+  if(!isKnownApiVersion)
+  {
+    res.statusCode = 404;
+    res.send({code: 3, message: "no such api version", data: null});
     return;
   }
   
   //check if this is a valid function name
   var isKnownFunctionname = false;
-  for(var knownFunctionname in functions)
+  for(var knownFunctionname in version[apiVersion])
   {
     if(knownFunctionname == functionName)
     {
@@ -105,6 +119,13 @@ exports.handle = function(functionName, fields, req, res)
     res.send({code: 3, message: "no such function", data: null});
     return;
   }
+  
+  //check the api key!
+  if(fields["apikey"] != apikey.trim())
+  {
+    res.send({code: 4, message: "no or wrong API Key", data: null});
+    return;
+  }
 
   //sanitize any pad id's before continuing
   if(fields["padID"])
@@ -112,7 +133,7 @@ exports.handle = function(functionName, fields, req, res)
     padManager.sanitizePadId(fields["padID"], function(padId)
     {
       fields["padID"] = padId;
-      callAPI(functionName, fields, req, res);
+      callAPI(apiVersion, functionName, fields, req, res);
     });
   }
   else if(fields["padName"])
@@ -120,23 +141,23 @@ exports.handle = function(functionName, fields, req, res)
     padManager.sanitizePadId(fields["padName"], function(padId)
     {
       fields["padName"] = padId;
-      callAPI(functionName, fields, req, res);
+      callAPI(apiVersion, functionName, fields, req, res);
     });
   }
   else
   {
-    callAPI(functionName, fields, req, res);
+    callAPI(apiVersion, functionName, fields, req, res);
   }
 }
 
 //calls the api function
-function callAPI(functionName, fields, req, res)
+function callAPI(apiVersion, functionName, fields, req, res)
 {
   //put the function parameters in an array
   var functionParams = [];
-  for(var i=0;i<functions[functionName].length;i++)
+  for(var i=0;i<version[apiVersion][functionName].length;i++)
   {
-    functionParams.push(fields[functions[functionName][i]]);
+    functionParams.push(fields[ version[apiVersion][functionName][i] ]);
   }
   
   //add a callback function to handle the response

--- a/src/node/hooks/express/apicalls.js
+++ b/src/node/hooks/express/apicalls.js
@@ -7,7 +7,7 @@ var apiHandler = require('../../handler/APIHandler');
 var apiCaller = function(req, res, fields) {
   res.header("Content-Type", "application/json; charset=utf-8");
 
-  apiLogger.info("REQUEST, " + req.params.func + ", " + JSON.stringify(fields));
+  apiLogger.info("REQUEST, v"+ req.params.version + ":" + req.params.func + ", " + JSON.stringify(fields));
 
   //wrap the send function so we can log the response
   //note: res._send seems to be already in use, so better use a "unique" name
@@ -24,19 +24,19 @@ var apiCaller = function(req, res, fields) {
   }
 
   //call the api handler
-  apiHandler.handle(req.params.func, fields, req, res);
+  apiHandler.handle(req.params.version, req.params.func, fields, req, res);
 }
 
 exports.apiCaller = apiCaller;
 
 exports.expressCreateServer = function (hook_name, args, cb) {
   //This is a api GET call, collect all post informations and pass it to the apiHandler
-  args.app.get('/api/1/:func', function (req, res) {
+  args.app.get('/api/:version/:func', function (req, res) {
     apiCaller(req, res, req.query)
   });
 
   //This is a api POST call, collect all post informations and pass it to the apiHandler
-  args.app.post('/api/1/:func', function(req, res) {
+  args.app.post('/api/:version/:func', function(req, res) {
     new formidable.IncomingForm().parse(req, function (err, fields, files) {
       apiCaller(req, res, fields)
     });


### PR DESCRIPTION
I'm not sure, whether this is the right way to do this, perhaps there should be multiple implementations of 'node/db/API.js' (one for each API version).

Anyway, if this is the right way, someone should add a comprehensive list of all the API endpoints that are supported by API version `1` (I haven't got time for this, atm) -- that's why I pushed it to Pita's repo...

EDIT: I've had time to do this, just now...
