### PR TITLE
Created a script to import data to all dbms

### DIFF
--- a/bin/importSqlFile.js
+++ b/bin/importSqlFile.js
@@ -61,7 +61,7 @@ require("ep_etherpad-lite/node_modules/npm").load({}, function(er,npm) {
         }
       });
       process.stdout.write("\n");
-      process.stdout.wirte("done. waiting for db to finish transaction. depended on dbms this may take some time...\n");
+      process.stdout.write("done. waiting for db to finish transaction. depended on dbms this may take some time...\n");
 
       db.doShutdown(function() {
         log("finished, imported " + keyNo + " keys.");


### PR DESCRIPTION
This script allows to import sql file created with convert.js to all supported dbms, not only mysql.
Tested with redis but uses ueberDB so should work with all others.
