### PR TITLE
Catch SIGTERM for graceful shutdown

### DIFF
--- a/src/node/hooks/express/errorhandling.js
+++ b/src/node/hooks/express/errorhandling.js
@@ -49,5 +49,8 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     //sigint is so far not working on windows
     //https://github.com/joyent/node/issues/1553
     process.on('SIGINT', exports.gracefulShutdown);
+    // when running as PID1 (e.g. in docker container)
+    // allow graceful shutdown on SIGTERM c.f. #3265
+    process.on('SIGTERM', exports.gracefulShutdown);
   }
 }


### PR DESCRIPTION
Shut down database connection and exit the node process
when SIGTERM is encountered. This is especially important
when nodejs is run as PID1, e.g. in a docker container.

Shutting down connections to clients (browsers) is beyond
this patche's scope.

Resolves #3265