### PR TITLE
Close extended chat window

### DIFF
--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -54,11 +54,18 @@ var chat = (function()
     },
     hide: function () 
     {
-      $("#chatcounter").text("0");
-      $("#chaticon").show();
-      $("#chatbox").hide();
-      $.gritter.removeAll();
-      $("#gritter-notice-wrapper").show();
+      // decide on hide logic based on chat window being maximized or not 
+      if ($('#options-stickychat').prop('checked')) {
+        chat.stickToScreen();
+        $('#options-stickychat').prop('checked', false);
+      }
+      else {  
+        $("#chatcounter").text("0");
+        $("#chaticon").show();
+        $("#chatbox").hide();
+        $.gritter.removeAll();
+        $("#gritter-notice-wrapper").show();
+      }
     },
     scrollDown: function()
     {

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -390,7 +390,7 @@
 
         <div id="chatbox">
             <div id="titlebar"><span id ="titlelabel" data-l10n-id="pad.chat"></span>
-              <a id="titlecross" onClick="minimizeChatbox();">-&nbsp;</a>
+              <a id="titlecross" onClick="chat.hide();return false;">-&nbsp;</a>
               <a id="titlesticky" onClick="chat.stickToScreen(true);$('#options-stickychat').prop('checked', true);return false;" title="Stick chat to screen">█&nbsp;&nbsp;</a>
             </div>
             <div id="chattext" class="authorColors">
@@ -476,18 +476,6 @@
               padeditbar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
               padimpexp = require('ep_etherpad-lite/static/js/pad_impexp').padimpexp;
             }());
-
-            function minimizeChatbox()
-            {
-              if ($('#options-stickychat').prop('checked')) {
-                chat.stickToScreen();
-                $('#options-stickychat').prop('checked', false);
-              } else {
-                chat.hide();
-              }
-              
-              return false;
-            }	
         </script>
         <% e.end_block(); %>
 </html>


### PR DESCRIPTION
This is an enhancement to the way the chatbox UI works. Ensures that there is always a title bar, even when chatbox is maximized. There is also a minimize button to get out of the maximized chatbox mode.

This should help resolve issue #1827 although does not go as far as adding the 3 button interface as suggested.
