### PR TITLE
Added --root argument to run.sh to bypass the root-check, fix for #1324

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -8,10 +8,18 @@ if [ -d "../bin" ]; then
   cd "../"
 fi
 
+ignoreRoot=0
+for ARG in $*
+do
+  if [ $ARG == '--root' ]; then
+    ignoreRoot=1
+  fi
+done
+
 #Stop the script if its started as root
-if [ "$(id -u)" -eq 0 ]; then
+if [ "$(id -u)" -eq 0 ] && [ $ignoreRoot -eq 0 ]; then
    echo "You shouldn't start Etherpad-Lite as root!"
-   echo "Please type 'Etherpad Lite rocks my socks' if you still want to start it as root"
+   echo "Please type 'Etherpad Lite rocks my socks' or supply the '--root' argument if you still want to start it as root"
    read rocks
    if [ ! $rocks = "Etherpad Lite rocks my socks" ]
    then


### PR DESCRIPTION
Fix for https://github.com/ether/etherpad-lite/issues/1324
