### PR TITLE
Start script should use bash instead of sh for argument handling

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
@@ -11,7 +11,7 @@ fi
 ignoreRoot=0
 for ARG in $*
 do
-  if [ $ARG == '--root' ]; then
+  if [ "$ARG" = "--root" ]; then
     ignoreRoot=1
   fi
 done


### PR DESCRIPTION
Using `==` on line 14 is a `bash`-ism. Since the script is executed with `/bin/sh`, if you supply the --root argument, the script breaks. Changing the shebang to explicitly use `bash` makes all work well.
