### PR TITLE
readme: Add formatting sugar for readibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Update to the latest version with `git pull origin`, then run `bin\installOnWind
 
 ## GNU/Linux and other UNIX-like systems
 You'll need gzip, git, curl, libssl develop libraries, python and gcc.  
-*For Debian/Ubuntu*: `apt-get install gzip git-core curl python libssl-dev pkg-config build-essential`  
-*For Fedora/CentOS*: `yum install gzip git-core curl python openssl-devel && yum groupinstall "Development Tools"`
-*For FreeBSD*: `portinstall node, npm, git (optional)`
+- *For Debian/Ubuntu*: `apt-get install gzip git-core curl python libssl-dev pkg-config build-essential`  
+- *For Fedora/CentOS*: `yum install gzip git-core curl python openssl-devel && yum groupinstall "Development Tools"`
+- *For FreeBSD*: `portinstall node, npm, git (optional)`
 
 Additionally, you'll need [node.js](http://nodejs.org) installed, Ideally the latest stable version, be careful of installing nodejs from apt.
 


### PR DESCRIPTION
- Added a bit more formatting for UNIX-like systems dependencies installation.

----------------- >8 -----------------------

The previous version made a bad impression on me when I read it on the GitHub repository base page (https://github.com/ether/etherpad-lite).

This change makes it a bit more easier to read while keeping it nice for those who'd just open the README.md as a textual file.
