### PR TITLE
Grammar nazi catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ documented codebase makes it easier for developers to improve the code and contr
 </table> 
 
 
-Etherpad Lite is designed to be easily embeddable and provides a [HTTP API](https://github.com/ether/etherpad-lite/wiki/HTTP-API) 
+Etherpad Lite is designed to be easily embeddable and provides an [HTTP API](https://github.com/ether/etherpad-lite/wiki/HTTP-API) 
 that allows your web application to manage pads, users and groups. It is recommended to use the client implementations available for this API, listed on [this wiki page](https://github.com/ether/etherpad-lite/wiki/HTTP-API-client-libraries).
 There is also a [jQuery plugin](https://github.com/johnyma22/etherpad-lite-jquery-plugin) that helps you to embed Pads into your website
 


### PR DESCRIPTION
change a HTTP to **an HTTP** ... also, is the API [RESTful](http://en.wikipedia.org/wiki/Representational_state_transfer)? If so, it might be wise to mention it...
