### PR TITLE
Add script that more efficiently imports large files.

### DIFF
--- a/bin/importLargeSqlFile.js
+++ b/bin/importLargeSqlFile.js
@@ -46,6 +46,7 @@ require("ep_etherpad-lite/node_modules/npm").load({}, function(er,npm) {
       var matchRegex = RegExp('^REPLACE INTO store VALUES', 'i');
 
       fp.on('data', function(data) {
+        fp.pause();
         var lines = data.split(/\r?\n/);
 
         lines[0] = buffer + data[0];
@@ -63,6 +64,7 @@ require("ep_etherpad-lite/node_modules/npm").load({}, function(er,npm) {
             keyNo++;
           }
         });
+        fp.resume();
       });
 
 


### PR DESCRIPTION
I was running into resource issues trying to import a sql dump ~500M(output below). In order to get around this I changed the import script to use a `ReadableStream` instead of `fs.readFileSync`. Because this makes reporting progress a little more difficult, I put it in a separate file to keep that available.

Thanks!

```
[etherpad@etherpad bin]$ node importSqlFile.js output.sql
[2013-05-14 21:58:47.904] [INFO] console - 0.319
initializing db
[2013-05-14 21:58:47.912] [INFO] console - 0.327
done
[2013-05-14 21:58:47.912] [INFO] console - 0.327
open output file...
FATAL ERROR: CALL_AND_RETRY_0 Allocation failed - process out of memory
```
