### PR TITLE
Fix race condition and a stack error caused by too old changesets

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -465,7 +465,9 @@ function handleUserChanges(client, message)
   var baseRev = message.data.baseRev;
   var wireApool = (new AttributePool()).fromJsonable(message.data.apool);
   var changeset = message.data.changeset;
-  var thisAuthor = sessioninfos[client.id].author;
+  // The client might disconnect between our callbacks. We should still
+  // finish processing the changeset, so keep a reference to the session.
+  var thisSession = sessioninfos[client.id];
       
   var r, apool, pad;
     
@@ -473,7 +475,7 @@ function handleUserChanges(client, message)
     //get the pad
     function(callback)
     {
-      padManager.getPad(sessioninfos[client.id].padId, function(err, value)
+      padManager.getPad(thisSession.padId, function(err, value)
       {
         if(ERR(err, callback)) return;
         pad = value;
@@ -550,7 +552,7 @@ function handleUserChanges(client, message)
         return;
       }
         
-      pad.appendRevision(changeset, thisAuthor);
+      pad.appendRevision(changeset, thisSession.author);
         
       var correctionChangeset = _correctMarkersInPad(pad.atext, pad.pool);
       if (correctionChangeset) {


### PR DESCRIPTION
Here are two fixes for server stability problems that we encountered when stress testing etherpad-lite.

We found the first problem while looking for the second problem. The second problem was seen during real use.

We developed a dedicated stresstest client in the process :) You can see it at https://bitbucket.org/rbraakman/etherpad-stresstest if you're interested. It doesn't implement the whole protocol, we were just using it to try to reproduce known problems.
