### PR TITLE
prefetch pad files from index page

### DIFF
--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var async = require('async');
 var eejs = require('ep_etherpad-lite/node/eejs');
 var toolbar = require("ep_etherpad-lite/node/utils/toolbar");
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
@@ -95,6 +96,26 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 *
 */
 function sendPadHeaderFiles(res, callback){
+  var plugins = hooks.plugins.plugins;
+  var pluginPaths = [];
+  // Go through each plugin and get the paths
+  Object.keys(plugins).forEach(function(key) {
+    if(key === "ep_etherpad-lite") return;
+    var plugin = plugins[key];
+    var client_hooks = plugin.parts[0].client_hooks;
+    Object.keys(client_hooks).forEach(function(k){
+      pluginPaths.push(client_hooks[k]);
+    });
+  });
+
+  var uniquePaths = pluginPaths.filter(function(item, pos) {
+    return pluginPaths.indexOf(item) == pos;
+  })
+
+  console.warn("paths", uniquePaths);
+
+  // Now we need to uniquify the array
+
   res.set('Link', '<static/js/require-kernel.js>; rel=prefetch \, \
     <javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define>; rel=prefetch \, \
     <javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define>; rel=prefetch \, \

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -119,7 +119,7 @@ function sendPadHeaderFiles(res, callback){
   var uniquePluginString = "";
 
   for (var i = 0; i < uniquePaths.length; i++) {
-    uniquePluginString += "<static/plugins/"+uniquePaths[i]+".js>; rel=prefetch\, ";
+    uniquePluginString += "</javascripts/lib/"+uniquePaths[i]+".js>; rel=prefetch\, ";
   }
 
   // console.log("unique plugin string...", uniquePluginString)

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -103,9 +103,11 @@ function sendPadHeaderFiles(res, callback){
     if(key === "ep_etherpad-lite") return;
     var plugin = plugins[key];
     var client_hooks = plugin.parts[0].client_hooks;
-    Object.keys(client_hooks).forEach(function(k){
-      pluginPaths.push(client_hooks[k]);
-    });
+    if(client_hooks){
+      Object.keys(client_hooks).forEach(function(k){
+        pluginPaths.push(client_hooks[k]);
+      });
+    }
   });
 
   // Now we need to uniquify the array so we only have unique paths
@@ -114,11 +116,13 @@ function sendPadHeaderFiles(res, callback){
   })
 
   // Next to join the array into a string so we can add it to the link value
-  var uniquePluginString = "'";
+  var uniquePluginString = "";
 
   for (var i = 0; i < uniquePaths.length; i++) {
-    uniquePluginString += "<"+uniquePaths[i]+".js>; rel=prefetch\,";
+    uniquePluginString += "<static/plugins/"+uniquePaths[i]+".js>; rel=prefetch\, ";
   }
+
+  // console.log("unique plugin string...", uniquePluginString)
 
   res.set('Link', uniquePluginString + " <static/js/require-kernel.js>; rel=prefetch\, \
 <javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define>; rel=prefetch\, \
@@ -133,6 +137,6 @@ function sendPadHeaderFiles(res, callback){
 <static/css/iframe_editor.css>; rel=prefetch\, \
 <pluginfw/plugin-definitions.json>; rel=prefetch\, \
 <locales.json>; rel=prefetch\, \
-<static/font/fontawesome-etherpad.woff>; rel=prefetch'");
+<static/font/fontawesome-etherpad.woff>; rel=prefetch");
   callback();
 }

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -108,27 +108,31 @@ function sendPadHeaderFiles(res, callback){
     });
   });
 
+  // Now we need to uniquify the array so we only have unique paths
   var uniquePaths = pluginPaths.filter(function(item, pos) {
     return pluginPaths.indexOf(item) == pos;
   })
 
-  console.warn("paths", uniquePaths);
+  // Next to join the array into a string so we can add it to the link value
+  var uniquePluginString = "'";
 
-  // Now we need to uniquify the array
+  for (var i = 0; i < uniquePaths.length; i++) {
+    uniquePluginString += "<"+uniquePaths[i]+".js>; rel=prefetch\,";
+  }
 
-  res.set('Link', '<static/js/require-kernel.js>; rel=prefetch \, \
-    <javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define>; rel=prefetch \, \
-    <javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define>; rel=prefetch \, \
-    <javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define>; rel=prefetch \, \
-    <javascripts/lib/unorm/lib/unorm.js?callback=require.define>; rel=prefetch \, \
-    <static/custom/pad.js>; rel=prefetch \, \
-    <static/js/html10n.js>; rel=prefetch \, \
-    <static/js/l10n.js>; rel=prefetch \, \
-    <static/css/pad.css>; rel=prefetch \, \
-    <static/custom/pad.css>; rel=prefetch \, \
-    <static/css/iframe_editor.css>; rel=prefetch \, \
-    <pluginfw/plugin-definitions.json>; rel=prefetch \, \
-    <locales.json>; rel=prefetch \, \
-    <static/font/fontawesome-etherpad.woff>; rel=prefetch');
+  res.set('Link', uniquePluginString + " <static/js/require-kernel.js>; rel=prefetch\, \
+<javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define>; rel=prefetch\, \
+<javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define>; rel=prefetch\, \
+<javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define>; rel=prefetch\, \
+<javascripts/lib/unorm/lib/unorm.js?callback=require.define>; rel=prefetch\, \
+<static/custom/pad.js>; rel=prefetch\, \
+<static/js/html10n.js>; rel=prefetch\, \
+<static/js/l10n.js>; rel=prefetch\, \
+<static/css/pad.css>; rel=prefetch\, \
+<static/custom/pad.css>; rel=prefetch\, \
+<static/css/iframe_editor.css>; rel=prefetch\, \
+<pluginfw/plugin-definitions.json>; rel=prefetch\, \
+<locales.json>; rel=prefetch\, \
+<static/font/fontawesome-etherpad.woff>; rel=prefetch'");
   callback();
 }

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -130,8 +130,11 @@ function sendPadHeaderFiles(res, callback){
 <javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define>; rel=prefetch\, \
 <javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define>; rel=prefetch\, \
 <javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define>; rel=prefetch\, \
+<javascripts/lib/ep_etherpad-lite/static/js/colorutils.js?callback=require.define>; rel=prefetch\, \
+<javascripts/lib/ep_etherpad-lite/static/js/hooks.js?callback=require.define>; rel=prefetch\, \
 <javascripts/lib/unorm/lib/unorm.js?callback=require.define>; rel=prefetch\, \
 <static/custom/pad.js>; rel=prefetch\, \
+<socket.io/socket.io.js>; rel=prefetch\, \
 <static/js/html10n.js>; rel=prefetch\, \
 <static/js/l10n.js>; rel=prefetch\, \
 <static/css/pad.css>; rel=prefetch\, \

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -105,7 +105,9 @@ function sendPadHeaderFiles(res, callback){
     var client_hooks = plugin.parts[0].client_hooks;
     if(client_hooks){
       Object.keys(client_hooks).forEach(function(k){
-        pluginPaths.push(client_hooks[k]);
+        var path = client_hooks[k];
+        path = path.split(":")[0];
+        pluginPaths.push(path);
       });
     }
   });

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -12,7 +12,9 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   //serve index.html under /
   args.app.get('/', function(req, res)
   {
-    res.send(eejs.require("ep_etherpad-lite/templates/index.html"));
+    sendPadHeaderFiles(res, function(){
+      res.send(eejs.require("ep_etherpad-lite/templates/index.html"));
+    });
   });
 
   //serve robots.txt
@@ -77,4 +79,22 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   });
 
 
+}
+
+function sendPadHeaderFiles(res, callback){
+  res.set('Link', '<static/js/require-kernel.js>; rel=prefetch \, \
+    <javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define>; rel=prefetch \, \
+    <javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define>; rel=prefetch \, \
+    <javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define>; rel=prefetch \, \
+    <javascripts/lib/unorm/lib/unorm.js?callback=require.define>; rel=prefetch \, \
+    <static/custom/pad.js>; rel=prefetch \, \
+    <static/js/html10n.js>; rel=prefetch \, \
+    <static/js/l10n.js>; rel=prefetch \, \
+    <static/css/pad.css>; rel=prefetch \, \
+    <static/custom/pad.css>; rel=prefetch \, \
+    <static/css/iframe_editor.css>; rel=prefetch \, \
+    <pluginfw/plugin-definitions.json>; rel=prefetch \, \
+    <locales.json>; rel=prefetch \, \
+    <static/font/fontawesome-etherpad.woff>; rel=prefetch');
+  callback();
 }

--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -3,6 +3,7 @@
     "pad.js"
   , "pad_utils.js"
   , "browser.js"
+  , "colorutils.js"
   , "pad_cookie.js"
   , "pad_editor.js"
   , "pad_editbar.js"

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -33,23 +33,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
         <link rel="shortcut icon" href="<%=settings.favicon%>">
         <link rel="localizations" type="application/l10n+json" href="locales.json">
-        <link rel="prefetch" href="static/css/pad.css">
-        <link rel="prefetch" href="static/custom/pad.css">
-        <link rel="prefetch" href="static/js/require-kernel.js">
-        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define">
-        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define">
-        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define">
-        <link rel="prefetch" href="javascripts/lib/unorm/lib/unorm.js?callback=require.define">
-        <link rel="prefetch" href="static/custom/pad.js">
-        <link rel="prefetch" href="pluginfw/plugin-definitions.json">
-        <link rel="prefetch" href="locales.json">
-        <link rel="prefetch" href="static/font/fontawesome-etherpad.woff">
-
-<!-- 
-  No point prefetching these as we load them below??...
-        <link rel="prefetch" href="static/js/html10n.js">
-        <link rel="prefetch" href="static/js/l10n.js">
--->
 
         <script type="text/javascript" src="static/js/html10n.js"></script>
         <script type="text/javascript" src="static/js/l10n.js"></script>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -34,6 +34,21 @@
         <link rel="shortcut icon" href="<%=settings.favicon%>">
 
         <link rel="localizations" type="application/l10n+json" href="locales.json">
+	<link rel="prefetch" href="static/css/pad.css">
+        <link rel="prefetch" href="static/custom/pad.css">
+        <link rel="prefetch" href="static/js/html10n.js">
+        <link rel="prefetch" href="static/js/l10n.js">
+        <link rel="prefetch" href="static/js/require-kernel.js">
+        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define">
+        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define">
+        <link rel="prefetch" href="static/custom/pad.js">
+        <link rel="prefetch" href="pluginfw/plugin-definitions.json">
+        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define">
+        <link rel="prefetch" href="locales.json">
+        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define">
+        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define">
+        <link rel="prefetch" href="javascripts/lib/unorm/lib/unorm.js?callback=require.define">
+
         <script type="text/javascript" src="static/js/html10n.js"></script>
         <script type="text/javascript" src="static/js/l10n.js"></script>
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -32,22 +32,24 @@
         <meta charset="utf-8"> 
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
         <link rel="shortcut icon" href="<%=settings.favicon%>">
-
         <link rel="localizations" type="application/l10n+json" href="locales.json">
-	<link rel="prefetch" href="static/css/pad.css">
+        <link rel="prefetch" href="static/css/pad.css">
         <link rel="prefetch" href="static/custom/pad.css">
-        <link rel="prefetch" href="static/js/html10n.js">
-        <link rel="prefetch" href="static/js/l10n.js">
         <link rel="prefetch" href="static/js/require-kernel.js">
         <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define">
         <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define">
-        <link rel="prefetch" href="static/custom/pad.js">
-        <link rel="prefetch" href="pluginfw/plugin-definitions.json">
-        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define">
-        <link rel="prefetch" href="locales.json">
-        <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define">
         <link rel="prefetch" href="javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define">
         <link rel="prefetch" href="javascripts/lib/unorm/lib/unorm.js?callback=require.define">
+        <link rel="prefetch" href="static/custom/pad.js">
+        <link rel="prefetch" href="pluginfw/plugin-definitions.json">
+        <link rel="prefetch" href="locales.json">
+        <link rel="prefetch" href="static/font/fontawesome-etherpad.woff">
+
+<!-- 
+  No point prefetching these as we load them below??...
+        <link rel="prefetch" href="static/js/html10n.js">
+        <link rel="prefetch" href="static/js/l10n.js">
+-->
 
         <script type="text/javascript" src="static/js/html10n.js"></script>
         <script type="text/javascript" src="static/js/l10n.js"></script>


### PR DESCRIPTION
This is thanks to the excellent work by @kentonv at @sandstorm as per https://github.com/kentonv/etherpad-lite/commit/910c507882d93ccd5440a6af0a5d41b937718c30

Prefetching the pad files while on the index.html makes a lot of sense as it's your most likely next destination.  

In this branch I'm going to explore using prefetch to optimize Etherpad performance for the client.

The develop branch going from index to pad: 
- index load time, 51ms 32.7Kb
- index > pad load time, 740ms 1.5Mb?? <-- doesn't add up
- pad refresh load time, 345ms 102Kb

In this branch:
- index load time, 129ms 121Kb
- index > pad load time, 669ms 208Kb?? <-- doesn't add up
- pad refresh load time, 239ms 185Kb
