### PR TITLE
Add a aceSelectionChanged hook to allow plugins to react when the cursor moves

### DIFF
--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -339,3 +339,14 @@ Things in context:
 
 This hook is provided to allow author highlight style to be modified.
 Registered hooks should return 1 if the plugin handles highlighting.  If no plugin returns 1, the core will use the default background-based highlighting.
+
+## aceSelectionChanged
+Called from: src/static/js/ace2_inner.js
+
+Things in context:
+
+1. rep - information about where the user's cursor is
+2. documentAttributeManager - information about attributes in the document
+
+This hook allows a plugin to react to a cursor or selection change,
+perhaps to update a UI element based on the style at the cursor location.

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2894,6 +2894,11 @@ function Ace2Inner(){
       rep.selFocusAtStart = newSelFocusAtStart;
       currentCallStack.repChanged = true;
 
+      hooks.callAll('aceSelectionChanged', {
+        rep: rep,
+        documentAttributeManager: documentAttributeManager,
+      });
+
       return true;
       //console.log("selStart: %o, selEnd: %o, focusAtStart: %s", rep.selStart, rep.selEnd,
       //String(!!rep.selFocusAtStart));


### PR DESCRIPTION
No current hook seems to address this use case; you can fake key-related movement with aceKeyEvent, but there doesn't seem to be a way to catch mouse-related cursor changes.