### PR TITLE
Fix lineassembler not finished

### DIFF
--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -929,7 +929,7 @@ exports.applyToText = function (cs, str) {
       removedLines += op.lines;
       newlines = strIter.newlines()
       strIter.skip(op.chars);
-      if(!(newlines - strIter.newlines() == op.lines)){
+      if(!(newlines - strIter.newlines() == 0) && (newlines - strIter.newlines() != op.lines)){
         newlinefail = true
       }
       break;


### PR DESCRIPTION
taken from https://github.com/ether/etherpad-lite/pull/2372#issuecomment-68175271
I have another script at https://github.com/webzwo0i/ep-debug-helper/blob/master/checkrep-line-assembler-not-finished.rb
If applied to a new default pad, it sends a changeset "Z:6c<1|3=g=1o-1$" which is wrong, because within the first "g"(16 in base 36) letter there are less than 3 newlines. All clients will disconnect with the error "line assembler not finished" and if you reconnect and go to the timeslider the whole node instance will crash with the same error. Might be that this is the same as #2375
With the commits in this pull request, the changeset is not applied.

applied to develop frontend-tests are okay
