### PR TITLE
fix large etherpad import, fixes #2524 

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -113,10 +113,8 @@ exports.doImport = function(req, res, padId)
         if(ERR(err, callback)) return callback();
         if(result.length > 0){ // This feels hacky and wrong..
           importHandledByPlugin = true;
-          callback();
-        }else{
-          callback();
         }
+        callback();
       });
     },
     function(callback) {
@@ -145,7 +143,7 @@ exports.doImport = function(req, res, padId)
     },
     //convert file to html
     function(callback) {
-      if(!importHandledByPlugin || !directDatabaseAccess){
+      if(!importHandledByPlugin && !directDatabaseAccess){
         var fileEnding = path.extname(srcFile).toLowerCase();
         var fileIsHTML = (fileEnding === ".html" || fileEnding === ".htm");
         var fileIsTXT = (fileEnding === ".txt");
@@ -171,28 +169,24 @@ exports.doImport = function(req, res, padId)
     },
     
     function(callback) {
-      if (!abiword){
-        if(!directDatabaseAccess) {
-          // Read the file with no encoding for raw buffer access.
-          fs.readFile(destFile, function(err, buf) {
-            if (err) throw err;
-            var isAscii = true;
-            // Check if there are only ascii chars in the uploaded file
-            for (var i=0, len=buf.length; i<len; i++) {
-              if (buf[i] > 240) {
-                isAscii=false;
-                break;
-              }
+      if (!abiword && !directDatabaseAccess){
+        // Read the file with no encoding for raw buffer access.
+        fs.readFile(destFile, function(err, buf) {
+          if (err) throw err;
+          var isAscii = true;
+          // Check if there are only ascii chars in the uploaded file
+          for (var i=0, len=buf.length; i<len; i++) {
+            if (buf[i] > 240) {
+              isAscii=false;
+              break;
             }
-            if (isAscii) {
-              callback();
-            } else {
-              callback("uploadFailed");
-            }
-          });
-        }else{
-          callback();
-        }
+          }
+          if (isAscii) {
+            callback();
+          } else {
+            callback("uploadFailed");
+          }
+        });
       } else {
         callback();
       }

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -21,20 +21,11 @@ var db = require("../db/DB").db;
 exports.setPadRaw = function(padId, records, callback){
   records = JSON.parse(records);
 
-  // !! HACK !!
-  // If you have a really large pad it will cause a Maximum Range Stack crash
-  // This is a temporary patch for that so things are kept stable.
-  var recordCount = Object.keys(records).length;
-  if(recordCount >= 50000){
-    console.warn("Etherpad file is too large to import..  We need to fix this.  See https://github.com/ether/etherpad-lite/issues/2524");
-    return callback("tooLarge", false);
-  }
-
   async.eachSeries(Object.keys(records), function(key, cb){
     var value = records[key]
 
     if(!value){
-      cb(); // null values are bad.
+      return setImmediate(cb);
     }
 
     // Author data
@@ -76,7 +67,7 @@ exports.setPadRaw = function(padId, records, callback){
     // Write the value to the server
     db.set(newKey, value);
 
-    cb();
+    setImmediate(cb);
   }, function(){
     callback(null, true);
   });


### PR DESCRIPTION
Made setPadRaw async. The async library expects functions to be asynchronous, but they aren't if you just call the callback immediately, and this can lead to blowing the stack. Wrapped callbacks in `setImmediate` to fix.

Also, file import handling streamlined a bit.

This will probably need some testing to make sure I didn't break the whole thing.

#2524 