### PR TITLE
Create hook to register events that won't scroll editor after aceEditEvt

### DIFF
--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -134,6 +134,13 @@ Things in context:
 
 This hook is made available to edit the edit events that might occur when changes are made. Currently you can change the editor information, some of the meanings of the edit, and so on. You can also make internal changes (internal to your plugin) that use the information provided by the edit event.
 
+## aceRegisterNonScrollableEditEvents
+Called from: src/static/js/ace2_inner.js
+
+Things in context: None
+
+When aceEditEvent (documented above) finishes processing the event, it scrolls the viewport to make caret visible to the user, but if you don't want that behavior to happen you can use this hook to register which edit events should not scroll viewport. The return value of this hook should be a list of event names.
+
 ## aceRegisterBlockElements
 Called from: src/static/js/ace2_inner.js
 
@@ -166,11 +173,11 @@ Called from: src/static/js/pad_editbar.js
 Things in context:
 
 1. ace - the ace object that is applied to this editor.
-2. toolbar - Editbar instance. See below for the Editbar documentation.  
+2. toolbar - Editbar instance. See below for the Editbar documentation.
 
 Can be used to register custom actions to the toolbar.
 
-Usage examples: 
+Usage examples:
 
 * [https://github.com/tiblu/ep_authorship_toggle]()
 

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -141,6 +141,13 @@ Things in context: None
 
 When aceEditEvent (documented above) finishes processing the event, it scrolls the viewport to make caret visible to the user, but if you don't want that behavior to happen you can use this hook to register which edit events should not scroll viewport. The return value of this hook should be a list of event names.
 
+Example:
+```
+exports.aceRegisterNonScrollableEditEvents = function(){
+  return [ 'repaginate', 'updatePageCount' ];
+}
+```
+
 ## aceRegisterBlockElements
 Called from: src/static/js/ace2_inner.js
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -369,6 +369,19 @@ function Ace2Inner(){
     return thisAuthor;
   }
 
+  var _nonScrollableEditEvents = {
+    "applyChangesToBase": 1
+  };
+
+  _.each(hooks.callAll('aceRegisterNonScrollableEditEvents'), function(eventType) {
+      _nonScrollableEditEvents[eventType] = 1;
+  });
+
+  function isScrollableEditEvent(eventType)
+  {
+    return !_nonScrollableEditEvents[eventType];
+  }
+
   var currentCallStack = null;
 
   function inCallStack(type, action)
@@ -506,7 +519,7 @@ function Ace2Inner(){
           {
             updateBrowserSelectionFromRep();
           }
-          if ((cs.docTextChanged || cs.userChangedSelection) && cs.type != "applyChangesToBase")
+          if ((cs.docTextChanged || cs.userChangedSelection) && isScrollableEditEvent(cs.type))
           {
             scrollSelectionIntoView();
           }


### PR DESCRIPTION
One of the plugins I use triggers edit events under the hood that might change the text of the pad. This makes the scroll position to change at the end of the event, but I need to prevent this behavior. (Just to give a more concrete example, the plugin paginates the pad -- in batches, to avoid freezing the editor when changing long pads)

One possible solution was to add a new flag to callstack and check for it when going to call `scrollSelectionIntoView`, but I thought that would be too intrusive, so instead I've created a new hook where plugins can register edit events that won't scroll the viewport when event is complete.

Thoughts? Concerns?