### PR TITLE
Add credentials arg to CLI module

### DIFF
--- a/src/node/utils/Cli.js
+++ b/src/node/utils/Cli.js
@@ -34,5 +34,10 @@ for ( var i = 0; i < argv.length; i++ ) {
     exports.argv.settings = arg;
   }
 
+  // Override location of credentials.json file
+  if ( prevArg == '--credentials' ) {
+    exports.argv.credentials = arg;
+  }
+
   prevArg = arg;
 }


### PR DESCRIPTION
As I was working on containerizing this for use in OpenShift, I realized that overriding the location of the credentials.json file didn't work properly. There is code to override the value in [Settings.js](https://github.com/ether/etherpad-lite/blob/develop/src/node/utils/Settings.js#L318), but it looks like Cli.js never actually pulls the value for credentials out of the argument list. Adding support for that here.