### PR TITLE
allow /admin to run in a subdirectory

### DIFF
--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -11,7 +11,7 @@ $(document).ready(function () {
 
   //connect
   var room = url + "pluginfw/installer";
-  socket = io.connect(room, {resource : resource});
+  socket = io.connect(room, {path: baseURL + "socket.io", resource : resource});
 
   function search(searchTerm, limit) {
     if(search.searchTerm != searchTerm) {

--- a/src/static/js/admin/settings.js
+++ b/src/static/js/admin/settings.js
@@ -10,7 +10,7 @@ $(document).ready(function () {
 
   //connect
   var room = url + "settings";
-  socket = io.connect(room, {resource : resource});
+  socket = io.connect(room, {path: baseURL + "socket.io", resource : resource});
 
   socket.on('settings', function (settings) {
 


### PR DESCRIPTION
this should allow the admin pages to run fully (socket.io was going to root) in a subdirectory or behind a reverse proxy and