### PR TITLE
Change class 'popup' for the dialog to fit in small spaces

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -746,8 +746,9 @@ input[type=checkbox] {
   float: right
 }
 .popup {
-  font-size: 14px;
-  width: 450px;
+  font-size: 12px;
+  width: 80%;
+  max-width: 450px;
   padding: 10px;
   border-radius: 0 0 6px 6px;
   border: 1px solid #ccc;


### PR DESCRIPTION
When the Pad is in a very small space, the dialog becomes unusable. The proposal here is that the dialogs can get smaller in smaller environments, like iframes or small screens.
