### PR TITLE
Complementing #2718 + Fixing empty toolbar when on read-only & menu_left has no button

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -216,6 +216,10 @@ li[data-key=showusers] > a #online_count {
   right: 0px;
   bottom: 0px;
   z-index: 1;
+
+  /* Required to fix toolbar on top/bottom of the screen on iOS: */
+  overflow: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 #editorcontainer iframe {
   height: 100%;

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -185,9 +185,31 @@ var padeditbar = (function()
       this.commands[cmd] = callback;
       return this;
     },
+    calculateEditbarHeight: function() {
+      // if we're on timeslider, there is nothing on editbar, so we just use zero
+      var onTimeslider = $('.menu_left').length === 0;
+      if (onTimeslider) return 0;
+
+      // if editbar has both menu left and right, its height must be
+      // the max between the height of these two parts
+      var leftMenuPosition = $('.menu_left').offset().top;
+      var rightMenuPosition = $('.menu_right').offset().top;
+      var editbarHasMenuLeftAndRight = (leftMenuPosition === rightMenuPosition);
+
+      var height;
+      if (editbarHasMenuLeftAndRight) {
+        height = Math.max($('.menu_left').height(), $('.menu_right').height());
+      }
+      else {
+        height = $('.menu_left').height();
+      }
+
+      return height;
+    },
     redrawHeight: function(){
-      var editbarHeight = $('.menu_left').height() + 1 + "px";
-      var containerTop = $('.menu_left').height() + 6 + "px";
+      var minimunEditbarHeight = self.calculateEditbarHeight();
+      var editbarHeight = minimunEditbarHeight + 1 + "px";
+      var containerTop = minimunEditbarHeight + 6 + "px";
       $('#editbar').css("height", editbarHeight);
 
       $('#editorcontainer').css("top", containerTop);


### PR DESCRIPTION
I've noticed my previous fix on #2718 was woking on my Etherpad because I have ep_page_view installed. When this plugin is not present, the editbar is still not fixed on top of the page when using iOS devices. So one of the commits of this PR is to fix that.

The other commit is to address an issue when pad is read-only and no button is on editbar, which I've noticed while testing the first commit:

![image](https://cloud.githubusercontent.com/assets/836386/8555946/f76eba50-24c9-11e5-8b7e-b1c07e894d16.png)

This time I've tested on an Etherpad with no plugins, on these 4 scenarios: regular pad, read-only pad, inside of an iframe (using https://github.com/ether/etherpad-lite-jquery-plugin), and on timeslider. I've also tested on Safari@iPhone, Chrome@iPad, Chrome@desktop, and FF@desktop.

I hope this is all we need this time.