### PR TITLE
Conver.js: Use current mysql client API

### DIFF
--- a/bin/convert.js
+++ b/bin/convert.js
@@ -34,13 +34,13 @@ var sql = "SET CHARACTER SET UTF8;\n" +
 fs.writeSync(sqlOutput, sql);
 log("done");
 
-//set setings for ep db
-var etherpadDB= new mysql.Client();
-etherpadDB.host = settings.etherpadDB.host; 
-etherpadDB.port = settings.etherpadDB.port;
-etherpadDB.database = settings.etherpadDB.database; 
-etherpadDB.user = settings.etherpadDB.user; 
-etherpadDB.password = settings.etherpadDB.password; 
+var etherpadDB = mysql.createConnection({
+  host     : settings.etherpadDB.host,
+  user     : settings.etherpadDB.user,
+  password : settings.etherpadDB.password,
+  database : settings.etherpadDB.database,
+  port     : settings.etherpadDB.port
+});
 
 //get the timestamp once
 var timestamp = new Date().getTime();


### PR DESCRIPTION
The used mysql client API was outdated. This change uses the current API and was successfully tested on a database containing ~2500 pads.