### PR TITLE
Use exec to switch to node process

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -35,5 +35,5 @@ bin/installDeps.sh $* || exit 1
 echo "Started Etherpad..."
 
 SCRIPTPATH=`pwd -P`
-node $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*
+exec node $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*
 


### PR DESCRIPTION
At the end of run, `exec` should be used to switch to the node process.  That way node will take over the pid of `sh run.sh`, making it easier to monitor and daemonize the server. 

```
    exec [command [arg ...]]
             Unless command is omitted, the shell process is replaced with the
             specified program (which must be a real program, not a shell
             built-in command or function).  Any redirections on the exec com-
             mand are marked as permanent, so that they are not undone when
             the exec command finishes.
```