### PR TITLE
fix for multiple cookies support (Also fix for, when session is not valid anymore)

### DIFF
--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -133,10 +133,16 @@ exports.checkAccess = function (padID, sessionCookie, token, password, callback)
               var now = Math.floor(new Date().getTime()/1000);
               
               //is it for this group?
-              if(sessionInfo.groupID != groupID) return;
+              if(sessionInfo.groupID != groupID) {
+            	  callback();
+            	  return;
+              }
               
               //is validUntil still ok?
-              if(sessionInfo.validUntil <= now) return;
+              if(sessionInfo.validUntil <= now){
+            	  callback();
+            	  return;
+              }
               
               // There is a valid session
               validSession = true;


### PR DESCRIPTION
This closes issue #1260

If the groupID doesn't equals the session groupID, the callback still has to be executed.
Also if the the session for the group is not valid anymore the callback still has to be executed.
