### PR TITLE
Allowing 'value' to be a localizable attribute on HTML elements.

### DIFF
--- a/src/static/js/html10n.js
+++ b/src/static/js/html10n.js
@@ -851,6 +851,7 @@ window.html10n = (function(window, document, undefined) {
        , "innerHTML": 1
        , "alt": 1
        , "textContent": 1
+       , "value": 1
        }
     if (index > 0 && str.id.substr(index + 1) in attrList) { // an attribute has been specified
       prop = str.id.substr(index + 1)


### PR DESCRIPTION
Currently only `title`, `innerHTML`, `alt`, and `textContent` can be localizable using html10n.js. But if you have a form with submit button, as the [ep_comments_page plugin] (https://github.com/JohnMcLear/ep_comments) has (check the comment when user suggested a change 
![image](https://cloud.githubusercontent.com/assets/836386/7795632/333dfa3a-02ad-11e5-8efc-c6ae88265643.png)
), the button won't be localizable.

I've added `value` as an attribute that is allowed to be localized, ran the backend and frontend tests, everything working fine.