### PR TITLE
Decode the sessionID before sending it to the server

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -191,7 +191,7 @@ function handshake()
       createCookie("token", token, 60);
     }
     
-    var sessionID = readCookie("sessionID");
+    var sessionID = decodeURIComponent(readCookie("sessionID"));
     var password = readCookie("password");
 
     var msg = {

--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -116,7 +116,7 @@ function init() {
 //sends a message over the socket
 function sendSocketMsg(type, data)
 {
-  var sessionID = readCookie("sessionID");
+  var sessionID = decodeURIComponent(readCookie("sessionID"));
   var password = readCookie("password");
 
   var msg = { "component" : "pad", // FIXME: Remove this stupidity!


### PR DESCRIPTION
Our separator `,` gets encoded on the client-side and we don't decode it before sending it to the server, so `securityManager.checkAccess` fails to split the sessionIDs into the individual IDs, because `.split(',')` does not work on `%2C`.
