### PR TITLE
Better HTML Export rewrite hook allows functions to be passed instead of strings means state is saved between plugins

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -245,7 +245,7 @@ Things in context:
 2. attribLine - line attributes
 3. text - line text
 
-This hook will allow a plug-in developer to re-write each line when exporting to HTML.
+This hook will allow a plug-in developer to re-write each line when exporting to HTML.  Note that you problably don't want to use this plugin and will probably get better results from `asyncLineHTMLForExport`
 
 Example:
 ```
@@ -268,6 +268,39 @@ function _analyzeLine(alineAttrs, apool) {
     }
   }
   return header;
+}
+```
+
+## asyncLineHTMLForExport
+Called from: src/node/utils/ExportHtml.js
+
+Things in context:
+
+1. The context of the line
+2. lineContents - The HTML of the line
+3. Attribute pool
+4. Attribute line
+5. Line Text
+
+This hook will allow functions to be returned to modify the HTML.
+
+Example: 
+
+```
+exports.asyncLineHTMLForExport = function (hook, context, cb) {
+  cb(rewriteLine);
+}
+
+function rewriteLine(context){
+  var lineContent = context.lineContent;
+  sizes.forEach(function(size){
+    size = size.replace("fs","");
+    if(lineContent){
+      lineContent = lineContent.replace("<fs"+size, "<span style='font-size:"+size+"px'");
+      lineContent = lineContent.replace("</fs"+size, "</span");
+    }
+  });
+  return lineContent;
 }
 ```
 

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -418,7 +418,12 @@ function getHTMLFromAtext(pad, atext, authorColors)
         attribLine: attribLines[i],
         text: textLines[i]
       }, function(err, newLineContent){
-          if(newLineContent.length !== 0) lineContent = newLineContent[0];
+//new Line Content is an array of each of the responses from aCallAll..  We should return a function to it
+console.error(newLineContent);
+          if(newLineContent.length !== 0){
+console.error("lC", newLineContent[0]);
+            lineContent = newLineContent[0];
+          }
         // modified lineContent here
       });
 

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -419,13 +419,14 @@ function getHTMLFromAtext(pad, atext, authorColors)
         text: textLines[i]
       }
 
-      // first context below seems superfluos
+      // See https://github.com/ether/etherpad-lite/issues/2486
       hooks.aCallAll("asyncLineHTMLForExport", context, function(err, newLineFunction){
+        // For each function returned by the hook call
+        // Process the text based on the function
         newLineFunction.forEach(function(fn){
           context.lineContent = fn(context); // note the fn
         });
-        //new Line Content is an array of each of the responses from aCallAll..  
-        // We should return a function to it
+        // We now have a line that has been processed by each hook function
         lineContent = context.lineContent; // modified lineContent here
       });
 

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -411,6 +411,18 @@ function getHTMLFromAtext(pad, atext, authorColors)
       }
       lists = []
 
+      hooks.aCallAll("asyncLineHTMLForExport", {
+        line: line,
+        lineContent: lineContent,
+        apool: apool,
+        attribLine: attribLines[i],
+        text: textLines[i]
+      }, function(err, newLineContent){
+          if(newLineContent.length !== 0) lineContent = newLineContent[0];
+        // modified lineContent here
+      });
+
+      // Old hook probably not to be used..
       var lineContentFromHook = hooks.callAllStr("getLineHTMLForExport", 
       {
         line: line,
@@ -419,6 +431,7 @@ function getHTMLFromAtext(pad, atext, authorColors)
         attribLine: attribLines[i],
         text: textLines[i]
       }, " ", " ", "");
+
       if (lineContentFromHook)
       {
         pieces.push(lineContentFromHook, '');

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -411,31 +411,26 @@ function getHTMLFromAtext(pad, atext, authorColors)
       }
       lists = []
 
-      hooks.aCallAll("asyncLineHTMLForExport", {
+      var context = {
         line: line,
         lineContent: lineContent,
         apool: apool,
         attribLine: attribLines[i],
         text: textLines[i]
-      }, function(err, newLineContent){
-//new Line Content is an array of each of the responses from aCallAll..  We should return a function to it
-console.error(newLineContent);
-          if(newLineContent.length !== 0){
-console.error("lC", newLineContent[0]);
-            lineContent = newLineContent[0];
-          }
-        // modified lineContent here
+      }
+
+      // first context below seems superfluos
+      hooks.aCallAll("asyncLineHTMLForExport", context, function(err, newLineFunction){
+        newLineFunction.forEach(function(fn){
+          context.lineContent = fn(context); // note the fn
+        });
+        //new Line Content is an array of each of the responses from aCallAll..  
+        // We should return a function to it
+        lineContent = context.lineContent; // modified lineContent here
       });
 
       // Old hook probably not to be used..
-      var lineContentFromHook = hooks.callAllStr("getLineHTMLForExport", 
-      {
-        line: line,
-        lineContent: lineContent,
-        apool: apool,
-        attribLine: attribLines[i],
-        text: textLines[i]
-      }, " ", " ", "");
+      var lineContentFromHook = hooks.callAllStr("getLineHTMLForExport", context, " ", " ", "");
 
       if (lineContentFromHook)
       {


### PR DESCRIPTION
Fix for https://github.com/ether/etherpad-lite/issues/2486