### PR TITLE
do not crash when encountering mismatched compositions. log the changese...

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1629,10 +1629,14 @@ function composePadChangesets(padId, startNum, endNum, callback)
       changeset = changesets[startNum];
       var pool = pad.apool();
 
-      for(var r=startNum+1;r<endNum;r++)
-      {
-        var cs = changesets[r];
-        changeset = Changeset.compose(changeset, cs, pool);
+      try {
+        for(var r=startNum+1;r<endNum;r++) {
+          var cs = changesets[r];
+          changeset = Changeset.compose(changeset, cs, pool);
+        }
+      } catch(e){
+        console.warn("failed to compose cs in pad:",padId);
+        return;
       }
 
       callback(null);

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1636,7 +1636,7 @@ function composePadChangesets(padId, startNum, endNum, callback)
         }
       } catch(e){
         console.warn("failed to compose cs in pad:",padId);
-        return;
+        return callback(e);
       }
 
       callback(null);

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1635,7 +1635,8 @@ function composePadChangesets(padId, startNum, endNum, callback)
           changeset = Changeset.compose(changeset, cs, pool);
         }
       } catch(e){
-        console.warn("failed to compose cs in pad:",padId);
+        // r-1 indicates the rev that was build starting with startNum, applying startNum+1, +2, +3
+        console.warn("failed to compose cs in pad:",padId," startrev:",startNum," current rev:",r);
         return callback(e);
       }
 

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1318,7 +1318,7 @@ exports.compose = function (cs1, cs2, pool) {
   var unpacked2 = exports.unpack(cs2);
   var len1 = unpacked1.oldLen;
   var len2 = unpacked1.newLen;
-  exports.assert(len2 == unpacked2.oldLen, "mismatched composition of two changesets");
+  exports.assert(len2 == unpacked2.oldLen, "mismatched composition of two changesets - cs1:",cs1," and cs2:",cs2);
   var len3 = unpacked2.newLen;
   var bankIter1 = exports.stringIterator(unpacked1.charBank);
   var bankIter2 = exports.stringIterator(unpacked2.charBank);

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1318,7 +1318,7 @@ exports.compose = function (cs1, cs2, pool) {
   var unpacked2 = exports.unpack(cs2);
   var len1 = unpacked1.oldLen;
   var len2 = unpacked1.newLen;
-  exports.assert(len2 == unpacked2.oldLen, "mismatched composition of two changesets - cs1:",cs1," and cs2:",cs2);
+  exports.assert(len2 == unpacked2.oldLen, "mismatched composition of two changesets");
   var len3 = unpacked2.newLen;
   var bankIter1 = exports.stringIterator(unpacked1.charBank);
   var bankIter2 = exports.stringIterator(unpacked2.charBank);


### PR DESCRIPTION
...ts and padid
If this happens than its either an old pad with broken changesets in it and we have to manually clean the database (or fix the cs and try to reimport the pad).
Or when it is a new changeset during normal pad editing and the client is the etherpad editor, than we probably have a new bug and need to fix the editor's code - so we need to know where to start debugging.

easysync/backend/frontend tests pass, but please check if I do the error handling (i.e. returning in async.series) correctly