### PR TITLE
Deny changesets if newline count is wrong

### DIFF
--- a/src/node/easysync_tests.js
+++ b/src/node/easysync_tests.js
@@ -149,7 +149,7 @@ function runTests() {
 
     var correctText = correct.join('');
     //print(literal(cs));
-    var outText = Changeset.applyToText(cs, inText);
+    var outText = Changeset.applyToText(cs, inText)[0];
     assertEqualStrings(correctText, outText);
   }
 
@@ -585,9 +585,9 @@ function runTests() {
     var change123a = Changeset.checkRep(Changeset.compose(change1, change23, p));
     assertEqualStrings(change123, change123a);
 
-    assertEqualStrings(text2, Changeset.applyToText(change12, startText));
-    assertEqualStrings(text3, Changeset.applyToText(change23, text1));
-    assertEqualStrings(text3, Changeset.applyToText(change123, startText));
+    assertEqualStrings(text2, Changeset.applyToText(change12, startText)[0]);
+    assertEqualStrings(text3, Changeset.applyToText(change23, text1)[0]);
+    assertEqualStrings(text3, Changeset.applyToText(change123, startText)[0]);
   }
 
   for (var i = 0; i < 30; i++) testCompose(i);
@@ -699,7 +699,7 @@ function runTests() {
     print("> testMakeSplice");
 
     var t = "a\nb\nc\n";
-    var t2 = Changeset.applyToText(Changeset.makeSplice(t, 5, 0, "def"), t);
+    var t2 = Changeset.applyToText(Changeset.makeSplice(t, 5, 0, "def"), t)[0];
     assertEqualStrings("a\nb\ncdef\n", t2);
 
   })();

--- a/src/node/easysync_tests.js
+++ b/src/node/easysync_tests.js
@@ -149,7 +149,7 @@ function runTests() {
 
     var correctText = correct.join('');
     //print(literal(cs));
-    var outText = Changeset.applyToText(cs, inText)[0];
+    var outText = Changeset.applyToText(cs, inText);
     assertEqualStrings(correctText, outText);
   }
 
@@ -585,9 +585,9 @@ function runTests() {
     var change123a = Changeset.checkRep(Changeset.compose(change1, change23, p));
     assertEqualStrings(change123, change123a);
 
-    assertEqualStrings(text2, Changeset.applyToText(change12, startText)[0]);
-    assertEqualStrings(text3, Changeset.applyToText(change23, text1)[0]);
-    assertEqualStrings(text3, Changeset.applyToText(change123, startText)[0]);
+    assertEqualStrings(text2, Changeset.applyToText(change12, startText));
+    assertEqualStrings(text3, Changeset.applyToText(change23, text1));
+    assertEqualStrings(text3, Changeset.applyToText(change123, startText));
   }
 
   for (var i = 0; i < 30; i++) testCompose(i);
@@ -699,7 +699,7 @@ function runTests() {
     print("> testMakeSplice");
 
     var t = "a\nb\nc\n";
-    var t2 = Changeset.applyToText(Changeset.makeSplice(t, 5, 0, "def"), t)[0];
+    var t2 = Changeset.applyToText(Changeset.makeSplice(t, 5, 0, "def"), t);
     assertEqualStrings("a\nb\ncdef\n", t2);
 
   })();

--- a/src/node/utils/padDiff.js
+++ b/src/node/utils/padDiff.js
@@ -101,8 +101,12 @@ PadDiff.prototype._createClearStartAtext = function(rev, callback){
        return callback(err);
      }
    
+     try {
      //apply the clearAuthorship changeset
      var newAText = Changeset.applyToAText(changeset, atext, self._pad.pool);
+     } catch(err) {
+      return callback(err)
+     }
      
      callback(null, newAText);
    });
@@ -209,10 +213,14 @@ PadDiff.prototype._createDiffAtext = function(callback) {
         if(superChangeset){
           var deletionChangeset = self._createDeletionChangeset(superChangeset,atext,self._pad.pool);
         
-          //apply the superChangeset, which includes all addings
-          atext = Changeset.applyToAText(superChangeset,atext,self._pad.pool);
-          //apply the deletionChangeset, which adds a deletions
-          atext = Changeset.applyToAText(deletionChangeset,atext,self._pad.pool);
+          try {
+            //apply the superChangeset, which includes all addings
+            atext = Changeset.applyToAText(superChangeset,atext,self._pad.pool);
+            //apply the deletionChangeset, which adds a deletions
+            atext = Changeset.applyToAText(deletionChangeset,atext,self._pad.pool);
+          } catch(err) {
+           return callback(err)
+          }
         }      
  
         callback(err, atext);

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -927,16 +927,12 @@ exports.applyToText = function (cs, str) {
       break;
     case '-':
       removedLines += op.lines;
-      newlines = strIter.newlines()
       strIter.skip(op.chars);
-      if(!(newlines - strIter.newlines() == 0) && (newlines - strIter.newlines() != op.lines)){
-        newlinefail = true
-      }
       break;
     case '=':
       newlines = strIter.newlines()
       assem.append(strIter.take(op.chars));
-      if(!(newlines - strIter.newlines() == op.lines)){
+      if(newlines - strIter.newlines() != op.lines){
         newlinefail = true
       }
       break;

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1620,7 +1620,7 @@ exports.makeAText = function (text, attribs) {
 exports.applyToAText = function (cs, atext, pool) {
   var text = exports.applyToText(cs, atext.text)
   if(text[1]){
-    throw new Error("newline count is wrong, cs:"+cs+" and text:"+atext)
+    throw new Error("newline count is wrong, cs:"+cs+" and text:"+atext.text)
   }
   return {
     text: text[0],

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -915,7 +915,7 @@ exports.applyToText = function (cs, str) {
   var csIter = exports.opIterator(unpacked.ops);
   var bankIter = exports.stringIterator(unpacked.charBank);
   var strIter = exports.stringIterator(str);
-  var newlinefail = false
+  var newlinefail = false;
   var assem = exports.stringAssembler();
   while (csIter.hasNext()) {
     var op = csIter.next();
@@ -924,7 +924,7 @@ exports.applyToText = function (cs, str) {
       //op is + and op.lines 0: no newlines must be in op.chars
       //op is + and op.lines >0: op.chars must include op.lines newlines
       if(op.lines != bankIter.peek(op.chars).split("\n").length - 1){
-        newlinefail = true
+        newlinefail = true;
       }
       assem.append(bankIter.take(op.chars));
       break;
@@ -932,7 +932,7 @@ exports.applyToText = function (cs, str) {
       //op is - and op.lines 0: no newlines must be in the deleted string
       //op is - and op.lines >0: op.lines newlines must be in the deleted string
       if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
-        newlinefail = true
+        newlinefail = true;
       }
       strIter.skip(op.chars);
       break;
@@ -940,7 +940,7 @@ exports.applyToText = function (cs, str) {
       //op is = and op.lines 0: no newlines must be in the copied string
       //op is = and op.lines >0: op.lines newlines must be in the copied string
       if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
-        newlinefail = true
+        newlinefail = true;
       }
       assem.append(strIter.take(op.chars));
       break;
@@ -1620,7 +1620,7 @@ exports.makeAText = function (text, attribs) {
 exports.applyToAText = function (cs, atext, pool) {
   var text = exports.applyToText(cs, atext.text)
   if(text[1]){
-    throw new Error("newline count is wrong, cs:"+cs+" and text:"+atext.text)
+    throw new Error("newline count is wrong, cs:"+cs+" and text:"+atext.text);
   }
   return {
     text: text[0],

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1239,7 +1239,7 @@ exports.mutateAttributionLines = function (cs, lines, pool) {
     }
   }
 
-  exports.assert(!lineAssem, "line assembler not finished");
+  exports.assert(!lineAssem, "line assembler not finished:"+cs);
   mut.close();
 
   //dmesg("-> "+lines.toSource());

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1620,7 +1620,7 @@ exports.makeAText = function (text, attribs) {
 exports.applyToAText = function (cs, atext, pool) {
   var text = exports.applyToText(cs, atext.text)
   if(text[1]){
-    throw new Error("newline count is wrong, cs:",cs," and text:",atext)
+    throw new Error("newline count is wrong, cs:"+cs+" and text:"+atext)
   }
   return {
     text: text[0],

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1620,7 +1620,7 @@ exports.makeAText = function (text, attribs) {
 exports.applyToAText = function (cs, atext, pool) {
   var text = exports.applyToText(cs, atext.text)
   if(text[1]){
-    throw new Error()
+    throw new Error("newline count is wrong, cs:",cs," and text:",atext)
   }
   return {
     text: text[0],

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -915,7 +915,6 @@ exports.applyToText = function (cs, str) {
   var csIter = exports.opIterator(unpacked.ops);
   var bankIter = exports.stringIterator(unpacked.charBank);
   var strIter = exports.stringIterator(str);
-  var newlinefail = false;
   var assem = exports.stringAssembler();
   while (csIter.hasNext()) {
     var op = csIter.next();
@@ -924,7 +923,7 @@ exports.applyToText = function (cs, str) {
       //op is + and op.lines 0: no newlines must be in op.chars
       //op is + and op.lines >0: op.chars must include op.lines newlines
       if(op.lines != bankIter.peek(op.chars).split("\n").length - 1){
-        newlinefail = true;
+        throw new Error("newline count is wrong in op +; cs:"+cs+" and text:"+str);
       }
       assem.append(bankIter.take(op.chars));
       break;
@@ -932,7 +931,7 @@ exports.applyToText = function (cs, str) {
       //op is - and op.lines 0: no newlines must be in the deleted string
       //op is - and op.lines >0: op.lines newlines must be in the deleted string
       if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
-        newlinefail = true;
+        throw new Error("newline count is wrong in op -; cs:"+cs+" and text:"+str);
       }
       strIter.skip(op.chars);
       break;
@@ -940,14 +939,14 @@ exports.applyToText = function (cs, str) {
       //op is = and op.lines 0: no newlines must be in the copied string
       //op is = and op.lines >0: op.lines newlines must be in the copied string
       if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
-        newlinefail = true;
+        throw new Error("newline count is wrong in op =; cs:"+cs+" and text:"+str);
       }
       assem.append(strIter.take(op.chars));
       break;
     }
   }
   assem.append(strIter.take(strIter.remaining()));
-  return [assem.toString(),newlinefail];
+  return assem.toString();
 };
 
 /**
@@ -1618,12 +1617,8 @@ exports.makeAText = function (text, attribs) {
  * @param pool {AttribPool} Attribute Pool to add to
  */
 exports.applyToAText = function (cs, atext, pool) {
-  var text = exports.applyToText(cs, atext.text)
-  if(text[1]){
-    throw new Error("newline count is wrong, cs:"+cs+" and text:"+atext.text);
-  }
   return {
-    text: text[0],
+    text: exports.applyToText(cs, atext.text),
     attribs: exports.applyToAttribution(cs, atext.attribs, pool)
   };
 };

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -910,14 +910,11 @@ exports.pack = function (oldLen, newLen, opsStr, bank) {
  * @params str {string} String to which a Changeset should be applied
  */
 exports.applyToText = function (cs, str) {
-  var totalNrOfLines = str.split("\n").length - 1;
-  var removedLines = 0;
   var unpacked = exports.unpack(cs);
   exports.assert(str.length == unpacked.oldLen, "mismatched apply: ", str.length, " / ", unpacked.oldLen);
   var csIter = exports.opIterator(unpacked.ops);
   var bankIter = exports.stringIterator(unpacked.charBank);
   var strIter = exports.stringIterator(str);
-  var newlines = 0
   var newlinefail = false
   var assem = exports.stringAssembler();
   while (csIter.hasNext()) {
@@ -937,7 +934,6 @@ exports.applyToText = function (cs, str) {
       if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
         newlinefail = true
       }
-      removedLines += op.lines;
       strIter.skip(op.chars);
       break;
     case '=':
@@ -946,12 +942,10 @@ exports.applyToText = function (cs, str) {
       if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
         newlinefail = true
       }
-      newlines = strIter.newlines()
       assem.append(strIter.take(op.chars));
       break;
     }
   }
-  exports.assert(totalNrOfLines >= removedLines,"cannot remove ", removedLines, " lines from text with ", totalNrOfLines, " lines");
   assem.append(strIter.take(strIter.remaining()));
   return [assem.toString(),newlinefail];
 };

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -910,7 +910,7 @@ exports.pack = function (oldLen, newLen, opsStr, bank) {
  * @params str {string} String to which a Changeset should be applied
  */
 exports.applyToText = function (cs, str) {
-  var totalNrOfLines = str.split("\n").length;
+  var totalNrOfLines = str.split("\n").length - 1;
   var removedLines = 0;
   var unpacked = exports.unpack(cs);
   exports.assert(str.length == unpacked.oldLen, "mismatched apply: ", str.length, " / ", unpacked.oldLen);

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -924,18 +924,30 @@ exports.applyToText = function (cs, str) {
     var op = csIter.next();
     switch (op.opcode) {
     case '+':
+      //op is + and op.lines 0: no newlines must be in op.chars
+      //op is + and op.lines >0: op.chars must include op.lines newlines
+      if(op.lines != bankIter.peek(op.chars).split("\n").length - 1){
+        newlinefail = true
+      }
       assem.append(bankIter.take(op.chars));
       break;
     case '-':
+      //op is - and op.lines 0: no newlines must be in the deleted string
+      //op is - and op.lines >0: op.lines newlines must be in the deleted string
+      if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
+        newlinefail = true
+      }
       removedLines += op.lines;
       strIter.skip(op.chars);
       break;
     case '=':
-      newlines = strIter.newlines()
-      assem.append(strIter.take(op.chars));
-      if(newlines - strIter.newlines() != op.lines){
+      //op is = and op.lines 0: no newlines must be in the copied string
+      //op is = and op.lines >0: op.lines newlines must be in the copied string
+      if(op.lines != strIter.peek(op.chars).split("\n").length - 1){
         newlinefail = true
       }
+      newlines = strIter.newlines()
+      assem.append(strIter.take(op.chars));
       break;
     }
   }

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -507,6 +507,7 @@ exports.opAssembler = function () {
  */ 
 exports.stringIterator = function (str) {
   var curIndex = 0;
+  // newLines is the number of \n between curIndex and str.length
   var newLines = str.split("\n").length - 1
   function getnewLines(){
     return newLines


### PR DESCRIPTION
This is similar to https://github.com/ether/etherpad-lite/pull/2405 
It adds the same sanity checks for + and - ops - just as the aforementioned pull request did for = op.
It prevents epl from accepting changesets that lie about newline counts. If such a cs is accepted it can result in disconnecting all clients and a crash of the whole epl instance can be triggered later on. ("lineassembler not finished")

Note that it does not prevent epl from crashing in case such a changeset was accepted in the past, but at least it prints the bad changeset now. You have to manually remove it from the database and repair/reimport - although this can be non-trivial because you may not precisely understand what the changeset was meant to do.

frontend&backend&easysync tests pass

Note also, that I actually made two mistakes in this other pull request and fixed them here. First I was off by 1 when counting newlines (I tried to check for wrong line count in - op although at that time I was not sure if this could trigger the same bug) and second I had an always-false branch condition. No harm was caused due to this, but also no use. 