### PR TITLE
Allow LibreOffice to be used when exporting a pad

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -86,9 +86,13 @@
      may cause problems during deployment. Set to 0 to disable caching */
   "maxAge" : 21600, // 60 * 60 * 6 = 6 hours
 
-  /* This is the path to the Abiword executable. Setting it to null, disables abiword.
+  /* This is the absolute path to the Abiword executable. Setting it to null, disables abiword.
      Abiword is needed to advanced import/export features of pads*/
   "abiword" : null,
+
+  /* This is the absolute path to the soffice executable. Setting it to null, disables LibreOffice exporting.
+     LibreOffice can be used in lieu of Abiword to export pads */
+  "soffice" : null,
 
   /* This is the path to the Tidy executable. Setting it to null, disables Tidy.
      Tidy is used to improve the quality of exported pads*/

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -123,8 +123,8 @@ function getHTMLFromAtext(pad, atext, authorColors)
         var newLength = props.push(propName);
         anumMap[a] = newLength -1;
 
-        css+=".removed {text-decoration: line-through; " + 
-             "-ms-filter:'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)'; "+ 
+        css+=".removed {text-decoration: line-through; " +
+             "-ms-filter:'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)'; "+
              "filter: alpha(opacity=80); "+
              "opacity: 0.8; "+
              "}\n";
@@ -287,7 +287,7 @@ function getHTMLFromAtext(pad, atext, authorColors)
 
         var s = taker.take(chars);
 
-        //removes the characters with the code 12. Don't know where they come 
+        //removes the characters with the code 12. Don't know where they come
         //from but they break the abiword parser and are completly useless
         s = s.replace(String.fromCharCode(12), "");
 
@@ -401,7 +401,7 @@ function getHTMLFromAtext(pad, atext, authorColors)
           pieces.push('<br><br>');
         }
       }*/
-      else//means we are getting closer to the lowest level of indentation or are at the same level 
+      else//means we are getting closer to the lowest level of indentation or are at the same level
       {
         var toClose = lists.length > 0 ? listLevels[listLevels.length - 2] - line.listLevel : 0
         if( toClose > 0){
@@ -455,7 +455,7 @@ function getHTMLFromAtext(pad, atext, authorColors)
       }
     }
   }
-  
+
   for (var k = lists.length - 1; k >= 0; k--)
   {
     if(lists[k][1] == "number")
@@ -484,14 +484,17 @@ exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
         stylesForExportCSS += css;
       });
       // Core inclusion of head etc.
-      var head = 
-        (noDocType ? '' : '<!doctype html>\n') + 
-        '<html lang="en">\n' + (noDocType ? '' : '<head>\n' + 
+      var head =
+        (noDocType ? '' : '<!doctype html>\n') +
+        '<html lang="en">\n' + (noDocType ? '' : '<head>\n' +
           '<title>' + Security.escapeHTML(padId) + '</title>\n' +
-          '<meta charset="utf-8">\n' + 
-          '<style> * { font-family: arial, sans-serif;\n' + 
-            'font-size: 13px;\n' + 
-            'line-height: 17px; }' + 
+          '<meta name="generator" content="Etherpad Lite">\n' +
+          '<meta name="author" content="Etherpad Lite">\n' +
+          '<meta name="changedby" content="Etherpad Lite">\n' +
+          '<meta charset="utf-8">\n' +
+          '<style> * { font-family: arial, sans-serif;\n' +
+            'font-size: 13px;\n' +
+            'line-height: 17px; }' +
             'ul.indent { list-style-type: none; }' +
 
             'ol { list-style-type: none; padding-left:0;}' +
@@ -577,8 +580,8 @@ exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
             'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 140px; }' +
             'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 150px; }' +
 
-            stylesForExportCSS + 
-            '</style>\n' + '</head>\n') + 
+            stylesForExportCSS +
+            '</style>\n' + '</head>\n') +
         '<body>';
       var foot = '</body>\n</html>\n';
 

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -488,9 +488,9 @@ exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
         (noDocType ? '' : '<!doctype html>\n') +
         '<html lang="en">\n' + (noDocType ? '' : '<head>\n' +
           '<title>' + Security.escapeHTML(padId) + '</title>\n' +
-          '<meta name="generator" content="Etherpad Lite">\n' +
-          '<meta name="author" content="Etherpad Lite">\n' +
-          '<meta name="changedby" content="Etherpad Lite">\n' +
+          '<meta name="generator" content="Etherpad">\n' +
+          '<meta name="author" content="Etherpad">\n' +
+          '<meta name="changedby" content="Etherpad">\n' +
           '<meta charset="utf-8">\n' +
           '<style> * { font-family: arial, sans-serif;\n' +
             'font-size: 13px;\n' +

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -1,0 +1,93 @@
+/**
+ * Controls the communication with LibreOffice
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var async = require("async");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var settings = require("./Settings");
+var spawn = require("child_process").spawn;
+
+// Conversion tasks will be queued up, so we don't overload the system
+var queue = async.queue(doConvertTask, 1);
+
+/**
+ * Convert a file from one type to another
+ *
+ * @param  {String}     srcFile     The path on disk to convert
+ * @param  {String}     destFile    The path on disk where the converted file should be stored
+ * @param  {String}     type        The type to convert into
+ * @param  {Function}   callback    Standard callback function
+ */
+exports.convertFile = function(srcFile, destFile, type, callback) {
+  queue.push({"srcFile": srcFile, "destFile": destFile, "type": type, "callback": callback});
+};
+
+function doConvertTask(task, callback) {
+  var tmpDir = os.tmpdir();
+
+  async.series([
+    // Generate a PDF file with LibreOffice
+    function(callback) {
+      var soffice = spawn(settings.soffice, [
+        '--headless',
+        '--invisible',
+        '--nologo',
+        '--nolockcheck',
+        '--convert-to', task.type,
+        task.srcFile,
+        '--outdir', tmpDir
+      ]);
+
+      var stdoutBuffer = '';
+
+      // Delegate the processing of stdout to another function
+      soffice.stdout.on('data', function(data) {
+        stdoutBuffer += data.toString();
+      });
+
+      // Append error messages to the buffer
+      soffice.stderr.on('data', function(data) {
+        stdoutBuffer += data.toString();
+      });
+
+      // Throw an exception if libreoffice failed
+      soffice.on('exit', function(code) {
+        if (code != 0) {
+          return callback("LibreOffice died with exit code " + code + " and message: " + stdoutBuffer);
+        }
+
+        callback();
+      })
+    },
+
+    // Move the PDF file to the correct place
+    function(callback) {
+      var filename = path.basename(task.srcFile);
+      var pdfFilename = filename.substr(0, filename.lastIndexOf('.')) + '.' + task.type;
+      var pdfPath = path.join(tmpDir, pdfFilename);
+      fs.rename(pdfPath, task.destFile, callback);
+    }
+  ], function(err) {
+    // Invoke the callback for the local queue
+    callback();
+
+    // Invoke the callback for the task
+    task.callback(err);
+  });
+}

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -153,6 +153,11 @@ exports.minify = true;
 exports.abiword = null;
 
 /**
+ * The path of the libreoffice executable
+ */
+exports.soffice = null;
+
+/**
  * The path of the tidy executable
  */
 exports.tidyHtml = null;


### PR DESCRIPTION
This commit adds support for LibreOffice when exporting a pad to doc, pdf, ..
It also cleans up some export logic when exporting to txt.

This is similar as what https://github.com/ether/etherpad-lite/pull/2783/files#diff-d7655657171b783c2bc082522988848e is achieving but it's more complete as it still supports PDF.