### PR TITLE
Added a template block for #users

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -153,6 +153,7 @@
         </div>
 
         <div id="users">
+            <% e.begin_block("userlist"); %>
             <div id="connectionstatus"></div>
             <div id="myuser">
                 <div id="mycolorpicker">
@@ -173,6 +174,7 @@
                 <div id="nootherusers"></div>
             </div>
             <div id="userlistbuttonarea"></div>
+            <% e.end_block(); %>
         </div>
 
         <div id="editorcontainerbox">


### PR DESCRIPTION
Added a block for `#users` (the unfolded user-list with colors, etc.) in `pad.html`.
Needed for https://github.com/ether/etherpad-lite/issues/1287 + all the other modals have hooks, so why not add one for the user-list?
