### PR TITLE
Avoid use of os.tmpDir() for keep node 0.6 compatibility

### DIFF
--- a/src/templates/admin/plugins-info.html
+++ b/src/templates/admin/plugins-info.html
@@ -17,7 +17,7 @@
       <pre><%- plugins.formatPlugins().replace(", ","\n") %></pre>
 
       <h2>Installed parts</h2>
-      <pre><%- plugins.formatParts() %></pre>
+      <pre><%= plugins.formatParts() %></pre>
 
       <h2>Installed hooks</h2>
       <h3>Server side hooks</h3>


### PR DESCRIPTION
Tested with node 0.6
Not tested in windows
Related with https://github.com/ether/etherpad-lite/issues/976
