### PR TITLE
fixed plugin dependency issue

### DIFF
--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -124,7 +124,7 @@ exports.getPackages = function (cb) {
   
     var tmp = {};
     tmp[data.name] = data;
-    flatten(tmp[undefined].dependencies);
+    flatten(tmp[data.name].dependencies);
     cb(null, packages);
   });
 };


### PR DESCRIPTION
running ./bin/run.sh after the 1st time caused the following error "TypeError: Cannot read property 'dependencies' of undefined".
fixed it.