### PR TITLE
fix timeslider rightstep button position

### DIFF
--- a/src/static/css/timeslider.css
+++ b/src/static/css/timeslider.css
@@ -113,7 +113,7 @@
   background-position: -29px -22px;
   right: 5px;
   top: 20px;
-  width: 29px;
+  width: 30px;
 }
 #timeslider .star {
   background-image: url(../../static/img/star.png);


### PR DESCRIPTION
fixes the cropped right border of the rightstep button

before the patch (screenshot from FF 17)

<img src=http://i.imgur.com/Om1Tr.png>

after the patch

<img src=http://i.imgur.com/IlcqA.png>

Checked in these browsers:
- Firefox 17
- Chrome
- IE8 -- in IE8 we have an IE problem with opacity, but this is a different problem and not in the scope of this fix. The patch works for IE8, too and does not introduce new problems.

For sake of completeness, I add a screenshot from IE8 **with intentionally introduced opacity for both step buttons**.
This shows the general opacity issue in IE8.

Watch also the (different) problem of "Zurück zum Pad" missing

<img src=http://i.imgur.com/GinAn.png>
