### PR TITLE
Added a better way of detecting when a url does not have a protocol spec...

### DIFF
--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -185,7 +185,7 @@ domline.createDomLine = function(nonEmpty, doesWrap, optBrowser, optDocument)
     {
       if (href)
       {
-        if(!~href.indexOf("http")) // if the url doesn't include http or https etc prefix it.
+        if(!~href.indexOf("://") && !~href.indexOf("mailto:")) // if the url doesn't include a protocol prefix, assume http
         {
           href = "http://"+href;
         }


### PR DESCRIPTION
This is a fix for  Issue #1776 - All links regardless of protocol translate to http:// links

When a protocol is not specified for a link, it is assumed that the protocol is http.
The issue was that the detection for when a protocol is not specified only checked for http. I've updated this to have broader detection.
