### PR TITLE
Removed duplicate method exports.getAuthorName()

### DIFF
--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -142,24 +142,6 @@ exports.getAuthor = function (author, callback)
 }
 
 /**
- * Returns the Author Name of the author
-  * @param {String} author The id of the author
-  * @param {Function} callback callback(err, name)
-  */
-
-exports.getAuthorName = function (authorID, callback)
-{
-  db.getSub("globalAuthor:" + author, ["name"], callback);
-  console.log(authorID);
-  db.getSub("globalAuthor:" + authorID, ["name"], function(err, authorName){
-    if(ERR(err, callback)) return;
-    callback(null, {authorName: authorName});
-  });
-}
-
-
-
-/**
  * Returns the color Id of the author
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, colorId)


### PR DESCRIPTION
No need for two of them.
