### PR TITLE
Fix import state hanging. Issue #976 & #1105

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -176,6 +176,6 @@ exports.doImport = function(req, res, padId)
     ERR(err);
   
     //close the connection
-    res.send("<script type='text/javascript' src='/static/js/jquery.js'></script><script> if ( (!$.browser.msie) && (!($.browser.mozilla && $.browser.version.indexOf(\"1.8.\") == 0)) ){document.domain = document.domain;}var impexp = window.top.require('/pad_impexp').padimpexp.handleFrameCall('" + status + "');</script>", 200);
+    res.send("<script type='text/javascript' src='/static/js/jquery.js'></script><script> if ( (!$.browser.msie) && (!($.browser.mozilla && $.browser.version.indexOf(\"1.8.\") == 0)) ){document.domain = document.domain;}var impexp = window.parent.require('/pad_impexp').padimpexp.handleFrameCall('" + status + "');</script>", 200);
   });
 }


### PR DESCRIPTION
Fix for the import state not changing, after successful import

closes #976 and #1105

Background: When etherpad lite was displayed in an iframe, the request was sent to the top most site (not the etherpadlite iframe, which is the parent)
