### PR TITLE
Feature: New server-side hook: onAccessCheck

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -116,7 +116,7 @@ Things in context:
 1. padID - the pad the user wants to access
 2. password - the password the user has given to access the pad
 3. token - the token of the author
-3. sessionCookie - the session the use has
+4. sessionCookie - the session the use has
 
 This hook gets called when the access to the concrete pad is being checked. Return `false` to deny access.
 

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -108,6 +108,18 @@ Usage examples:
 
 * https://github.com/tiblu/ep_authorship_toggle
 
+## onAccessCheck
+Called from: src/node/db/SecurityManager.js
+
+Things in context:
+
+1. padID - the pad the user wants to access
+2. password - the password the user has given to access the pad
+3. token - the token of the author
+3. sessionCookie - the session the use has
+
+This hook gets called when the access to the concrete pad is being checked. Return `false` to deny access.
+
 ## padCreate
 Called from: src/node/db/Pad.js
 

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -22,6 +22,7 @@
 var ERR = require("async-stacktrace");
 var async = require("async");
 var authorManager = require("./AuthorManager");
+var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks.js");
 var padManager = require("./PadManager");
 var sessionManager = require("./SessionManager");
 var settings = require("../utils/Settings");
@@ -41,6 +42,14 @@ exports.checkAccess = function (padID, sessionCookie, token, password, callback)
   var statusObject;
   
   if(!padID) {
+    callback(null, {accessStatus: "deny"});
+    return;
+  }
+
+  // allow plugins to deny access
+  var deniedByHook = hooks.callAll("onAccessCheck", {'padID': padID, 'password': password, 'token': token, 'sessionCookie': sessionCookie}).indexOf(false) > -1;
+  if(deniedByHook)
+  {
     callback(null, {accessStatus: "deny"});
     return;
   }


### PR DESCRIPTION
This hook allows plugins to control access to pad. It gives an alternative way to grant/deny access. I've used it to create a simple solution that only requires password to create a new pad, not to access already created one.