### PR TITLE
Added variables for APIKEY, SESSIONKEY and plugin initialization file into settings.json

### DIFF
--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -24,17 +24,18 @@ var fs = require("fs");
 var api = require("../db/API");
 var padManager = require("../db/PadManager");
 var randomString = require("../utils/randomstring");
+var settings = require("../utils/Settings");
 
 //ensure we have an apikey
 var apikey = null;
 try
 {
-  apikey = fs.readFileSync("./APIKEY.txt","utf8");
+  apikey = fs.readFileSync(settings.apiKeyFile,"utf8");
 }
 catch(e)
 {
   apikey = randomString(32);
-  fs.writeFileSync("./APIKEY.txt",apikey,"utf8");
+  fs.writeFileSync(settings.apiKeyFile,apikey,"utf8");
 }
 
 //a list of all functions

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -80,6 +80,10 @@ exports.dbType = "dirty";
  */
 exports.dbSettings = { "filename" : path.join(exports.root, "dirty.db") };
 
+exports.sessionKeyFile = "./SESSIONKEY.txt";
+exports.apiKeyFile = "./APIKEY.txt";
+exports.pluginsInitializedFile = "./.ep_plugins_initialized";
+
 /**
  * The default Text of a new pad
  */
@@ -331,10 +335,10 @@ exports.reloadSettings = function reloadSettings() {
 
   if (!exports.sessionKey) {
     try {
-      exports.sessionKey = fs.readFileSync("./SESSIONKEY.txt","utf8");
+      exports.sessionKey = fs.readFileSync(exports.sessionKeyFile,"utf8");
     } catch(e) {
       exports.sessionKey = randomString(32);
-      fs.writeFileSync("./SESSIONKEY.txt",exports.sessionKey,"utf8");
+      fs.writeFileSync(exports.sessionKeyFile,exports.sessionKey,"utf8");
     }
   } else {
     console.warn("Declaring the sessionKey in the settings.json is deprecated. This value is auto-generated now. Please remove the setting from the file.");

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -6,6 +6,7 @@ var fs = require("fs");
 var tsort = require("./tsort");
 var util = require("util");
 var _ = require("underscore");
+var settings = require("../../../node/utils/Settings");
 
 var pluginUtils = require('./shared');
 
@@ -59,10 +60,10 @@ exports.callInit = function (cb) {
     Object.keys(exports.plugins),
     function (plugin_name, cb) {
       var plugin = exports.plugins[plugin_name];
-      fs.stat(path.normalize(path.join(plugin.package.path, ".ep_initialized")), function (err, stats) {
+      fs.stat(path.normalize(settings.pluginsInitializedFile), function (err, stats) {
         if (err) {
           async.waterfall([
-            function (cb) { fs.writeFile(path.normalize(path.join(plugin.package.path, ".ep_initialized")), 'done', cb); },
+            function (cb) { fs.writeFile(path.normalize(settings.pluginsInitializedFile), 'done', cb); },
             function (cb) { hooks.aCallAll("init_" + plugin_name, {}, cb); },
             cb,
           ]);


### PR DESCRIPTION
This allows to run etherpad-lite without touching files in its directory, which is good when it is installed by a package in the read-only location.
