### PR TITLE
Log the client ip on pad access

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -32,6 +32,7 @@ var securityManager = require("../db/SecurityManager");
 var plugins = require("ep_etherpad-lite/static/js/pluginfw/plugins.js");
 var log4js = require('log4js');
 var messageLogger = log4js.getLogger("message");
+var accessLogger = log4js.getLogger("access");
 var _ = require('underscore');
 var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks.js");
 
@@ -120,6 +121,10 @@ exports.handleDisconnect = function(client)
       client.broadcast.to(session.padId).json.send(messageToTheOtherUsers);
     }); 
   }
+  
+  client.get('remoteAddress', function(er, ip) {
+    accessLogger.info('[LEAVE] Author "'+session.author+'" on client '+client.id+' with IP "'+ip+'" left pad "'+session.padId+'"')
+  })
   
   //Delete the sessioninfos entrys of this session
   delete sessioninfos[client.id]; 
@@ -910,6 +915,10 @@ function handleClientReady(client, message)
       sessioninfos[client.id].readOnlyPadId = padIds.readOnlyPadId;
       sessioninfos[client.id].readonly = padIds.readonly;
       
+      client.get('remoteAddress', function(er, ip) {
+        accessLogger.info('[ENTER] Client '+client.id+' with IP "'+ip+'" entered pad "'+padIds.padId+'"')
+      })
+
       //If this is a reconnect, we don't have to send the client the ClientVars again
       if(message.reconnect == true)
       {

--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -55,13 +55,14 @@ exports.setSocketIO = function(_socket)
   
   socket.sockets.on('connection', function(client)
   {
+    client.set('remoteAddress', client.handshake.address.address);
     var clientAuthorized = false;
     
     //wrap the original send function to log the messages
     client._send = client.send;
     client.send = function(message)
     {
-      messageLogger.info("to " + client.id + ": " + stringifyWithoutPassword(message));
+      messageLogger.debug("to " + client.id + ": " + stringifyWithoutPassword(message));
       client._send(message);
     }
   
@@ -79,7 +80,7 @@ exports.setSocketIO = function(_socket)
         //check if component is registered in the components array        
         if(components[message.component])
         {
-          messageLogger.info("from " + client.id + ": " + stringifyWithoutPassword(message));
+          messageLogger.debug("from " + client.id + ": " + stringifyWithoutPassword(message));
           components[message.component].handleMessage(client, message);
         }
       }


### PR DESCRIPTION
Establishes a new logger `'access'`, that's used to log relevant information to the console when a users enters or leaves a pad, ie. the users ip address and the pad they enter.

I also changed the log level of all messageLogger messages to `'debug'`, which would probably also be a reasonable change for the http logger.

This fixes #1399 -- In order to just log pad access you'll need to change your log4js config in the settings file.
