### PR TITLE
Use 'evt.shiftKey' instead of matching 'charCodes'

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3749,7 +3749,7 @@ function Ace2Inner(){
           toggleAttributeOnSelection('strikethrough');
           specialHandled = true;
         }
-	if ((!specialHandled) && isTypeForCmdKey && String.fromCharCode(which) == "L" && (evt.metaKey || evt.ctrlKey))
+        if ((!specialHandled) && isTypeForCmdKey && String.fromCharCode(which).toLowerCase() == "l" && (evt.metaKey || evt.ctrlKey) && evt.shiftKey)
         {
           // cmd-shift-L (unorderedlist)
           fastIncorp(9);
@@ -3757,7 +3757,7 @@ function Ace2Inner(){
           doInsertUnorderedList()
           specialHandled = true;
 	}
-	if ((!specialHandled) && isTypeForCmdKey && String.fromCharCode(which) == "N" && (evt.metaKey || evt.ctrlKey))
+	  if ((!specialHandled) && isTypeForCmdKey && String.fromCharCode(which).toLowerCase() == "n" && (evt.metaKey || evt.ctrlKey) && evt.shiftKey)
         {
           // cmd-shift-N (orderedlist)
           fastIncorp(9);


### PR DESCRIPTION
The shortcut wasn't running consistently and was blocking
<kbd>Cmd+L</kbd> on Chrome 38. Instead of going to the location bar
it would tooggle the list. Strangely, it did not override
<kbd>Cmd+N</kbd>. Using `evt.shiftKey` instead of matching the `charCode`
to the uppercase letter solves the problem.
