### PR TITLE
fix for error handling in the callback code

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -176,7 +176,9 @@ exports.handleMessage = function(client, message)
     
     // Call handleMessage hook. If a plugin returns null, the message will be dropped. Note that for all messages 
     // handleMessage will be called, even if the client is not authorized
-    hooks.aCallAll("handleMessage", { client: client, message: message }, function ( messages ) {
+    hooks.aCallAll("handleMessage", { client: client, message: message }, function ( err, messages ) {
+      if(ERR(err, callback)) return;
+      
       _.each(messages, function(newMessage){
         if ( newMessage === null ) {
           dropMessage = true;


### PR DESCRIPTION
The callback code does not follow error handling guidelines, thus always
receiving NULL instead of results array. 

Please review the error handling logic, I used analogy from other places and guess it should be handled this way here. 
