### PR TITLE
[fix] Do not show a 'pad deleted' message when pad is copied

### DIFF
--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -464,10 +464,6 @@ Pad.prototype.copy = function copy(destinationID, force, callback) {
   }
   else force = true;
 
-  //kick everyone from this pad
-  // TODO: this presents a message on the client saying that the pad was 'deleted'. Fix this?
-  padMessageHandler.kickSessionsFromPad(sourceID);
-
   // flush the source pad:
   _this.saveToDatabase();
 


### PR DESCRIPTION
Message should be shown when pad is deleted or moved, not when it is copied.

Tests performed:

* pad is deleted using API => shows message to client
* pad is moved to another name using API => shows message to client
* pad is copied to another name using API => **does not** show message to client

Fix #3183 