### PR TITLE
Importer convert to HTML by default and allow basic import/export features without abiword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.2.1
+ * Allow ! in urls inside the editor (Not Pad urls)
+ * Allow comments in language files
+ * More languages (Finish, Spanish, Bengali, Dutch) Thanks to TranslateWiki.net team.  See https://translatewiki.net/w/i.php?title=Special:MessageGroupStats&group=out-etherpad-lite for more details
+ * Bugfix for IE7/8 issue with a JS error #1186
+ * Bugfix windows package extraction issue and make the .zip file smaller
+ * Bugfix group pad API export
+ * Kristen Stewart is a terrible actress and Twilight sucks.
+
 # v1.2
  * Internationalization / Language / Translation support (i18n) with support for German/French
  * A frontend/client side testing framework and backend build tests

--- a/bin/loadTesting/README
+++ b/bin/loadTesting/README
@@ -3,7 +3,7 @@ This load tester is extremely useful for testing how many dormant clients can co
 TODO:
 Emulate characters being typed into a pad
 
-HOW TO USE (from @mjd75) proper formatting at: https://github.com/Pita/etherpad-lite/issues/360
+HOW TO USE (from @mjd75) proper formatting at: https://github.com/ether/etherpad-lite/issues/360
 
 Server 1:
 Installed Node.js (etc), EtherPad Lite and MySQL

--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -9,7 +9,7 @@ The API gives another web application control of the pads. The basic functions a
 
 The API is designed in a way, so you can reuse your existing user system with their permissions, and map it to etherpad lite. Means: Your web application still has to do authentication, but you can tell etherpad lite via the api, which visitors should get which permissions. This allows etherpad lite to fit into any web application and extend it with real-time functionality. You can embed the pads via an iframe into your website.
 
-Take a look at [HTTP API client libraries](https://github.com/Pita/etherpad-lite/wiki/HTTP-API-client-libraries) to see if a library in your favorite language.
+Take a look at [HTTP API client libraries](https://github.com/ether/etherpad-lite/wiki/HTTP-API-client-libraries) to see if a library in your favorite language.
 
 ## Examples
 

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -26,7 +26,7 @@ exports.createServer = function () {
   {
     console.warn("Can't get git version for server header\n" + e.message)
   }
-  console.log("Report bugs at https://github.com/Pita/etherpad-lite/issues")
+  console.log("Report bugs at https://github.com/ether/etherpad-lite/issues")
 
   serverName = "Etherpad-Lite " + version + " (http://j.mp/ep-lite)";
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name"           : "ep_etherpad-lite",
   "description"    : "A Etherpad based on node.js",
-  "homepage"       : "https://github.com/Pita/etherpad-lite",
+  "homepage"       : "https://github.com/ether/etherpad-lite",
   "keywords"       : ["etherpad", "realtime", "collaborative", "editor"],
   "author"         : "Peter 'Pita' Martischka <petermartischka@googlemail.com> - Primary Technology Ltd",
   "contributors"   : [
@@ -46,5 +46,5 @@
   "engines"        : { "node" : ">=0.6.0",
                        "npm"  : ">=1.0"
                      }, 
-  "version"        : "1.2.0"
+  "version"        : "1.2.1"
 }

--- a/src/static/js/AttributePool.js
+++ b/src/static/js/AttributePool.js
@@ -3,7 +3,7 @@
  * 90% of the code is still like in the original Etherpad
  * Look at https://github.com/ether/pad/blob/master/infrastructure/ace/www/easysync2.js
  * You can find a explanation what a attribute pool is here:
- * https://github.com/Pita/etherpad-lite/blob/master/doc/easysync/easysync-notes.txt
+ * https://github.com/ether/etherpad-lite/blob/master/doc/easysync/easysync-notes.txt
  */
 
 /*

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3266,7 +3266,7 @@ function Ace2Inner(){
       }
     }
     //hide the dropdownso
-    if(window.parent.parent.padeditbar){ // required in case its in an iframe should probably use parent..  See Issue 327 https://github.com/Pita/etherpad-lite/issues/327
+    if(window.parent.parent.padeditbar){ // required in case its in an iframe should probably use parent..  See Issue 327 https://github.com/ether/etherpad-lite/issues/327
       window.parent.parent.padeditbar.toggleDropDown("none");
     }
   }

--- a/src/static/js/l10n.js
+++ b/src/static/js/l10n.js
@@ -902,7 +902,7 @@ document.webL10n = (function(window, document, undefined) {
   // browser-specific startup
   if (document.addEventListener) { // modern browsers and IE9+
     document.addEventListener('DOMContentLoaded', function() {
-      var lang = document.documentElement.lang || navigator.language;
+      var lang = document.documentElement.lang || navigator.language || navigator.userLanguage || 'en';
       loadLocale(lang, translateFragment);
     }, false);
   } else if (window.attachEvent) { // IE8 and before (= oldIE)
@@ -977,7 +977,7 @@ document.webL10n = (function(window, document, undefined) {
     // startup for IE<9
     window.attachEvent('onload', function() {
       gTextProp = document.body.textContent ? 'textContent' : 'innerText';
-      var lang = document.documentElement.lang || window.navigator.userLanguage;
+      var lang = document.documentElement.lang || navigator.language || navigator.userLanguage || 'en';
       loadLocale(lang, translateFragment);
     });
   }

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -310,7 +310,7 @@ function handshake()
       }
       else if(obj.accessStatus == "wrongPassword")
       {
-        $("#editorloadingbox").html("<b>You're password was wrong</b><br>" +
+        $("#editorloadingbox").html("<b>Your password was wrong</b><br>" +
                                     "<input id='passwordinput' type='password' name='password'>"+
                                     "<button type='button' onclick=\"" + padutils.escapeHtml('require('+JSON.stringify(module.id)+").savePassword()") + "\">ok</button>");
       }

--- a/tests/frontend/runner.css
+++ b/tests/frontend/runner.css
@@ -15,12 +15,15 @@ body {
 #iframe-container {
   width: 50%;
   height: 100%;
-  float:right;
 }
 
 #iframe-container iframe {
-  width: 100%;
   height: 100%;
+  position:absolute;
+  min-width:500px;
+  max-width:800px;
+  left:50%;
+  width:100%;
 }
 
 #mocha {

--- a/tests/frontend/specs/keystroke_urls_become_clickable.js
+++ b/tests/frontend/specs/keystroke_urls_become_clickable.js
@@ -21,4 +21,27 @@ describe("urls", function(){
       return inner$("div").first().find("a").length === 1;
     }, 2000).done(done);
   });
+
+  it("when you enter a url containing a !, it becomes clickable and contains the whole URL", function(done) {
+    var inner$ = helper.padInner$;
+    var chrome$ = helper.padChrome$;
+
+    //get the first text element out of the inner iframe
+    var firstTextElement = inner$("div").first();
+    var url = "http://etherpad.org/!foo";
+
+    // simulate key presses to delete content
+    firstTextElement.sendkeys('{selectall}'); // select all
+    firstTextElement.sendkeys('{del}'); // clear the first line
+    firstTextElement.sendkeys(url); // insert a URL
+
+    helper.waitFor(function(){
+      if(inner$("div").first().find("a").length === 1){ // if it contains an A link
+        if(inner$("div").first().find("a")[0].href === url){
+          return true;
+        }
+      };
+    }, 2000).done(done);
+  });
+
 });

--- a/tests/frontend/specs/language.js
+++ b/tests/frontend/specs/language.js
@@ -1,36 +1,42 @@
+function deletecookie(name) {
+    document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+}
+
 describe("Language select and change", function(){
+  // Destroy language cookies
+  deletecookie("language", null);
+
   //create a new pad before each test run
   beforeEach(function(cb){
     helper.newPad(cb);
     this.timeout(60000);
   });
+ 
+  // Destroy language cookies
 
   it("makes text german", function(done) {
     var inner$ = helper.padInner$;
     var chrome$ = helper.padChrome$;
-
+ 
     //click on the settings button to make settings visible
     var $settingsButton = chrome$(".buttonicon-settings");
     $settingsButton.click();
-
+ 
     //click the language button
     var $language = chrome$("#languagemenu");
     var $languageoption = $language.find("[value=de]");
-
+ 
     //select german
     $languageoption.attr('selected','selected');
     $language.change();
-
-    var localizedEventFired = false;
-    $(chrome$.window).bind('localized', function() {
-      localizedEventFired = true;
-    })
-
-    helper.waitFor(function() { return localizedEventFired;})
+ 
+    helper.waitFor(function() { 
+      return chrome$(".buttonicon-bold").parent()[0]["title"] = "Fett (Strg-B)";
+     })
     .done(function(){
       //get the value of the bold button
       var $boldButton = chrome$(".buttonicon-bold").parent();
-
+ 
       //get the title of the bold button
       var boldButtonTitle = $boldButton[0]["title"];
 
@@ -39,43 +45,40 @@ describe("Language select and change", function(){
       done();
     });
   });
-
+ 
   it("makes text English", function(done) {
     var inner$ = helper.padInner$;
     var chrome$ = helper.padChrome$;
-
+ 
     //click on the settings button to make settings visible
     var $settingsButton = chrome$(".buttonicon-settings");
     $settingsButton.click();
-
+ 
     //click the language button
     var $language = chrome$("#languagemenu");
     var $languageoption = $language.find("[value=en]");
-
+ 
     //select german
     $languageoption.attr('selected','selected');
     $language.change();
+ 
+    //get the value of the bold button
+    var $boldButton = chrome$(".buttonicon-bold").parent();
 
-    var localizedEventFired = false;
-    $(chrome$.window).bind('localized', function() {
-      localizedEventFired = true;
-    })
-
-    helper.waitFor(function() { return localizedEventFired;})
+    helper.waitFor(function() { return $boldButton[0]["title"] != "Fett (Strg-B)";})
     .done(function(){
-
+ 
       //get the value of the bold button
       var $boldButton = chrome$(".buttonicon-bold").parent();
-
+ 
       //get the title of the bold button
       var boldButtonTitle = $boldButton[0]["title"];
-
+ 
       //check if the language is now English
       expect(boldButtonTitle).to.be("Bold (Ctrl-B)");
       done();
-
+ 
     });
   });
-
+ 
 });
-


### PR DESCRIPTION
-  The ImportHandler use abiword to convert to HTML instead of plain text for keep the bold, italic, etc atributes of original document.
-  Allow import from .txt and .html files and export to HTML, Plain text and Dokuwiki without abiword installed.
