### PR TITLE
Check author attribution and fix clearAuthorship test

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -656,7 +656,12 @@ function handleUserChanges(data, cb)
           , op
         while(iterator.hasNext()) {
           op = iterator.next()
-          if(op.opcode != '+') continue;
+
+          //+ can add text with attribs
+          //= can change or add attribs
+          //- can have attribs, but they are discarded and don't show up in the apool
+          if(op.opcode == '-') continue;
+
           op.attribs.split('*').forEach(function(attr) {
             if(!attr) return
             attr = wireApool.getAttrib(attr)

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -665,7 +665,8 @@ function handleUserChanges(data, cb)
             if(!attr) return
             attr = wireApool.getAttrib(attr)
             if(!attr) return
-            if('author' == attr[0] && attr[1] != thisSession.author) throw new Error("Trying to submit changes as another author in changeset "+changeset);
+            //the empty author is used in the clearAuthorship functionality so this should be the only exception
+            if('author' == attr[0] && (attr[1] != thisSession.author && attr[1] != '')) throw new Error("Trying to submit changes as another author in changeset "+changeset);
           })
         }
 

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -659,8 +659,7 @@ function handleUserChanges(data, cb)
 
           //+ can add text with attribs
           //= can change or add attribs
-          //- can have attribs, but they are discarded and don't show up in the apool
-          if(op.opcode == '-') continue;
+          //- can have attribs, but they are discarded and don't show up in the attribs - but do show up in the  pool
 
           op.attribs.split('*').forEach(function(attr) {
             if(!attr) return

--- a/tests/frontend/specs/clear_authorship_colors.js
+++ b/tests/frontend/specs/clear_authorship_colors.js
@@ -47,6 +47,10 @@ describe("clear authorship colors button", function(){
       var hasAuthorClass = inner$("div").first().attr("class").indexOf("author") !== -1;
       expect(hasAuthorClass).to.be(false);
 
+
+      var disconnectVisible = chrome$("div.disconnected").attr("class").indexOf("visible") === -1
+      expect(disconnectVisible).to.be(false);
+
       done();
     });
 

--- a/tests/frontend/specs/clear_authorship_colors.js
+++ b/tests/frontend/specs/clear_authorship_colors.js
@@ -47,9 +47,10 @@ describe("clear authorship colors button", function(){
       var hasAuthorClass = inner$("div").first().attr("class").indexOf("author") !== -1;
       expect(hasAuthorClass).to.be(false);
 
-
-      var disconnectVisible = chrome$("div.disconnected").attr("class").indexOf("visible") === -1
-      expect(disconnectVisible).to.be(false);
+      setTimeout(function(){
+        var disconnectVisible = chrome$("div.disconnected").attr("class").indexOf("visible") === -1
+        expect(disconnectVisible).to.be(true);
+      },1000);
 
       done();
     });


### PR DESCRIPTION
Users can submit changes as another author. Clients/new users think someone else did the change. Another possibility is that an author which never exists in globalAuthor is introduced to the pad's pool.

As of now I only know of one exception to the rule "only accept changes of the client's authorId' namely clearAuthorship which uses an empty author (like epl itself does, when it introduces newlines to the end of the document).