### PR TITLE
very simple fix that might break other things but stops the caret focus ...

### DIFF
--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -178,5 +178,5 @@ p {
 #overlaysdiv { position: absolute; left: -1000px; top: -1000px; }
 
 .ace-line{
-  overflow:hidden;
+  overflow:hidden; /* Stops super long lines without being spaces such as aaaaaaaaaaaaaa*100 breaking the editor */
 }


### PR DESCRIPTION
...being moved to the end of new lines when a long string without spaces is pasted into a pad

Resolves https://github.com/ether/etherpad-lite/issues/762

Only tested in Chrome and I had a few drinks this evening so please double check it.
