### PR TITLE
wrong path of generate.js

### DIFF
--- a/bin/doc/README.md
+++ b/bin/doc/README.md
@@ -72,5 +72,5 @@ Each type of heading has a description block.
 
 Run the following from the etherpad-lite root directory:
 ```sh
-$ node tools/doc/generate doc/index.md --format=html --template=doc/template.html > out.html
+$ node bin/doc/generate doc/index.md --format=html --template=doc/template.html > out.html
 ```


### PR DESCRIPTION
The generate.js is in the `/bin/doc/` directory.
And the origin cmd will cause error.
![image](https://cloud.githubusercontent.com/assets/11813936/24664584/a458187e-198d-11e7-9848-772db068961b.png)


