### PR TITLE
Changed relative path to Etherpad main page in admin settings.

### DIFF
--- a/src/templates/admin/index.html
+++ b/src/templates/admin/index.html
@@ -10,7 +10,7 @@
   <body>
     <div id="wrapper">
       <div class="menu">
-        <h1><a href="../../">Etherpad</a></h1>
+        <h1><a href="../">Etherpad</a></h1>
         <ul>
         <% e.begin_block("adminMenu");  %>
           <li><a href="plugins">Plugin manager</a> </li>

--- a/src/templates/admin/plugins-info.html
+++ b/src/templates/admin/plugins-info.html
@@ -11,7 +11,7 @@
   <body>
     <div id="wrapper">
       <div class="menu">
-        <h1><a href="../../../">Etherpad</a></h1>
+        <h1><a href="../../">Etherpad</a></h1>
         <ul>
           <% e.begin_block("adminMenu"); %>
           <li><a href="../plugins">Plugin manager</a> </li>

--- a/src/templates/admin/plugins.html
+++ b/src/templates/admin/plugins.html
@@ -20,7 +20,7 @@
       <% } %>
 
        <div class="menu">
-        <h1><a href="../../">Etherpad</a></h1>
+        <h1><a href="../">Etherpad</a></h1>
         <ul>
           <% e.begin_block("adminMenu"); %>
           <li><a href="plugins">Plugin manager</a> </li>

--- a/src/templates/admin/settings.html
+++ b/src/templates/admin/settings.html
@@ -24,7 +24,7 @@
 
 
       <div class="menu">
-        <h1><a href="../../">Etherpad</a></h1>
+        <h1><a href="../">Etherpad</a></h1>
         <ul>
           <% e.begin_block("adminMenu"); %>
           <li><a href="plugins">Plugin manager</a> </li>


### PR DESCRIPTION
There was one '../' too much.
Hence the link target was wrong if Etherpad Lite was not installed in the web server's root directory but in a subdir.
