### PR TITLE
Bugfix: new pads not in listAllPads data if padList cache already created.

### DIFF
--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -39,6 +39,7 @@ var globalPads = {
     set: function (name, value) 
     {
       this[':'+name] = value;
+      padList.addPad(name);
     },
     remove: function (name) {
       delete this[':'+name];


### PR DESCRIPTION
Since commit 200f2507172d50084cd8cfe6aae6b25a3045fb09, the new pads
aren't listed in listAllPads data.
They appears only if we don't have called listAllPads before creating
the new pad (because we read the db at first listAllPads call).
