### PR TITLE
Removed debug code from Timeslider

### DIFF
--- a/src/static/js/broadcast_slider.js
+++ b/src/static/js/broadcast_slider.js
@@ -107,16 +107,16 @@ function loadBroadcastSliderJS(fireWhenAllScriptsAreLoaded)
     {
       newpos = Number(newpos);
       if (newpos < 0 || newpos > sliderLength) return;
-      window.location.hash = "#" + newpos;
       if(!newpos){
         newpos = 0; // stops it from displaying NaN if newpos isn't set
       }
+      window.location.hash = "#" + newpos;
       $("#ui-slider-handle").css('left', newpos * ($("#ui-slider-bar").width() - 2) / (sliderLength * 1.0));
       $("a.tlink").map(function()
       {
         $(this).attr('href', $(this).attr('thref').replace("%revision%", newpos));
       });
-      console.log(newpos);
+
       $("#revision_label").html(html10n.get("timeslider.version", { "version": newpos}));
 
       if (newpos == 0)


### PR DESCRIPTION
Removed `console.log` and moved `window.location.hash` setting after the parameter checking.
