### PR TITLE
Fix USERINFO_UPDATE crash

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -210,6 +210,7 @@ exports.handleMessage = function(client, message)
       } else if (message.data.type == "SAVE_REVISION") {
         handleSaveRevisionMessage(client, message);
       } else if (message.data.type == "CLIENT_MESSAGE" &&
+                 message.data.payload != null &&
                  message.data.payload.type == "suggestUserName") {
         handleSuggestUserName(client, message);
       } else {


### PR DESCRIPTION
Fixes https://github.com/ether/etherpad-lite/issues/1429
Server no longer crashes when a client sends a empty `USERINFO_UPDATE`-message, like so:

``` javascript
  var message = {};
  message.type = 'USERINFO_UPDATE';
  pad.collabClient.sendMessage(message);
```
