### PR TITLE
Added raw JSON export

### DIFF
--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -21,6 +21,7 @@
 var ERR = require("async-stacktrace");
 var exporthtml = require("../utils/ExportHtml");
 var exportdokuwiki = require("../utils/ExportDokuWiki");
+var exportraw = require("../utils/ExportRaw");
 var padManager = require("../db/PadManager");
 var async = require("async");
 var fs = require("fs");
@@ -63,6 +64,17 @@ exports.doExport = function(req, res, padId, type)
       {
         res.send(pad.text());
       }
+    });
+  }
+  else if(type == "raw")
+  {
+    padManager.getPad(padId, function(err, pad)
+    {
+      ERR(err);
+      exportraw.getPadRaw(pad, req.params.rev, function(err, json) {
+        res.attachment(padId + ".json");
+        res.send(json);
+      })
     });
   }
   else if(type == 'dokuwiki')

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -5,7 +5,7 @@ var importHandler = require('../../handler/ImportHandler');
 
 exports.expressCreateServer = function (hook_name, args, cb) {
   args.app.get('/p/:pad/:rev?/export/:type', function(req, res, next) {
-    var types = ["pdf", "doc", "txt", "html", "odt", "dokuwiki"];
+    var types = ["pdf", "doc", "txt", "html", "odt", "dokuwiki", "raw"];
     //send a 404 if we don't support this filetype
     if (types.indexOf(req.params.type) == -1) {
       next();

--- a/src/node/utils/ExportRaw.js
+++ b/src/node/utils/ExportRaw.js
@@ -1,0 +1,89 @@
+var async = require("async");
+var Changeset = require("ep_etherpad-lite/static/js/Changeset");
+var ERR = require("async-stacktrace");
+
+function getChangesets(pad, fromRev, callback) {
+  var rev = fromRev + 1;
+  var toRev = pad.getHeadRevisionNumber();
+
+  //find out which revisions we need
+  var revisions = [];
+  for (var i=rev; i<toRev; i++){
+    revisions.push(i);
+  }
+
+  var changesets = [];
+
+  //get all needed revisions
+  async.forEach(revisions, 
+
+    function(rev, callback){
+      pad.getRevision(rev, function(err, revision){
+        if(err){
+          return callback(err)
+        }
+        changesets.push(revision.changeset);
+        callback();
+      });
+    },
+
+    function(err){
+      callback(err, changesets);
+    }
+  );
+}
+
+function getPadRaw(pad, fromRev, callback) {
+
+  //check parameters
+  if(!pad || !pad.id || !pad.atext || !pad.pool) {
+    throw new Error('Invalid pad');
+  }
+
+  if (!fromRev) {
+    fromRev = pad.getHeadRevisionNumber();
+  } else {
+    fromRev = parseInt(fromRev, 10);
+    if(fromRev < 0 || fromRev > pad.getHeadRevisionNumber()) { 
+      throw new Error('Invalid start revision ' + fromRev); 
+    }
+  }
+
+  var atext;
+  var changesets;
+
+  async.series([
+  //get all needed data out of the database
+  function(callback) {
+    async.parallel([
+
+    // fetch start revision atext
+    function (callback) {
+
+      pad.getInternalRevisionAText(fromRev, function (err, revisionAText) {
+        if(ERR(err, callback)) return;
+        atext = revisionAText;
+      });
+      
+      callback();
+    },
+
+    // get the changesets
+    function(callback) {
+      getChangesets(pad, fromRev, function(err, cs) { changesets = cs; callback(); }); 
+    }
+
+    ], callback);
+  }], 
+
+  // run final callback
+  function (err) {
+    if(ERR(err, callback)) return;
+    if (changesets.length == 0) {
+      changesets = undefined;
+    }
+    callback(null, {apool: pad.apool().numToAttrib, atext: { rev: fromRev, attributes: atext.attribs, text: atext.text}, changesets: changesets});
+  });
+}
+
+exports.getPadRaw = getPadRaw;


### PR DESCRIPTION
This is a "raw" export in json. You can specify a start revision and you'll get the atext, apool and changesets from that rev up to head.
