### PR TITLE
Use HTTPS for images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # A really-real time collaborative word processor for the web
-![alt text](http://i.imgur.com/zYrGkg3.gif "Etherpad in action on PrimaryPad")
+![alt text](https://i.imgur.com/zYrGkg3.gif "Etherpad in action on PrimaryPad")
 
 # About
 Etherpad is a really-real time collaborative editor maintained by the Etherpad Community.


### PR DESCRIPTION
This change prevents mixed-content warnings on pages displaying the readme via HTTPS.