### PR TITLE
Addressed a potential never finishing forEach in PadMessageHandler.padUsers

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1570,6 +1570,8 @@ exports.padUsers = function (padID, callback) {
         result.push(author);
         callback();
       });
+    } else {
+      callback();
     }
   }, function(err) {
     if(ERR(err, callback)) return;


### PR DESCRIPTION
If the session info `s` for a client would be null or undefined, the forEach
callback would never get called which means the padUsers callback would
never get trigged. This could potentially block API request as this function
is exposed at an HTTP API endpoint.
