### PR TITLE
Fix #2772.

### DIFF
--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -139,7 +139,14 @@ Called from: src/static/js/ace2_inner.js
 
 Things in context: None
 
-The return value of this hook will add elements into the "lineMarkerAttribute" category, making the aceDomLineProcessLineAttributes hook (documented below) call for those elements.
+The return value of this hook will add elements into the "lineMarkerAttribute" category, making the aceDomLineProcessLineAttributes hook (documented below) call for those elements. This hook is usually used with aceRegisterLineAttributes hook (documented below).
+
+## aceRegisterLineAttributes
+Called from: src/static/js/AttributeManager.js
+
+Things in context: None
+
+Similar to `aceRegisterBlockElements`, but here instead of HTML tags the return value of this hook should be an array of attribute names used by the plugin when calling `AttributeManager.setAttributeOnLine` and `AttributeManager.removeAttributeOnLine`.
 
 ## aceInitialized
 Called from: src/static/js/ace2_inner.js


### PR DESCRIPTION
Create new hook `aceRegisterLineAttributes` to have a list of all line attributes used by Etherpad and the plugins.

This PR fixes #2772 but might impact other plugins that call `AttributeManager.removeAttributeOnLine()`. This will only happen if:
1. line has two line attributes (one being the attribute defined by plugin) __and__
2. user removes line attribute not defined by the plugin (remove list or outdent, for example).

To fix the plugin: simply define the hook `aceRegisterLineAttributes`.