### PR TITLE
WA added  in #1766 is not longer needed

### DIFF
--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -58,9 +58,11 @@ body.doesWrap {
   white-space: normal;
 }
 
-body.doesWrap:not(.noprewrap) > div{
-  /* Related to #1766 */
-  white-space: pre-wrap;
+@-moz-document url-prefix() {
+  body.doesWrap:not(.noprewrap) > div{
+    /* Related to #1766 */
+    white-space: pre-wrap;
+  }
 }
 
 #innerdocbody {


### PR DESCRIPTION
Looks like the WA done in #1766 is now affecting to the newest Safari and epiphany browser versions and is not longer required for the latest version of Chrome. I just reverted this one and the copy&paste works well now in Epiphany:

See discussion here (https://github.com/ether/etherpad-lite/issues/2742) and  here (https://github.com/ether/etherpad-lite/issues/2078)