### PR TITLE
Revert "Adding missing code to make toolbar be fixed on top/bottom of the screen for iOS devices."

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -216,10 +216,6 @@ li[data-key=showusers] > a #online_count {
   right: 0px;
   bottom: 0px;
   z-index: 1;
-
-  /* Required to fix toolbar on top/bottom of the screen on iOS: */
-  overflow: scroll;
-  -webkit-overflow-scrolling: touch;
 }
 #editorcontainer iframe {
   height: 100%;


### PR DESCRIPTION
This reverts commit 8a0a1a65b1e9594e5e3bee2a73c7690c0589a008.

This commit needs to be reverted because it causes desktop browsers to show a duplicate, and useless, scroll bar for the editor window. Seems cool to add support for iOS, but let us not mess up desktop browsers in the process.