### PR TITLE
catch control S and send an event to save a revision #1128

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3537,7 +3537,7 @@ function Ace2Inner(){
     var keyCode = evt.keyCode;
     var which = evt.which;
 
-    // prevent ESC key and Control S
+    // prevent ESC key
     if (keyCode == 27)
     {
       evt.preventDefault();


### PR DESCRIPTION
Since PrimaryPad migrated to Etherpad Lite I began noticing that my habbit of pressing Control S to save a document brought up the save window dialogue, this is really bad from a UX perspective so here is a fix that silently saves a revision.

@analphabet I don't like the way I do parent.parent but I couldn't find a cleaner way, please enlighten me.

This resolves #1128
