### PR TITLE
Remember, the `class` symbol is reserved in some environments.

### DIFF
--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -150,7 +150,7 @@ linestylefilter.getLineStyleFilter = function(lineLength, aline, textAndClassFun
       var disableAuthColorForThisLine = hooks.callAll("disableAuthorColorsForThisLine", {
         linestylefilter: linestylefilter,
         text: txt,
-        class: cls
+        "class": cls
       }, " ", " ", "");   
       var disableAuthors = (disableAuthColorForThisLine==null||disableAuthColorForThisLine.length==0)?false:disableAuthColorForThisLine[0];
       while (txt.length > 0)


### PR DESCRIPTION
Fixes issue introduced in 9be69ef2582dfc2c1b050041d4586cbd90d20e2c.
