### PR TITLE
Fix settings object having constructors of another vm.context

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -157,6 +157,7 @@ exports.reloadSettings = function reloadSettings() {
   try {
     if(settingsStr) {
       settings = vm.runInContext('exports = '+settingsStr, vm.createContext(), "settings.json");
+      settings = JSON.parse(JSON.stringify(settings)) // fix objects having constructors of other vm.context
     }
   }catch(e){
     console.error('There was an error processing your settings.json file: '+e.message);


### PR DESCRIPTION
This made it impossible to rely on `instanceof` to work as expected on (even parts of) the settings object
Fixes #1570
