### PR TITLE
use the existing padimpexp object from the parent window, Issue #1395

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -176,7 +176,7 @@ exports.doImport = function(req, res, padId)
     ERR(err);
   
     //close the connection
-    res.send("<head><script type='text/javascript' src='../../static/js/jquery.js'></script></head><script>$(window).load(function(){if ( (!$.browser.msie) && (!($.browser.mozilla && $.browser.version.indexOf(\"1.8.\") == 0)) ){document.domain = document.domain;}var impexp = window.parent.require('/pad_impexp').padimpexp.handleFrameCall('" + status + "');})</script>", 200);
+    res.send("<head><script type='text/javascript' src='../../static/js/jquery.js'></script></head><script>$(window).load(function(){if ( (!$.browser.msie) && (!($.browser.mozilla && $.browser.version.indexOf(\"1.8.\") == 0)) ){document.domain = document.domain;}var impexp = window.parent.padimpexp.handleFrameCall('" + status + "');})</script>", 200);
   });
 }
 


### PR DESCRIPTION
The script didn't use the padimpexp object, the timeout was in. That's why the timeout kept running.
closes #1395
