### PR TITLE
Fix plugins not being fetched.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -27,7 +27,7 @@
                       "nodemailer"              : "0.3.x",
                       "jsdom-nocontextifiy"     : "0.2.10",
                       "async-stacktrace"        : "0.0.2",
-                      "npm"                     : "1.2.x",
+                      "npm"                     : "1.4.x",
                       "ejs"                     : "0.6.1",
                       "graceful-fs"             : "1.1.5",
                       "slide"                   : "1.1.3",


### PR DESCRIPTION
Updating npm dependency fixes plugins not being fetched in the plugin manager.

Related issues:
#2087
#2094
