### PR TITLE
A nicer way to handle the API versions

### DIFF
--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -64,7 +64,8 @@ Portal submits content into new blog post
 The latest version is `1.2.7`
 
 The current version can be queried via /api.
-A list of all available API versions can be obtained via /API/versions
+
+A list of all available API versions can be obtained via /API/versions.
 
 ### Request Format
 

--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -64,6 +64,7 @@ Portal submits content into new blog post
 The latest version is `1.2.7`
 
 The current version can be queried via /api.
+A list of all available API versions can be obtained via /API/versions
 
 ### Request Format
 

--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -63,9 +63,13 @@ Portal submits content into new blog post
 ### API version
 The latest version is `1.2.7`
 
-The current version can be queried via /api.
+The current version and a list of all available API versions can be obtained via 
 
-A list of all available API versions can be obtained via /API/versions.
+> `http://pad.domain/api`
+
+and
+
+> `http://pad.domain/api/versions`.
 
 ### Request Format
 

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -38,8 +38,7 @@ catch(e)
 }
 
 //a list of all functions
-var version =
-{ "1":
+var API_V1 =
   { "createGroup"               : []
   , "createGroupIfNotExistsFor" : ["groupMapper"]
   , "deleteGroup"               : ["groupID"]
@@ -67,154 +66,43 @@ var version =
   , "setPassword"               : ["padID", "password"]
   , "isPasswordProtected"       : ["padID"]
   , "listAuthorsOfPad"          : ["padID"]
-  , "padUsersCount"             : ["padID"]
-  }
-, "1.1":
-  { "createGroup"               : []
-  , "createGroupIfNotExistsFor" : ["groupMapper"]
-  , "deleteGroup"               : ["groupID"]
-  , "listPads"                  : ["groupID"]
-  , "createPad"                 : ["padID", "text"]
-  , "createGroupPad"            : ["groupID", "padName", "text"]
-  , "createAuthor"              : ["name"]
-  , "createAuthorIfNotExistsFor": ["authorMapper" , "name"]
-  , "listPadsOfAuthor"          : ["authorID"]
-  , "createSession"             : ["groupID", "authorID", "validUntil"]
-  , "deleteSession"             : ["sessionID"]
-  , "getSessionInfo"            : ["sessionID"]
-  , "listSessionsOfGroup"       : ["groupID"]
-  , "listSessionsOfAuthor"      : ["authorID"]
-  , "getText"                   : ["padID", "rev"]
-  , "setText"                   : ["padID", "text"]
-  , "getHTML"                   : ["padID", "rev"]
-  , "setHTML"                   : ["padID", "html"]
-  , "getRevisionsCount"         : ["padID"]
-  , "getLastEdited"             : ["padID"]
-  , "deletePad"                 : ["padID"]
-  , "getReadOnlyID"             : ["padID"]
-  , "setPublicStatus"           : ["padID", "publicStatus"]
-  , "getPublicStatus"           : ["padID"]
-  , "setPassword"               : ["padID", "password"]
-  , "isPasswordProtected"       : ["padID"]
-  , "listAuthorsOfPad"          : ["padID"]
-  , "padUsersCount"             : ["padID"]
-  , "getAuthorName"             : ["authorID"]
-  , "padUsers"                  : ["padID"]
+  , "padUsersCount"             : ["padID"] };
+
+var API_V1_1 =
+  { "getAuthorName"             : ["authorID"]
+  ,  "padUsers"                 : ["padID"]
   , "sendClientsMessage"        : ["padID", "msg"]
-  , "listAllGroups"             : []
-  }
-, "1.2":
-  { "createGroup"               : []
-  , "createGroupIfNotExistsFor" : ["groupMapper"]
-  , "deleteGroup"               : ["groupID"]
-  , "listPads"                  : ["groupID"]
-  , "createPad"                 : ["padID", "text"]
-  , "createGroupPad"            : ["groupID", "padName", "text"]
-  , "createAuthor"              : ["name"]
-  , "createAuthorIfNotExistsFor": ["authorMapper" , "name"]
-  , "listPadsOfAuthor"          : ["authorID"]
-  , "createSession"             : ["groupID", "authorID", "validUntil"]
-  , "deleteSession"             : ["sessionID"]
-  , "getSessionInfo"            : ["sessionID"]
-  , "listSessionsOfGroup"       : ["groupID"]
-  , "listSessionsOfAuthor"      : ["authorID"]
-  , "getText"                   : ["padID", "rev"]
-  , "setText"                   : ["padID", "text"]
-  , "getHTML"                   : ["padID", "rev"]
-  , "setHTML"                   : ["padID", "html"]
-  , "getRevisionsCount"         : ["padID"]
-  , "getLastEdited"             : ["padID"]
-  , "deletePad"                 : ["padID"]
-  , "getReadOnlyID"             : ["padID"]
-  , "setPublicStatus"           : ["padID", "publicStatus"]
-  , "getPublicStatus"           : ["padID"]
-  , "setPassword"               : ["padID", "password"]
-  , "isPasswordProtected"       : ["padID"]
-  , "listAuthorsOfPad"          : ["padID"]
-  , "padUsersCount"             : ["padID"]
-  , "getAuthorName"             : ["authorID"]
-  , "padUsers"                  : ["padID"]
-  , "sendClientsMessage"        : ["padID", "msg"]
-  , "listAllGroups"             : []
-  , "checkToken"                : []
-  }
-, "1.2.1":
-  { "createGroup"               : []
-  , "createGroupIfNotExistsFor" : ["groupMapper"]
-  , "deleteGroup"               : ["groupID"]
-  , "listPads"                  : ["groupID"]
-  , "listAllPads"               : []
-  , "createPad"                 : ["padID", "text"]
-  , "createGroupPad"            : ["groupID", "padName", "text"]
-  , "createAuthor"              : ["name"]
-  , "createAuthorIfNotExistsFor": ["authorMapper" , "name"]
-  , "listPadsOfAuthor"          : ["authorID"]
-  , "createSession"             : ["groupID", "authorID", "validUntil"]
-  , "deleteSession"             : ["sessionID"]
-  , "getSessionInfo"            : ["sessionID"]
-  , "listSessionsOfGroup"       : ["groupID"]
-  , "listSessionsOfAuthor"      : ["authorID"]
-  , "getText"                   : ["padID", "rev"]
-  , "setText"                   : ["padID", "text"]
-  , "getHTML"                   : ["padID", "rev"]
-  , "setHTML"                   : ["padID", "html"]
-  , "getRevisionsCount"         : ["padID"]
-  , "getLastEdited"             : ["padID"]
-  , "deletePad"                 : ["padID"]
-  , "getReadOnlyID"             : ["padID"]
-  , "setPublicStatus"           : ["padID", "publicStatus"]
-  , "getPublicStatus"           : ["padID"]
-  , "setPassword"               : ["padID", "password"]
-  , "isPasswordProtected"       : ["padID"]
-  , "listAuthorsOfPad"          : ["padID"]
-  , "padUsersCount"             : ["padID"]
-  , "getAuthorName"             : ["authorID"]
-  , "padUsers"                  : ["padID"]
-  , "sendClientsMessage"        : ["padID", "msg"]
-  , "listAllGroups"             : []
-  , "checkToken"                : []
-  }
-, "1.2.7":
-  { "createGroup"               : []
-  , "createGroupIfNotExistsFor" : ["groupMapper"]
-  , "deleteGroup"               : ["groupID"]
-  , "listPads"                  : ["groupID"]
-  , "listAllPads"               : []
-  , "createDiffHTML"	        : ["padID", "startRev", "endRev"]
-  , "createPad"                 : ["padID", "text"]
-  , "createGroupPad"            : ["groupID", "padName", "text"]
-  , "createAuthor"              : ["name"]
-  , "createAuthorIfNotExistsFor": ["authorMapper" , "name"]
-  , "listPadsOfAuthor"          : ["authorID"]
-  , "createSession"             : ["groupID", "authorID", "validUntil"]
-  , "deleteSession"             : ["sessionID"]
-  , "getSessionInfo"            : ["sessionID"]
-  , "listSessionsOfGroup"       : ["groupID"]
-  , "listSessionsOfAuthor"      : ["authorID"]
-  , "getText"                   : ["padID", "rev"]
-  , "setText"                   : ["padID", "text"]
-  , "getHTML"                   : ["padID", "rev"]
-  , "setHTML"                   : ["padID", "html"]
-  , "getRevisionsCount"         : ["padID"]
-  , "getLastEdited"             : ["padID"]
-  , "deletePad"                 : ["padID"]
-  , "getReadOnlyID"             : ["padID"]
-  , "setPublicStatus"           : ["padID", "publicStatus"]
-  , "getPublicStatus"           : ["padID"]
-  , "setPassword"               : ["padID", "password"]
-  , "isPasswordProtected"       : ["padID"]
-  , "listAuthorsOfPad"          : ["padID"]
-  , "padUsersCount"             : ["padID"]
-  , "getAuthorName"             : ["authorID"]
-  , "padUsers"                  : ["padID"]
-  , "sendClientsMessage"        : ["padID", "msg"]
-  , "listAllGroups"             : []
-  , "checkToken"                : []
+  , "listAllGroups"             : [] };
+
+var API_V1_2 =
+  { "checkToken"                : [] };
+
+var API_V1_2_1 =
+  { "listAllPads"               : [] };
+
+var API_V1_2_7 =
+  { "createDiffHTML"            : ["padID", "startRev", "endRev"]
   , "getChatHistory"            : ["padID"]
   , "getChatHistory"            : ["padID", "start", "end"]
-  , "getChatHead"               : ["padID"]
-  }
-};
+  , "getChatHead"               : ["padID"] };
+
+function apiConcat(v1, v2) {
+ for (var key in v1) {
+  v2[key] = v1[key];
+ }
+ return v2;
+}
+
+API_V1_1   =  apiConcat(API_V1,     API_V1_1)   ;
+API_V1_2   =  apiConcat(API_V1_1,   API_V1_2)   ;
+API_V1_2_1 =  apiConcat(API_V1_2,   API_V1_2_1) ;
+API_V1_2_7 =  apiConcat(API_V1_2_1, API_V1_2_7) ;
+
+var version = { "1"     : API_V1
+              , "1.1"   : API_V1_1
+              , "1.2"   : API_V1_2
+              , "1.2.1" : API_V1_2_1
+              , "1.2.7" : API_V1_2_7 };
 
 // set the latest available API version here
 exports.latestApiVersion = '1.2.7';

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -37,6 +37,14 @@ catch(e)
   fs.writeFileSync("./APIKEY.txt",apikey,"utf8");
 }
 
+//liitle helper for concatenating the following API versions
+function apiConcat(v1, v2) {
+ for (var key in v1) {
+  v2[key] = v1[key];
+ }
+ return v2;
+}
+
 //a list of all functions
 var API_V1 =
   { "createGroup"               : []
@@ -86,13 +94,6 @@ var API_V1_2_7 =
   , "getChatHistory"            : ["padID", "start", "end"]
   , "getChatHead"               : ["padID"] };
 
-function apiConcat(v1, v2) {
- for (var key in v1) {
-  v2[key] = v1[key];
- }
- return v2;
-}
-
 API_V1_1   =  apiConcat(API_V1,     API_V1_1)   ;
 API_V1_2   =  apiConcat(API_V1_1,   API_V1_2)   ;
 API_V1_2_1 =  apiConcat(API_V1_2,   API_V1_2_1) ;
@@ -106,6 +107,11 @@ var version = { "1"     : API_V1
 
 // set the latest available API version here
 exports.latestApiVersion = '1.2.7';
+
+//collect all available API versions and make it available for API endpoint
+versions = [];
+for (key in version) versions.push(key);
+exports.versions = versions;
 
 // exports the versions so it can be used by the new Swagger endpoint
 exports.version = version;

--- a/src/node/hooks/express/apicalls.js
+++ b/src/node/hooks/express/apicalls.js
@@ -62,4 +62,9 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   args.app.get('/api', function (req, res) {
      res.json({"currentVersion" : apiHandler.latestApiVersion});
   });
+  
+  //Provide a possibility to query a list of all available API versions
+  args.app.get('/api/versions', function (req, res) {
+     res.json(apiHandler.versions);
+  });
 }


### PR DESCRIPTION
- Instead of manually copy/pasting the API version functions every time we version bump, we should reuse the content of a previous API version.
- Also a possibility for querying a list of all available API versions is available under /API/versions