### PR TITLE
Test coverage and backend support for setHTML.

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -408,12 +408,18 @@ exports.setHTML = function(padID, html, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-
     // add a new changeset with the new html to the pad
-    importHtml.setPadHTML(pad, cleanText(html), callback);
-
-    //update the clients on the pad
-    padMessageHandler.updatePadClients(pad, callback);
+    importHtml.setPadHTML(pad, cleanText(html), function(e){
+      if(e){
+        callback(new customError("HTML is malformed","apierror"));
+        return;
+      }else{
+        //update the clients on the pad
+        padMessageHandler.updatePadClients(pad, callback);
+        callback();
+        return;
+      }
+    });
 
   });
 }

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -416,7 +416,6 @@ exports.setHTML = function(padID, html, callback)
       }else{
         //update the clients on the pad
         padMessageHandler.updatePadClients(pad, callback);
-        callback();
         return;
       }
     });

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -196,11 +196,9 @@ exports.doImport = function(req, res, padId)
     function(callback) {
       var fileEnding = path.extname(srcFile).toLowerCase();
       if (abiword || fileEnding == ".htm" || fileEnding == ".html") {
-        try{
-          importHtml.setPadHTML(pad, text);
-        }catch(e){
-          apiLogger.warn("Error importing, possibly caused by malformed HTML");
-        }
+        importHtml.setPadHTML(pad, text, function(e){
+          if(e) apiLogger.warn("Error importing, possibly caused by malformed HTML");
+        });
       } else {
         pad.setText(text);
       }

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -22,7 +22,6 @@ var cheerio = require("cheerio");
 function setPadHTML(pad, html, callback)
 {
   var apiLogger = log4js.getLogger("ImportHtml");
-console.warn("setting padhtml");
   var $ = cheerio.load(html);
   // Appends a line break, used by Etherpad to ensure a caret is available
   // below the last line of an import

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -89,7 +89,7 @@ function setPadHTML(pad, html, callback)
   apiLogger.debug('The changeset: ' + theChangeset);
   pad.setText("");
   pad.appendRevision(theChangeset);
-  callback();
+  callback(null);
 }
 
 exports.setPadHTML = setPadHTML;

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -22,9 +22,8 @@ var cheerio = require("cheerio");
 function setPadHTML(pad, html, callback)
 {
   var apiLogger = log4js.getLogger("ImportHtml");
-
+console.warn("setting padhtml");
   var $ = cheerio.load(html);
-
   // Appends a line break, used by Etherpad to ensure a caret is available
   // below the last line of an import
   $('body').append("<p></p>");
@@ -40,7 +39,7 @@ function setPadHTML(pad, html, callback)
     cc.collectContent(doc);
   }catch(e){
     apiLogger.warn("HTML was not properly formed", e);
-    return; // We don't process the HTML because it was bad..
+    return callback(e); // We don't process the HTML because it was bad..
   }
 
   var result = cc.finish();
@@ -91,6 +90,7 @@ function setPadHTML(pad, html, callback)
   apiLogger.debug('The changeset: ' + theChangeset);
   pad.setText("");
   pad.appendRevision(theChangeset);
+  callback();
 }
 
 exports.setPadHTML = setPadHTML;

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -61,6 +61,9 @@ describe('Permission', function(){
                -> setText(padId)
                 -> getLastEdited(padID) -- Should be when setText was performed
                  -> padUsers(padID) -- Should be when setText was performed
+                  -> setHTML(padID) -- Should fail on invalid HTML
+                   -> setHTML(padID) -- Should fail on invalid HTML
+                    -> getHTML(padID) -- Should return HTML close to posted HTML
 */
 
 describe('deletePad', function(){
@@ -259,6 +262,42 @@ describe('padUsers', function(){
     api.get(endPoint('padUsers')+"&padID="+testPadId)
     .expect(function(res){
       if(res.body.data.padUsers.length !== 0) throw new Error("Incorrect Pad Users")
+    })
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+})
+
+describe('setHTML', function(){
+  it('Sets the HTML of a Pad', function(done) {
+    var html = "<!DOCTYPE html><html><head><title>Hello HTML</title></head><body<p>Hello World!</p></body></html>";
+    api.get(endPoint('setHTML')+"&padID="+testPadId+"&html="+html)
+    .expect(function(res){
+      if(res.body.code !== 0) throw new Error("Error importing HTML")
+    })
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+})
+
+describe('setHTML', function(){
+  it('Sets the HTML of a Pad attempting to pass ugly HTML', function(done) {
+    var html = "<div><b>Hello HTML</title></head></div>";
+    api.get(endPoint('setHTML')+"&padID="+testPadId+"&html="+html)
+    .expect(function(res){
+      if(res.body.code !== 1) throw new Error("Allowing crappy HTML to be imported")
+    })
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+})
+
+describe('setHTML', function(){
+  it('Sets the HTML of a Pad attempting to pass ugly HTML', function(done) {
+    var html = "<!DOCTYPE html><html><head></head><body><ul><li>Hello World!</li><li>foo</li></ul></body></html>";
+    api.get(endPoint('setHTML')+"&padID=test&html="+html)
+    .expect(function(res){
+      if(res.body.code !== 0) throw new Error("List HTML cant be imported")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -294,7 +294,7 @@ describe('setHTML', function(){
 
 describe('setHTML', function(){
   it('Sets the HTML of a Pad attempting to pass ugly HTML', function(done) {
-    var html = "<!DOCTYPE html><html><head></head><body><ul><li>Hello World!</li><li>foo</li></ul></body></html>";
+    var html = "<!DOCTYPE html><html><head></head><body><ul><li>UL1</li><ul><li>UL2</li></ul></ul></body></html>";
     api.get(endPoint('setHTML')+"&padID=test&html="+html)
     .expect(function(res){
       if(res.body.code !== 0) throw new Error("List HTML cant be imported")

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -293,8 +293,8 @@ describe('setHTML', function(){
 })
 
 describe('setHTML', function(){
-  it('Sets the HTML of a Pad attempting to pass ugly HTML', function(done) {
-    var html = "<!DOCTYPE html><html><head></head><body><ul><li>UL1</li><ul><li>UL2</li></ul></ul></body></html>";
+  it('Sets the HTML of a Pad with a bunch of weird unordered lists inserted', function(done) {
+    var html = "<!DOCTYPE html><html><head></head><body><ul><li>one</li><li>2</li></ul><br/><ul><ul><li>UL2</li></ul></ul></body></html>";
     api.get(endPoint('setHTML')+"&padID=test&html="+html)
     .expect(function(res){
       if(res.body.code !== 0) throw new Error("List HTML cant be imported")

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -319,6 +319,18 @@ describe('getHTML', function(){
   // </ul>
   // It will look right in the browser but the export will get it horriby wrong
 
+  // This is what the export puts out
+  // <ul class="bullet">
+  //  <li>one</li>
+  //  <li>2</li>
+  // </ul>
+  // <br>
+  // <ul class="bullet">
+  // NOTE THIS IS WHAT'S MISSING
+  //   <li>UL2</li>
+  // </ul>
+  // <br>
+
   it('Gets the HTML of a Pad with a bunch of weird unordered lists inserted', function(done) {
     api.get(endPoint('getHTML')+"&padID=test")
     .expect(function(res){

--- a/tests/backend/specs/api/sessionsAndGroups.js
+++ b/tests/backend/specs/api/sessionsAndGroups.js
@@ -5,7 +5,6 @@ var assert = require('assert')
       path = require('path');
 
 var filePath = path.join(__dirname, '../../../../APIKEY.txt');
-
 var apiKey = fs.readFileSync(filePath,  {encoding: 'utf-8'});
 apiKey = apiKey.replace(/\n$/, "");
 var apiVersion = 1;


### PR DESCRIPTION
don't merge yet, I still need to add full test coverage

1) Reports correct failure for setHTML
2) Provides setHTML test coverage
3) Ultimately needs to provide functionality to create li intented stuff 

Attempting to add test coverage for https://github.com/ether/etherpad-lite/issues/1604