### PR TITLE
bump ueberdb for more performance on mysql

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,7 @@
                       "require-kernel"          : "1.0.5",
                       "resolve"                 : "0.2.x",
                       "socket.io"               : "0.9.x",
-                      "ueberDB"                 : "0.2.x",
+                      "ueberDB"                 : ">=0.2.2",
                       "express"                 : "3.1.0",
                       "async"                   : "0.1.x",
                       "connect"                 : "2.7.x",


### PR DESCRIPTION
UeberDB switches InnoDB out for MyISAM and this gives a huge performance upgrade.  It has been tested on a lot of live instances and it is stable and worth the change.

Documentation for how to upgrade will be required for pre-existing instances..  This will want to go into the README :)  

It might also be worth doing an console.warn if the database is still set to InnoDB although one might argue that's up to UeberDB to do but Ueber doesn't have any log handling.  Worth investigating this approach imho.
