### PR TITLE
escape rendered npm package info

### DIFF
--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -81,7 +81,7 @@ $(document).ready(function () {
         if(attr == "name"){ // Hack to rewrite URLS into name
           row.find(".name").html("<a target='_blank' title='Plugin details' href='https://npmjs.org/package/"+plugin['name']+"'>"+plugin['name'].substr(3)+"</a>"); // remove 'ep_'
         }else{
-          row.find("." + attr).html(plugin[attr]);
+          row.find("." + attr).text(plugin[attr]);
         }
       }
       row.find(".version").html( plugin.version );


### PR DESCRIPTION
I noticed a template bug in `admin/plugins` - npm package info sometimes contains html tags, but it is unescaped before output.

This patch uses jQuery.text() instaed of jQuery.html() to output the npm values.

I didn't look through the codebase to see if there are other instances when remote data is rendered using html() - this is a potential attack vector, right?
