### PR TITLE
don't call ace_getInInternationalComposition if editor is not fully load...

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -124,6 +124,7 @@ function Ace2Editor()
 
   editor.getInInternationalComposition = function()
   {
+    if (!loaded) return false;
     return info.ace_getInInternationalComposition();
   };
 


### PR DESCRIPTION
this fixes https://github.com/ether/etherpad-lite/issues/1678 for me.
it sounds weird to return false because this method is called to find out if a NEW_CHANGES goes to msgQueue or to  changesettracker. applyChangesToBase but it's ok as applyChangesToBase calls are cached in case initialization is not complete. the server can start sending changesets even if the editor is not fully loaded.

before https://github.com/ether/etherpad-lite/commit/957a0aa873f2df13483a9b17589c064cc229a80a a global object property was accessed to find out if we are in a composition event and properties can be undefined, thats why there was no difference in the false branches of "if(undefined)" and "if(false)".
