### PR TITLE
Remove [ and ] from the regexp used by the URL filter.

### DIFF
--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -265,7 +265,7 @@ linestylefilter.getRegexpFilter = function(regExp, tag)
 
 
 linestylefilter.REGEX_WORDCHAR = /[\u0030-\u0039\u0041-\u005A\u0061-\u007A\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\u0100-\u1FFF\u3040-\u9FFF\uF900-\uFDFF\uFE70-\uFEFE\uFF10-\uFF19\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFDC]/;
-linestylefilter.REGEX_URLCHAR = new RegExp('(' + /[-:@a-zA-Z0-9_.,~%+\/\\?=&#!;()\[\]$]/.source + '|' + linestylefilter.REGEX_WORDCHAR.source + ')');
+linestylefilter.REGEX_URLCHAR = new RegExp('(' + /[-:@a-zA-Z0-9_.,~%+\/\\?=&#!;()$]/.source + '|' + linestylefilter.REGEX_WORDCHAR.source + ')');
 linestylefilter.REGEX_URL = new RegExp(/(?:(?:https?|s?ftp|ftps|file|nfs):\/\/|(about|geo|mailto|tel):|www\.)/.source + linestylefilter.REGEX_URLCHAR.source + '*(?![:.,;])' + linestylefilter.REGEX_URLCHAR.source, 'g');
 linestylefilter.getURLFilter = linestylefilter.getRegexpFilter(
 linestylefilter.REGEX_URL, 'url');

--- a/tests/frontend/specs/urls_become_clickable.js
+++ b/tests/frontend/specs/urls_become_clickable.js
@@ -44,4 +44,27 @@ describe("urls", function(){
     }, 2000).done(done);
   });
 
+  it("when you enter a url followed by a ], the ] is not included in the URL", function(done) {
+    var inner$ = helper.padInner$;
+    var chrome$ = helper.padChrome$;
+
+    //get the first text element out of the inner iframe
+    var firstTextElement = inner$("div").first();
+    var url = "http://etherpad.org/";
+
+    // simulate key presses to delete content
+    firstTextElement.sendkeys('{selectall}'); // select all
+    firstTextElement.sendkeys('{del}'); // clear the first line
+    firstTextElement.sendkeys(url); // insert a URL
+    firstTextElement.sendkeys(']'); // put a ] after it
+
+    helper.waitFor(function(){
+      if(inner$("div").first().find("a").length === 1){ // if it contains an A link
+        if(inner$("div").first().find("a")[0].href === url){
+          return true;
+        }
+      };
+    }, 2000).done(done);
+  });
+
 });


### PR DESCRIPTION
These characters are rarely used in URLs, and including them leads to
mislinkifying when editing various formats, such as wiki markup formats that
use [] around links.