### PR TITLE
Slight tweaks to the startup script for Windows

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,1 +1,5 @@
-node node_modules\ep_etherpad-lite\node\server.js
+@echo off
+start "Etherpad-Lite Server" /min /D "%CD%" "%CD%\node" "%CD%\node_modules\ep_etherpad-lite\node\server.js"
+echo "Please wait for the server to finish starting"
+pause
+start http://%COMPUTERNAME%.%USERDNSDOMAIN%:9001


### PR DESCRIPTION
This uses the path to the batch file (assuming it is being launched as a shortcut), and then opens the default browser with the path to Etherpad.

This does all assume that this is being run on a user's desktop rather than on a server. Perhaps a subsequent change for running in server-only mode should be proposed?