### PR TITLE
fix imported ol that were turned into ul

### DIFF
--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -516,7 +516,7 @@ function makeContentCollector(collectStyles, browser, apool, domInterface, class
           {
             var type;
             var rr = cls && /(?:^| )list-([a-z]+[12345678])\b/.exec(cls);
-            type = rr && rr[1] || "bullet" + String(Math.min(_MAX_LIST_LEVEL, (state.listNesting || 0) + 1));
+            type = rr && rr[1] || (tname == "ul" ? "bullet" : "number") + String(Math.min(_MAX_LIST_LEVEL, (state.listNesting || 0) + 1));
             oldListTypeOrNull = (_enterList(state, type) || 'none');
           }
           else if ((tname == "div" || tname == "p") && cls && cls.match(/(?:^| )ace-line\b/))


### PR DESCRIPTION
to reproduce the issue, setHTML with ol elements:

```
curl -d apikey=`cat APIKEY.txt` -d 'padID=wtf' -d 'html=<div><h1>foo234</h1>^M<br>^Mfnordfofowersdf<h2>foooo</h2><div><ol><li>foo</li><li>bar</li></ol></div>^Mwtf</div>' 'http://localhost:9001/api/1/setHTML
```
