### PR TITLE
On Import, when successful, loading circle didn't go away

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -467,7 +467,7 @@ var pad = {
   {
     var newHref = new RegExp(/.*\/p\/[^\/]+/).exec(document.location.pathname) || clientVars.padId;
     newHref = newHref[0];    
-    if (options != null){
+    if (typeof options != "undefined" && options != null){
       newHref = newHref + '?' + options;
     }
 


### PR DESCRIPTION
After successfully importing a document, the loading circle didn't hide itself.

This can happen, if you try to access a variable, which was not declared before. Even if you soft-check it against null, when it was not declared before JS throws a ReferenceError (and doesn't return undefined).