### PR TITLE
Kick the user if the deleteSession-API is called

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -252,14 +252,22 @@ function handshake()
   socket.on('message', function(obj)
   {
     //the access was not granted, give the user a message
-    if(!receivedClientVars && obj.accessStatus)
+    if(obj.accessStatus)
     {
-      $('.passForm').submit(require(module.id).savePassword);
+      if(!receivedClientVars)
+        $('.passForm').submit(require(module.id).savePassword);
 
       if(obj.accessStatus == "deny")
       {
         $('#loading').hide();
         $("#permissionDenied").show();
+
+        if(receivedClientVars)
+        {
+          // got kicked
+          $("#editorcontainer").hide();
+          $("#editorloadingbox").show();
+        }
       }
       else if(obj.accessStatus == "needPassword")
       {


### PR DESCRIPTION
Currently when a user already has a connection (which has been successfully  authenticated) and a developer calls `deleteSession` via the API the user does not get kicked. This is because the session only gets validated once, when the `CLIENT_READY` message arrives.

This PR makes etherpad-lite validate **every** socket.io package. When the auth fails the new `accessStatus` is sent to the client which displays the normal "Your are not allowed to view this"-message.

Fixed #815.
