### PR TITLE
timeslider: Fix export links

### DIFF
--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -147,7 +147,7 @@ function handleClientVars(message)
     // export_links is a jQuery Array, so .each is allowed.
     export_links.each(function()
     {
-      this.setAttribute('href', this.href.replace( /(.+?)\/\w+\/(\d+\/)?export/ , '$1/' + padId + '/' + revno + '/export'));
+      this.setAttribute('href', this.href.replace( /(.+?)\/[^\/]+\/(\d+\/)?export/ , '$1/' + padId + '/' + revno + '/export'));
     });
   });
 


### PR DESCRIPTION
Names of the pads can contain more charaters than \w. So while
transforming the export links, we simply can allow all charaters
except the slash as pad names.