### PR TITLE
Upgrade to Yajsml with another Windows backslash fix.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -10,7 +10,7 @@
                         "name": "Robin Buse" }
                      ],
   "dependencies"   : {
-                      "yajsml"              : "1.1.4",
+                      "yajsml"              : "1.1.5",
                       "request"             : "2.9.100",
                       "require-kernel"      : "1.0.5",
                       "resolve"             : "0.2.x",


### PR DESCRIPTION
Yup, more problems with the `\` path separator!

Fixes #989
