### PR TITLE
Guarding against null forwards from composed changesets

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1362,8 +1362,10 @@ function handleChangesetRequest(client, message)
       //build the requested rough changesets and send them back
       getChangesetInfo(padIds.padId, start, end, granularity, function(err, changesetInfo)
       {
-        if(err) return console.error('Error while handling a changeset request for '+padIds.padId, err, message.data);
-
+	if(err) {
+		stats.meter('failedChangesets').mark();
+		return console.error('Error while handling a changeset request for '+padIds.padId, err, message.data);
+	}
         var data = changesetInfo;
         data.requestID = message.data.requestID;
 
@@ -1485,6 +1487,9 @@ function getChangesetInfo(padId, startNum, endNum, granularity, callback)
         }
 
         var forwards = composedChangesets[compositeStart + "/" + compositeEnd];
+	if (forwards == null) {
+		return callback(new Error("Unable to retrieve composed changesets"));
+	}
         var backwards = Changeset.inverse(forwards, lines.textlines, lines.alines, pad.apool());
 
         Changeset.mutateAttributionLines(forwards, lines.alines, pad.apool());


### PR DESCRIPTION
Hi,

This is a pull request to prevent graceful shutdowns from a null *forwards* value in *PadMessageHandler.js*. It checks *forwards* for a null value and marks the *failedChangesets* stat value if an error is found.

We encoutered this error several time, using etherpad-lite 1.5.6 with a mysql database.

```
[2015-09-29 11:31:30.424] [ERROR] console - Error: Not a exports: null
at Object.error (/home/webapps/etherpad/src/static/js/Changeset.js:39:11)
at Object.exports.unpack (/home/webapps/etherpad/src/static/js/Changeset.js:874:13)
at Object.exports.inverse (/home/webapps/etherpad/src/static/js/Changeset.js:1880:26)
at async.series.callback.forwardsChangesets (/home/webapps/etherpad/src/node/handler/PadMessageHandler.js:1488:35)
at /home/webapps/etherpad/src/node_modules/async/lib/async.js:610:21
at /home/webapps/etherpad/src/node_modules/async/lib/async.js:249:17
at iterate (/home/webapps/etherpad/src/node_modules/async/lib/async.js:149:13)
at /home/webapps/etherpad/src/node_modules/async/lib/async.js:160:25
at /home/webapps/etherpad/src/node_modules/async/lib/async.js:251:21
at /home/webapps/etherpad/src/node_modules/async/lib/async.js:615:34
```

Thanks you for considering this request.