### PR TITLE
Check for valid session in handleUserInfoUpdate

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -544,14 +544,22 @@ function handleUserInfoUpdate(client, message)
     return;
   }
 
+  // Check that we have a valid session and author to update.
+  var session = sessioninfos[client.id];
+  if(!session || !session.author || !session.padId)
+  {
+    messageLogger.warn("Dropped message, USERINFO_UPDATE Session not ready." + message.data);
+    return;
+  }
+
   //Find out the author name of this session
-  var author = sessioninfos[client.id].author;
+  var author = session.author;
 
   //Tell the authorManager about the new attributes
   authorManager.setAuthorColorId(author, message.data.userInfo.colorId);
   authorManager.setAuthorName(author, message.data.userInfo.name);
 
-  var padId = sessioninfos[client.id].padId;
+  var padId = session.padId;
 
   var infoMsg = {
     type: "COLLABROOM",


### PR DESCRIPTION
Address issue 2674 by checking that the session is valid and has a valid
author and padId before using it to update the userInfo for that
session. Otherwise it is possible that by the time we try to update a
session with new userInfo that session has disconnected and is no longer
available to be updated. Without this commit the etherpad-lite service
gracefully shutsdown whenever this happens.