### PR TITLE
fix dropping of messages in handleMessage

### DIFF
--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -8,7 +8,7 @@ var hookCallWrapper = function (hook, hook_name, args, cb) {
 
   // Normalize output to list for both sync and async cases
   var normalize = function(x) {
-    if (x == undefined) return [];
+    if (x === undefined) return [];
     return x;
   }
   var normalizedhook = function () {


### PR DESCRIPTION
``` javascript
exports.handleMessage = function (hook, context, cb) {
  cb(null);
};
```

This should drop all messages, just like it is [documented](http://etherpad.org/doc/v1.4.0/#index_handlemessage). Currently, this does nothing, because all hook-results which are `==` to `undefined` are removed. Since `null` is `==` to `undefined`, the result is discarded and the code calling the `handleMessage` never gets the `null`, which should have caused it to drop the message.
