### PR TITLE
Pass arguments from safeRun.sh to run.sh

### DIFF
--- a/bin/safeRun.sh
+++ b/bin/safeRun.sh
@@ -16,6 +16,7 @@ TIME_BETWEEN_EMAILS=600 # 10 minutes
 # DON'T EDIT AFTER THIS LINE
 
 LAST_EMAIL_SEND=0
+LOG="$1"
 
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
@@ -26,7 +27,7 @@ if [ -d "../bin" ]; then
 fi
 
 #check if a logfile parameter is set
-if [ -z "$1" ]; then
+if [ -z "${LOG}" ]; then
   echo "Set a logfile as the first parameter"
   exit 1
 fi
@@ -34,18 +35,19 @@ fi
 while [ 1 ]
 do
   #try to touch the file if it doesn't exist
-  if [ ! -f $1 ]; then
-    touch $1 || ( echo "Logfile '$1' is not writeable" && exit 1 )
+  if [ ! -f ${LOG} ]; then
+    touch ${LOG} || ( echo "Logfile '${LOG}' is not writeable" && exit 1 )
   fi
   
   #check if the file is writeable
-  if [ ! -w $1 ]; then
-    echo "Logfile '$1' is not writeable"
+  if [ ! -w ${LOG} ]; then
+    echo "Logfile '${LOG}' is not writeable"
     exit 1
   fi
 
   #start the application
-  bin/run.sh >>$1 2>>$1
+  shift
+  bin/run.sh $@ >>${LOG} 2>>${LOG}
   
   #Send email
   if [ $ERROR_HANDLING = 1 ]; then
@@ -53,13 +55,13 @@ do
     TIME_SINCE_LAST_SEND=$(($TIME_NOW - $LAST_EMAIL_SEND))
     
     if [ $TIME_SINCE_LAST_SEND -gt $TIME_BETWEEN_EMAILS ]; then
-      printf "Server was restared at: $(date)\nThe last 50 lines of the log before the error happens:\n $(tail -n 50 $1)" | mail -s "Pad Server was restarted" $EMAIL_ADDRESS
+      printf "Server was restared at: $(date)\nThe last 50 lines of the log before the error happens:\n $(tail -n 50 ${LOG})" | mail -s "Pad Server was restarted" $EMAIL_ADDRESS
       
       LAST_EMAIL_SEND=$TIME_NOW
     fi
   fi
   
-  echo "RESTART!" >>$1
+  echo "RESTART!" >>${LOG}
   
   #Sleep 10 seconds before restart
   sleep 10


### PR DESCRIPTION
The `run.sh` script takes an argument `-s` to determine the path to the `settings.json` file.

When using `safeRun.sh` you need to give a path to the log file, but other arguments are ignored instead of being passed on to `run.sh`.

After applying this patch arguments to `safeRun.sh` after the logfile path are passed on to `run.sh` so you can call 

```
bin/safeRun.sh /path/to/log -s /path/to/settings.json
```
