### PR TITLE
Fix toolbar and chat positioning on mobile devices

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -1109,7 +1109,7 @@ input[type=checkbox] {
       vertical-align:top !important;
     }
     #chaticon {
-      position:absolute;
+      position:fixed;
       right:48px;
     }
     .popup {
@@ -1138,7 +1138,7 @@ input[type=checkbox] {
       line-height: 24px
     }
     #chatbox{
-      position:absolute;
+      position:fixed;
       bottom:33px !important;
       margin: 65px 0 0 0;
     }

--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -1059,10 +1059,11 @@ input[type=checkbox] {
     #editorcontainer {
       margin-bottom: 33px
     }
-    .toolbar ul.menu_left {
-      right:0px;
+    /* cancel non-mobile border (will be defined on ".toolbar ul.menu_left" bellow) */
+    .toolbar {
+      border-bottom: 0;
     }
-    .toolbar ul.menu_right {
+    .toolbar ul {
       background: #f7f7f7;
       background: -webkit-linear-gradient(#f7f7f7, #f1f1f1 80%);
       background: -moz-linear-gradient(#f7f7f7, #f1f1f1 80%);
@@ -1070,8 +1071,18 @@ input[type=checkbox] {
       background: -ms-linear-gradient(#f7f7f7, #f1f1f1 80%);
       background: linear-gradient(#f7f7f7, #f1f1f1 80%);
       width: 100%;
-      right:0px !important;
       overflow: hidden;
+    }
+    .toolbar ul.menu_left {
+      right:0px;
+      position: fixed;
+      top: 0;
+      padding-top: 4px;
+      border-bottom: 1px solid #ccc;
+      z-index: 10;
+    }
+    .toolbar ul.menu_right {
+      right:0px !important;
       height: 32px;
       position: fixed;
       bottom: 0;


### PR DESCRIPTION
On mobile devices (or at least on some iOS ones), if user scrolls the toolbar is not displayed anymore, and chat does not stick to the bottom of the page:

![image](https://cloud.githubusercontent.com/assets/836386/8505072/3d93a96a-21b3-11e5-9c3d-809176472d75.png)

Tested on a Safari on Simulator + on Chrome on iPhone 5S with iOS 8.3.

With this PR:
![image](https://cloud.githubusercontent.com/assets/836386/8505091/abb2822c-21b3-11e5-9c00-200f071692a4.png)
![image](https://cloud.githubusercontent.com/assets/836386/8505092/b1d49c4e-21b3-11e5-9487-ece4395ef985.png)
