### PR TITLE
Update frontend language tests for new keyboard shortcut convention

### DIFF
--- a/tests/frontend/specs/language.js
+++ b/tests/frontend/specs/language.js
@@ -11,31 +11,31 @@ describe("Language select and change", function(){
     helper.newPad(cb);
     this.timeout(60000);
   });
- 
+
   // Destroy language cookies
   it("makes text german", function(done) {
     var inner$ = helper.padInner$;
     var chrome$ = helper.padChrome$;
- 
+
     //click on the settings button to make settings visible
     var $settingsButton = chrome$(".buttonicon-settings");
     $settingsButton.click();
- 
+
     //click the language button
     var $language = chrome$("#languagemenu");
     var $languageoption = $language.find("[value=de]");
- 
+
     //select german
     $languageoption.attr('selected','selected');
     $language.change();
- 
-    helper.waitFor(function() { 
+
+    helper.waitFor(function() {
       return chrome$(".buttonicon-bold").parent()[0]["title"] == "Fett (Strg-B)";
      })
     .done(function(){
       //get the value of the bold button
       var $boldButton = chrome$(".buttonicon-bold").parent();
- 
+
       //get the title of the bold button
       var boldButtonTitle = $boldButton[0]["title"];
 
@@ -44,58 +44,58 @@ describe("Language select and change", function(){
       done();
     });
   });
- 
+
   it("makes text English", function(done) {
     var inner$ = helper.padInner$;
     var chrome$ = helper.padChrome$;
- 
+
     //click on the settings button to make settings visible
     var $settingsButton = chrome$(".buttonicon-settings");
     $settingsButton.click();
- 
+
     //click the language button
     var $language = chrome$("#languagemenu");
     //select english
     $language.val("en");
     $language.change();
- 
+
     //get the value of the bold button
     var $boldButton = chrome$(".buttonicon-bold").parent();
 
-    helper.waitFor(function() { return $boldButton[0]["title"] != "Fett (Strg-B)";})
+    helper.waitFor(function() { return $boldButton[0]["title"] != "Fett (Strg+B)";})
     .done(function(){
- 
+
       //get the value of the bold button
       var $boldButton = chrome$(".buttonicon-bold").parent();
- 
+
       //get the title of the bold button
       var boldButtonTitle = $boldButton[0]["title"];
- 
+
       //check if the language is now English
-      expect(boldButtonTitle).to.be("Bold (Ctrl-B)");
+      expect(boldButtonTitle).to.be("Bold (Ctrl+B)");
       done();
- 
+
     });
   });
-  
+
   it("changes direction when picking an rtl lang", function(done) {
     var inner$ = helper.padInner$;
     var chrome$ = helper.padChrome$;
- 
+
     //click on the settings button to make settings visible
     var $settingsButton = chrome$(".buttonicon-settings");
     $settingsButton.click();
- 
+
     //click the language button
     var $language = chrome$("#languagemenu");
     var $languageoption = $language.find("[value=ar]");
- 
+
     //select arabic
     // $languageoption.attr('selected','selected'); // Breaks the test..
     $language.val("ar");
     $languageoption.change();
 
-    helper.waitFor(function() { 
+    helper.waitFor(function() {
       return chrome$("html")[0]["dir"] != 'ltr';
      })
     .done(function(){


### PR DESCRIPTION
8af34a2295f2ff85cf0b introduced a [failing test frontend test](https://travis-ci.org/ether/etherpad-lite/builds/37931978).

This commit updates both the German and English strings even though
the German locale files haven't been updated yet. The tests will
continue to fail but will stop as soon as translatewiki catches up.
