### PR TITLE
Run npm in a separate worker process

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -27,7 +27,7 @@
                       "nodemailer"              : "0.3.x",
                       "jsdom-nocontextifiy"     : "0.2.10",
                       "async-stacktrace"        : "0.0.2",
-                      "npm"                     : "1.2.x",
+                      "npm"                     : "*",
                       "ejs"                     : "0.6.1",
                       "graceful-fs"             : "1.1.5",
                       "slide"                   : "1.1.3",
@@ -40,7 +40,8 @@
                       "swagger-node-express"    : "1.2.3",
                       "channels"                : "0.0.x",
                       "jsonminify"              : "0.2.2",
-                      "measured"                : "0.1.3"
+                      "measured"                : "0.1.3",
+                      "rpc-stream"              : "1.0.x"
                      },
   "bin":             { "etherpad-lite": "./node/server.js" },
   "devDependencies": {

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -1,6 +1,6 @@
 var plugins = require("ep_etherpad-lite/static/js/pluginfw/plugins");
 var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");
-var npm = require("npm");
+var npm = require("./npm-master");
 
 var npmIsLoaded = false;
 var withNpm = function (npmfn) {

--- a/src/static/js/pluginfw/npm-master.js
+++ b/src/static/js/pluginfw/npm-master.js
@@ -1,0 +1,19 @@
+/**
+ * This module exposes the same methods as installer.js, but runs them in a separate child process
+ */
+var child_process = require('child_process')
+  , rpc = require('rpc-stream')
+
+var worker = child_process.fork(__dirname+'/npm-worker', {silent:true})
+
+var client = rpc()
+
+worker.stdout.pipe(client).pipe(worker.stdin)
+
+worker.stderr.pipe(process.stdout)
+
+module.exports = {
+  commands: client.wrap(['install', 'uninstall', 'search'])
+, load: function(opts, cb) {cb()}
+, on: function(){}
+}

--- a/src/static/js/pluginfw/npm-worker.js
+++ b/src/static/js/pluginfw/npm-worker.js
@@ -1,0 +1,24 @@
+/**
+ * This is a worker that should be run using child_process.fork (see installer-master.js for reference)
+ * Stdin and stdout are connected to an rpc server exposing the methods of installer.js
+ */
+var RPC = require('rpc-stream')
+  , npm = require('npm')
+
+npm.load({}, function (er) {
+  if(er) throw er
+})
+console.log = function() {process.stderr.write(Array.prototype.slice(arguments).join('')+'\n')}
+
+var server = RPC({
+  search: function(args, cb) {
+    npm.commands.search.apply(npm, Array.prototype.concat(args, [cb]))
+  }
+, install: function(args, cb) {
+    npm.commands.install.apply(npm, Array.prototype.concat(args, [cb]))
+  }
+, uninstall: function(args, cb) {
+    npm.commands.uninstall.apply(npm, Array.prototype.concat(args, [cb]))
+  }
+})
+process.stdin.pipe(server).pipe(process.stdout)


### PR DESCRIPTION
This is an experiment. It establishes a nice security wall between npm and etherpad helps keep memory usage of the main process low.

I'm not sure whether it should keep the same process running the whole time (it's allocated around 300-500Mb on my machine, if I read the stats correctly), on the other hand, creating a new child process for every plugin search is probably too costly, too.

Maybe we can just throw in a timeout of say 5mins and after that the npm worker is killed.

This addresses #1975, I'm not sure it will solve #1992
