### PR TITLE
Create plugin to run tests for line attribs + fix #3118

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 install:
   - "bin/installDeps.sh"
   - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
+  - "npm install ep_test_line_attrib"
 before_script:
   - "tests/frontend/travis/sauce_tunnel.sh"
 script:

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -1782,9 +1782,9 @@ function Ace2Inner(){
     return !!STYLE_ATTRIBS[aname];
   }
 
-  function isIncorpedAttribute(aname)
+  function isOtherIncorpedAttribute(aname)
   {
-    return ( !! STYLE_ATTRIBS[aname]) || ( !! OTHER_INCORPED_ATTRIBS[aname]);
+    return !!OTHER_INCORPED_ATTRIBS[aname];
   }
 
   function insertDomLines(nodeToAddAfter, infoStructs, isTimeUp)
@@ -2526,7 +2526,6 @@ function Ace2Inner(){
 
   function doIncorpLineSplice(startLine, deleteCount, newLineEntries, lineAttribs, hints)
   {
-
     var startOldChar = rep.lines.offsetOfIndex(startLine);
     var endOldChar = rep.lines.offsetOfIndex(startLine + deleteCount);
 
@@ -2760,7 +2759,7 @@ function Ace2Inner(){
   {
     function incorpedAttribFilter(anum)
     {
-      return isStyleAttribute(rep.apool.getAttribKey(anum));
+      return !isOtherIncorpedAttribute(rep.apool.getAttribKey(anum));
     }
 
     function attribRuns(attribs)


### PR DESCRIPTION
Besides fixing #3118, this PR also includes the plugin [ep_test_line_attrib](https://github.com/storytouch/ep_test_line_attrib) when running tests on Travis. This was necessary because there was no way to run tests with the current Etherpad structure, due to the fact that there are no line attribs defined by Etherpad besides the one with lists -- and code was already working properly with lists, but was failing for other line attribs.

This plugin will also allow other tests for plugin-related features in the future.

Does anyone have any concerns about adding this plugin to the test?