### PR TITLE
set charset for mysql connection in settings.json

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -47,7 +47,8 @@
                     "user"    : "root",
                     "host"    : "localhost",
                     "password": "",
-                    "database": "store"
+                    "database": "store",
+                    "charset" : "utf8mb4"
                   },
   */
 


### PR DESCRIPTION
See https://github.com/ether/etherpad-lite/issues/2516#issuecomment-164768811
Maybe we should output a warning on console if this parameter isn't set?!

This pull request is related to my change for ueberDB:
https://github.com/Pita/ueberDB/pull/87