### PR TITLE
Sanitize pad names

### DIFF
--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -295,10 +295,10 @@ Group pads are normal pads, but with the name schema GROUPID$PADNAME. A security
 #### createPad(padID [, text])
  * API >= 1
 
-creates a new (non-group) pad.  Note that if you need to create a group Pad, you should call **createGroupPad**.
+creates a new (non-group) pad.  Note that if you need to create a group Pad, you should call **createGroupPad**. Returns the actual PadID that was recorded (Checked against a regex so that nothing breaks when accessed.)
 
 *Example returns:*
-  * `{code: 0, message:"ok", data: null}`
+  * `{code: 0, message:"ok", data: {"padID":"asdf_as_d"}}`
   * `{code: 1, message:"pad does already exist", data: null}`
 
 #### getRevisionsCount(padID)

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -331,7 +331,7 @@ exports.createPad = function(padID, text, callback)
     callback(new customError("createPad can't create group pads","apierror"));
     return;
   }
-  padID = padID.replace(/[^a-z0-9_\-]/gi, '_'); 
+  padID = padID.replace(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|]/gi, '_'); 
   //create pad
   getPadSafe(padID, false, text, function(err)
   {

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -331,7 +331,7 @@ exports.createPad = function(padID, text, callback)
     callback(new customError("createPad can't create group pads","apierror"));
     return;
   }
-  padID = padID.replace(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|]/gi, '_'); 
+  padID = padID.replace(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|%<>\*#]/gi, '_'); 
   //create pad
   getPadSafe(padID, false, text, function(err)
   {

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -331,12 +331,12 @@ exports.createPad = function(padID, text, callback)
     callback(new customError("createPad can't create group pads","apierror"));
     return;
   }
-  
+  padID = padID.replace(/[^a-z0-9_\-]/gi, '_'); 
   //create pad
   getPadSafe(padID, false, text, function(err)
   {
     if(ERR(err, callback)) return;
-    callback();
+    callback(null, {padID: padID});
   });
 }
 

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -27,7 +27,11 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   //serve pad.html under /p
   args.app.get('/p/:pad', function(req, res, next)
   {    
-    res.send(eejs.require("ep_etherpad-lite/templates/pad.html", {req: req}));
+    /*if(!!(req.params.pad.match(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|%<>\*#]/gi))){
+      res.send(404, "Such a padname is forbidden");
+    }else{*/
+      res.send(eejs.require("ep_etherpad-lite/templates/pad.html", {req: req}));
+    //}
   });
 
   //serve timeslider.html under /p/$padname/timeslider
@@ -35,7 +39,16 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   {
     res.send(eejs.require("ep_etherpad-lite/templates/timeslider.html", {req: req}));
   });
-
+  args.app.get('/p/:pad/*', function(req, res, next)
+  {
+    if(req.url.split("/")[3] == "timeslider"){
+      //Just a safeguard, sometimes these URLs get messed up and should be
+      //actually rerouted to the timeslider instead of an error page.
+      res.send(eejs.require("ep_etherpad-lite/templates/timeslider.html", {req: req}));
+    }else{
+      res.send(404, "Such a padname is forbidden");
+    }
+  });
   //serve favicon.ico from all path levels except as a pad name
   args.app.get( /\/favicon.ico$/, function(req, res)
   {

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -42,7 +42,7 @@
               if(language) document.documentElement.lang = language[1];
             })(document)
         </script>
-        <script type="text/javascript" src="static/js/l10n.js" async></script>
+        <script type="text/javascript" src="static/js/l10n.js"></script>
 
         <style>
             html, body {
@@ -158,8 +158,8 @@
 
         <div id="wrapper">
             <div id="inner">
-                <div id="button" onclick="go2Random()" data-l10n-id="index.newPad"><div id="content-btn" data-possible="New Pad,নতুন প্যাড,Neues Pad,Nuevo Pad,Uusi muistio,Nouveau Pad,Nieuw pad"></div></div>
-                <div id="label" data-l10n-id="index.createOpenPad"><div id="newwithname" data-possible="or create/open a Pad with the name:,অথবা নাম লিখে প্যাড খুলুন/তৈরী করুন:,Pad mit folgendem Namen öffnen,o puedes crear/abrir un Pad con el nombre:,tai avaa muistio nimellä:,ou créer/ouvrir un Pad intitulé,Maak of open pad met de naam:"></div></div> 
+                <div id="button" onclick="go2Random()" data-l10n-id="index.newPad"></div>
+                <div id="label" data-l10n-id="index.createOpenPad"></div> 
                 <form action="#" onsubmit="go2Name();return false;"> 
                     <input type="text" id="padname" autofocus x-webkit-speech> 
                     <button type="submit">OK</button>
@@ -196,30 +196,5 @@
             
             // start the custom js
             if (typeof customStart == "function") customStart();
-
-            var type = $("#content-btn").attr("data-possible").split(",");
-            var type2 = $("#newwithname").attr("data-possible").split(",");
-            var go = 1;
-            var go2 = 1;
-            $("#content-btn").text(type[0]).fadeIn(300).delay(800).fadeOut(300).queue(namer);
-            $("#newwithname").text(type2[0]).fadeIn(300).delay(800).fadeOut(300).queue(namer2);
-            function namer(){
-              $(this).text(type[go]).fadeIn(300).delay(800).fadeOut(300).queue(namer);
-              if(go < type.length - 1){
-                go++;
-              }else{
-                go = 0;
-              }
-                $(this).dequeue();
-            }  
-            function namer2(){
-              $(this).text(type2[go2]).fadeIn(300).delay(800).fadeOut(300).queue(namer2);
-              if(go2 < type2.length - 1){
-                go2++;
-              }else{
-                go2 = 0;
-              }
-                $(this).dequeue();
-            }  
         </script>
 </html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -171,7 +171,7 @@
             function go2Name() 
             {
               
-                var padname = document.getElementById("padname").value.replace(/[^a-z0-9_\-]/gi, '_');
+                var padname = document.getElementById("padname").value.replace(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|]/gi, '_');
                 padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name");
             }
  

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -173,7 +173,7 @@
             {
               
                 var padname = document.getElementById("padname").value.replace(/[^a-z0-9_\-]/gi, '_');
-                padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name")
+                padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name");
             }
  
             function go2Random() 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -31,6 +31,7 @@
 
         <meta charset="utf-8"> 
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+        <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
         <link rel="resource" type="application/l10n" href="locales.ini" />
         <link rel="shortcut icon" href="<%=settings.favicon%>">
         
@@ -157,8 +158,8 @@
 
         <div id="wrapper">
             <div id="inner">
-                <div id="button" onclick="go2Random()" data-l10n-id="index.newPad"></div>
-                <div id="label" data-l10n-id="index.createOpenPad"></div> 
+                <div id="button" onclick="go2Random()" data-l10n-id="index.newPad"><div id="content-btn" data-possible="New Pad,নতুন প্যাড,Neues Pad,Nuevo Pad,Uusi muistio,Nouveau Pad,Nieuw pad"></div></div>
+                <div id="label" data-l10n-id="index.createOpenPad"><div id="newwithname" data-possible="or create/open a Pad with the name:,অথবা নাম লিখে প্যাড খুলুন/তৈরী করুন:,Pad mit folgendem Namen öffnen,o puedes crear/abrir un Pad con el nombre:,tai avaa muistio nimellä:,ou créer/ouvrir un Pad intitulé,Maak of open pad met de naam:"></div></div> 
                 <form action="#" onsubmit="go2Name();return false;"> 
                     <input type="text" id="padname" autofocus x-webkit-speech> 
                     <button type="submit">OK</button>
@@ -168,7 +169,6 @@
 
         <script src="static/custom/index.js"></script>
         <script> 
-      
             function go2Name() 
             {
                 var padname = document.getElementById("padname").value;
@@ -195,5 +195,30 @@
             
             // start the custom js
             if (typeof customStart == "function") customStart();
+
+            var type = $("#content-btn").attr("data-possible").split(",");
+            var type2 = $("#newwithname").attr("data-possible").split(",");
+            var go = 1;
+            var go2 = 1;
+            $("#content-btn").text(type[0]).fadeIn(300).delay(800).fadeOut(300).queue(namer);
+            $("#newwithname").text(type2[0]).fadeIn(300).delay(800).fadeOut(300).queue(namer2);
+            function namer(){
+              $(this).text(type[go]).fadeIn(300).delay(800).fadeOut(300).queue(namer);
+              if(go < type.length - 1){
+                go++;
+              }else{
+                go = 0;
+              }
+                $(this).dequeue();
+            }  
+            function namer2(){
+              $(this).text(type2[go2]).fadeIn(300).delay(800).fadeOut(300).queue(namer2);
+              if(go2 < type2.length - 1){
+                go2++;
+              }else{
+                go2 = 0;
+              }
+                $(this).dequeue();
+            }  
         </script>
 </html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -31,7 +31,6 @@
 
         <meta charset="utf-8"> 
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-        <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
         <link rel="resource" type="application/l10n" href="locales.ini" />
         <link rel="shortcut icon" href="<%=settings.favicon%>">
         

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -171,7 +171,8 @@
         <script> 
             function go2Name() 
             {
-                var padname = document.getElementById("padname").value;
+              
+                var padname = document.getElementById("padname").value.replace(/[^a-z0-9_\-]/gi, '_');
                 padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name")
             }
  

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -171,7 +171,7 @@
             function go2Name() 
             {
               
-                var padname = document.getElementById("padname").value.replace(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|]/gi, '_');
+                var padname = document.getElementById("padname").value.replace(/[;\/\?:@&=\+\$,{}\\\^\[\]\`\|%<>\*#]/gi, '_');
                 padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name");
             }
  


### PR DESCRIPTION
This addresses issue #1241 about pad sanitization - The API would allow for creation of pads that could possibly harm the internals, along with being inaccessible - (Would contain /, \\ and other characters that could cause issues.) along with adding a catcher for anything under /p/ that is unhandled so that a GET to /p/asd/asd would result in a `Such a padname is forbidden` instead of a `Cannot GET /p/asd/asd` 