### PR TITLE
Drop method deprecated in Express 3.x.

### DIFF
--- a/src/node/utils/caching_middleware.js
+++ b/src/node/utils/caching_middleware.js
@@ -48,7 +48,7 @@ CachingMiddleware.prototype = new function () {
     var old_res = {};
 
     var supportsGzip =
-        req.header('Accept-Encoding', '').indexOf('gzip') != -1;
+        (req.get('Accept-Encoding') || '').indexOf('gzip') != -1;
 
     var path = require('url').parse(req.url).path;
     var cacheKey = (new Buffer(path)).toString('base64').replace(/[\/\+=]/g, '');


### PR DESCRIPTION
Exceptions were being thrown in the caching middleware.
