### PR TITLE
aceEditorCSS hook to allow absolute paths to resources to include external CSS

### DIFF
--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -111,7 +111,7 @@ Called from: src/static/js/ace.js
 
 Things in context: None
 
-This hook is provided to allow custom CSS files to be loaded. The return value should be an array of paths relative to the plugins directory.
+This hook is provided to allow custom CSS files to be loaded. The return value should be an array of resource urls or paths relative to the plugins directory.
 
 ## aceInitInnerdocbodyHead
 Called from: src/static/js/ace.js

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -229,7 +229,12 @@ function Ace2Editor()
       $$INCLUDE_CSS("../static/css/pad.css");
       $$INCLUDE_CSS("../static/custom/pad.css");
 
-      var additionalCSS = _(hooks.callAll("aceEditorCSS")).map(function(path){ return '../static/plugins/' + path });
+      var additionalCSS = _(hooks.callAll("aceEditorCSS")).map(function(path){
+        if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
+          return path;
+        }
+        return '../static/plugins/' + path;
+      });
       includedCSS = includedCSS.concat(additionalCSS);
 
       pushStyleTagsFor(iframeHTML, includedCSS);
@@ -308,7 +313,12 @@ window.onload = function () {\n\
       $$INCLUDE_CSS("../static/custom/pad.css");
 
 
-      var additionalCSS = _(hooks.callAll("aceEditorCSS")).map(function(path){ return '../static/plugins/' + path });
+      var additionalCSS = _(hooks.callAll("aceEditorCSS")).map(function(path){
+        if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
+          return path;
+        }
+        return '../static/plugins/' + path }
+      );
       includedCSS = includedCSS.concat(additionalCSS);
 
       pushStyleTagsFor(outerHTML, includedCSS);


### PR DESCRIPTION
``aceEditorCSS`` hook to allow absolute paths to resources to include external CSS. 
Initially developed for https://github.com/tiblu/ep_themes_ext
This patch was the only way I could think of to make loading of externals stylesheets work without style flicker.