### PR TITLE
Better display of the import/export popup

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -626,8 +626,6 @@ table#otheruserstable {
 }
 
 #importsubmitinput {
-  height: 25px;
-  width: 85px;
   margin-top: 12px;
 }
 #importstatusball {


### PR DESCRIPTION
I'm using etherpad with the french locale ad the import/export popup was not displayed correctly.
![original layout](https://f.cloud.github.com/assets/1179174/1185498/075ed50c-22ac-11e3-87c7-f5beb0d82883.png)

With the first commit, the layout looks like this :
![new layout](https://f.cloud.github.com/assets/1179174/1185497/0760dbf4-22ac-11e3-8e5e-9af9621e51ce.png)

Finally, the import button's value in french is a bit long and was partially hidden. The second commit correct this issue. 
![button without constraint sizes](https://f.cloud.github.com/assets/1179174/1185496/07586b54-22ac-11e3-93a5-6f54ec329163.png)
