### PR TITLE
Removing style that makes editor scroll to the top on iOS without any action from the user

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -217,8 +217,7 @@ li[data-key=showusers] > a #online_count {
   bottom: 0px;
   z-index: 1;
 
-  /* Required to fix toolbar on top/bottom of the screen on iOS: */
-  overflow: scroll;
+  /* Required to be able to scroll on iOS: */
   -webkit-overflow-scrolling: touch;
 }
 #editorcontainer iframe {


### PR DESCRIPTION
tl;dr
- avoid focus to be moved to the top every second when on iOS;
- but move back the issue that shows toolbar in the middle of the screen when editing on iOS:
![image](https://cloud.githubusercontent.com/assets/836386/9063741/6d873fec-3a9f-11e5-9409-5f2a964589f3.png)

Long story:

This PR reverts part of #2721, because that change made scroll on iOS devices very unstable. Using `position:scroll` as it was before this PR made the editor scroll to the top every second or so, even without any action from the user. I'm not sure if this issue is related to #2224, so maybe fixing one might fix both.

Anyway, I thought it was much worse to keep moving the focus to the top of the editor than having a toolbar "flying" on the screen when editing the pad.

Thoughts about these issues? Any suggestion?