### PR TITLE
Don't error in listSessionsOfGroup when there are non-existing sessions

### DIFF
--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -347,7 +347,15 @@ function listSessionsWithDBKey (dbkey, callback)
       {
         exports.getSessionInfo(sessionID, function(err, sessionInfo)
         {
-          if(ERR(err, callback)) return;
+          if (err == "apierror: sessionID does not exist")
+          {
+            console.warn("Found bad session " + sessionID + " in " + dbkey + ".");
+          }
+          else if(ERR(err, callback))
+          {
+            return;
+          }
+
           sessions[sessionID] = sessionInfo;
           callback();
         });


### PR DESCRIPTION
This implements the fix proposed by eldiddio in #1519.
Sessions which are in a `group2session` or `author2session`-entry, but are no longer existent will be logged so that the request can be answered correctly.
