### PR TITLE
filter historical author data

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -953,8 +953,7 @@ function handleClientReady(client, message)
             authorManager.getAuthor(authorId, function(err, author)
             {
               if(ERR(err, callback)) return;
-              delete author.timestamp;
-              historicalAuthorData[authorId] = author;
+              historicalAuthorData[authorId] = {name: author.name, colorId: author.colorId}; // Filter author attribs (e.g. don't send author's pads to all clients)
               callback();
             });
           }, callback);


### PR DESCRIPTION
 I think this is a better attempt to address the issue, as:
- you wouldn't want to send out all the other attribs on a normally accessed pad either
- you probably want to have historicalAuthorData to view the timeslider and see older edits in the color of the author.

Warning: This is untested.
