### PR TITLE
Add settings to scroll on edition out of viewport

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -121,6 +121,21 @@
   /* Privacy: disable IP logging */
   "disableIPlogging" : false,
 
+  /*
+  * By default, when caret is moved out of viewport, it scrolls the minimum height needed to make this
+  * line visible.
+  */
+  "scrollWhenFocusLineIsOutOfViewport": {
+    /*
+    * Percentage of viewport height to be additionally scrolled.
+    * E.g use "percentage": 0.5, to place caret line in the middle of viewport.
+    * Set to 0 to disable extra scrolling
+   */
+    "percentage": 0,
+    /* Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation */
+    "duration": 0
+  },
+
   /* Users for basic authentication. is_admin = true gives access to /admin.
      If you do not uncomment this, /admin will not be available! */
   /*

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -936,7 +936,7 @@ function handleSwitchToPad(client, message)
   var currentSession = sessioninfos[client.id];
   var padId = currentSession.padId;
   var roomClients = _getRoomClients(padId);
-  
+
   async.forEach(roomClients, function(client, callback) {
     var sinfo = sessioninfos[client.id];
     if(sinfo && sinfo.author == currentSession.author) {
@@ -1115,7 +1115,7 @@ function handleClientReady(client, message)
 
       //Check if this author is already on the pad, if yes, kick the other sessions!
       var roomClients = _getRoomClients(pad.id);
-      
+
       async.forEach(roomClients, function(client, callback) {
         var sinfo = sessioninfos[client.id];
         if(sinfo && sinfo.author == author) {
@@ -1214,6 +1214,10 @@ function handleClientReady(client, message)
             "parts": plugins.parts,
           },
           "indentationOnNewLine": settings.indentationOnNewLine,
+          "scrollWhenFocusLineIsOutOfViewport": {
+            "percentage": settings.scrollWhenFocusLineIsOutOfViewport.percentage,
+            "duration": settings.scrollWhenFocusLineIsOutOfViewport.duration,
+          },
           "initialChangesets": [] // FIXME: REMOVE THIS SHIT
         }
 
@@ -1676,13 +1680,13 @@ function composePadChangesets(padId, startNum, endNum, callback)
 
 function _getRoomClients(padID) {
   var roomClients = []; var room = socketio.sockets.adapter.rooms[padID];
-  
+
   if (room) {
     for (var id in room.sockets) {
       roomClients.push(socketio.sockets.sockets[id]);
     }
   }
-  
+
   return roomClients;
 }
 

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -214,6 +214,21 @@ exports.users = {};
 */
 exports.showSettingsInAdminPage = true;
 
+/*
+* By default, when caret is moved out of viewport, it scrolls the minimum height needed to make this
+* line visible.
+*/
+exports.scrollWhenFocusLineIsOutOfViewport = {
+  /*
+  * Percentage of viewport height to be additionally scrolled.
+  */
+  "percentage": 0,
+  /*
+  * Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation
+  */
+  "duration": 0
+};
+
 //checks if abiword is avaiable
 exports.abiwordAvailable = function()
 {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -20,7 +20,6 @@
  * limitations under the License.
  */
 var _, $, jQuery, plugins, Ace2Common;
-
 var browser = require('./browser');
 if(browser.msie){
   // Honestly fuck IE royally.
@@ -5211,7 +5210,10 @@ function Ace2Inner(){
   {
     // requires element (non-text) node;
     // if node extends above top of viewport or below bottom of viewport (or top of scrollbar),
-    // scroll it the minimum distance needed to be completely in view.
+    // and scrollAmountWhenFocusLineIsOutOfViewport is set to 0 (default), scroll it the minimum distance
+    // needed to be completely in view. If the value is greater than 0 and less than or equal to 1,
+    // besides of scrolling the minimum needed to be visible, it scrolls additionally
+    // (viewport height * scrollAmountWhenFocusLineIsOutOfViewport) pixels
     var win = outerWin;
     var odoc = outerWin.document;
     var distBelowTop = node.offsetTop + iframePadTop - win.scrollY;
@@ -5219,12 +5221,50 @@ function Ace2Inner(){
 
     if (distBelowTop < 0)
     {
-      win.scrollBy(0, distBelowTop);
+      var pixelsToScroll   = distBelowTop - getPixelsRelativeToPercentageOfViewport(node);
+      scrollYPage(win, pixelsToScroll);
     }
     else if (distAboveBottom < 0)
     {
-      win.scrollBy(0, -distAboveBottom);
+      var pixelsToScroll = -distAboveBottom + getPixelsRelativeToPercentageOfViewport(node);
+      scrollYPage(win, pixelsToScroll);
     }
+  }
+
+  function scrollYPage(win, pixelsToScroll)
+  {
+    var durationOfAnimationToShowFocusline = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport.duration;
+    if(durationOfAnimationToShowFocusline){
+      scrollYPageWithAnimation(win, pixelsToScroll, durationOfAnimationToShowFocusline);
+    }else{
+      scrollYPageWithoutAnimation(win, pixelsToScroll);
+    }
+  }
+
+  function scrollYPageWithoutAnimation(win, pixelsToScroll)
+  {
+    win.scrollBy(0, pixelsToScroll);
+  }
+
+  function scrollYPageWithAnimation(win, pixelsToScroll, durationOfAnimationToShowFocusline)
+  {
+    var outerDocBody = win.document.getElementById("outerdocbody");
+    $(outerDocBody).animate({
+      scrollTop: '+=' + pixelsToScroll
+    }, durationOfAnimationToShowFocusline);
+  }
+
+  // By default, when user makes an edition in a line out of viewport, this line goes
+  // to the edge of viewport. This function gets the extra pixels necessary to get the
+  // caret line in a position X relative to Y% viewport.
+  function getPixelsRelativeToPercentageOfViewport(node)
+  {
+    var pixels = 0;
+    var scrollPercentageRelativeToViewport = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage;
+    if(scrollPercentageRelativeToViewport > 0 && scrollPercentageRelativeToViewport <= 1){
+      pixels = ( getInnerHeight() * scrollPercentageRelativeToViewport ) - node.offsetHeight;
+    }
+    return pixels;
   }
 
   function scrollXHorizontallyIntoView(pixelX)

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -1,0 +1,271 @@
+describe('scroll when focus line is out of viewport', function () {
+  before(function (done) {
+    helper.newPad(function(){
+      cleanPad(function(){
+        createPadWithSeveralLines(function(){
+          resizeEditor();
+          done();
+        });
+      });
+    });
+    this.timeout(20000);
+  });
+
+  context('when user edits the last line of viewport', function(){
+    context('and scroll percentage config is set to 0 on settings.json', function(){
+      var lastLineOfViewportBeforeEnter = 10;
+      before(function () {
+        // the default value
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+
+        // make sure the last line on viewport is the 10th one
+        placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
+        pressEnter();
+      });
+
+      it('keeps the focus line on the bottom of the viewport', function (done) {
+        var lastLineOfViewportAfterEnter = getLastLineVisibleOfViewport();
+        var scrolledOneLineDown = lastLineOfViewportAfterEnter === lastLineOfViewportBeforeEnter + 1;
+        expect(scrolledOneLineDown).to.be(true);
+        done();
+      });
+    });
+
+    context('and scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.3', function(){ // this value is arbitrary
+      var lastLineOfViewportBeforeEnter = 10;
+      before(function () {
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.3);
+
+        // make sure the last line on viewport is the 10th one
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
+        pressEnter();
+      });
+
+      it('scrolls 30% of viewport up', function (done) {
+        var lastLineOfViewportAfterEnter = getLastLineVisibleOfViewport();
+
+        // default behavior is to scroll one line at the bottom of viewport, but as
+        // scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.3, we have an extra 30% of lines scrolled
+        // (3 lines, which are the 30% of the 10 that are visible on viewport)
+        var scrolledThreeLinesDown = lastLineOfViewportAfterEnter === lastLineOfViewportBeforeEnter + 3;
+        expect(scrolledThreeLinesDown).to.be(true);
+        done();
+      });
+    });
+
+    context('and it is set to a value that overflow the interval [0, 1]', function(){
+      var lastLineOfViewportBeforeEnter = 10;
+      before(function(){
+        var scrollPercentageWhenFocusLineIsOutOfViewport = 1.5;
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
+        setScrollPercentageWhenFocusLineIsOutOfViewport(scrollPercentageWhenFocusLineIsOutOfViewport);
+        pressEnter();
+      });
+
+      it('keeps the default behavior of moving the focus line on the bottom of the viewport', function (done) {
+        var lastLineOfViewportAfterEnter = getLastLineVisibleOfViewport();
+        var scrolledOneLineDown = lastLineOfViewportAfterEnter === lastLineOfViewportBeforeEnter + 1;
+        expect(scrolledOneLineDown).to.be(true);
+        done();
+      });
+    });
+  });
+
+  context('when user edits a line above the viewport', function(){
+    context('and scroll percentage config is set to 0 on settings.json', function(){
+      var focusLine = 10;
+      before(function () {
+        // the default value
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+
+        // firstly, scroll to make the focusLine visible. After that, scroll to make it out of viewport
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(focusLine); // place caret in the 10th line
+        scrollEditorToBottomOfPad();
+        pressBackspace(); // edit the line where the caret is, which is above the viewport
+      });
+
+      it('keeps the focus line on the top of the viewport', function (done) {
+        var firstLineOfViewportAfterEnter = getFirstLineVisibileOfViewport();
+        var keepLineEditedOnTopOfViewport = firstLineOfViewportAfterEnter === focusLine;
+        expect(keepLineEditedOnTopOfViewport).to.be(true);
+        done();
+      });
+    });
+
+    context('and scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.2', function(){ // this value is arbitrary
+      var focusline = 50;
+      before(function () {
+        // we force the line edited to be above the top of the viewport
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2); // set scroll jump to 20%
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(focusline);
+        scrollEditorToBottomOfPad();
+        pressBackspace(); // edit line
+      });
+
+      it('scrolls 20% of viewport down', function (done) {
+        // default behavior is to scroll one line at the top of viewport, but as
+        // scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.2, we have an extra 20% of lines scrolled
+        // (2 lines, which are the 20% of the 10 that are visible on viewport)
+        var firstLineVisibileOfViewport = getFirstLineVisibileOfViewport();
+        var focusLineIsTwoLinesFromTop = focusline === firstLineVisibileOfViewport + 2;
+        expect(focusLineIsTwoLinesFromTop).to.be(true);
+        done();
+      });
+    });
+  });
+
+  /* ********************* Helper functions/constants ********************* */
+  var TOP_OF_PAGE = 0;
+  var BOTTOM_OF_PAGE = 5000; // we use a big value to force the page to be scrolled all the way down
+  var LINES_OF_PAD = 100;
+  var ENTER = 13;
+  var BACKSPACE = 9;
+  var LINES_ON_VIEWPORT = 10;
+
+  var cleanPad = function(callback) {
+    var inner$ = helper.padInner$;
+    var $padContent = inner$("#innerdocbody");
+    $padContent.html("");
+
+    // wait for Etherpad to re-create first line
+    helper.waitFor(function(){
+      var lineNumber = inner$("div").length;
+      return lineNumber === 1;
+    }, 2000).done(callback);
+  };
+
+  var createPadWithSeveralLines = function(done) {
+    var line = "<span>a</span><br>";
+    var $firstLine = helper.padInner$('div').first();
+    var lines = line.repeat(LINES_OF_PAD); //arbitrary number, we need to create lines that is over the viewport
+    $firstLine.html(lines);
+
+    helper.waitFor(function(){
+      var linesCreated = helper.padInner$('div').length;
+      return linesCreated === LINES_OF_PAD;
+    }, 4000).done(done);
+  };
+
+  // resize the editor to make the tests easier
+  var resizeEditor = function() {
+    var chrome$ = helper.padChrome$;
+    chrome$("#editorcontainer").css("height", getSizeOfViewport());
+  };
+
+  var getSizeOfViewport = function() {
+    return getLinePositionOnViewport(LINES_ON_VIEWPORT + 1) - getLinePositionOnViewport(0);
+  };
+
+  var scrollPageTo = function(value) {
+    var outer$ = helper.padOuter$;
+    var $ace_outer = outer$('#outerdocbody').parent();
+    $ace_outer.parent().scrollTop(value);
+  };
+
+  var scrollEditorToTopOfPad = function() {
+    scrollPageTo(TOP_OF_PAGE);
+  };
+
+  var scrollEditorToBottomOfPad = function() {
+    scrollPageTo(BOTTOM_OF_PAGE);
+  };
+
+  var getLine = function(lineNum) {
+    var inner$ = helper.padInner$;
+    var $line = inner$("div").slice(lineNum, lineNum + 1);
+    return $line;
+  };
+
+  var placeCaretAtTheEndOfLine = function(lineNum) {
+    var $targetLine = getLine(lineNum);
+    var lineLength = $targetLine.text().length;
+    helper.selectLines($targetLine, $targetLine, lineLength, lineLength);
+  };
+
+  var getFirstLineVisibileOfViewport = function() {
+    return  _.find(_.range(0, LINES_OF_PAD - 1), isLineOnViewport);
+  };
+
+  var getLastLineVisibleOfViewport = function() {
+    return  _.find(_.range(LINES_OF_PAD - 1, 0, -1), isLineOnViewport);
+  };
+
+  var pressKey = function(keyCode){
+    var inner$ = helper.padInner$;
+    var evtType;
+    if(inner$(window)[0].bowser.firefox || inner$(window)[0].bowser.modernIE){ // if it's a mozilla or IE
+      evtType = "keypress";
+    }else{
+      evtType = "keydown";
+    }
+    var e = inner$.Event(evtType);
+    e.keyCode = keyCode;
+    inner$("#innerdocbody").trigger(e);
+  };
+
+  var pressEnter = function() {
+    pressKey(ENTER);
+  };
+
+  var pressBackspace = function() {
+    pressKey(BACKSPACE);
+  };
+
+  var isLineOnViewport = function(lineNumber) {
+    // in the function scrollNodeVerticallyIntoView from ace2_inner.js, iframePadTop is used to calculate
+    // how much scroll is needed. Although the name refers to padding-top, this value is not set on the
+    // padding-top.
+    var iframePadTop = 8;
+    var inner$ = helper.padInner$;
+    var outer$ = helper.padOuter$;
+    var $line = inner$("div").slice(lineNumber, lineNumber + 1);
+    var linePosition = $line.get(0).getBoundingClientRect();
+    var scrollTopFirefox = outer$('#outerdocbody').parent().scrollTop(); // works only on firefox
+    var scrolltop = outer$('#outerdocbody').scrollTop() || scrollTopFirefox;
+
+    // position relative to the current viewport
+    var linePositionTopOnViewport = linePosition.bottom - scrolltop + iframePadTop;
+    var linePositionBottomOnViewport = linePosition.bottom - scrolltop + iframePadTop;
+    var lineAboveViewportTop = linePositionTopOnViewport <= 0;
+    var lineBelowViewportBottom = linePositionBottomOnViewport > getClientHeight();
+
+    return !(lineAboveViewportTop || lineBelowViewportBottom);
+  };
+
+  var getClientHeight = function () {
+    var outer$ = helper.padOuter$;
+    var $ace_outer = outer$('#outerdocbody').parent();
+    var ace_outerHeight = $ace_outer.get(0).clientHeight;
+    var ace_outerPaddingTop = getIntValueOfCSSProperty($ace_outer, "padding-top");
+
+    var clientHeight = ace_outerHeight - ace_outerPaddingTop;
+
+    return clientHeight;
+  };
+
+  var getIntValueOfCSSProperty = function($element, property){
+    var valueString = $element.css(property);
+    return parseInt(valueString) || 0;
+  };
+
+  var setScrollPercentageWhenFocusLineIsOutOfViewport = function(value) {
+    helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage = value;
+  };
+
+  var getLinePositionOnViewport = function(lineNumber) {
+    var $line = getLine(lineNumber);
+    var linePosition = $line.get(0).getBoundingClientRect();
+
+    var outer$ = helper.padOuter$;
+    var scrollTopFirefox = outer$('#outerdocbody').parent().scrollTop(); // works only on firefox
+    var scrolltop = outer$('#outerdocbody').scrollTop() || scrollTopFirefox;
+
+    // position relative to the current viewport
+    return linePosition.top - scrolltop;
+  };
+});
+


### PR DESCRIPTION
By default, when there is an edition of a line, which is out of the
viewport, Etherpad scrolls the minimum necessary to make this line
visible. This makes that the line stays either on the top or the bottom
of the viewport. With this commit, we add a setting to make possible to
scroll to a position x% pixels from the viewport. Besides of that, we
add a setting to make an animation of this scroll.
If nothing is changed on settings.json the Etherpad default behavior is
kept.

Etherpad Default
![eto](https://cloud.githubusercontent.com/assets/4945372/22115088/df7675ca-de52-11e6-8cbe-6d53af44ce7c.gif)

Google Docs
![gdo](https://cloud.githubusercontent.com/assets/4945372/22113272/d93180c0-de4c-11e6-8ade-f98623ff88f5.gif)

Microsoft Word
![scroll_ms_word](https://cloud.githubusercontent.com/assets/4945372/22115435/1d244d06-de54-11e6-97c8-91d9dc8c1ea8.gif)

