### PR TITLE
Templates: relative links instead of absolute ones for /static directory

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -233,7 +233,7 @@
                 </div>
                 <div class="reconnecting">
                   <h1>Reestablishing connection...</h1>
-                  <p><img alt="" border="0" src="/static/img/connectingbar.gif" /></p>
+                  <p><img alt="" border="0" src="../static/img/connectingbar.gif" /></p>
                 </div>
                 <div class="userdup">
                   <h1>Opened in another window.</h1>

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -83,7 +83,7 @@
     </div>
     <div class="reconnecting">
       <h1>Reestablishing connection...</h1>
-      <p><img alt="" border="0" src="/static/img/connectingbar.gif" /></p>
+      <p><img alt="" border="0" src="../../static/img/connectingbar.gif" /></p>
     </div>
     <div class="userdup">
       <h1>Opened in another window.</h1>


### PR DESCRIPTION
Hi (again)!

Two links were absolute ("/static/...") instead of relative ("../static"). The image was not loaded with sites behind reverse proxies and subdirectory.

In my Apache log:

A.B.C.D - user [24/Oct/2012:16:05:55 +0200] "GET /static/img/connectingbar.gif HTTP/1.1" 404 2277 "https://WEBSITE/pad/p/XXXXX" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0"

This pull request corrects this (against develop branch, this time :-)
