### PR TITLE
Update socket.io to 1.7.3

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,7 @@
                       "request"                 : "2.55.0",
                       "etherpad-require-kernel" : "1.0.9",
                       "resolve"                 : "1.1.7",
-                      "socket.io"               : "1.6.0",
+                      "socket.io"               : "1.7.3",
                       "ueberdb2"                : "0.3.0",
                       "express"                 : "4.13.4",
                       "express-session"         : "1.13.0",


### PR DESCRIPTION
That in turn upgrades engine.io to 1.8.2. This fixes a crash for me when running behind a traefik reverse proxy.

The error is as described here: https://github.com/socketio/socket.io/issues/2779