### PR TITLE
Limit padname input field to 50 characters

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -163,7 +163,7 @@
                 <buttOn id="button" onclick="go2Random()" data-l10n-id="index.newPad"></button>
                 <label id="label" for="padname" data-l10n-id="index.createOpenPad"></label> 
                 <form action="#" onsubmit="go2Name();return false;"> 
-                    <input type="text" id="padname" autofocus x-webkit-speech> 
+                    <input type="text" id="padname" maxlength="50" autofocus x-webkit-speech> 
                     <button type="submit">OK</button>
                 </form>
             </div>


### PR DESCRIPTION
It seems good to limit the padname length in the input field. As I could check, the max length accepted is 50 characters.

If this config depends on other server/installation configs, please let me know.