### PR TITLE
Fixing @font-face src path to be able to use font icons on plugins when minify is on

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -189,7 +189,7 @@ a img {
   left:0px;
   right:250px;
 }
-  
+
 .toolbar ul.menu_right {
   right:0px;
 }
@@ -1029,7 +1029,7 @@ input[type=checkbox] {
     left:0px;
     right:100px;
   }
-  
+
   .toolbar ul.menu_right {
     right:0px;
   }
@@ -1091,7 +1091,7 @@ input[type=checkbox] {
       background: none !important
     }
     li[data-key="showusers"] > a {
-      
+
       margin-top:-10px;
       padding-top:2px !important;
       line-height:20px;
@@ -1248,11 +1248,11 @@ input[type=checkbox] {
 
 @font-face {
   font-family: "fontawesome-etherpad";
-  src:url("../font/fontawesome-etherpad.eot");
-  src:url("../font/fontawesome-etherpad.eot?#iefix") format("embedded-opentype"),
-    url("../font/fontawesome-etherpad.woff") format("woff"),
-    url("../font/fontawesome-etherpad.ttf") format("truetype"),
-    url("../font/fontawesome-etherpad.svg#fontawesome-etherpad") format("svg");
+  src:url("../../static/font/fontawesome-etherpad.eot");
+  src:url("../../static/font/fontawesome-etherpad.eot?#iefix") format("embedded-opentype"),
+    url("../../static/font/fontawesome-etherpad.woff") format("woff"),
+    url("../../static/font/fontawesome-etherpad.ttf") format("truetype"),
+    url("../../static/font/fontawesome-etherpad.svg#fontawesome-etherpad") format("svg");
   font-weight: normal;
   font-style: normal;
 


### PR DESCRIPTION
When plugins use font icons from `fontawesome-etherpad` and `minify` is on, the icons cannot be displayed because the URL seems to be incorrect: it looks for the font at `http://localhost:9001/font/fontawesome-etherpad.*`, but the correct path is `http://localhost:9001/static/font/fontawesome-etherpad.*`.

To reproduce this, use `ep_comments_page` and check for the delete icon on the comment.
Should be:
![image](https://cloud.githubusercontent.com/assets/836386/8337131/83384dee-1a7f-11e5-8803-cd38d16ac83d.png)

But is:
![image](https://cloud.githubusercontent.com/assets/836386/8337108/57e40214-1a7f-11e5-9918-866fe78d4e69.png)

This is the same change of 56ce8e8, but for `fontawesome-etherpad`, instead of `opendyslexic`.