### PR TITLE
Added new API call to get all comments from a pad

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -32,6 +32,16 @@ var importHtml = require("../utils/ImportHtml");
 var cleanText = require("./Pad").cleanText;
 var PadDiff = require("../utils/padDiff");
 
+//ensure we have the comments plugin
+var CommentManager = null;
+try
+{
+    CommentManager = require("ep_comments_page/commentManager");
+}
+catch(e)
+{
+    console.info("ep_comments_page module not installed");
+}
 /**********************/
 /**GROUP FUNCTIONS*****/
 /**********************/
@@ -101,12 +111,39 @@ Example returns:
 }
 
 */
-exports.getAttributePool = function (padID, callback) 
+exports.getAttributePool = function (padID, callback)
 {
   getPadSafe(padID, true, function(err, pad)
   {
     if (ERR(err, callback)) return;
     callback(null, {pool: pad.pool});
+  });
+}
+
+/**
+ getPadComments(padID) returns the comments of a pad
+
+ Example returns:
+ {
+  "code":0,
+  "message":"ok",
+  "data": {
+     "comments":[
+     ]
+  }
+ }
+ */
+exports.getPadComments = function (padID, callback)
+{
+    if(!CommentManager) return callback(new customError("ep_comments_page plugin not available", "pluginerror"));
+
+    //get the pad
+  getPadSafe(padID, true, function(err, pad)
+  {
+    if (ERR(err, callback)) return;
+
+      //call comment manager to get the comments from this pad
+      CommentManager.getComments(pad.id, callback);
   });
 }
 
@@ -165,7 +202,7 @@ exports.getRevisionChangeset = function(padID, rev, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     //the client asked for a special revision
     if(rev !== undefined)
     {
@@ -175,12 +212,12 @@ exports.getRevisionChangeset = function(padID, rev, callback)
         callback(new customError("rev is higher than the head revision of the pad","apierror"));
         return;
       }
-      
+
       //get the changeset for this revision
       pad.getRevisionChangeset(rev, function(err, changeset)
       {
         if(ERR(err, callback)) return;
-        
+
         callback(null, changeset);
       })
     }
@@ -198,7 +235,7 @@ exports.getRevisionChangeset = function(padID, rev, callback)
 }
 
 /**
-getText(padID, [rev]) returns the text of a pad 
+getText(padID, [rev]) returns the text of a pad
 
 Example returns:
 
@@ -213,7 +250,7 @@ exports.getText = function(padID, rev, callback)
     callback = rev;
     rev = undefined;
   }
-  
+
   //check if rev is a number
   if(rev !== undefined && typeof rev != "number")
   {
@@ -228,26 +265,26 @@ exports.getText = function(padID, rev, callback)
       return;
     }
   }
-  
+
   //ensure this is not a negativ number
   if(rev !== undefined && rev < 0)
   {
     callback(new customError("rev is a negativ number","apierror"));
     return;
   }
-  
+
   //ensure this is not a float value
   if(rev !== undefined && !is_int(rev))
   {
     callback(new customError("rev is a float value","apierror"));
     return;
   }
-  
+
   //get the pad
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     //the client asked for a special revision
     if(rev !== undefined)
     {
@@ -257,14 +294,14 @@ exports.getText = function(padID, rev, callback)
         callback(new customError("rev is higher than the head revision of the pad","apierror"));
         return;
       }
-      
+
       //get the text of this revision
       pad.getInternalRevisionAText(rev, function(err, atext)
       {
         if(ERR(err, callback)) return;
-        
+
         var data = {text: atext.text};
-        
+
         callback(null, data);
       })
     }
@@ -277,7 +314,7 @@ exports.getText = function(padID, rev, callback)
 }
 
 /**
-setText(padID, text) sets the text of a pad 
+setText(padID, text) sets the text of a pad
 
 Example returns:
 
@@ -286,7 +323,7 @@ Example returns:
 {code: 1, message:"text too long", data: null}
 */
 exports.setText = function(padID, text, callback)
-{    
+{
   //text is required
   if(typeof text != "string")
   {
@@ -298,10 +335,10 @@ exports.setText = function(padID, text, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     //set the text
     pad.setText(text);
-    
+
     //update the clients on the pad
     padMessageHandler.updatePadClients(pad, callback);
   });
@@ -340,7 +377,7 @@ exports.appendText = function(padID, text, callback)
 
 
 /**
-getHTML(padID, [rev]) returns the html of a pad 
+getHTML(padID, [rev]) returns the html of a pad
 
 Example returns:
 
@@ -352,7 +389,7 @@ exports.getHTML = function(padID, rev, callback)
   if(typeof rev == "function")
   {
     callback = rev;
-    rev = undefined; 
+    rev = undefined;
   }
 
   if (rev !== undefined && typeof rev != "number")
@@ -383,7 +420,7 @@ exports.getHTML = function(padID, rev, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     //the client asked for a special revision
     if(rev !== undefined)
     {
@@ -393,8 +430,8 @@ exports.getHTML = function(padID, rev, callback)
         callback(new customError("rev is higher than the head revision of the pad","apierror"));
         return;
       }
-     
-      //get the html of this revision 
+
+      //get the html of this revision
       exportHtml.getPadHTML(pad, rev, function(err, html)
       {
           if(ERR(err, callback)) return;
@@ -491,20 +528,20 @@ exports.getChatHistory = function(padID, start, end, callback)
       return;
     }
   }
-  
+
   //get the pad
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
     var chatHead = pad.chatHead;
-    
+
     // fall back to getting the whole chat-history if a parameter is missing
     if(!start || !end)
     {
     start = 0;
     end = pad.chatHead;
     }
-    
+
     if(start > chatHead)
     {
       callback(new customError("start is higher than the current chatHead","apierror"));
@@ -515,7 +552,7 @@ exports.getChatHistory = function(padID, start, end, callback)
       callback(new customError("end is higher than the current chatHead","apierror"));
       return;
     }
-    
+
     // the the whole message-log and return it to the client
     pad.getChatMessages(start, end,
       function(err, msgs)
@@ -542,7 +579,7 @@ exports.appendChatMessage = function(padID, text, authorID, time, callback)
     callback(new customError("text is no string","apierror"));
     return;
   }
-  
+
   // if time is not an integer value
   if(time === undefined || !is_int(time))
   {
@@ -562,7 +599,7 @@ exports.appendChatMessage = function(padID, text, authorID, time, callback)
 /*****************/
 
 /**
-getRevisionsCount(padID) returns the number of revisions of this pad 
+getRevisionsCount(padID) returns the number of revisions of this pad
 
 Example returns:
 
@@ -575,7 +612,7 @@ exports.getRevisionsCount = function(padID, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     callback(null, {revisions: pad.getHeadRevisionNumber()});
   });
 }
@@ -713,7 +750,7 @@ exports.getLastEdited = function(padID, callback)
 }
 
 /**
-createPad(padName [, text]) creates a new pad in this group 
+createPad(padName [, text]) creates a new pad in this group
 
 Example returns:
 
@@ -721,7 +758,7 @@ Example returns:
 {code: 1, message:"pad does already exist", data: null}
 */
 exports.createPad = function(padID, text, callback)
-{  
+{
   //ensure there is no $ in the padID
   if(padID)
   {
@@ -747,7 +784,7 @@ exports.createPad = function(padID, text, callback)
 }
 
 /**
-deletePad(padID) deletes a pad 
+deletePad(padID) deletes a pad
 
 Example returns:
 
@@ -759,7 +796,7 @@ exports.deletePad = function(padID, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     pad.remove(callback);
   });
 }
@@ -876,7 +913,7 @@ exports.restoreRevision = function (padID, rev, callback)
 };
 
 /**
-copyPad(sourceID, destinationID[, force=false]) copies a pad. If force is true, 
+copyPad(sourceID, destinationID[, force=false]) copies a pad. If force is true,
   the destination will be overwritten if it exists.
 
 Example returns:
@@ -889,13 +926,13 @@ exports.copyPad = function(sourceID, destinationID, force, callback)
   getPadSafe(sourceID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     pad.copy(destinationID, force, callback);
   });
 }
 
 /**
-movePad(sourceID, destinationID[, force=false]) moves a pad. If force is true, 
+movePad(sourceID, destinationID[, force=false]) moves a pad. If force is true,
   the destination will be overwritten if it exists.
 
 Example returns:
@@ -908,7 +945,7 @@ exports.movePad = function(sourceID, destinationID, force, callback)
   getPadSafe(sourceID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     pad.copy(destinationID, force, function(err) {
       if(ERR(err, callback)) return;
       pad.remove(callback);
@@ -916,7 +953,7 @@ exports.movePad = function(sourceID, destinationID, force, callback)
   });
 }
 /**
-getReadOnlyLink(padID) returns the read only link of a pad 
+getReadOnlyLink(padID) returns the read only link of a pad
 
 Example returns:
 
@@ -929,7 +966,7 @@ exports.getReadOnlyID = function(padID, callback)
   getPadSafe(padID, true, function(err)
   {
     if(ERR(err, callback)) return;
-    
+
     //get the readonlyId
     readOnlyManager.getReadOnlyId(padID, function(err, readOnlyId)
     {
@@ -966,7 +1003,7 @@ exports.getPadID = function(roID, callback)
 }
 
 /**
-setPublicStatus(padID, publicStatus) sets a boolean for the public status of a pad 
+setPublicStatus(padID, publicStatus) sets a boolean for the public status of a pad
 
 Example returns:
 
@@ -986,20 +1023,20 @@ exports.setPublicStatus = function(padID, publicStatus, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     //convert string to boolean
     if(typeof publicStatus == "string")
       publicStatus = publicStatus == "true" ? true : false;
-    
+
     //set the password
     pad.setPublicStatus(publicStatus);
-    
+
     callback();
   });
 }
 
 /**
-getPublicStatus(padID) return true of false 
+getPublicStatus(padID) return true of false
 
 Example returns:
 
@@ -1014,18 +1051,18 @@ exports.getPublicStatus = function(padID, callback)
     callback(new customError("You can only get/set the publicStatus of pads that belong to a group","apierror"));
     return;
   }
-  
+
   //get the pad
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     callback(null, {publicStatus: pad.getPublicStatus()});
   });
 }
 
 /**
-setPassword(padID, password) returns ok or a error message 
+setPassword(padID, password) returns ok or a error message
 
 Example returns:
 
@@ -1040,21 +1077,21 @@ exports.setPassword = function(padID, password, callback)
     callback(new customError("You can only get/set the password of pads that belong to a group","apierror"));
     return;
   }
-  
+
   //get the pad
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     //set the password
     pad.setPassword(password == "" ? null : password);
-    
+
     callback();
   });
 }
 
 /**
-isPasswordProtected(padID) returns true or false 
+isPasswordProtected(padID) returns true or false
 
 Example returns:
 
@@ -1074,13 +1111,13 @@ exports.isPasswordProtected = function(padID, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     callback(null, {isPasswordProtected: pad.isPasswordProtected()});
   });
 }
 
 /**
-listAuthorsOfPad(padID) returns an array of authors who contributed to this pad 
+listAuthorsOfPad(padID) returns an array of authors who contributed to this pad
 
 Example returns:
 
@@ -1093,7 +1130,7 @@ exports.listAuthorsOfPad = function(padID, callback)
   getPadSafe(padID, true, function(err, pad)
   {
     if(ERR(err, callback)) return;
-    
+
     callback(null, {authorIDs: pad.getAllAuthors()});
   });
 }
@@ -1185,7 +1222,7 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback){
       return;
     }
   }
- 
+
   //check if rev is a number
   if(endRev !== undefined && typeof endRev != "number")
   {
@@ -1200,28 +1237,28 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback){
       return;
     }
   }
- 
+
   //get the pad
   getPadSafe(padID, true, function(err, pad)
   {
     if(err){
       return callback(err);
     }
- 
+
     try {
       var padDiff = new PadDiff(pad, startRev, endRev);
     } catch(e) {
       return callback({stop:e.message});
     }
     var html, authors;
- 
+
     async.series([
       function(callback){
         padDiff.getHtml(function(err, _html){
           if(err){
             return callback(err);
           }
- 
+
           html = _html;
           callback();
         });
@@ -1231,7 +1268,7 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback){
           if(err){
             return callback(err);
           }
- 
+
           authors = _authors;
           callback();
         });
@@ -1248,7 +1285,7 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback){
 
 //checks if a number is an int
 function is_int(value)
-{ 
+{
   return (parseFloat(value) == parseInt(value)) && !isNaN(value)
 }
 
@@ -1267,19 +1304,19 @@ function getPadSafe(padID, shouldExist, text, callback)
     callback(new customError("padID is not a string","apierror"));
     return;
   }
-  
+
   //check if the padID maches the requirements
   if(!padManager.isValidPadId(padID))
   {
     callback(new customError("padID did not match requirements","apierror"));
     return;
   }
-  
+
   //check if the pad exists
   padManager.doesPadExists(padID, function(err, exists)
   {
     if(ERR(err, callback)) return;
-    
+
     //does not exist, but should
     if(exists == false && shouldExist == true)
     {

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -495,10 +495,62 @@ var version =
   , "restoreRevision"           : ["padID", "rev"]
   , "appendText"                : ["padID", "text"]
   }
+  ,"1.2.14":
+{ "createGroup"               : []
+  , "createGroupIfNotExistsFor" : ["groupMapper"]
+  , "deleteGroup"               : ["groupID"]
+  , "listPads"                  : ["groupID"]
+  , "listAllPads"               : []
+  , "createDiffHTML"            : ["padID", "startRev", "endRev"]
+  , "createPad"                 : ["padID", "text"]
+  , "createGroupPad"            : ["groupID", "padName", "text"]
+  , "createAuthor"              : ["name"]
+  , "createAuthorIfNotExistsFor": ["authorMapper" , "name"]
+  , "listPadsOfAuthor"          : ["authorID"]
+  , "createSession"             : ["groupID", "authorID", "validUntil"]
+  , "deleteSession"             : ["sessionID"]
+  , "getSessionInfo"            : ["sessionID"]
+  , "listSessionsOfGroup"       : ["groupID"]
+  , "listSessionsOfAuthor"      : ["authorID"]
+  , "getText"                   : ["padID", "rev"]
+  , "setText"                   : ["padID", "text"]
+  , "getHTML"                   : ["padID", "rev"]
+  , "setHTML"                   : ["padID", "html"]
+  , "getAttributePool"          : ["padID"]
+  , "getRevisionsCount"         : ["padID"]
+  , "getSavedRevisionsCount"    : ["padID"]
+  , "listSavedRevisions"        : ["padID"]
+  , "saveRevision"              : ["padID", "rev"]
+  , "getRevisionChangeset"      : ["padID", "rev"]
+  , "getLastEdited"             : ["padID"]
+  , "deletePad"                 : ["padID"]
+  , "copyPad"                   : ["sourceID", "destinationID", "force"]
+  , "movePad"                   : ["sourceID", "destinationID", "force"]
+  , "getReadOnlyID"             : ["padID"]
+  , "getPadID"                  : ["roID"]
+  , "setPublicStatus"           : ["padID", "publicStatus"]
+  , "getPublicStatus"           : ["padID"]
+  , "setPassword"               : ["padID", "password"]
+  , "isPasswordProtected"       : ["padID"]
+  , "listAuthorsOfPad"          : ["padID"]
+  , "padUsersCount"             : ["padID"]
+  , "getAuthorName"             : ["authorID"]
+  , "padUsers"                  : ["padID"]
+  , "sendClientsMessage"        : ["padID", "msg"]
+  , "listAllGroups"             : []
+  , "checkToken"                : []
+  , "appendChatMessage"         : ["padID", "text", "authorID", "time"]
+  , "getChatHistory"            : ["padID"]
+  , "getChatHistory"            : ["padID", "start", "end"]
+  , "getChatHead"               : ["padID"]
+  , "restoreRevision"           : ["padID", "rev"]
+  , "appendText"                : ["padID", "text"]
+    , "getPadComments"          : ["padID"]
+}
 };
 
 // set the latest available API version here
-exports.latestApiVersion = '1.2.13';
+exports.latestApiVersion = '1.2.14';
 
 // exports the versions so it can be used by the new Swagger endpoint
 exports.version = version;
@@ -542,7 +594,7 @@ exports.handle = function(apiVersion, functionName, fields, req, res)
     }
   }
 
-  //say goodbye if this is a unkown function
+  //say goodbye if this is a unknown function
   if(!isKnownFunctionname)
   {
     res.send({code: 3, message: "no such function", data: null});
@@ -605,6 +657,11 @@ function callAPI(apiVersion, functionName, fields, req, res)
     else if(err.name == "apierror")
     {
       res.send({code: 1, message: err.message, data: null});
+    }
+    // user trying to make an api call that requires a plugin
+    else if(err.name == "pluginerror")
+    {
+      res.send({code: 3, message: err.message, data: null});
     }
     //an unkown error happend
     else


### PR DESCRIPTION
- Increased API version to 1.2.14 with new function ("getPadComments")
- System checks if the comments plugin is installed, if not returns a new "pluginerror" with a message, so the user knows the plugin is not installed
- If everything goes well the user gets the list of comments through the call 