### PR TITLE
run.sh [: too many arguments

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -21,7 +21,7 @@ if [ "$(id -u)" -eq 0 ] && [ $ignoreRoot -eq 0 ]; then
    echo "You shouldn't start Etherpad as root!"
    echo "Please type 'Etherpad rocks my socks' or supply the '--root' argument if you still want to start it as root"
    read rocks
-   if [ ! $rocks = "Etherpad rocks my socks" ]
+   if [ ! "$rocks" == "Etherpad rocks my socks" ]
    then
      echo "Your input was incorrect"
      exit 1


### PR DESCRIPTION
$rocks has to be enclosed into a "string" so bash can treat is as a string.
We can compare two strings with the == operator then, ...