### PR TITLE
Move `title` attribute of buttons from `<span>` to `<a>`

### DIFF
--- a/src/node/utils/toolbar.js
+++ b/src/node/utils/toolbar.js
@@ -99,8 +99,8 @@ _.extend(Button.prototype, {
       "data-key": this.attributes.command,
     };
     return tag("li", liAttributes,
-      tag("a", { "class": this.grouping },
-        tag("span", { "class": " "+ this.attributes.class, "data-l10n-id": this.attributes.localizationId })
+      tag("a", { "class": this.grouping, "data-l10n-id": this.attributes.localizationId },
+        tag("span", { "class": " "+ this.attributes.class })
       )
     );
   }
@@ -203,13 +203,13 @@ module.exports = {
     settings: defaultButtonAttributes("settings"),
     embed: defaultButtonAttributes("embed"),
     showusers: defaultButtonAttributes("showusers"),
-    
+
     timeslider_export: {
       command: "import_export",
       localizationId: "timeslider.toolbar.exportlink.title",
       class: "buttonicon buttonicon-import_export"
     },
-    
+
     timeslider_returnToPad: {
       command: "timeslider_returnToPad",
       localizationId: "timeslider.toolbar.returnbutton",


### PR DESCRIPTION
The `.toolbar ul li a` that holds the `span.button` has a
padding of `4px 5px`. This means if the mouse is on the edge
of the button the `:hover` state is active but the relevant
tooltip does not show up. Moving the `title` attribute to
the `<a>` itself solves this problem.

Also removed some extra whitespace.
