### PR TITLE
Fix #1203: non-escaped html in plugins info

### DIFF
--- a/src/templates/admin/plugins-info.html
+++ b/src/templates/admin/plugins-info.html
@@ -14,7 +14,7 @@
       <div class="separator"></div>
 
       <h2>Installed plugins</h2>
-      <pre><%= plugins.formatPlugins() %></pre>
+      <pre><%- plugins.formatPlugins().replace(", ","\n") %></pre>
 
       <h2>Installed parts</h2>
       <pre><%= plugins.formatParts() %></pre>


### PR DESCRIPTION
https://github.com/ether/etherpad-lite/issues/1203
