### PR TITLE
Get git commit hash even if the repo only points to a bare repo.

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -218,8 +218,14 @@ exports.getGitCommit = function() {
   try
   {
     var rootPath = path.resolve(npm.dir, '..');
-    var ref = fs.readFileSync(rootPath + "/.git/HEAD", "utf-8");
-    var refPath = rootPath + "/.git/" + ref.substring(5, ref.indexOf("\n"));
+    if (fs.lstatSync(rootPath + '/.git').isFile()) {
+      rootPath = fs.readFileSync(rootPath + '/.git', "utf8");
+      rootPath = rootPath.split(' ').pop().trim();
+    } else {
+      rootPath += '/.git';
+    }
+    var ref = fs.readFileSync(rootPath + "/HEAD", "utf-8");
+    var refPath = rootPath + "/" + ref.substring(5, ref.indexOf("\n"));
     version = fs.readFileSync(refPath, "utf-8");
     version = version.substring(0, 7);
   }


### PR DESCRIPTION
* Used by https://github.com/debops/ansible-etherpad