### PR TITLE
If exportFileName hook isn’t defined don’t return empty filename.

### DIFF
--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -52,7 +52,7 @@ exports.doExport = function(req, res, padId, type)
   hooks.aCallFirst("exportFileName", padId, 
     function(err, hookFileName){
       // if fileName is set then set it to the padId, note that fileName is returned as an array.
-      if(hookFileName) fileName = hookFileName; 
+      if(hookFileName.length) fileName = hookFileName;
 
 
       //tell the browser that this is a downloadable file


### PR DESCRIPTION
This commit should fix #2251.

If `exportFileName` hook is not defined, `hookFileName` should be an empty array. Test the length of `hookFileName` before overriding `fileName`, the export filename.
