### PR TITLE
Add check if uploaded file only contains ascii chars when abiword disabled

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -113,6 +113,30 @@ exports.doImport = function(req, res, padId)
       }
     },
     
+    function(callback) {
+      if (!abiword) {
+        // Read the file with no encoding for raw buffer access.
+        fs.readFile(destFile, function(err, buf) {
+          if (err) throw err;
+          var isAscii = true;
+          // Check if there are only ascii chars in the uploaded file
+          for (var i=0, len=buf.length; i<len; i++) {
+            if (buf[i] > 240) {
+              isAscii=false;
+              break;
+            }
+          }
+          if (isAscii) {
+            callback();
+          } else {
+            callback("uploadFailed");
+          }
+        });
+      } else {
+        callback();
+      }
+    },
+        
     //get the pad object
     function(callback) {
       padManager.getPad(padId, function(err, _pad){


### PR DESCRIPTION
Fixes #1838

I noticed that I only get problems with binary import if abiword is disabled. So the fix is only when abiword is disabled.
