### PR TITLE
linux environment variables in safeRun.sh

### DIFF
--- a/bin/cleanRun.sh
+++ b/bin/cleanRun.sh
@@ -3,6 +3,9 @@
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
 
+#Parse settings.json
+eval $(python parsejson.py)
+
 #Was this script started in the bin folder? if yes move out
 if [ -d "../bin" ]; then
   cd "../"
@@ -38,4 +41,4 @@ bin/installDeps.sh $* || exit 1
 echo "Started Etherpad..."
 
 SCRIPTPATH=`pwd -P`
-node $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*
+$NODEJS $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*

--- a/bin/debugRun.sh
+++ b/bin/debugRun.sh
@@ -3,6 +3,9 @@
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
 
+#Parse settings.json
+eval $(python parsejson.py)
+
 #Was this script started in the bin folder? if yes move out
 if [ -d "../bin" ]; then
   cd "../"
@@ -11,18 +14,18 @@ fi
 #prepare the enviroment
 bin/installDeps.sh || exit 1
 
-hash node-inspector > /dev/null 2>&1 || { 
+hash node-inspector > /dev/null 2>&1 || {
   echo "You need to install node-inspector to run the tests!" >&2
   echo "You can install it with npm" >&2
   echo "Run: npm install -g node-inspector" >&2
-  exit 1 
+  exit 1
 }
 
 node-inspector &
 
 echo "If you are new to node-inspector, take a look at this video: http://youtu.be/AOnK3NVnxL8"
 
-node --debug node_modules/ep_etherpad-lite/node/server.js $*
+$NODEJS --debug node_modules/ep_etherpad-lite/node/server.js $*
 
-#kill node-inspector before ending 
+#kill node-inspector before ending
 kill $!

--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -3,6 +3,9 @@
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
 
+#Parse settings.json
+eval $(python parsejson.py)
+
 #Was this script started in the bin folder? if yes move out
 if [ -d "../bin" ]; then
   cd "../"
@@ -24,7 +27,7 @@ hash curl > /dev/null 2>&1 || {
 
 #Is node installed?
 #not checking io.js, default installation creates a symbolic link to node
-hash node > /dev/null 2>&1 || {
+hash $NODEJS > /dev/null 2>&1 || {
   echo "Please install node.js ( http://nodejs.org )" >&2
   exit 1
 }
@@ -44,7 +47,7 @@ if [ $(echo $NPM_MAIN_VERSION) = "0" ]; then
 fi
 
 #check node version
-NODE_VERSION=$(node --version)
+NODE_VERSION=$($NODEJS --version)
 NODE_V_MINOR=$(echo $NODE_VERSION | cut -d "." -f 1-2)
 NODE_V_MAIN=$(echo $NODE_VERSION | cut -d "." -f 1)
 #iojs version checking added

--- a/bin/parsejson.py
+++ b/bin/parsejson.py
@@ -1,0 +1,43 @@
+import json
+import re
+
+# Regular expression for comments
+comment_re = re.compile(
+    '(^)?[^\S\n]*/(?:\*(.*?)\*/[^\S\n]*|/[^\n]*)($)?',
+    re.DOTALL | re.MULTILINE
+)
+
+def parse_json(filename):
+    """ Parse a JSON file
+        First remove comments and then use the json module package
+        Comments look like :
+            // ...
+        or
+            /*
+            ...
+            */
+    """
+    with open(filename) as f:
+        content = ''.join(f.readlines())
+
+        ## Looking for comments
+        match = comment_re.search(content)
+        while match:
+            # single line comment
+            content = content[:match.start()] + content[match.end():]
+            match = comment_re.search(content)
+
+
+        #print content
+
+        # Return json file
+        return json.loads(content)
+
+if __name__ == '__main__':
+    f = '../settings.json'
+    data = parse_json(f)
+    print "LOG="+data['log']
+    print "ERROR_HANDLING="+str(data['errorHandling'])
+    print "EMAIL_ADDRESS="+data['emailAddress']
+    print "TIME_BETWEEN_EMAILS="+str(data['timeBetweenEmails'])
+    print "NODEJS="+data['nodejs']

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,6 +3,9 @@
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
 
+#Parse settings.json
+eval $(python parsejson.py)
+
 #Was this script started in the bin folder? if yes move out
 if [ -d "../bin" ]; then
   cd "../"
@@ -35,5 +38,5 @@ bin/installDeps.sh $* || exit 1
 echo "Started Etherpad..."
 
 SCRIPTPATH=`pwd -P`
-node $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*
+$NODEJS $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*
 

--- a/bin/safeRun.sh
+++ b/bin/safeRun.sh
@@ -2,24 +2,18 @@
 
 #This script ensures that ep-lite is automatically restarting after an error happens
 
-#Handling Errors
-# 0 silent
-# 1 email
-ERROR_HANDLING=0
-# Your email address which should recieve the error messages
-EMAIL_ADDRESS="no-reply@example.com"
-# Sets the minimun amount of time betweens the sending of error emails. 
-# This ensures you not get spamed while a endless reboot loop 
-# It's the time in seconds
-TIME_BETWEEN_EMAILS=600 # 10 minutes
-
 # DON'T EDIT AFTER THIS LINE
-
-LAST_EMAIL_SEND=0
-LOG="$1"
 
 #Move to the folder where ep-lite is installed
 cd `dirname $0`
+
+#Parse settings.json
+eval $(python parsejson.py)
+
+LAST_EMAIL_SEND=0
+if [ -z "$LOG" ]; then
+  LOG="$1"
+fi
 
 #Was this script started in the bin folder? if yes move out
 if [ -d "../bin" ]; then
@@ -32,14 +26,14 @@ if [ -z "${LOG}" ]; then
   exit 1
 fi
 
-shift
+[ "$#" -gt 0 ] && shift
 while [ 1 ]
 do
   #try to touch the file if it doesn't exist
   if [ ! -f ${LOG} ]; then
     touch ${LOG} || ( echo "Logfile '${LOG}' is not writeable" && exit 1 )
   fi
-  
+
   #check if the file is writeable
   if [ ! -w ${LOG} ]; then
     echo "Logfile '${LOG}' is not writeable"
@@ -48,21 +42,21 @@ do
 
   #start the application
   bin/run.sh $@ >>${LOG} 2>>${LOG}
-  
+
   #Send email
   if [ $ERROR_HANDLING = 1 ]; then
     TIME_NOW=$(date +%s)
     TIME_SINCE_LAST_SEND=$(($TIME_NOW - $LAST_EMAIL_SEND))
-    
+
     if [ $TIME_SINCE_LAST_SEND -gt $TIME_BETWEEN_EMAILS ]; then
       printf "Server was restarted at: $(date)\nThe last 50 lines of the log before the error happens:\n $(tail -n 50 ${LOG})" | mail -s "Pad Server was restarted" $EMAIL_ADDRESS
-      
+
       LAST_EMAIL_SEND=$TIME_NOW
     fi
   fi
-  
+
   echo "RESTART!" >>${LOG}
-  
+
   #Sleep 10 seconds before restart
   sleep 10
 done

--- a/settings.json.template
+++ b/settings.json.template
@@ -48,6 +48,25 @@
                   },
   */
 
+  //Handling errors
+  //0 silent
+  //1 email
+  "errorHandling" : 0,
+
+  //Your email adress which should receive error messages
+  "emailAddress" : "no-reply@example.com",
+
+  //Sets the minimun amount of time betweens the sending of error emails.
+  //This ensures you not get spamed while a endless reboot loop
+  //It's the time in seconds
+  "timeBetweenEmails" : 600, // 10 minutes
+
+  //Node.js binary file
+  "nodejs" : "/usr/bin/node",
+
+  //Logfile (if no specified, define it as a parameter at program start)
+  "log" : "/var/log/etherpad-lite.log",
+
   //the default text of a pad
   "defaultPadText" : "Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at http:\/\/etherpad.org\n",
 

--- a/settings.json.template
+++ b/settings.json.template
@@ -62,10 +62,10 @@
   "timeBetweenEmails" : 600, // 10 minutes
 
   //Node.js binary file
-  "nodejs" : "/usr/bin/node",
+  "nodejs" : "node",
 
   //Logfile (if no specified, define it as a parameter at program start)
-  "log" : "/var/log/etherpad-lite.log",
+  "log" : "etherpad-lite.log",
 
   //the default text of a pad
   "defaultPadText" : "Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at http:\/\/etherpad.org\n",


### PR DESCRIPTION
If etherpad-lite is cloned to a server and the bin/safeRun.sh is used, then the variables should be excluded from git. So I created a configuration file where the variables are stored. Additional the logfile and the nodejs binary can be specified on that configuration too.

The new file is something like that (an example exists):
<pre>
# Handling Errors
# 0 silent
# 1 email
ERROR_HANDLING=0

# Your email address which should recieve the error messages
EMAIL_ADDRESS="no-reply@example.com"

# Sets the minimun amount of time betweens the sending of error emails. 
# This ensures you not get spamed while a endless reboot loop 
# It's the time in seconds
TIME_BETWEEN_EMAILS=600 # 10 minutes

# Node.js binary file
NODEJS=/usr/bin/nodejs

# Logfile (if not specified, define it as a parameter at program start).
LOG="$HOME/etherpad-lite.log"
</pre>