### PR TITLE
SECURITY PATCH: Don't crash pad if bad author data is passed to the server

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -550,11 +550,16 @@ function handleUserChanges(client, message)
             throw "Attribute pool is missing attribute "+n+" for changeset "+changeset;
           }
         });
+
+        // Validate all 'author' attribs to be the same value as the current user
+        wireApool.eachAttrib(function(type, value) {
+          if('author' == type && value != thisSession.author) throw "Trying to submit changes as another author"
+        })
       }
       catch(e)
       {
         // There is an error in this changeset, so just refuse it
-        console.warn("Can't apply USER_CHANGES "+changeset+", because it failed checkRep");
+        console.warn("Can't apply USER_CHANGES "+changeset+", because: "+e);
         client.json.send({disconnect:"badChangeset"});
         return;
       }


### PR DESCRIPTION
Type of attack: Persistent Denial-of-service.

Important: This security issue affects all old/legacy Etherpad instances also, they should update ASAP.

Outcome of attack: A user can send a single liner and access to a pad is completely broken for all users.

Steps to replicate: I wont provide steps to replicate here because all servers are currently vulnerable.  Feel free to contact me directly if you are a site admin looking for a way to replicate/test.

Thanks to Sebastian Nerz for spotting this.

Just on a related note our security audit from Mozilla is due to be published soon.
