### PR TITLE
Fix getRevisionChangeset API call making etherpad crash

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -187,7 +187,12 @@ exports.getRevisionChangeset = function(padID, rev, callback)
     //the client wants the latest changeset, lets return it to him
     else
     {
-      callback(null, {"changeset": pad.getRevisionChangeset(pad.getHeadRevisionNumber())});
+      pad.getRevisionChangeset(pad.getHeadRevisionNumber(), function(err, changeset)
+      {
+        if(ERR(err, callback)) return;
+
+        callback(null, changeset);
+      })
     }
   });
 }


### PR DESCRIPTION
Using `getRevisionChangeset` makes etherpad crash.

Here's my log:
    [2013-11-07 22:07:05.331] [INFO] API - REQUEST, v1.2.8:getRevisionChangeset, {"apikey":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","padID":"test"}
    [2013-11-07 22:07:05.371] [INFO] API - RESPONSE, getRevisionChangeset, 500
    [2013-11-07 22:07:05.413] [ERROR] console - TypeError: Property 'callback' of object #<Object> is not a function
        at /var/www/etherpad/src/node_modules/ueberDB/CloneAndAtomicLayer.js:139:17
        at exports.database.getSub (/var/www/etherpad/src/node_modules/ueberDB/CacheAndBufferLayer.js:378:7)
        at exports.database.get (/var/www/etherpad/src/node_modules/ueberDB/CacheAndBufferLayer.js:157:5)
        at exports.database.getSub (/var/www/etherpad/src/node_modules/ueberDB/CacheAndBufferLayer.js:350:8)
        at doOperation [as operatorFunction](/var/www/etherpad/src/node_modules/ueberDB/CloneAndAtomicLayer.js:133:18)
        at exports.channels.emit (/var/www/etherpad/src/node_modules/ueberDB/node_modules/channels/channels.js:38:11)
        at exports.database.getSub (/var/www/etherpad/src/node_modules/ueberDB/CloneAndAtomicLayer.js:77:17)
        at Pad.getRevisionChangeset (/var/www/etherpad/src/node/db/Pad.js:123:6)
        at exports.getRevisionChangeset (/var/www/etherpad/src/node/db/API.js:190:40)
        at Object.exports.getPad (/var/www/etherpad/src/node/db/PadManager.js:162:5)

Here's a patch making it work correctly.
