### PR TITLE
Fix pad URL leaks through HTTP referer header in HTML5-compatible browsers

### DIFF
--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -284,7 +284,10 @@ function getHTMLFromAtext(pad, atext, authorColors)
         var url = urlData[1];
         var urlLength = url.length;
         processNextChars(startIndex - idx);
-        assem.append('<a href="' + Security.escapeHTMLAttribute(url) + '">');
+        // Using rel="noreferrer" stops leaking the URL/location of the exported HTML when clicking links in the document.
+        // Not all browsers understand this attribute, but it's part of the HTML5 standard.
+        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
+        assem.append('<a href="' + Security.escapeHTMLAttribute(url) + '" rel="noreferrer">');
         processNextChars(urlLength);
         assem.append('</a>');
       });

--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -197,7 +197,10 @@ domline.createDomLine = function(nonEmpty, doesWrap, optBrowser, optDocument)
         {
           href = "http://"+href;
         }
-        extraOpenTags = extraOpenTags + '<a href="' + Security.escapeHTMLAttribute(href) + '">';
+        // Using rel="noreferrer" stops leaking the URL/location of the pad when clicking links in the document.
+        // Not all browsers understand this attribute, but it's part of the HTML5 standard.
+        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
+        extraOpenTags = extraOpenTags + '<a href="' + Security.escapeHTMLAttribute(href) + '" rel="noreferrer">';
         extraCloseTags = '</a>' + extraCloseTags;
       }
       if (simpleTags)

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -220,7 +220,10 @@ var padutils = {
         var startIndex = urls[j][0];
         var href = urls[j][1];
         advanceTo(startIndex);
-        pieces.push('<a ', (target ? 'target="' + Security.escapeHTMLAttribute(target) + '" ' : ''), 'href="', Security.escapeHTMLAttribute(href), '">');
+        // Using rel="noreferrer" stops leaking the URL/location of the pad when clicking links in the document.
+        // Not all browsers understand this attribute, but it's part of the HTML5 standard.
+        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
+        pieces.push('<a ', (target ? 'target="' + Security.escapeHTMLAttribute(target) + '" ' : ''), 'href="', Security.escapeHTMLAttribute(href), '" rel="noreferrer">');
         advanceTo(startIndex + href.length);
         pieces.push('</a>');
       }


### PR DESCRIPTION
See #1603.

Added `rel="noreferrer"` to automatically generated links in the main pad
window as well as the chat window. Also applied the fix to exported HTML documents.

[`rel="noreferrer"` is part of the HTML5 standard.](http://www.w3.org/TR/html5/links.html#link-type-noreferrer) While browser support
isn't 100%, it's better than nothing. Future alternative solutions with
wider browser support, such as intermediary redirect pages, are unaffected
by this change.