### PR TITLE
Make APIKEY and SESSIONKEY file customizable

### DIFF
--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -24,17 +24,19 @@ var fs = require("fs");
 var api = require("../db/API");
 var padManager = require("../db/PadManager");
 var randomString = require("../utils/randomstring");
+var argv = require('../utils/Cli').argv;
 
 //ensure we have an apikey
 var apikey = null;
+var apikeyFilename = argv.apikey || "./APIKEY.txt";
 try
 {
-  apikey = fs.readFileSync("./APIKEY.txt","utf8");
+  apikey = fs.readFileSync(apikeyFilename,"utf8");
 }
 catch(e)
 {
   apikey = randomString(32);
-  fs.writeFileSync("./APIKEY.txt",apikey,"utf8");
+  fs.writeFileSync(apikeyFilename,apikey,"utf8");
 }
 
 //a list of all functions

--- a/src/node/utils/Cli.js
+++ b/src/node/utils/Cli.js
@@ -39,5 +39,15 @@ for ( var i = 0; i < argv.length; i++ ) {
     exports.argv.credentials = arg;
   }
 
+  // Override location of settings.json file
+  if ( prevArg == '--sessionkey' || prevArg == '-k' ) {
+    exports.argv.sessionkey = arg;
+  }
+
+  // Override location of settings.json file
+  if ( prevArg == '--apikey' || prevArg == '-k' ) {
+    exports.argv.apikey = arg;
+  }
+
   prevArg = arg;
 }

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -449,11 +449,12 @@ exports.reloadSettings = function reloadSettings() {
   }
 
   if (!exports.sessionKey) {
+    var sessionkeyFilename = argv.sessionkey || "./SESSIONKEY.txt";
     try {
-      exports.sessionKey = fs.readFileSync("./SESSIONKEY.txt","utf8");
+      exports.sessionKey = fs.readFileSync(sessionkeyFilename,"utf8");
     } catch(e) {
       exports.sessionKey = randomString(32);
-      fs.writeFileSync("./SESSIONKEY.txt",exports.sessionKey,"utf8");
+      fs.writeFileSync(sessionkeyFilename,exports.sessionKey,"utf8");
     }
   } else {
     console.warn("Declaring the sessionKey in the settings.json is deprecated. This value is auto-generated now. Please remove the setting from the file.");


### PR DESCRIPTION
Running multiple instances sometimes requires different api- and session-keys for security reasons.