### PR TITLE
Don't stop processing changesets if there is an error

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -617,7 +617,7 @@ function handleUserChanges(data, cb)
         // There is an error in this changeset, so just refuse it
         console.warn("Can't apply USER_CHANGES "+changeset+", because: "+e);
         client.json.send({disconnect:"badChangeset"});
-        return;
+        return callback();
       }
         
       //ex. adoptChangesetAttribs
@@ -653,7 +653,7 @@ function handleUserChanges(data, cb)
             }catch(e){
               console.warn("Can't apply USER_CHANGES "+changeset+", possibly because of mismatched follow error");
               client.json.send({disconnect:"badChangeset"});
-              return;
+              return callback();
             }
 
             if ((r - baseRev) % 200 == 0) { // don't let the stack get too deep
@@ -676,8 +676,7 @@ function handleUserChanges(data, cb)
       {
         console.warn("Can't apply USER_CHANGES "+changeset+" with oldLen " + Changeset.oldLen(changeset) + " to document of length " + prevText.length);
         client.json.send({disconnect:"badChangeset"});
-        callback();
-        return;
+        return callback();
       }
         
       pad.appendRevision(changeset, thisSession.author);


### PR DESCRIPTION
I couldn't reproduce #1895, so i looked through the changes that were made before the release of 1.2.11 and noticed that we had just introduced the changeset queue..

There are multiple places in the code for processing incoming changesets, where an error halts the current pad's queue, because the queue callback isn't called. So, I fixed that and now ask @rchllc and @ldidry to test this branch (`git pull origin && git checkout fix/handle-message-continuation`)
