### PR TITLE
warning when SSL is disabled - instead of info

### DIFF
--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -66,7 +66,7 @@ exports.restartServer = function () {
 
   } else {
 
-    console.log( "SSL -- not enabled!" );
+    console.warn( "SSL -- not enabled!" );
 
     var http = require('http');
     server = http.createServer(app);


### PR DESCRIPTION
it's better to warn users if SSL inactive
- switch this from info to warn console
