### PR TITLE
 dont use top, use the scheduler

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3651,7 +3651,7 @@ function Ace2Inner(){
           evt.preventDefault();
           var originalBackground = parent.parent.$('#revisionlink').css("background")
           parent.parent.$('#revisionlink').css({"background":"lightyellow"});
-          top.setTimeout(function(){
+          scheduler.setTimeout(function(){
             parent.parent.$('#revisionlink').css({"background":originalBackground});
           }, 1000);
           parent.parent.pad.collabClient.sendMessage({"type":"SAVE_REVISION"}); /* The parent.parent part of this is BAD and I feel bad..  It may break something */


### PR DESCRIPTION
If you embed a pad and hit ctrl-s it would fire a JS error. 
