### PR TITLE
Bugfixes to getChatHistory API method

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -325,17 +325,17 @@ exports.getChatHistory = function(padID, start, end, callback)
     if(!start || !end)
     {
 	  start = 0;
-	  end = pad.chatHead - 1;
+	  end = pad.chatHead;
     }
     
-    if(start >= chatHead)
+    if(start >= chatHead && chatHead > 0)
     {
       callback(new customError("start is higher or equal to the current chatHead","apierror"));
       return;
     }
-    if(end >= chatHead)
+    if(end > chatHead)
     {
-      callback(new customError("end is higher or equal to the current chatHead","apierror"));
+      callback(new customError("end is higher than the current chatHead","apierror"));
       return;
     }
     


### PR DESCRIPTION
Fixes two issues:

When called without `start` and `end` arguments on a pad _without_ any chat history, this api error is (I believe) incorrectly returned: "start is higher or equal to the current chatHead." Instead, it should return an empty array.

When called without `start` and `end` arguments on a pad _with_ chat history, the most recent chat message is not returned. Instead, they should all be returned.
