### PR TITLE
Guard against malicious clients in USERINFO_UPDATE handling

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -415,22 +415,34 @@ function handleUserInfoUpdate(client, message)
   authorManager.setAuthorName(author, message.data.userInfo.name);
   
   var padId = sessioninfos[client.id].padId;
+
+  var infoMsg = {
+    type: "COLLABROOM",
+    data: {
+      // The Client doesn't know about USERINFO_UPDATE, use USER_NEWINFO
+      type: "USER_NEWINFO",
+      userInfo: {
+        userId: author,
+        name: message.data.userInfo.name,
+        colorId: message.data.userInfo.colorId,
+        userAgent: "Anonymous",
+        ip: "127.0.0.1",
+      }
+    }
+  };
   
   //set a null name, when there is no name set. cause the client wants it null
-  if(message.data.userInfo.name == null)
+  if(infoMsg.data.userInfo.name == null)
   {
-    message.data.userInfo.name = null;
+    infoMsg.data.userInfo.name = null;
   }
-  
-  //The Client don't know about a USERINFO_UPDATE, it can handle only new user_newinfo, so change the message type
-  message.data.type = "USER_NEWINFO";
   
   //Send the other clients on the pad the update message
   for(var i in pad2sessions[padId])
   {
     if(pad2sessions[padId][i] != client.id)
     {
-      socketio.sockets.sockets[pad2sessions[padId][i]].json.send(message);
+      socketio.sockets.sockets[pad2sessions[padId][i]].json.send(infoMsg);
     }
   }
 }


### PR DESCRIPTION
The server was reusing the client's message when broadcasting userinfo updates. This would allow a malicious client to insert arbitrary fields into a message that the other clients would trust as coming from the server. For example, adding "disconnect" or renaming other authors.

Instead of analyzing all the ways this could be abused, I made a patch to have the server create its own message for broadcast. I realize that etherpad-lite is meant for collaboration, so presumably the users trust each other, but I still like to close this kind of hole when I find it :)
