### PR TITLE
Support CA bundle files

### DIFF
--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -40,10 +40,27 @@ exports.restartServer = function () {
     console.log( "SSL -- server key file: " + settings.ssl.key );
     console.log( "SSL -- Certificate Authority's certificate file: " + settings.ssl.cert );
     
+    if (settings.ssl.ca) {
+      var ca = [];
+      var chain = fs.readFileSync(settings.ssl.ca, 'utf8');
+      chain = chain.split("\n");
+      var cert = [];
+      for (_i = 0, _len = chain.length; _i < _len; _i++) {
+        line = chain[_i];
+        if (!(line.length !== 0)) continue;
+        cert.push(line);
+        if (line.match(/-END CERTIFICATE-/)) {
+          ca.push(cert.join("\n"));
+          cert = [];
+        }
+      }
+    }
+    
     var options = {
       key: fs.readFileSync( settings.ssl.key ),
       cert: fs.readFileSync( settings.ssl.cert )
     };
+    if (settings.ssl.ca) options.ca = ca;
     
     var https = require('https');
     server = https.createServer(options, app);

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -40,6 +40,11 @@ exports.restartServer = function () {
     console.log( "SSL -- server key file: " + settings.ssl.key );
     console.log( "SSL -- Certificate Authority's certificate file: " + settings.ssl.cert );
     
+    var options = {
+      key: fs.readFileSync( settings.ssl.key ),
+      cert: fs.readFileSync( settings.ssl.cert )
+    };
+    
     if (settings.ssl.ca) {
       var ca = [];
       var chain = fs.readFileSync(settings.ssl.ca, 'utf8');
@@ -54,13 +59,8 @@ exports.restartServer = function () {
           cert = [];
         }
       }
+      options.ca = ca;
     }
-    
-    var options = {
-      key: fs.readFileSync( settings.ssl.key ),
-      cert: fs.readFileSync( settings.ssl.cert )
-    };
-    if (settings.ssl.ca) options.ca = ca;
     
     var https = require('https');
     server = https.createServer(options, app);


### PR DESCRIPTION
This adds support for the intermediate certificate files that some SSL providers require. Code adapted from http://www.benjiegillam.com/2012/06/node-dot-js-ssl-certificate-chain/

If you want to use a CA bundle, then add the path of the file to `settings.ssl.ca` in the settings.json file.