### PR TITLE
Remove sessions script

### DIFF
--- a/bin/removeOldPadData.js
+++ b/bin/removeOldPadData.js
@@ -1,0 +1,79 @@
+/*
+  This is a debug tool. It removes old pad data from a couch database
+*/
+
+//get the padID
+var padId = process.argv[2];
+
+//initalize the variables
+var db, settings, keys, values;
+var npm = require("../src/node_modules/npm");
+var async = require("../src/node_modules/async");
+
+async.series([
+  //load npm
+  function(callback) {
+    npm.load({}, function(er) {
+      callback(er);
+    })
+  },
+  //load modules
+  function(callback) {
+    settings = require('../src/node/utils/Settings');
+    db = require('../src/node/db/DB');
+
+    //intallize the database
+    db.init(callback);
+  },
+  //get the session info
+  function (callback){
+    db.db.findKeys("pad:*",null, function(err, dbkeys){
+      keys = dbkeys;
+      callback();
+    });
+  },
+  function (callback)
+  {
+    values = {};
+    async.eachSeries(keys, function(key, cb){
+      db.db.get(key, function(err, value){
+        // console.log("err", err);
+        // console.log("value", key, value);
+        values[key] = value;
+        cb();
+      });
+    }, function(){
+      callback();
+    });
+  },
+  // Removing all old pad data record
+  function (callback){
+    async.each(keys, function(key, cb){
+      console.log("Removing", key);
+        db.db.remove(key, function(err){
+        if(err) console.log("err", err);
+        cb();
+      });
+    }, function(){
+      callback();
+    });
+  },
+  // Add latest data back in for a pad
+  function (callback){
+    async.eachSeries(keys, function(key, cb){
+      console.log("Adding data back in for", key);
+      db.db.set(key, values[key]);
+      cb();
+    }, function(){
+      callback();
+    });
+  }
+], function (err)
+{
+  if(err) throw err;
+  else{
+    console.log("finished");
+    process.exit(0);
+  }
+});
+

--- a/bin/removeOldPadData.js
+++ b/bin/removeOldPadData.js
@@ -1,5 +1,6 @@
 /*
-  This is a debug tool. It removes old pad data from a couch database
+  This is a debug tool. It removes old pad data from a non-dirty database
+  It also removes previous pad history so use it carefully.
 */
 
 //get the padID

--- a/bin/removeOldSessions.js
+++ b/bin/removeOldSessions.js
@@ -1,0 +1,87 @@
+/*
+  This is a debug tool. It removes old sessions from a couch database
+*/
+
+/*
+if(process.argv.length != 3)
+{
+  console.error("Use: node bin/checkPad.js $PADID");
+  process.exit(1);
+}
+*/
+
+//get the padID
+var padId = process.argv[2];
+
+//initalize the variables
+var db, settings, keys, values;
+var npm = require("../src/node_modules/npm");
+var async = require("../src/node_modules/async");
+
+async.series([
+  //load npm
+  function(callback) {
+    npm.load({}, function(er) {
+      callback(er);
+    })
+  },
+  //load modules
+  function(callback) {
+    settings = require('../src/node/utils/Settings');
+    db = require('../src/node/db/DB');
+
+    //intallize the database
+    db.init(callback);
+  },
+  //get the session info
+  function (callback){
+    db.db.findKeys("sessionstorage:*",null, function(err, dbkeys){
+      keys = dbkeys;
+      callback();
+    });
+  },
+  function (callback)
+  {
+    values = {};
+    async.eachSeries(keys, function(key, cb){
+      db.db.get(key, function(err, value){
+        // console.log("err", err);
+        // console.log("value", key, value);
+        values[key] = value;
+        cb();
+      });
+    }, function(){
+      callback();
+    });
+  },
+  // Removing a session record
+  function (callback){
+    async.each(keys, function(key, cb){
+      console.log("Removing", key);
+        db.db.remove(key, function(err){
+        if(err) console.log("err", err);
+        cb();
+      });
+    }, function(){
+      callback();
+    });
+  },
+  // Add latest data back in for a session
+  function (callback){
+    async.eachSeries(keys, function(key, cb){
+      console.log("Adding data back in for", key);
+      db.db.set(key, values[key]);
+      cb();
+    }, function(){
+      callback();
+    });
+  }
+], function (err)
+{
+  if(err) throw err;
+  else{
+    console.log("finished");
+    process.exit(0);
+  }
+});
+

--- a/src/package.json
+++ b/src/package.json
@@ -17,7 +17,7 @@
                       "etherpad-require-kernel" : "1.0.9",
                       "resolve"                 : "1.1.6",
                       "socket.io"               : "1.3.7",
-                      "ueberdb2"                : "0.3.0",
+                      "ueberdb2"                : "0.3.1",
                       "express"                 : "4.12.3",
                       "express-session"         : "1.11.1",
                       "cookie-parser"           : "1.3.4",


### PR DESCRIPTION
DO NOT MERGE YET

Contains two scripts:
- One that removes pointless sessions that clutter the database
- One that removes old pad data, this removes the ability to play back pads from the timeslider

Still to do before merge:
- [ ] Discover why so many database entries are made for sessions
- [ ] See if there is a way to remove pad database entries without breaking timeslider functionality
