### PR TITLE
Underscore Version: Update package.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -34,7 +34,7 @@
                       "semver"                  : "1.0.13",
                       "security"                : "1.0.0",
                       "tinycon"                 : "0.0.1",
-                      "underscore"              : "1.3.1",
+                      "underscore"              : "1.5.1",
                       "unorm"                   : "1.0.0",
                       "languages4translatewiki" : "0.1.3",
                       "swagger-node-express"    : "1.2.3",


### PR DESCRIPTION
updated the underscore version number to 1.5.1 (from 1.3.1). Not lifted to most current version because frontend tests broke from 1.5.2 upwards.
