### PR TITLE
listAllPads should return an object, not an arraay. issue #1374

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -46,7 +46,7 @@ exports.createGroupPad = groupManager.createGroupPad;
 /**PADLIST FUNCTION****/
 /**********************/
 
-exports.listAllPads = padManager.getPads;
+exports.listAllPads = padManager.listAllPads;
 
 /**********************/
 /**AUTHOR FUNCTIONS****/

--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -158,12 +158,12 @@ exports.getPad = function(id, text, callback)
   }
 }
 
-exports.getPads = function(callback)
+exports.listAllPads = function(callback)
 {
   if(callback != null){
-    callback(null,padList.getPads());
+    callback(null,{padIDs: padList.getPads()});
   }else{
-    return padList.getPads();
+    return {padIDs: padList.getPads()};
   }
 }
 


### PR DESCRIPTION
Change listAllPads to return something like `{"padIDs": ["pad1", "pad2"]}`, per issue #1374.
