### PR TITLE
fix for infinite loop on bad changeset

### DIFF
--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1867,7 +1867,7 @@ exports.inverse = function (cs, lines, alines, pool) {
       curLineOpIterLine = curLine;
       var indexIntoLine = 0;
       var done = false;
-      while (!done) {
+      while (!done && curLineOpIter.hasNext()) {
         curLineOpIter.next(curLineNextOp);
         if (indexIntoLine + curLineNextOp.chars >= curChar) {
           curLineNextOp.chars -= (curChar - indexIntoLine);


### PR DESCRIPTION
In case pad state is broken, or bad changeset somehow was submitted to the store, this check is required to avoid infinite loop in the consuming code.
