### PR TITLE
Avoid space removal when pasting text from word processor.

### DIFF
--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -100,7 +100,7 @@ function makeContentCollector(collectStyles, abrowser, apool, domInterface, clas
   function textify(str)
   {
     return sanitizeUnicode(
-    str.replace(/\n/g, '').replace(/[\n\r ]/g, ' ').replace(/\xa0/g, ' ').replace(/\t/g, '        '));
+    str.replace(/(\n | \n)/g, ' ').replace(/[\n\r ]/g, ' ').replace(/\xa0/g, ' ').replace(/\t/g, '        '));
   }
 
   function getAssoc(node, name)


### PR DESCRIPTION
Since bf380eea504662ea41aa431e30d7e30ad6a36cd3, some spaces were removed when pasting text from a word processor (at least using Libre Office). To avoid double space creations and space removal, we only remove line break which are tight to a space character.