### PR TITLE
Prevent server crash if author is not set

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1020,7 +1020,7 @@ function handleClientReady(client, message)
           {
             authorManager.getAuthor(authorId, function(err, author)
             {
-              if(ERR(err, callback)) return;
+              if(ERR(err, callback) || !author) return;
               historicalAuthorData[authorId] = {name: author.name, colorId: author.colorId}; // Filter author attribs (e.g. don't send author's pads to all clients)
               callback();
             });


### PR DESCRIPTION
The author variable should be set in normal cases, but during development on a plugin I have produced this error everytime. If you reproduce this behaviour on client side you can produce a server crash.
