### PR TITLE
added clientReady hook

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -384,3 +384,20 @@ exports.userLeave = function(hook, session, callback) {
   console.log('%s left pad %s', session.author, session.padId);
 };
 ```
+
+### clientReady
+Called from src/node/handler/PadMessageHandler.js
+
+This in context:
+
+1. message
+
+This hook gets called when handling a CLIENT_READY which is the first message from the client to the server.
+
+Example:
+
+```
+exports.clientReady = function(hook, message) {
+  console.log('Client has entered the pad' + message.padId);
+};
+```

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1009,6 +1009,8 @@ function handleClientReady(client, message)
   var currentTime;
   var padIds;
 
+  hooks.callAll("clientReady", message);
+
   async.series([
     //Get ro/rw id:s
     function (callback)


### PR DESCRIPTION
I'm developing a plugin to send stats over from Etherpad to Graphite. I've added a new hook that I will use for the plugin, called from within the handleClientReady() function within PadMessageHandler.js. This seemed to be a good place to account for whenever a user enters a pad, and it also contains some information that I need---namely message.padId.

Let me know if you have any issue with this addition.