### PR TITLE
throw and post err on bad pad data - DO NOT MERGE

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -188,10 +188,13 @@ function Ace2Inner(){
             try{
               setDocAText(atext);
             }catch(err){
-              var err = {
-                errorInfo: "Text is broken so wont load on the client"
+              var padId = top.pad.getPadId();
+              var errMsg = "Pad data wont load for pad: " +padId;
+              top.console.error(errMsg);
+              var error = {
+                errorInfo: errMsg
               }
-              $.post('/jserror', err);
+              $.post('/jserror', error);
             }
           },
           applyChangesetToDocument: function(changeset, preferInsertionAfterCaret)


### PR DESCRIPTION
Helps debug bad pad data a bit..  Note that I'm doing a POST here and this is bad, I can't remember how we wrote the stuff that posts to jserror and really this pull request needs those bits adding before merging.  For now this is enough for me to write some pad debug stuff.
