### PR TITLE
mozilla bug 844796 - use node crypto module for randomString

### DIFF
--- a/src/node/utils/randomstring.js
+++ b/src/node/utils/randomstring.js
@@ -1,16 +1,13 @@
 /**
  * Generates a random String with the given length. Is needed to generate the Author, Group, readonly, session Ids
  */
+var crypto = require('crypto');
+
 var randomString = function randomString(len)
 {
-  var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-  var randomstring = '';
-  for (var i = 0; i < len; i++)
-  {
-    var rnum = Math.floor(Math.random() * chars.length);
-    randomstring += chars.substring(rnum, rnum + 1);
-  }
-  return randomstring;
+  crypto.randomBytes(48, function(ex, buf) {
+    return buf.toString('hex');
+  });
 };
 
 module.exports = randomString;


### PR DESCRIPTION
This makes `randomString()` cryptographically secure.

I tried to modify the copy of this in `src/static/js/pad_utils.js` as well, but apparently that is used on the client side and the `crypto` module is not available there. I need to figure out exactly what this is used for on the client.
