### PR TITLE
Don't crash on bad plugins.json; fixes #2323

### DIFF
--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -66,7 +66,12 @@ exports.getAvailablePlugins = function(maxCacheAge, cb) {
     if(exports.availablePlugins && maxCacheAge && Math.round(+new Date/1000)-cacheTimestamp <= maxCacheAge) {
       return cb && cb(null, exports.availablePlugins)
     }
-    plugins = JSON.parse(plugins);
+    try {
+      plugins = JSON.parse(plugins);
+    } catch (err) {
+      console.error('error parsing plugins.json:', err);
+      plugins = [];
+    }
     exports.availablePlugins = plugins;
     cacheTimestamp = Math.round(+new Date/1000);
     cb && cb(null, plugins)


### PR DESCRIPTION
When http://etherpad.org/plugins.json returns bad data (as it is now because of an issue with how DNS is setup to point to GitHub) it crashes an entire etherpad-lite instance; this change instead logs the parse error and returns an empty list of plugins.
