### PR TITLE
Bump API version to v1.1

### DIFF
--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -68,7 +68,9 @@ var version =
   , "isPasswordProtected"       : ["padID"]
   , "listAuthorsOfPad"          : ["padID"]
   , "padUsersCount"             : ["padID"]
-  , "getAuthorName"             : ["authorID"]
+  }
+, "1.1":
+  { "getAuthorName"             : ["authorID"]
   , "padUsers"                  : ["padID"]
   , "sendClientsMessage"        : ["padID", "msg"]
   }


### PR DESCRIPTION
As some people pointed out on the mailing list, we shouldn't add new functionality while sticking with the same API version, so, following up on my previous patch adding support for multiple api versions, this bumps the API version.

Check out this to see, which new endpoints were added: https://github.com/Pita/etherpad-lite/compare/master...develop#L20R40
