### PR TITLE
strip title out of html during import, pesky abiword behavior

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -151,7 +151,10 @@ exports.doImport = function(req, res, padId)
       fs.readFile(destFile, "utf8", function(err, _text){
         if(ERR(err, callback)) return;
         text = _text;
-        
+        // Title needs to be stripped out else it appends it to the pad..
+        text = text.replace("<title>", "<!-- <title>");
+        text = text.replace("</title>-->");
+
         //node on windows has a delay on releasing of the file lock.  
         //We add a 100ms delay to work around this
         if(os.type().indexOf("Windows") > -1){

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -100,7 +100,7 @@ else
     {
       //add data to buffer
       stdoutBuffer+=data.toString();
-      
+
       //we're searching for the prompt, cause this means everything we need is in the buffer
       if(stdoutBuffer.search("AbiWord:>") != -1)
       {


### PR DESCRIPTION
Before abiword would place the file name in the html title and that woudl show up on a pad, this is unexpected behavior..  My fix could probably be more clean, feel free to clean it up
