### PR TITLE
Removed limitation of the colorpicker color space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/static/js/jquery.js
 npm-debug.log
 *.DS_Store
 .ep_initialized
+.*.sw?
+.sw?

--- a/src/static/js/farbtastic.js
+++ b/src/static/js/farbtastic.js
@@ -2,7 +2,7 @@
 (function ($) {
   
 var __debug = false;
-var __factor = 0.5;
+var __factor = 1;
 
 $.fn.farbtastic = function (options) {
   $.farbtastic(this, options);


### PR DESCRIPTION
Some people complained (some guy in the #jupis IRC channel, which has the incompetencecompetence), that the color picker in Etherpad Lite limits the HSV colorspace to colors. Therefore I removed this limitation because I see no reason for this.
