### PR TITLE
Fix missing callback in SecurityManager.checkAccess

### DIFF
--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -133,6 +133,7 @@ exports.checkAccess = function (padID, sessionCookie, token, password, callback)
               //skip session if it doesn't exist
               if(err && err.message == "sessionID does not exist")
               {
+                authLogger.debug("Auth failed: unknown session");
                 callback();
                 return;
               }


### PR DESCRIPTION
`securityManager.checkAccess` does not call the callback of its `async.forEach` when there is just one session and this one is invalid. This causes the client request to hang forever.

Note that `validSession` is still false so this change does not cause any problems further down the line, but tells the user that they don't have access instead of letting them wait forever.
