### PR TITLE
Adding support for providing intermediate CA certificates 

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -25,6 +25,7 @@
   "ssl" : {
             "key"  : "/path-to-your/epl-server.key",
             "cert" : "/path-to-your/epl-server.crt"
+            "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
           },
 
   */

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -46,6 +46,13 @@ exports.restartServer = function () {
       key: fs.readFileSync( settings.ssl.key ),
       cert: fs.readFileSync( settings.ssl.cert )
     };
+    if (settings.ssl.ca) {
+      options.ca = [];
+      for(var i = 0; i < settings.ssl.ca.length; i++) {
+        var caFileName = settings.ssl.ca[i];
+        options.ca.push(fs.readFileSync(caFileName));
+      }
+    }
     
     var https = require('https');
     server = https.createServer(options, app);


### PR DESCRIPTION
When running etherpad-lite with ssl through Node/expressjs, you would typically like to be able to provide intermediate certificates as part of the SSL handshake. This is supported by expressjs, but some extra config was needed.