### PR TITLE
Notify user if cookies can't be created

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,7 +24,7 @@
   "pad.colorpicker.cancel": "Cancel",
 
   "pad.loading": "Loading...",
-  "pad.nocookie": "Cookie could not be found. Please allow cookies in your browser!",
+  "pad.noCookie": "Cookie could not be found. Please allow cookies in your browser!",
   "pad.passwordRequired": "You need a password to access this pad",
   "pad.permissionDenied": "You do not have permission to access this pad",
   "pad.wrongPassword": "Your password was wrong",

--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -1086,7 +1086,7 @@ input[type=checkbox] {
   display:none;
 }
 
-#nocookie{
+#noCookie{
   display:none;
 }
 

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -450,7 +450,7 @@ var pad = {
       if (!readCookie("test"))
       {
         $('#loading').hide();
-        $('#nocookie').show();
+        $('#noCookie').show();
       }
     });
   },

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -114,8 +114,8 @@
               <div id="wrongPassword">
                 <p data-l10n-id="pad.wrongPassword">Your password was wrong</p>
               </div>
-              <div id="nocookie">
-                <p data-l10n-id="pad.nocookie">Cookie could not be found. Please allow cookies in your browser!</p>
+              <div id="noCookie">
+                <p data-l10n-id="pad.noCookie">Cookie could not be found. Please allow cookies in your browser!</p>
               </div>
               <% e.begin_block("loading"); %>
               <p data-l10n-id="pad.loading" id="loading">Loading...</p>


### PR DESCRIPTION
It's related to #2408 
To reject cookies from being created in firefox you can install firebug. Go to the cookie tab and change the dropdown from "Default (Accept cookies)" to "Deny cookies from...".
Or you can simple reject all cookies in all browser settings from being created.
After that, try to open a pad url.
