### PR TITLE
Account for any top margin on the first line.

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -5459,7 +5459,16 @@ function Ace2Inner(){
           // and the line-numbers don't line up unless we pay
           // attention to where the divs are actually placed...
           // (also: padding on TTs/SPANs in IE...)
-          h = b.nextSibling.offsetTop - b.offsetTop;
+          if (b === doc.body.firstChild) {
+            // It's the first line. For line number alignment purposes, its
+            // height is taken to be the top offset of the next line. If we
+            // didn't do this special case, we would miss out on any top margin
+            // included on the first line. The default stylesheet doesn't add
+            // extra margins, but plugins might.
+            h = b.nextSibling.offsetTop;
+          } else {
+            h = b.nextSibling.offsetTop - b.offsetTop;
+          }
         }
         if (h)
         {


### PR DESCRIPTION
Without this change, a top margin on any element on the first line of pad
content would throw off the alignment of line numbers. The default stylesheet
doesn't define any elements with top margins, but plugins might. (This is also
explained in a code comment.)

In order to see the problem, add the following clause to `iframe_editor.css`
(before incorporating this commit):

    #innerdocbody > :first-child {
      margin-top: 100px;
    }