### PR TITLE
fixed 'client implementations'-link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ documented codebase makes it easier for developers to improve the code and contr
 
 
 Etherpad Lite is designed to be easily embeddable and provides a [HTTP API](https://github.com/ether/etherpad-lite/wiki/HTTP-API) 
-that allows your web application to manage pads, users and groups. It is recommended to use the [available client implementations]((https://github.com/ether/etherpad-lite/wiki/HTTP-API-client-libraries) in order to interact with this API. There is also a [jQuery plugin](https://github.com/johnyma22/etherpad-lite-jquery-plugin) that helps you to embed Pads into your website.
+that allows your web application to manage pads, users and groups. It is recommended to use the [available client implementations](https://github.com/ether/etherpad-lite/wiki/HTTP-API-client-libraries) in order to interact with this API. There is also a [jQuery plugin](https://github.com/johnyma22/etherpad-lite-jquery-plugin) that helps you to embed Pads into your website.
 There's also a full-featured plugin framework, allowing you to easily add your own features.
 Finally, Etherpad Lite comes with translations into tons of different languages!
 


### PR DESCRIPTION
Does not need a description, does it?

Changed
`[available client implementations]((https://git`
to
`[available client implementations](https://git`
...
