### PR TITLE
Added extra block elements to contentcollector.js

### DIFF
--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -78,7 +78,14 @@ function makeContentCollector(collectStyles, browser, apool, domInterface, class
     "div": 1,
     "p": 1,
     "pre": 1,
-    "li": 1
+    "li": 1,
+    "h1": 1,
+    "h2": 1,
+    "h3": 1,
+    "h4": 1,
+    "h5": 1,
+    "h6": 1,
+    "code": 1
   };
 
   function isBlockElement(n)


### PR DESCRIPTION
Not sure whether this is the correct way to resolve this issue, but there is a bug with ep_headings which means on import, all styles are stripped out from the pad:

https://github.com/fourplusone/etherpad-plugins/issues/38

I am assuming there is a more **proper** way to actually implement this within the actual plugin, rather than the core, but I am at a loss.  If someone could point me in the right direction that would be awesome.
