### PR TITLE
Restore newline-adding to setText() if passed string does not end in '\n'.

### DIFF
--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -290,7 +290,14 @@ Pad.prototype.setText = function setText(newText) {
   var oldText = this.text();
 
   //create the changeset
-  var changeset = Changeset.makeSplice(oldText, 0, oldText.length, newText);
+  // We want to ensure the pad still ends with a \n, but otherwise keep
+  // getText() and setText() consistent.
+  var changeset;
+  if (newText[newText.length - 1] == '\n') {
+    changeset = Changeset.makeSplice(oldText, 0, oldText.length, newText);
+  } else {
+    changeset = Changeset.makeSplice(oldText, 0, oldText.length-1, newText);
+  }
 
   //append the changeset
   this.appendRevision(changeset);

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -211,7 +211,7 @@ describe('getText', function(){
   it('gets the Pad text', function(done) {
     api.get(endPoint('getText')+"&padID="+testPadId)
     .expect(function(res){
-      if(res.body.data.text !== "testTextTwo") throw new Error("Setting Text")
+      if(res.body.data.text !== "testTextTwo\n") throw new Error("Setting Text")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)
@@ -387,7 +387,30 @@ describe('getText', function(){
     api.get(endPoint('getText')+"&padID="+testPadId)
     .expect(function(res){
       if(res.body.code !== 0) throw new Error("Pad Get Text failed")
-      if(res.body.data.text !== text) throw new Error("Pad Text not set properly");
+      if(res.body.data.text !== text+"\n") throw new Error("Pad Text not set properly");
+    })
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+})
+
+describe('setText', function(){
+  it('Sets text on a pad Id including an explicit newline', function(done) {
+    api.get(endPoint('setText')+"&padID="+testPadId+"&text="+text+'%0A')
+    .expect(function(res){
+      if(res.body.code !== 0) throw new Error("Pad Set Text failed")
+    })
+    .expect('Content-Type', /json/)
+    .expect(200, done)
+  });
+})
+
+describe('getText', function(){
+  it("Gets text on a pad Id and doesn't have an excess newline", function(done) {
+    api.get(endPoint('getText')+"&padID="+testPadId)
+    .expect(function(res){
+      if(res.body.code !== 0) throw new Error("Pad Get Text failed")
+      if(res.body.data.text !== text+"\n") throw new Error("Pad Text not set properly");
     })
     .expect('Content-Type', /json/)
     .expect(200, done)
@@ -420,7 +443,7 @@ describe('getText', function(){
   it('Gets text on a pad Id', function(done) {
     api.get(endPoint('getText')+"&padID="+newPadId)
     .expect(function(res){
-      if(res.body.data.text !== text) throw new Error("Pad Get Text failed")
+      if(res.body.data.text !== text+"\n") throw new Error("Pad Get Text failed")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)
@@ -442,7 +465,7 @@ describe('getText', function(){
   it('Gets text on a pad Id', function(done) {
     api.get(endPoint('getText')+"&padID="+testPadId)
     .expect(function(res){
-      if(res.body.data.text !== text) throw new Error("Pad Get Text failed")
+      if(res.body.data.text !== text+"\n") throw new Error("Pad Get Text failed")
     })
     .expect('Content-Type', /json/)
     .expect(200, done)


### PR DESCRIPTION
Also adds a test for the ending-in-'\n' case and update tests for the other case.

This is a followup to my previous pull request #2649 intended to fix issue #2700.