### PR TITLE
Make the creation of clientVars hookable

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -175,6 +175,27 @@ function handleMessage ( hook, context, callback ) {
 };
 ```
 
+## clientVars
+Called from: src/node/handler/PadMessageHandler.js
+
+Things in context:
+
+1. clientVars - the basic `clientVars` built by the core
+2. pad - the pad this session is about
+
+This hook will be called once a client connects and the `clientVars` are being sent. Plugins can use this hook to give the client a initial configuriation, like the tracking-id of an external analytics-tool that is used on the client-side. You can also overwrite values from the original `clientVars`.
+
+Example:
+
+```
+exports.clientVars = function(hook, context, callback)
+{
+  // tell the client which year we are in
+  return callback({ "currentYear": new Date().getFullYear() });
+};
+```
+
+This can be accessed on the client-side using `clientVars.currentYear`.
 
 ## getLineHTMLForExport
 Called from: src/node/utils/ExportHtml.js

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1063,10 +1063,22 @@ function handleClientReady(client, message)
           clientVars.userName = authorName;
         }
         
-        //Send the clientVars to the Client
-        client.json.send({type: "CLIENT_VARS", data: clientVars});
-        //Save the current revision in sessioninfos, should be the same as in clientVars
-        sessioninfos[client.id].rev = pad.getHeadRevisionNumber();
+        //call the clientVars-hook so plugins can modify them before they get sent to the client
+        hooks.aCallAll("clientVars", { clientVars: clientVars, pad: pad }, function ( err, messages ) {
+          if(ERR(err, callback)) return;
+          
+          _.each(messages, function(newVars) {
+            //combine our old object with the new attributes from the hook
+            for(var attr in newVars) {
+              clientVars[attr] = newVars[attr];
+            }
+          });
+        
+          //Send the clientVars to the Client
+          client.json.send({type: "CLIENT_VARS", data: clientVars});
+          //Save the current revision in sessioninfos, should be the same as in clientVars
+          sessioninfos[client.id].rev = pad.getHeadRevisionNumber();
+        });
       }
         
       sessioninfos[client.id].author = author;


### PR DESCRIPTION
Creates the hook `clientVars` that can be used to modify the `clientVars` before they are sent to the client.

Fix for https://github.com/ether/etherpad-lite/issues/1326
