### PR TITLE
Don't hardcode /socket.io

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -170,7 +170,9 @@ function handshake()
   var resource =  exports.baseURL.substring(1)  + "socket.io";
   //connect
   socket = pad.socket = io.connect(url, {
-    resource: resource,
+    // Allow deployers to host Etherpad on a non-root path
+    'path': exports.baseURL + "socket.io",
+    'resource': resource,
     'max reconnection attempts': 3,
     'sync disconnect on unload' : false
   });


### PR DESCRIPTION
This small PR allows to run Etherpad on a base URL. For example, we run multiple etherpad servers and shard them through an identifier in the URL.

/etherpad/0/\* ----> go to machine 0
/etherpad/1/\*  ---> go to machine 1
etc..

This fix allows us to do that as now we have URLs such as /etherpad/0/socket.io, /etherpad/1/socket.io ,etc..
