### PR TITLE
Pass through the "item" parameter to registerAceCommand callbacks.

### DIFF
--- a/doc/api/editbar.md
+++ b/doc/api/editbar.md
@@ -12,7 +12,7 @@ Shows the dropdown `div.popup` whose `id` equals `dropdown`.
 Register a handler for a specific command. Commands are fired if the corresponding button is clicked or the corresponding select is changed.
 
 ## registerAceCommand(cmd, callback)
-Creates an ace callstack and calls the callback with an ace instance: `callback(cmd, ace)`.
+Creates an ace callstack and calls the callback with an ace instance (and a toolbar item, if applicable): `callback(cmd, ace, item)`.
 
 Example:
 ```

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -242,9 +242,9 @@ var padeditbar = (function()
       });
     },
     registerAceCommand: function (cmd, callback) {
-      this.registerCommand(cmd, function (cmd, ace) {
+      this.registerCommand(cmd, function (cmd, ace, item) {
         ace.callWithAce(function (ace) {
-          callback(cmd, ace);
+          callback(cmd, ace, item);
         }, cmd, true);
       });
     },


### PR DESCRIPTION
Passing through the item parameter makes it easier to have one registerAceCommand callback that handles multiple toolbar items in a plugin and makes the interface more similar between registerCommand() and registerAceCommand().
