### PR TITLE
When using setText(), replace the entire existing text of the pad.

### DIFF
--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -290,7 +290,7 @@ Pad.prototype.setText = function setText(newText) {
   var oldText = this.text();
 
   //create the changeset
-  var changeset = Changeset.makeSplice(oldText, 0, oldText.length-1, newText);
+  var changeset = Changeset.makeSplice(oldText, 0, oldText.length, newText);
 
   //append the changeset
   this.appendRevision(changeset);

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -89,7 +89,7 @@ function setPadHTML(pad, html, callback)
   // the changeset is ready!
   var theChangeset = builder.toString();
   apiLogger.debug('The changeset: ' + theChangeset);
-  pad.setText("");
+  pad.setText("\n");
   pad.appendRevision(theChangeset);
   callback(null);
 }

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -260,13 +260,13 @@ exports.checkRep = function (cs) {
       break;
     case '-':
       oldPos += o.chars;
-      exports.assert(oldPos < oldLen, oldPos, " >= ", oldLen, " in ", cs);
+      exports.assert(oldPos <= oldLen, oldPos, " > ", oldLen, " in ", cs);
       break;
     case '+':
       {
         calcNewLen += o.chars;
         numInserted += o.chars;
-        exports.assert(calcNewLen < newLen, calcNewLen, " >= ", newLen, " in ", cs);
+        exports.assert(calcNewLen <= newLen, calcNewLen, " > ", newLen, " in ", cs);
         break;
       }
     }
@@ -1408,8 +1408,8 @@ exports.makeSplice = function (oldFullText, spliceStart, numRemoved, newText, op
   if (spliceStart >= oldLen) {
     spliceStart = oldLen - 1;
   }
-  if (numRemoved > oldFullText.length - spliceStart - 1) {
-    numRemoved = oldFullText.length - spliceStart - 1;
+  if (numRemoved > oldFullText.length - spliceStart) {
+    numRemoved = oldFullText.length - spliceStart;
   }
   var oldText = oldFullText.substring(spliceStart, spliceStart + numRemoved);
   var newLen = oldLen + newText.length - oldText.length;

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -210,7 +210,7 @@ describe('getText', function(){
   it('gets the Pad text', function(done) {
     api.get(endPoint('getText')+"&padID="+testPadId)
     .expect(function(res){
-      if(res.body.data.text !== "testTextTwo\n") throw new Error("Setting Text")
+      if(res.body.data.text !== "testTextTwo") throw new Error("Setting Text")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)
@@ -386,7 +386,7 @@ describe('getText', function(){
     api.get(endPoint('getText')+"&padID="+testPadId)
     .expect(function(res){
       if(res.body.code !== 0) throw new Error("Pad Get Text failed")
-      if(res.body.data.text !== text+"\n") throw new Error("Pad Text not set properly");
+      if(res.body.data.text !== text) throw new Error("Pad Text not set properly");
     })
     .expect('Content-Type', /json/)
     .expect(200, done)
@@ -419,7 +419,7 @@ describe('getText', function(){
   it('Gets text on a pad Id', function(done) {
     api.get(endPoint('getText')+"&padID="+newPadId)
     .expect(function(res){
-      if(res.body.data.text !== text+"\n") throw new Error("Pad Get Text failed")
+      if(res.body.data.text !== text) throw new Error("Pad Get Text failed")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)
@@ -441,7 +441,7 @@ describe('getText', function(){
   it('Gets text on a pad Id', function(done) {
     api.get(endPoint('getText')+"&padID="+testPadId)
     .expect(function(res){
-      if(res.body.data.text !== text+"\n") throw new Error("Pad Get Text failed")
+      if(res.body.data.text !== text) throw new Error("Pad Get Text failed")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)


### PR DESCRIPTION
Fix setText() to replace the full pad text rather than replacing all except the last letter.  Previously, e.g., calling setText() with a pad's existing contents would make the pad one character longer.