### PR TITLE
fix timeslider not working because last changeset is not fetched

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1500,8 +1500,8 @@ function composePadChangesets(padId, startNum, endNum, callback)
       var changesetsNeeded=[];
 
       var headNum = pad.getHeadRevisionNumber();
-      if (endNum > headNum)
-        endNum = headNum;
+      if (endNum > headNum+1)
+        endNum = headNum+1;
       if (startNum < 0)
         startNum = 0;
       //create a array for all changesets, we will


### PR DESCRIPTION
I admit I have no understanding why the check is necessary. It seems like the condition is already checked earlier in program flow. But if the check is really necessary, it should at least be correct. This fixes the timeslider for now till the refractoring is done.
