### PR TITLE
Update author when removing line attribute from line

### DIFF
--- a/src/static/js/AttributeManager.js
+++ b/src/static/js/AttributeManager.js
@@ -278,6 +278,9 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
      if (attrib[0] === attributeName && (!attributeValue || attrib[0] === attributeValue)){
        found = true;
        return [attributeName, ''];
+     }else if (attrib[0] === 'author'){
+       // update last author to make changes to line attributes on this line
+       return [attributeName, this.author];
      }
      return attrib;
    });


### PR DESCRIPTION
This avoids raising error 'Trying to submit changes as another author in
changeset' when 2 authors change line attributes of the same line. This
fixes issue #2925.