### PR TITLE
Don't shut down the whole server, if error handling middleware is called...

### DIFF
--- a/src/node/hooks/express/errorhandling.js
+++ b/src/node/hooks/express/errorhandling.js
@@ -38,7 +38,6 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   args.app.error(function(err, req, res, next){
     res.send(500);
     console.error(err.stack ? err.stack : err.toString());
-    exports.gracefulShutdown();
   });
 
   //connect graceful shutdown with sigint and uncaughtexception


### PR DESCRIPTION
The errors passed to error handling middleware aren't that severe, so it's fine to just stay alive...

Actually, this can be very annoying: #964
