### PR TITLE
Fix text lines mutator

### DIFF
--- a/src/tests/frontend/specs/easysync.js
+++ b/src/tests/frontend/specs/easysync.js
@@ -188,6 +188,11 @@ describe('easysync', function () {
     ['insert', 'a'],
     ['insert', 'c\n', 1],
   ], ['ac\n']);
+  runMutationTest(10, ['\n'], [
+    ['remove', 1, 1, '\n'],
+    ['insert', 'a\n', 1],
+    ['insert', 'c'],
+  ], ['a\n', 'c']); // TODO find out if c must have a newline because of unknown constraints
 
   const poolOrArray = (attribs) => {
     if (attribs.getAttrib) {

--- a/src/tests/frontend/specs/easysync.js
+++ b/src/tests/frontend/specs/easysync.js
@@ -179,16 +179,28 @@ describe('easysync', function () {
   ], ['banana\n', 'cabbage\n', 'duffle\n']);
 
   // #2836 regressions
-  runMutationTest(8, ['\n'], [
+  runMutationTest(8, ['\n', 'foo\n', '\n'], [
+    ['remove', 1, 1, '\n'],
+    ['skip', 4, 1, false],
+    ['remove', 1, 1, '\n'],
+    ['insert', 'c'],
+  ], ['foo\n', 'c']);
+  runMutationTest(9, ['\n', 'foo\n', '\n'], [
+    ['remove', 1, 1, '\n'],
+    ['skip', 3, 0, false],
+    ['remove', 2, 2, '\n\n'],
+    ['insert', 'c'],
+  ], ['fooc']);
+  runMutationTest(10, ['\n'], [
     ['remove', 1, 1, '\n'],
     ['insert', 'c', 0],
-  ], ['c']);
-  runMutationTest(9, ['\n'], [
+  ], ['c']); // TODO find out if c must have a newline because of unknown constraints
+  runMutationTest(11, ['\n'], [
     ['remove', 1, 1, '\n'],
     ['insert', 'a'],
     ['insert', 'c\n', 1],
   ], ['ac\n']);
-  runMutationTest(10, ['\n'], [
+  runMutationTest(12, ['\n'], [
     ['remove', 1, 1, '\n'],
     ['insert', 'a\n', 1],
     ['insert', 'c'],

--- a/src/tests/frontend/specs/easysync.js
+++ b/src/tests/frontend/specs/easysync.js
@@ -178,6 +178,17 @@ describe('easysync', function () {
     ['skip', 1, 1, true],
   ], ['banana\n', 'cabbage\n', 'duffle\n']);
 
+  // #2836 regressions
+  runMutationTest(8, ['\n'], [
+    ['remove', 1, 1, '\n'],
+    ['insert', 'c', 0],
+  ], ['c']);
+  runMutationTest(9, ['\n'], [
+    ['remove', 1, 1, '\n'],
+    ['insert', 'a'],
+    ['insert', 'c\n', 1],
+  ], ['ac\n']);
+
   const poolOrArray = (attribs) => {
     if (attribs.getAttrib) {
       return attribs; // it's already an attrib pool


### PR DESCRIPTION
This should address https://github.com/ether/etherpad-lite/issues/2836 but please do not merge this yet!
As you can see there are some "TODOs" left.

The textLinesMutator gets lines of text and a changeset and applies the latter to the former. It should work for attribution and normal text lines. Sometimes when there are no lines left but the changeset is not finished it will crash.

I am not sure I did this right, but I will try to solve the remaining TODOs. I want to ask if anyone has a good idea how to test this stuff. It is used in the timeslider and on clients before submitting changesets. What I need is working test data:
- take a running epl instance and dozens of html (from different revisions) and etherpad exports
- the html exports represent text lines
- randomly take two html exports and calculate composed changesets in both directions using the revisions from etherpad exports
- apply the composed changesets to the html export's lines and test for equality with the other html export

Does this sound reasonable to you? Any other ideas how to be sure this does not break anything?
