### PR TITLE
use `parent.parent` instead of `top` in `collab_client.js`

### DIFF
--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -295,7 +295,7 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
 
         if (newRev != (oldRev + 1))
         {
-          top.console.warn("bad message revision on NEW_CHANGES: " + newRev + " not " + (oldRev + 1));
+          parent.parent.console.warn("bad message revision on NEW_CHANGES: " + newRev + " not " + (oldRev + 1));
           // setChannelState("DISCONNECTED", "badmessage_newchanges");
           return;
         }
@@ -305,7 +305,7 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
 
       if (newRev != (rev + 1))
       {
-        top.console.warn("bad message revision on NEW_CHANGES: " + newRev + " not " + (rev + 1));
+        parent.parent.console.warn("bad message revision on NEW_CHANGES: " + newRev + " not " + (rev + 1));
         // setChannelState("DISCONNECTED", "badmessage_newchanges");
         return;
       }
@@ -319,7 +319,7 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
       {
         if (newRev != (msgQueue[msgQueue.length - 1].newRev + 1))
         {
-          top.console.warn("bad message revision on ACCEPT_COMMIT: " + newRev + " not " + (msgQueue[msgQueue.length - 1][0] + 1));
+          parent.parent.console.warn("bad message revision on ACCEPT_COMMIT: " + newRev + " not " + (msgQueue[msgQueue.length - 1][0] + 1));
           // setChannelState("DISCONNECTED", "badmessage_acceptcommit");
           return;
         }
@@ -329,7 +329,7 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
 
       if (newRev != (rev + 1))
       {
-        top.console.warn("bad message revision on ACCEPT_COMMIT: " + newRev + " not " + (rev + 1));
+        parent.parent.console.warn("bad message revision on ACCEPT_COMMIT: " + newRev + " not " + (rev + 1));
         // setChannelState("DISCONNECTED", "badmessage_acceptcommit");
         return;
       }


### PR DESCRIPTION
`top` in `collab_client.js` breaks embedding when a pad is embedded (same origin policy).
