### PR TITLE
Add an indicator of the sync status to the toolbar.

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -1291,4 +1291,10 @@ input[type=checkbox] {
   display:none !important;
 }
 
-
+.toolbar ul li.syncstatus {
+  display: none;
+  line-height: 32px;
+  margin-left: 10px;
+  font-size: 14pt;
+  color: #666;
+}

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -65,6 +65,8 @@
                 <% e.begin_block("editbarMenuLeft"); %>
                 <%- toolbar.menu(settings.toolbar.left, isReadOnly) %>
                 <% e.end_block(); %>
+                <li class="syncstatus" id="syncstatussyncing">Saving...</li>
+                <li class="syncstatus" id="syncstatusdone">Saved.</li>
             </ul>
             <ul class="menu_right" role="toolbar">
                 <% e.begin_block("editbarMenuRight"); %>


### PR DESCRIPTION
Interestingly, there's already javascript in src/static/js/pad_editbar.js to change the visibility of elements to reflect the sync status.  However, there's no elements with the relevant classes to hide and show.  This commit adds such elements to provide an indication of whether your latest changes have finished saving or not.