### PR TITLE
Fixed IE crash related to console usage. (Issue #1321)

### DIFF
--- a/src/static/js/html10n.js
+++ b/src/static/js/html10n.js
@@ -23,9 +23,9 @@
 window.html10n = (function(window, document, undefined) {
   var console = window.console
   function interceptConsole(method){
-      var original = console[method]
-
       if (!console) return function() {}
+
+      var original = console[method]
 
       // do sneaky stuff
       if (original.bind){


### PR DESCRIPTION
Moved console existence check before the variable is used.  This was causing a crash in Internet Explorer when the console was not enabled (console is off by default).
