### PR TITLE
Longer timeout

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -242,7 +242,7 @@ function handshake()
       
       pad.collabClient.setChannelState("RECONNECTING");
       
-      disconnectTimeout = setTimeout(disconnectEvent, 10000);
+      disconnectTimeout = setTimeout(disconnectEvent, 20000);
     }
   });
 


### PR DESCRIPTION
This is a more sane timeout duration, sometimes if you restart Etherpad it can take up to 20 seconds for 
- The server to restart
- Your reverse proxy to realize it's healthy again
