### PR TITLE
Use an EEJS template for HTML export instead of inlining it in the JS code.

### DIFF
--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -76,7 +76,7 @@ exports.doExport = function(req, res, padId, type)
       }
       else if(type == "txt")
       {
-        exporttxt.getPadTXTDocument(padId, req.params.rev, false, function(err, txt)
+        exporttxt.getPadTXTDocument(padId, req.params.rev, function(err, txt)
         {
           if(ERR(err)) return;
           res.send(txt);

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -92,7 +92,7 @@ exports.doExport = function(req, res, padId, type)
           //render the html document
           function(callback)
           {
-            exporthtml.getPadHTMLDocument(padId, req.params.rev, false, function(err, _html)
+            exporthtml.getPadHTMLDocument(padId, req.params.rev, function(err, _html)
             {
               if(ERR(err, callback)) return;
               html = _html;

--- a/src/node/hooks/express/padreadonly.js
+++ b/src/node/hooks/express/padreadonly.js
@@ -7,7 +7,7 @@ var exporthtml = require("../../utils/ExportHtml");
 exports.expressCreateServer = function (hook_name, args, cb) {
   //serve read only pad
   args.app.get('/ro/:id', function(req, res)
-  { 
+  {
     var html;
     var padId;
 
@@ -40,7 +40,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
         hasPadAccess(req, res, function()
         {
           //render the html document
-          exporthtml.getPadHTMLDocument(padId, null, false, function(err, _html)
+          exporthtml.getPadHTMLDocument(padId, null, function(err, _html)
           {
             if(ERR(err, callback)) return;
             html = _html;

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -22,6 +22,7 @@ var ERR = require("async-stacktrace");
 var _ = require('underscore');
 var Security = require('ep_etherpad-lite/static/js/security');
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+var eejs = require('ep_etherpad-lite/node/eejs');
 var _analyzeLine = require('./ExportHelper')._analyzeLine;
 var _encodeWhitespace = require('./ExportHelper')._encodeWhitespace;
 
@@ -490,112 +491,17 @@ exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
       stylesForExport.forEach(function(css){
         stylesForExportCSS += css;
       });
-      // Core inclusion of head etc.
-      var head =
-        (noDocType ? '' : '<!doctype html>\n') +
-        '<html lang="en">\n' + (noDocType ? '' : '<head>\n' +
-          '<title>' + Security.escapeHTML(padId) + '</title>\n' +
-          '<meta name="generator" content="Etherpad">\n' +
-          '<meta name="author" content="Etherpad">\n' +
-          '<meta name="changedby" content="Etherpad">\n' +
-          '<meta charset="utf-8">\n' +
-          '<style> * { font-family: arial, sans-serif;\n' +
-            'font-size: 13px;\n' +
-            'line-height: 17px; }' +
-            'ul.indent { list-style-type: none; }' +
-
-            'ol { list-style-type: none; padding-left:0;}' +
-            'body > ol { counter-reset: first second third fourth fifth sixth seventh eigth ninth tenth eleventh twelth thirteenth fourteenth fifteenth sixteenth; }' +
-            'ol > li:before {' +
-            'content: counter(first) ". " ;'+
-            'counter-increment: first;}' +
-
-            'ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) ". " ;'+
-            'counter-increment: second;}' +
-
-            'ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) ". ";'+
-            'counter-increment: third;}' +
-
-            'ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) ". ";'+
-            'counter-increment: fourth;}' +
-
-            'ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) ". ";'+
-            'counter-increment: fifth;}' +
-
-            'ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) ". ";'+
-            'counter-increment: sixth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) ". ";'+
-            'counter-increment: seventh;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) ". ";'+
-            'counter-increment: eigth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) ". ";'+
-            'counter-increment: ninth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) ". ";'+
-            'counter-increment: tenth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) ". ";'+
-            'counter-increment: eleventh;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) ". ";'+
-            'counter-increment: twelth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) "." counter(thirteenth) ". ";'+
-            'counter-increment: thirteenth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) "." counter(thirteenth) "." counter(fourteenth) ". ";'+
-            'counter-increment: fourteenth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "."  counter(eigth) "."  counter(ninth) "."  counter(tenth) "."  counter(eleventh) "."  counter(twelth) "."  counter(thirteenth) "."  counter(fourteenth) "." counter(fifteenth) ". ";'+
-            'counter-increment: fifteenth;}' +
-
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {' +
-            'content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "."  counter(eigth) "."  counter(ninth) "."  counter(tenth) "."  counter(eleventh) "."  counter(twelth) "."  counter(thirteenth) "."  counter(fourteenth) "."  counter(fifteenth) "."  counter(sixthteenth) ". ";'+
-            'counter-increment: sixthteenth;}' +
-
-            'ol{ text-indent: 0px; }' +
-            'ol > ol{ text-indent: 10px; }' +
-            'ol > ol > ol{ text-indent: 20px; }' +
-            'ol > ol > ol > ol{ text-indent: 30px; }' +
-            'ol > ol > ol > ol > ol{ text-indent: 40px; }' +
-            'ol > ol > ol > ol > ol > ol{ text-indent: 50px; }' +
-            'ol > ol > ol > ol > ol > ol > ol{ text-indent: 60px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 70px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 80px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 90px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 100px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 110px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol { text-indent: 120px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 130px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 140px; }' +
-            'ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol{ text-indent: 150px; }' +
-
-            stylesForExportCSS +
-            '</style>\n' + '</head>\n') +
-        '<body>';
-      var foot = '</body>\n</html>\n';
 
       getPadHTML(pad, revNum, function (err, html)
       {
         if(ERR(err, callback)) return;
-        callback(null, head + html + foot);
+        var exportedDoc = eejs.require("ep_etherpad-lite/templates/export_html.html", {
+          body: html,
+          doctype: noDocType ? '' : '<!doctype html>',
+          padId: Security.escapeHTML(padId),
+          extraCSS: stylesForExportCSS
+        });
+        callback(null, exportedDoc);
       });
     });
   });

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -479,7 +479,7 @@ function getHTMLFromAtext(pad, atext, authorColors)
   return pieces.join('');
 }
 
-exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
+exports.getPadHTMLDocument = function (padId, revNum, callback)
 {
   padManager.getPad(padId, function (err, pad)
   {
@@ -497,7 +497,6 @@ exports.getPadHTMLDocument = function (padId, revNum, noDocType, callback)
         if(ERR(err, callback)) return;
         var exportedDoc = eejs.require("ep_etherpad-lite/templates/export_html.html", {
           body: html,
-          doctype: noDocType ? '' : '<!doctype html>',
           padId: Security.escapeHTML(padId),
           extraCSS: stylesForExportCSS
         });

--- a/src/node/utils/ExportTxt.js
+++ b/src/node/utils/ExportTxt.js
@@ -192,7 +192,7 @@ function getTXTFromAtext(pad, atext, authorColors)
               tags2close.push(i);
             }
           }
-          
+
           for (var i = 0; i < propVals.length; i++)
           {
             if (propVals[i] === ENTER || propVals[i] === STAY)
@@ -208,10 +208,10 @@ function getTXTFromAtext(pad, atext, authorColors)
         {
           chars--; // exclude newline at end of line, if present
         }
-        
+
         var s = taker.take(chars);
 
-        // removes the characters with the code 12. Don't know where they come 
+        // removes the characters with the code 12. Don't know where they come
         // from but they break the abiword parser and are completly useless
         // s = s.replace(String.fromCharCode(12), "");
 
@@ -221,7 +221,7 @@ function getTXTFromAtext(pad, atext, authorColors)
 
         assem.append(s);
       } // end iteration over spans in line
-      
+
       var tags2close = [];
       for (var i = propVals.length - 1; i >= 0; i--)
       {
@@ -231,7 +231,7 @@ function getTXTFromAtext(pad, atext, authorColors)
           propVals[i] = false;
         }
       }
-      
+
     } // end processNextChars
     processNextChars(text.length - idx);
     return(assem.toString());
@@ -271,7 +271,7 @@ function getTXTFromAtext(pad, atext, authorColors)
 }
 exports.getTXTFromAtext = getTXTFromAtext;
 
-exports.getPadTXTDocument = function (padId, revNum, noDocType, callback)
+exports.getPadTXTDocument = function (padId, revNum, callback)
 {
   padManager.getPad(padId, function (err, pad)
   {

--- a/src/templates/export_html.html
+++ b/src/templates/export_html.html
@@ -1,4 +1,4 @@
-<%- doctype %>
+<!doctype html>
 <html lang="en">
 <head>
 <title><%- padId %></title>

--- a/src/templates/export_html.html
+++ b/src/templates/export_html.html
@@ -1,0 +1,143 @@
+<%- doctype %>
+<html lang="en">
+<head>
+<title><%- padId %></title>
+<meta name="generator" content="Etherpad">
+<meta name="author" content="Etherpad">
+<meta name="changedby" content="Etherpad">
+<meta charset="utf-8">
+<style>
+* {
+  font-family: arial, sans-serif;
+  font-size: 13px;
+  line-height: 17px;
+}
+ul.indent {
+  list-style-type: none;
+}
+ol {
+  list-style-type: none;
+  padding-left: 0;
+}
+body > ol {
+  counter-reset: first second third fourth fifth sixth seventh eigth ninth tenth eleventh twelth thirteenth fourteenth fifteenth sixteenth;
+}
+ol > li:before {
+  content: counter(first) ". ";
+  counter-increment: first;
+}
+ol > ol > li:before {
+  content: counter(first) "." counter(second) ". ";
+  counter-increment: second;
+}
+ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) ". ";
+  counter-increment: third;
+}
+ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) ". ";
+  counter-increment: fourth;
+}
+ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) ". ";
+  counter-increment: fifth;
+}
+ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) ". ";
+  counter-increment: sixth;
+}
+ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) ". ";
+  counter-increment: seventh;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) ". ";
+  counter-increment: eigth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) ". ";
+  counter-increment: ninth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) ". ";
+  counter-increment: tenth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) ". ";
+  counter-increment: eleventh;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) ". ";
+  counter-increment: twelth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) "." counter(thirteenth) ". ";
+  counter-increment: thirteenth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) "." counter(thirteenth) "." counter(fourteenth) ". ";
+  counter-increment: fourteenth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) "." counter(thirteenth) "." counter(fourteenth) "." counter(fifteenth) ". ";
+  counter-increment: fifteenth;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > li:before {
+  content: counter(first) "." counter(second) "." counter(third) "." counter(fourth) "." counter(fifth) "." counter(sixth) "." counter(seventh) "." counter(eigth) "." counter(ninth) "." counter(tenth) "." counter(eleventh) "." counter(twelth) "." counter(thirteenth) "." counter(fourteenth) "." counter(fifteenth) "." counter(sixthteenth) ". ";
+  counter-increment: sixthteenth;
+}
+ol {
+  text-indent: 0px;
+}
+ol > ol {
+  text-indent: 10px;
+}
+ol > ol > ol {
+  text-indent: 20px;
+}
+ol > ol > ol > ol {
+  text-indent: 30px;
+}
+ol > ol > ol > ol > ol {
+  text-indent: 40px;
+}
+ol > ol > ol > ol > ol > ol {
+  text-indent: 50px;
+}
+ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 60px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 70px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 80px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 90px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 100px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 110px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 120px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 130px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 140px;
+}
+ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
+  text-indent: 150px;
+}
+<%- extraCSS %>
+</style>
+</head>
+<body>
+<%- body %>
+</body>
+</html>


### PR DESCRIPTION
The semantics of all the substitutions are identical to what they were before. I _did_ take the liberty of formatting the CSS to be a bit more readable (at the cost of adding a little bit of whitespace).

**Note:** I did _not_ fix the pre-existing misspellings in the CSS, e.g. `eigth`, `twelth`, and `sixthteenth`. Other than whitespace, I left the export document contents alone.

I checked both front-end and back-end tests, and they all seem to be okay when run on my local machine. (Two of the back-end tests come back as "pending." I assume that's okay because that's how they also report when I run on a clean checkout of the `develop` branch.)