### PR TITLE
Fix connectingbar img path in timeslider.html

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -285,7 +285,7 @@
                 </div>
                 <div class="reconnecting">
                   <h1 data-l10n-id="pad.modals.reconnecting"></h1>
-                  <p><img alt="" border="0" src="../../static/img/connectingbar.gif" /></p>
+                  <p><img alt="" border="0" src="../static/img/connectingbar.gif" /></p>
                 </div>
                 <div class="userdup">
                   <h1 data-l10n-id="pad.modals.uderdup"></h1>


### PR DESCRIPTION
The patch corrects the path of an image when being on a timeslider page.

When being on https://www.example.org/p/test/timeslider ,

Firebug shows 
"NetworkError: 404 Not Found - https://www.example.org/p/static/img/connectingbar.gif"
