### PR TITLE
Bugfix innerText

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -1982,7 +1982,11 @@ function Ace2Inner(){
 
   function nodeText(n)
   {
-    return n.innerText || n.textContent || n.nodeValue || '';
+      if (browser.msie) {
+	  return n.innerText;
+      } else {
+	  return n.textContent || n.nodeValue || '';
+      }
   }
 
   function getLineAndCharForPoint(point)


### PR DESCRIPTION
In two lines of ace2_inner.js, the innerText property is used only for MSIE:
* https://github.com/ether/etherpad-lite/blob/develop/src/static/js/ace2_inner.js#L3230
* https://github.com/ether/etherpad-lite/blob/develop/src/static/js/ace2_inner.js#L3247

In a third line, innerText is used for any browser that implements innerText. That includes Chrome. 
* https://github.com/ether/etherpad-lite/blob/develop/src/static/js/ace2_inner.js#L1985

That fact causes a bug in a plug-in we#re developing. We worked around that bug, but liked to have a solution in etherpad.

Description of bug at https://github.com/tm-linkwerk/ep_linebreak/blob/WR-72-linebreak-cursorverhalten/static/hooks.js#L94
