### PR TITLE
show light yellow for .5 secs on save revision keypress

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3650,9 +3650,9 @@ function Ace2Inner(){
         {
           evt.preventDefault();
           var originalBackground = parent.parent.$('#revisionlink').css("background")
-          parent.parent.$('#revisionlink').css({"background":"lightyellow", 'box-shadow': '0 0 50px yellow'});
+          parent.parent.$('#revisionlink').css({"background":"lightyellow"});
           top.setTimeout(function(){
-            parent.parent.$('#revisionlink').css({"background":originalBackground, 'box-shadow': 'none'});
+            parent.parent.$('#revisionlink').css({"background":originalBackground});
           }, 1000);
           parent.parent.pad.collabClient.sendMessage({"type":"SAVE_REVISION"}); /* The parent.parent part of this is BAD and I feel bad..  It may break something */
           specialHandled = true;


### PR DESCRIPTION
This is just a very minor UX thing that makes it a little more obvious to people that Ctrl S saves a revision..  We never say "saved" or anything like so it stays on our core values of trying to modify the behaviour of how people use collaborative tools.
