### PR TITLE
Use the cookie parser middleware

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -6,6 +6,7 @@ var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
 var ueberStore = require('../../db/SessionStore');
 var stats = require('ep_etherpad-lite/node/stats');
 var sessionModule = require('express-session');
+var cookieParser = require('cookie-parser');
 
 //checks for basic http auth
 exports.basicAuth = function (req, res, next) {
@@ -76,7 +77,7 @@ exports.basicAuth = function (req, res, next) {
      Note that the process could stop already in step 3 with a redirect to login page.
 
   */
- 
+
   authorize(function (ok) {
     if (ok) return next();
     authenticate(function (ok) {
@@ -120,6 +121,8 @@ exports.expressConfigure = function (hook_name, args, cb) {
 
   args.app.sessionStore = exports.sessionStore;
   args.app.use(sessionModule({secret: exports.secret, store: args.app.sessionStore, resave: true, saveUninitialized: true, name: 'express_sid' }));
+
+  args.app.use(cookieParser(settings.sessionKey, {}));
 
   args.app.use(exports.basicAuth);
 }

--- a/src/node/padaccess.js
+++ b/src/node/padaccess.js
@@ -3,10 +3,6 @@ var securityManager = require('./db/SecurityManager');
 
 //checks for padAccess
 module.exports = function (req, res, callback) {
-
-  // FIXME: Why is this ever undefined??
-  if (req.cookies === undefined) req.cookies = {};
-
   securityManager.checkAccess(req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password, function(err, accessObj) {
     if(ERR(err, callback)) return;
 


### PR DESCRIPTION
When running etherpad with:
 - settings.requireSession = true;
 - settings.sessionKey = "some value";

the PDF export will *always* return 403 because the cookies never get parsed and the access check in `src/node/padaccess` boils down to:

```javascript
req.cookies = {};
checkAccess(.., req.cookies.sessionID, ...);
```