### PR TITLE
Remove deprecated comment

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -116,7 +116,7 @@ exports.expressConfigure = function (hook_name, args, cb) {
 
   if (!exports.sessionStore) {
     exports.sessionStore = new ueberStore();
-    exports.secret = settings.sessionKey; // Isn't this being reset each time the server spawns?
+    exports.secret = settings.sessionKey;
   }
 
   args.app.sessionStore = exports.sessionStore;


### PR DESCRIPTION
The session key is currently stored in SESSIONKEY.txt, so it is no longer reset
every time the server starts.