### PR TITLE
Do not assume window object exists

### DIFF
--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -311,7 +311,7 @@ function makeContentCollector(collectStyles, browser, apool, domInterface, class
       ['insertorder', 'first']
     ].concat(
       _.map(state.lineAttributes,function(value,key){
-        if (window.console) console.log([key, value])
+        if (typeof(window)!= 'undefined' && window.console) console.log([key, value])
         return [key, value];
       })
     );


### PR DESCRIPTION
this fixes server side hooking of collectContentPre
