### PR TITLE
Create git pre-commit hook for preventing tabs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,11 @@ Also, keep it maintainable. We don't wanna end up as the monster Etherpad was!
 
 ## Coding style
 * Do write comments. (You don't have to comment every line, but if you come up with something thats a bit complex/weird, just leave a comment. Bear in mind that you will probably leave the project at some point and that other people will read your code. Undocumented huge amounts of code are worthless!)
+* Please, use our git hooks. It helps to keep the same coding style everywhere. The best way to do it is:
+```
+cd .git/hooks
+ln -s ../../git-hooks/pre-commit .
+```
 * Never ever use tabs
 * Indentation: JS/CSS: 2 spaces; HTML: 4 spaces
 * Don't overengineer. Don't try to solve any possible problem in one step, but try to solve problems as easy as possible and improve the solution over time!

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/bash
+# vim:set sw=2 ts=2 sts=2 expandtab:
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM HEAD)
+grep -P "^ *\t" $FILES >/dev/null 2>&1
+if [[ $? -eq 0 ]]
+then
+  echo "Tabs indentation detected (see below)"
+  echo
+  grep --color=auto -n -T -P "^ *\t" $FILES
+  echo
+  echo "Aborting commit"
+  exit 1
+fi


### PR DESCRIPTION
In order to prevent use of tabs, I created a pre-commit hook, aborting commit if tabs are in the commit.
- Update documentation in CONTRIBUTING.md to include git hooks

Should we provide a script (or a Makefile) which creates links to the hooks or should we let the users do the links them-selves?
Should the documentation of the hooks be in CONTRIBUTING.md or elsewhere ? README.md ? Just asking.
