### PR TITLE
Set correct API version in doc

### DIFF
--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -61,7 +61,7 @@ Portal submits content into new blog post
 ## Usage
 
 ### API version
-The latest version is `1.2.9`
+The latest version is `1.2.10`
 
 The current version can be queried via /api.
 


### PR DESCRIPTION
The doc says current version is 1.2.9, but there is getPadID which uses version 1.2.10.