### PR TITLE
Added LibreJS support

### DIFF
--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -16,6 +16,13 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     res.send(eejs.require("ep_etherpad-lite/templates/index.html"));
   });
 
+  //serve javascript.html
+  args.app.get('/javascript', function(req, res)
+  {
+    res.send(eejs.require("ep_etherpad-lite/templates/javascript.html"));
+  });
+
+
   //serve robots.txt
   args.app.get('/robots.txt', function(req, res)
   {

--- a/src/templates/admin/index.html
+++ b/src/templates/admin/index.html
@@ -20,5 +20,6 @@
         </ul>
       </div>
     </div>
+  <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
   </body>
 </html>

--- a/src/templates/admin/plugins-info.html
+++ b/src/templates/admin/plugins-info.html
@@ -41,5 +41,6 @@
 
       </div>
     </div>
+  <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
   </body>
 </html>

--- a/src/templates/admin/plugins.html
+++ b/src/templates/admin/plugins.html
@@ -112,5 +112,6 @@
 
       </div>
     </div>
+  <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
   </body>
 </html>

--- a/src/templates/admin/settings.html
+++ b/src/templates/admin/settings.html
@@ -50,5 +50,6 @@
       </div>
 
     </div>
+  <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
   </body>
 </html>

--- a/src/templates/export_html.html
+++ b/src/templates/export_html.html
@@ -139,5 +139,6 @@ ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol > ol {
 </head>
 <body>
 <%- body %>
+<div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
 </body>
 </html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -29,7 +29,7 @@
       */
     </script>
 
-        <meta charset="utf-8"> 
+        <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
         <link rel="shortcut icon" href="<%=settings.favicon%>">
 
@@ -121,7 +121,7 @@
             input[type="text"] {
               border-radius: 3px;
               box-sizing: border-box;
-              -moz-box-sizing: border-box;   
+              -moz-box-sizing: border-box;
               line-height:36px; /* IE8 hack */
               padding: 0px 45px 0 10px;
               *padding: 0; /* IE7 hack */
@@ -148,22 +148,22 @@
                 margin-top: 0;
               }
               #inner {
-                width: 95%;        
+                width: 95%;
               }
               #label {
                 text-align: center;
               }
             }
         </style>
-        <link href="static/custom/index.css" rel="stylesheet"> 
+        <link href="static/custom/index.css" rel="stylesheet">
 
         <div id="wrapper">
         <% e.begin_block("indexWrapper"); %>
             <div id="inner">
                 <buttOn id="button" onclick="go2Random()" data-l10n-id="index.newPad"></button>
-                <label id="label" for="padname" data-l10n-id="index.createOpenPad"></label> 
-                <form action="#" onsubmit="go2Name();return false;"> 
-                    <input type="text" id="padname" maxlength="50" autofocus x-webkit-speech> 
+                <label id="label" for="padname" data-l10n-id="index.createOpenPad"></label>
+                <form action="#" onsubmit="go2Name();return false;">
+                    <input type="text" id="padname" maxlength="50" autofocus x-webkit-speech>
                     <button type="submit">OK</button>
                 </form>
             </div>
@@ -171,33 +171,35 @@
         </div>
 
         <script src="static/custom/index.js"></script>
-        <script> 
-      
-            function go2Name() 
+        <script>
+            // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
+            function go2Name()
             {
                 var padname = document.getElementById("padname").value;
                 padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name")
             }
- 
-            function go2Random() 
+
+            function go2Random()
             {
                 window.location = "p/" + randomPadName();
             }
- 
-            function randomPadName() 
+
+            function randomPadName()
             {
                 var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
                 var string_length = 10;
                 var randomstring = '';
-                for (var i = 0; i < string_length; i++) 
+                for (var i = 0; i < string_length; i++)
                 {
                     var rnum = Math.floor(Math.random() * chars.length);
                     randomstring += chars.substring(rnum, rnum + 1);
                 }
                 return randomstring;
             }
-            
+
             // start the custom js
             if (typeof customStart == "function") customStart();
+            // @license-end
         </script>
+        <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
 </html>

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+    <head>
+      <title>JavaScript license information</title>
+          <meta charset="utf-8">
+          <meta name="robots" content="noindex, nofollow">
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+    </head>
+    <body>
+        <table id="jslicense-labels1">
+            <tr>
+                <td><a href="/static/js/jquery-2.1.1.min.js">jquery-2.1.1.min.js</a></td>
+                <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+                <td><a href="/static/js/jquery.js">jquery.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/html10n.js">html10n.js</a></td>
+                <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+                <td><a href="/static/js/html10n.js">html10n.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/l10n.js">l10n.js</a></td>
+                <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache-2.0-only</a></td>
+                <td><a href="/static/js/l10n.js">l10n.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/socket.io.js">socket.io.js</a></td>
+                <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+                <td><a href="/static/js/socket.io.js">socket.io.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/require-kernel.js">require-kernel.js</a></td>
+                <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+                <td><a href="/static/js/require-kernel.js">require-kernel.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/custom/index.js">index.js</a></td>
+                <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache-2.0-only</a></td>
+                <td><a href="/static/custom/index.js">index.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/custom/timeslider.js">timeslider.js</a></td>
+                <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache-2.0-only</a></td>
+                <td><a href="/static/custom/timeslider.js">timeslider.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/custom/pad.js">pad.js</a></td>
+                <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache-2.0-only</a></td>
+                <td><a href="/static/custom/pad.js">pad.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/admin/plugins.js">plugins.js</a></td>
+                <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache-2.0-only</a></td>
+                <td><a href="/static/js/admin/plugins.js">plugins.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/admin/minify.json.js">minify.json.js</a></td>
+                <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+                <td><a href="/static/js/admin/minify.json.js">minify.json.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/admin/settings.js">settings.js</a></td>
+                <td><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache-2.0-only</a></td>
+                <td><a href="/static/js/admin/settings.js">settings.js</a></td>
+            </tr>
+            <tr>
+                <td><a href="/static/js/admin/jquery.autosize.js">jquery.autosize.js</a></td>
+                <td><a href="http://www.jclark.com/xml/copying.txt">Expat</a></td>
+                <td><a href="/static/js/admin/jquery.autosize.js">jquery.autosize.js</a></td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -350,6 +350,7 @@
 
         <% e.begin_block("scripts"); %>
         <script type="text/javascript">
+            // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             (function() {
               // Display errors on page load to the user
               // (Gets overridden by padutils.setupGlobalExceptionHandler)
@@ -363,6 +364,7 @@
                 if(typeof(originalHandler) == 'function') originalHandler.call(null, arguments);
               };
             })();
+            // @license-end
         </script>
 
         <script type="text/javascript" src="../static/js/require-kernel.js"></script>
@@ -378,6 +380,7 @@
 
         <!-- Bootstrap page -->
         <script type="text/javascript">
+            // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             var clientVars = {};
             (function () {
               var pathComponents = location.pathname.split('/');
@@ -415,6 +418,8 @@
               padeditbar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
               padimpexp = require('ep_etherpad-lite/static/js/pad_impexp').padimpexp;
             }());
+            // @license-end
         </script>
+        <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
         <% e.end_block(); %>
 </html>

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -230,6 +230,7 @@
 
 <!-- Bootstrap -->
 <script type="text/javascript" >
+  // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
   var clientVars = {};
   var BroadcastSlider;
   (function () {
@@ -266,8 +267,9 @@
       padeditbar.init()
     });
   })();
+  // @license-end
 </script>
 <% e.end_block(); %>
+<div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
 </body>
 </html>
-


### PR DESCRIPTION
The source code should now be 100% LibreJS compliant via the web labels method (the least invasive, no modification to any of the JavaScript files required).

I could only test the homepage because LibreJS breaks when the callback is passed, but that's not Etherpad's fault and it's something they should look into.

Closes #2913, all changes released under the same license as etherpad-lite (Apache 2.0)