### PR TITLE
revert 53d6d08 socket.io also for IE8

### DIFF
--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -36,10 +36,13 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     });
   });
 
-  // there shouldn#t be a browser that isn't compatible to all 
-  // transports in this list at once
-  // e.g. XHR is disabled in IE by default, so in IE it should use jsonp-polling
-  io.set('transports', ['xhr-polling', 'jsonp-polling', 'htmlfile']);
+  // the following has been successfully tested with the following browsers 
+  // works also behind reverse proxy
+  // Firefox 17.0
+  // IE8 with Native XMLHTTP support
+  // IE8 without Native XMLHTTP support
+  // Chrome 21.0.1180.79
+  io.set('transports', ['jsonp-polling']);
 
   var socketIOLogger = log4js.getLogger("socket.io");
   io.set('logger', {


### PR DESCRIPTION
#### proposal to revert #53d6d08

I propose to revert the patch 53d6d08 . I again confirm expressly, that 
`io.set('transports', ['jsonp-polling']);` method works in all browser including IE8 with or without XMLHTTP support enabled, but it breaks the working if you add further methods to socket.io. 

@Marcelkehr admitted that he tested IE9 and not IE8

I admit that a better solution needs to be found (which avoids annyoing browser effects like described in https://github.com/ether/etherpad-lite/issues/1232 and shown in http://www.youtube.com/watch?v=Muoi3PyfkiE ) and will do my very best to reach this goal.
#### until a solution of #1232 is found

Until then I suggest and ask to keep the JSONP-POLLING as only method in socket.io , because it works 100% reliably.

`io.set('transports', ['jsonp-polling']);`
