### PR TITLE
Font on innerdoc body

### DIFF
--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -70,7 +70,7 @@ body.grayedout { background-color: #eee !important }
 
 #innerdocbody {
   font-size: 12px; /* overridden by body.style */
-  font-family: monospace; /* overridden by body.style */
+  font-family:Arial, sans-serif; /* overridden by body.style */
   line-height: 16px; /* overridden by body.style */
 }
 
@@ -87,7 +87,6 @@ body.doesWrap {
   overflow: hidden;
   /* blank 1x1 gif, so that IE8 doesn't consider the body transparent */
   background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==);
-  font-family:Arial, sans-serif;
 }
 
 #sidediv {


### PR DESCRIPTION
Paste events sometimes lose font-family, this simply places a default fault on all content, I'm not sure why we removed this previously..  Hopefully it wont break ep_font_family plugin.

I also put some details about how removing/adding pre-wrap breaks line break pasting in webkit.
