### PR TITLE
Feature: Support for uploading .rtf files rich text format

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -90,7 +90,7 @@ exports.doImport = function(req, res, padId)
     //this allows us to accept source code files like .c or .java
     function(callback) {
       var fileEnding = path.extname(srcFile).toLowerCase()
-        , knownFileEndings = [".txt", ".doc", ".docx", ".pdf", ".odt", ".html", ".htm", ".etherpad"]
+        , knownFileEndings = [".txt", ".doc", ".docx", ".pdf", ".odt", ".html", ".htm", ".etherpad", ".rtf"]
         , fileEndingKnown = (knownFileEndings.indexOf(fileEnding) > -1);
       
       //if the file ending is known, continue as normal


### PR DESCRIPTION
## Challenge 
Etherpad process .rtf files as txt files. It just reads all the ascii text from the file and displays it on the pad. This results in printing all the junk that's inside .rtf along with the actual text.
### Before
[ScreenshotBefore](http://imgur.com/a/lpFEV)
### After
[ScreenshotAfter](http://imgur.com/a/NcQ2T)
## Solution
Use abiword to process .rtf files

Issue link #3235 