### PR TITLE
added setting to make author text colored in read only

### DIFF
--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -24,6 +24,7 @@ var Security = require('ep_etherpad-lite/static/js/security');
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
 var _analyzeLine = require('./ExportHelper')._analyzeLine;
 var _encodeWhitespace = require('./ExportHelper')._encodeWhitespace;
+var markAuthorsReadOnly = require('./Settings').markAuthorsReadOnly;
 
 function getPadHTML(pad, revNum, callback)
 {
@@ -54,7 +55,19 @@ function getPadHTML(pad, revNum, callback)
   function (callback)
   {
     html = getHTMLFromAtext(pad, atext);
-    callback(null);
+
+    if (markAuthorsReadOnly) {
+      pad.getAllAuthorColors(function(err, authorColors){
+        if(err){
+          return callback(err);
+        }
+
+		html = getHTMLFromAtext(pad, atext, authorColors);
+	    callback(null);
+      });
+    } else {
+      callback(null);
+    }
   }],
   // run final callback
 

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -251,6 +251,12 @@ exports.getEpVersion = function() {
   return require('ep_etherpad-lite/package.json').version;
 }
 
+/**
+ * If set to true, author text will be colored in read only mode
+ * @type {boolean}
+ */
+exports.markAuthorsReadOnly = false;
+
 exports.reloadSettings = function reloadSettings() {
   // Discover where the settings file lives
   var settingsFilename = argv.settings || "settings.json";


### PR DESCRIPTION
Added setting `markAuthorsReadOnly` to settings. If set to `true` text will be colored by author colors in read-only mode.
