### PR TITLE
Session deletion error, when group2session/author2session are not available

### DIFF
--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -263,12 +263,16 @@ exports.deleteSession = function(sessionID, callback)
       db.remove("session:" + sessionID);
       
       //remove session from group2sessions
-      delete group2sessions.sessionIDs[sessionID];
-      db.set("group2sessions:" + groupID, group2sessions);
-      
+      if(group2sessions != null) { // Maybe the group was already deleted
+          delete group2sessions.sessionIDs[sessionID];
+          db.set("group2sessions:" + groupID, group2sessions);
+      }
+
       //remove session from author2sessions
-      delete author2sessions.sessionIDs[sessionID];
-      db.set("author2sessions:" + authorID, author2sessions);
+      if(author2sessions != null) { // Maybe the author was already deleted
+          delete author2sessions.sessionIDs[sessionID];
+          db.set("author2sessions:" + authorID, author2sessions);
+      }
       
       callback();
     }


### PR DESCRIPTION
Sometimes, the author2session / group2session don't exist anymore, but the session does.
It should be possible to delete a session, if they don't exist

This fixes it.
