### PR TITLE
Allow plugins handle "esc" key event

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3641,12 +3641,6 @@ function Ace2Inner(){
     var altKey = evt.altKey;
     var shiftKey = evt.shiftKey;
 
-    // prevent ESC key
-    if (keyCode == 27)
-    {
-      evt.preventDefault();
-      return;
-    }
     // Is caret potentially hidden by the chat button?
     var myselection = document.getSelection(); // get the current caret selection
     var caretOffsetTop = myselection.focusNode.parentNode.offsetTop | myselection.focusNode.offsetTop; // get the carets selection offset in px IE 214
@@ -3837,6 +3831,15 @@ function Ace2Inner(){
           {
             outerWin.scrollBy(-100, 0);
           }, 0);
+          specialHandled = true;
+        }
+        if ((!specialHandled) && isTypeForSpecialKey && keyCode == 27)
+        {
+          // prevent esc key;
+          // in mozilla versions 14-19 avoid reconnecting pad.
+
+          fastIncorp(4);
+          evt.preventDefault();
           specialHandled = true;
         }
         if ((!specialHandled) && isTypeForCmdKey && String.fromCharCode(which).toLowerCase() == "s" && (evt.metaKey || evt.ctrlKey) && !evt.altKey) /* Do a saved revision on ctrl S */


### PR DESCRIPTION
PR #984 fixed an issue with "esc" on older versions of Firefox (15-19), but avoided the key event to be sent to plugins on aceKeyEvent.
This issue was fixed in Firefox versions 20 and above. 
With this commit we keep the fix for the older Firefox versions, besides to allow to handle "ESC" by plugins.

More details about this issue :
 http://blog.ffextensionguru.com/2013/01/11/changes-to-esc-key-behavior/

This was tested in Firefox 15, 20, 41 for Linux.
