### PR TITLE
Fix #2136: update cache and group list when copying pads

### DIFF
--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -552,7 +552,7 @@ Pad.prototype.copy = function copy(destinationID, force, callback) {
     },
     function(callback) {
       // Group pad? Add it to the group's list
-      if(destGroupID) db.setSub("group:" + destGroupID, ["pads", padID], 1);
+      if(destGroupID) db.setSub("group:" + destGroupID, ["pads", destinationID], 1);
 
       // Initialize the new pad (will update the listAllPads cache)
       padManager.getPad(destinationID, null, callback)


### PR DESCRIPTION
Should fix #2136 -- please test, though!

(Sorry for the line noise)
