### PR TITLE
Use require("ueberdb2") for requiring new version of ueberDB

### DIFF
--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-var ueberDB = require("ueberDB");
+var ueberDB = require("ueberdb2");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
 


### PR DESCRIPTION
A recent commit uses a new version of UeberDB (239f517a). This causes the error reported in issue #2869.