### PR TITLE
Add author information to the context for padCreate and padUpdate hooks.

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -110,6 +110,7 @@ Called from: src/node/db/Pad.js
 Things in context:
 
 1. pad - the pad instance
+2. author - the id of the author who created the pad
 
 This hook gets called when a new pad was created.
 
@@ -128,6 +129,7 @@ Called from: src/node/db/Pad.js
 Things in context:
 
 1. pad - the pad instance
+2. author - the id of the author who updated the pad
 
 This hook gets called when an existing pad was updated.
 

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -105,9 +105,9 @@ Pad.prototype.appendRevision = function appendRevision(aChangeset, author) {
     authorManager.addPad(author, this.id);
 
   if (this.head == 0) {
-    hooks.callAll("padCreate", {'pad':this});
+    hooks.callAll("padCreate", {'pad':this, 'author': author});
   } else {
-    hooks.callAll("padUpdate", {'pad':this});
+    hooks.callAll("padUpdate", {'pad':this, 'author': author});
   }
 };
 


### PR DESCRIPTION
This gives the hooks access to information that's otherwise awkward to get.

Ran backend tests and they pass.