### PR TITLE
Fix the path of run.sh for linux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Additionally, you'll need [node.js](http://nodejs.org).
 1. Move to a folder where you want to install Etherpad Lite. Clone the git repository `git clone git://github.com/ether/etherpad-lite.git`
 2. Change into the new directory containing the cloned source code `cd etherpad-lite`
 
-Now, run `bin\run.sh` and open <http://127.0.0.1:9001> in your browser. 
+Now, run `bin/run.sh` and open <http://127.0.0.1:9001> in your browser. 
 
 Update to the latest version with `git pull origin`. The next start with bin/run.sh will update the dependencies.
 


### PR DESCRIPTION
In Linux forward slash is used for file path and not backslash
