### PR TITLE
Add settings to scroll on edition out of viewport 

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -150,6 +150,20 @@
   /* Time (in seconds) to automatically reconnect pad when a "Force reconnect"
      message is shown to user. Set to 0 to disable automatic reconnection */
   "automaticReconnectionTimeout" : 0,
+  /*
+  * By default, when caret is moved out of viewport, it scrolls the minimum height needed to make this
+  * line visible.
+  */
+  "scrollWhenFocusLineIsOutOfViewport": {
+    /*
+    * Percentage of viewport height to be additionally scrolled.
+    * E.g use "percentage": 0.5, to place caret line in the middle of viewport.
+    * Set to 0 to disable extra scrolling
+   */
+    "percentage": 0,
+    /* Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation */
+    "duration": 0
+  },
 
   /* Users for basic authentication. is_admin = true gives access to /admin.
      If you do not uncomment this, /admin will not be available! */

--- a/settings.json.template
+++ b/settings.json.template
@@ -166,7 +166,13 @@
     /*
     * Flag to control if it should scroll when user places the caret in the last line of the viewport
     */
-    "scrollWhenCaretIsInTheLastLineOfViewport": false
+    "scrollWhenCaretIsInTheLastLineOfViewport": false,
+    /*
+    * Percentage of viewport height to be additionally scrolled when user presses arrow up
+    * in the line of the top of the viewport.
+    * Set to 0 to let the scroll to be handled as default by the browser
+   */
+    "percentageToScrollWhenUserPressesArrowUp": 0
   },
 
   /* Users for basic authentication. is_admin = true gives access to /admin.

--- a/settings.json.template
+++ b/settings.json.template
@@ -162,7 +162,11 @@
    */
     "percentage": 0,
     /* Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation */
-    "duration": 0
+    "duration": 0,
+    /*
+    * Flag to control if it should scroll when user places the caret in the last line of the viewport
+    */
+    "scrollWhenCaretIsInTheLastLineOfViewport": false
   },
 
   /* Users for basic authentication. is_admin = true gives access to /admin.

--- a/settings.json.template
+++ b/settings.json.template
@@ -157,10 +157,14 @@
   "scrollWhenFocusLineIsOutOfViewport": {
     /*
     * Percentage of viewport height to be additionally scrolled.
-    * E.g use "percentage": 0.5, to place caret line in the middle of viewport.
+    * E.g use "percentage.editionAboveViewport": 0.5, to place caret line in the
+    * middle of viewport, when user edits a line above of the viewport
     * Set to 0 to disable extra scrolling
    */
-    "percentage": 0,
+    "percentage": {
+      "editionAboveViewport": 0,
+      "editionBelowViewport": 0
+    },
     /* Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation */
     "duration": 0,
     /*
@@ -170,7 +174,7 @@
     /*
     * Percentage of viewport height to be additionally scrolled when user presses arrow up
     * in the line of the top of the viewport.
-    * Set to 0 to let the scroll to be handled as default by the browser
+    * Set to 0 to let the scroll to be handled as default by the Etherpad
    */
     "percentageToScrollWhenUserPressesArrowUp": 0
   },

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1217,7 +1217,10 @@ function handleClientReady(client, message)
           },
           "indentationOnNewLine": settings.indentationOnNewLine,
           "scrollWhenFocusLineIsOutOfViewport": {
-            "percentage": settings.scrollWhenFocusLineIsOutOfViewport.percentage,
+            "percentage" : {
+              "editionAboveViewport": settings.scrollWhenFocusLineIsOutOfViewport.percentage.editionAboveViewport,
+              "editionBelowViewport": settings.scrollWhenFocusLineIsOutOfViewport.percentage.editionBelowViewport,
+            },
             "duration": settings.scrollWhenFocusLineIsOutOfViewport.duration,
             "scrollWhenCaretIsInTheLastLineOfViewport": settings.scrollWhenFocusLineIsOutOfViewport.scrollWhenCaretIsInTheLastLineOfViewport,
             "percentageToScrollWhenUserPressesArrowUp": settings.scrollWhenFocusLineIsOutOfViewport.percentageToScrollWhenUserPressesArrowUp,

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1220,6 +1220,7 @@ function handleClientReady(client, message)
             "percentage": settings.scrollWhenFocusLineIsOutOfViewport.percentage,
             "duration": settings.scrollWhenFocusLineIsOutOfViewport.duration,
             "scrollWhenCaretIsInTheLastLineOfViewport": settings.scrollWhenFocusLineIsOutOfViewport.scrollWhenCaretIsInTheLastLineOfViewport,
+            "percentageToScrollWhenUserPressesArrowUp": settings.scrollWhenFocusLineIsOutOfViewport.percentageToScrollWhenUserPressesArrowUp,
           },
           "initialChangesets": [] // FIXME: REMOVE THIS SHIT
         }

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1216,6 +1216,10 @@ function handleClientReady(client, message)
             "parts": plugins.parts,
           },
           "indentationOnNewLine": settings.indentationOnNewLine,
+          "scrollWhenFocusLineIsOutOfViewport": {
+            "percentage": settings.scrollWhenFocusLineIsOutOfViewport.percentage,
+            "duration": settings.scrollWhenFocusLineIsOutOfViewport.duration,
+          },
           "initialChangesets": [] // FIXME: REMOVE THIS SHIT
         }
 

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1219,6 +1219,7 @@ function handleClientReady(client, message)
           "scrollWhenFocusLineIsOutOfViewport": {
             "percentage": settings.scrollWhenFocusLineIsOutOfViewport.percentage,
             "duration": settings.scrollWhenFocusLineIsOutOfViewport.duration,
+            "scrollWhenCaretIsInTheLastLineOfViewport": settings.scrollWhenFocusLineIsOutOfViewport.scrollWhenCaretIsInTheLastLineOfViewport,
           },
           "initialChangesets": [] // FIXME: REMOVE THIS SHIT
         }

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -263,6 +263,11 @@ exports.scrollWhenFocusLineIsOutOfViewport = {
   /*
   * Flag to control if it should scroll when user places the caret in the last line of the viewport
   */
+  /*
+  * Percentage of viewport height to be additionally scrolled when user presses arrow up
+  * in the line of the top of the viewport.
+   */
+  "percentageToScrollWhenUserPressesArrowUp": 0,
   "scrollWhenCaretIsInTheLastLineOfViewport": false
 };
 

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -255,7 +255,10 @@ exports.scrollWhenFocusLineIsOutOfViewport = {
   /*
   * Percentage of viewport height to be additionally scrolled.
   */
-  "percentage": 0,
+  "percentage": {
+    "editionAboveViewport": 0,
+    "editionBelowViewport": 0
+  },
   /*
   * Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation
   */

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -259,7 +259,11 @@ exports.scrollWhenFocusLineIsOutOfViewport = {
   /*
   * Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation
   */
-  "duration": 0
+  "duration": 0,
+  /*
+  * Flag to control if it should scroll when user places the caret in the last line of the viewport
+  */
+  "scrollWhenCaretIsInTheLastLineOfViewport": false
 };
 
 //checks if abiword is avaiable

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -247,6 +247,21 @@ exports.users = {};
 */
 exports.showSettingsInAdminPage = true;
 
+/*
+* By default, when caret is moved out of viewport, it scrolls the minimum height needed to make this
+* line visible.
+*/
+exports.scrollWhenFocusLineIsOutOfViewport = {
+  /*
+  * Percentage of viewport height to be additionally scrolled.
+  */
+  "percentage": 0,
+  /*
+  * Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation
+  */
+  "duration": 0
+};
+
 //checks if abiword is avaiable
 exports.abiwordAvailable = function()
 {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -5353,7 +5353,7 @@ function Ace2Inner(){
         var caretIsAboveOfViewport = distanceOfTopOfViewport < 0;
         var caretIsBelowOfViewport = distanceOfBottomOfViewport < 0;
         if(caretIsAboveOfViewport){
-          var pixelsToScroll = distanceOfTopOfViewport - getPixelsRelativeToPercentageOfViewport();
+          var pixelsToScroll = distanceOfTopOfViewport - getPixelsRelativeToPercentageOfViewport(true);
           scrollYPage(win, pixelsToScroll);
         }else if(caretIsBelowOfViewport){
           var pixelsToScroll = -distanceOfBottomOfViewport + getPixelsRelativeToPercentageOfViewport();
@@ -5409,14 +5409,26 @@ function Ace2Inner(){
   // By default, when user makes an edition in a line out of viewport, this line goes
   // to the edge of viewport. This function gets the extra pixels necessary to get the
   // caret line in a position X relative to Y% viewport.
-  function getPixelsRelativeToPercentageOfViewport()
+  function getPixelsRelativeToPercentageOfViewport(editionIsAboveOfViewport)
   {
     var pixels = 0;
-    var scrollPercentageRelativeToViewport = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage;
+    var scrollPercentageRelativeToViewport = getPercentageToScroll(editionIsAboveOfViewport);
     if(scrollPercentageRelativeToViewport > 0 && scrollPercentageRelativeToViewport <= 1){
       pixels = parseInt(getInnerHeight() * scrollPercentageRelativeToViewport);
     }
     return pixels;
+  }
+
+  // we use different percentages when change selection. It depends on if it is
+  // either above the top or below the bottom of the page
+  function getPercentageToScroll(editionIsAboveOfViewport)
+  {
+    var scrollSettings = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport;
+    var percentageToScroll = scrollSettings.percentage.editionBelowViewport;
+    if(editionIsAboveOfViewport){
+      percentageToScroll = scrollSettings.percentage.editionAboveViewport;
+    }
+    return percentageToScroll;
   }
 
   function scrollXHorizontallyIntoView(pixelX)

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -4163,7 +4163,9 @@ function Ace2Inner(){
               if(arrowUpWasPressedInTheFirstLineOfTheViewport){
                 var win = outerWin;
                 var pixelsToScroll = getPixelsToScrollWhenUserPressesArrowUp();
-                scrollYPage(win, -pixelsToScroll);
+                // by default, the browser scrolls to the middle of the pad. To avoid the twist made
+                // when we apply a second scroll, we made it immediately (without animation)
+                scrollYPageWithoutAnimation(win, -pixelsToScroll);
               }else{
                 scrollNodeVerticallyIntoView();
               }

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2927,7 +2927,7 @@ function Ace2Inner(){
         // than it fits on viewport
         var multipleLinesSelected = rep.selStart[0] !== rep.selEnd[0];
 
-        if (isScrollableEvent && !multipleLinesSelected && isCaretAtTheBottomOfViewport(rep)) {
+        if (isScrollableEvent && !multipleLinesSelected && isCaretAtTheBottomOfViewport()) {
           // when scrollWhenFocusLineIsOutOfViewport.percentage is 0, pixelsToScroll is 0
           var pixelsToScroll = getPixelsRelativeToPercentageOfViewport();
           scrollYPage(outerWin, pixelsToScroll);
@@ -2958,12 +2958,15 @@ function Ace2Inner(){
   // Some plugins might set a minimum height to the editor (ex: ep_page_view), so checking
   // if (caretLine() === rep.lines.length() - 1) is not enough. We need to check if there are
   // other lines after caretLine(), and all of them are out of viewport.
-  function isCaretAtTheBottomOfViewport(rep)
+  function isCaretAtTheBottomOfViewport()
   {
     // computing a line position using getBoundingClientRect() is expensive.
+    // (obs: getBoundingClientRect() is called on caretPosition.getPosition())
     // To avoid that, we only call this function when it is possible that the
     // caret is in the bottom of viewport
-    if (isPossibleCaretIsInTheBottomOfViewport(rep)) {
+    if (caretIsOnALinePartiallyVisibleOnViewport()) {
+      // as the rep line is partially visible. We need to call caretPosition.getPosition()
+      // to know if the browser line where the caret is, it is in the bottom of the viewport
       var caretLinePosition = caretPosition.getPosition();
       var viewportBottom = getViewPortTopBottom().bottom;
 
@@ -2976,18 +2979,14 @@ function Ace2Inner(){
     return false;
   }
 
-  function isPossibleCaretIsInTheBottomOfViewport(rep)
+  function caretIsOnALinePartiallyVisibleOnViewport()
   {
     var caretLineNumber = rep.selStart[0];
     var caretLineNode = rep.lines.atIndex(caretLineNumber);
-    var caretLinePosition = getLineEntryTopBottom(caretLineNode, {});
+    var caretLinePosition = getLineEntryTopBottom(caretLineNode);
     var caretLineTop = caretLinePosition.top;
     var caretLineBottom = caretLinePosition.bottom;
     var viewportBottom = getViewPortTopBottom().bottom;
-
-    // here we calculate if the rep.line where the caret is, it includes the
-    // line (browser.line),  which is at the bottom of the viewport
-    // we consider as browser.line, how the lines are showed in the browser to the user
     var topOfLineIsAboveOfViewportBottom = caretLineTop < viewportBottom;
     var bottomOfLineIsOnOrBelowOfViewportBottom = caretLineBottom >= viewportBottom;
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2942,7 +2942,10 @@ function Ace2Inner(){
       // avoid scrolling to the end of pad, when user press shortcut to select all (Cmd + A)
       var hasSelection = rep.selStart[0] !== rep.selEnd[0];
 
-      if(caretIsInTheLastLineOfViewport && caretLineIsInTheBottomOfTheViewport && !hasSelection)
+      // avoid scrolling when pad loads
+      var isPadLoading = currentCallStack.type === "setBaseText";
+
+      if(caretIsInTheLastLineOfViewport && caretLineIsInTheBottomOfTheViewport && !hasSelection && !isPadLoading)
       {
 
         var win = outerWin;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2916,26 +2916,29 @@ function Ace2Inner(){
         documentAttributeManager: documentAttributeManager,
       });
 
-      // when the caret is placed at the last line visible of the viewport, it scrolls
-      // a percentage of viewport height defined by scrollWhenFocusLineIsOutOfViewport.percentage.
-      // When scrollWhenFocusLineIsOutOfViewport.percentage is 0, it keeps the default behavior
-      // that does not scroll at all.
-      // However, it scrolls only if the last line visible is in the bottom of the viewport.
-      // E.g., when there is only one line in the pad, this line(div) is the last line of
-      // the viewport, but it is not in the bottom of the viewport, so it should not scroll.
-      // This case only happens when it has a plugin of pagination, like ep_page_view
-      var hasSelection = rep.selStart[0] !== rep.selEnd[0];
+      var scrollSettings = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport;
+      var scrollWhenCaretInInTheLastLineOfViewport =  scrollSettings.scrollWhenCaretIsInTheLastLineOfViewport;
+      if (scrollWhenCaretInInTheLastLineOfViewport) {
+        // when the caret is placed at the last line visible of the viewport, it scrolls
+        // a percentage of viewport height defined by scrollWhenFocusLineIsOutOfViewport.percentage.
+        // When scrollWhenFocusLineIsOutOfViewport.percentage is 0, it keeps the default behavior
+        // that does not scroll at all.
+        // However, it scrolls only if the last line visible is in the bottom of the viewport.
+        // E.g., when there is only one line in the pad, this line(div) is the last line of
+        // the viewport, but it is not in the bottom of the viewport, so it should not scroll.
+        // This case only happens when it has a plugin of pagination, like ep_page_view
+        var hasSelection = rep.selStart[0] !== rep.selEnd[0];
 
-      // avoid scrolling when pad loads
-      var isPadLoading = (currentCallStack.type === "setBaseText") || (currentCallStack.type === "importText");
+        // avoid scrolling when pad loads
+        var isPadLoading = (currentCallStack.type === "setBaseText") || (currentCallStack.type === "importText");
+        if(!isPadLoading && !hasSelection && isCaretInTheLastLineOfViewport())
+        {
+          var win = outerWin;
 
-      if(!isPadLoading && !hasSelection && isCaretInTheLastLineOfViewport())
-      {
-        var win = outerWin;
-
-        // when scrollWhenFocusLineIsOutOfViewport.percentage is 0, pixelsToScroll is 0
-        var pixelsToScroll = getPixelsRelativeToPercentageOfViewport();
-        scrollYPage(win, pixelsToScroll);
+          // when scrollWhenFocusLineIsOutOfViewport.percentage is 0, pixelsToScroll is 0
+          var pixelsToScroll = getPixelsRelativeToPercentageOfViewport();
+          scrollYPage(win, pixelsToScroll);
+        }
       }
 
       return true;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2952,7 +2952,9 @@ function Ace2Inner(){
     var caretLinePosition = caretPosition.getPosition();
     var viewportTop = getViewPortTopBottom().top;
     var previousLineTop = caretLinePosition.top - caretLinePosition.height;
-    return previousLineTop <= viewportTop;
+    var previousLineIsAboveViewportTop = previousLineTop <= viewportTop;
+    var caretLineInBelowViewportTop = caretLinePosition.top >= viewportTop;
+    return previousLineIsAboveViewportTop && caretLineInBelowViewportTop;
   }
 
   // Some plugins might set a minimum height to the editor (ex: ep_page_view), so checking

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2922,7 +2922,7 @@ function Ace2Inner(){
       var shouldScrollWhenCaretIsAtBottomOfViewport =  scrollSettings.scrollWhenCaretIsInTheLastLineOfViewport;
       if (shouldScrollWhenCaretIsAtBottomOfViewport) {
         // avoid scrolling when pad loads
-        var isScrollableEvent = !isPadLoading(currentCallStack.type);
+        var isScrollableEvent = !isPadLoading(currentCallStack.type) && isScrollableEditEvent(currentCallStack.type);
         // avoid scrolling when selection includes multiple lines -- user can potentially be selecting more lines
         // than it fits on viewport
         var multipleLinesSelected = rep.selStart[0] !== rep.selEnd[0];

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2974,8 +2974,7 @@ function Ace2Inner(){
     var caretLineIsPartiallyVisibleOnViewport = isLinePartiallyVisibleOnViewport(caretLine);
     var lineAfterCaretLineIsPartiallyVisibleOnViewport = isLinePartiallyVisibleOnViewport(firstLineVisibleAfterCaretLine);
     if (caretLineIsPartiallyVisibleOnViewport || lineAfterCaretLineIsPartiallyVisibleOnViewport) {
-      // as the rep line is partially visible. We need to call caretPosition.getPosition()
-      // to know if the browser line where the caret is, it is in the bottom of the viewport
+      // check if the caret is in the bottom of the viewport
       var caretLinePosition = caretPosition.getPosition();
       var viewportBottom = getViewPortTopBottom().bottom;
       var nextLineBottom = caretPosition.getBottomOfNextBrowserLine(caretLinePosition, rep);

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -60,7 +60,7 @@ function Ace2Inner(){
   var SkipList = require('./skiplist');
   var undoModule = require('./undomodule').undoModule;
   var AttributeManager = require('./AttributeManager');
-  var Scroll = require('./Scroll');
+  var Scroll = require('./scroll');
 
   var DEBUG = false; //$$ build script replaces the string "var DEBUG=true;//$$" with "var DEBUG=false;"
   // changed to false
@@ -4035,19 +4035,8 @@ function Ace2Inner(){
 
             if(selection){
               var arrowUp = evt.which === 38;
-
-              // if percentageScrollArrowUp is 0, let the scroll to be handled as default, put the previous
-              // rep line on the top of the viewport
               var innerHeight = getInnerHeight();
-              if(scroll.arrowUpWasPressedInTheFirstLineOfTheViewport(arrowUp, rep)){
-                var pixelsToScroll = scroll.getPixelsToScrollWhenUserPressesArrowUp(innerHeight);
-
-                // by default, the browser scrolls to the middle of the viewport. To avoid the twist made
-                // when we apply a second scroll, we made it immediately (without animation)
-                scroll.scrollYPageWithoutAnimation(-pixelsToScroll);
-              }else{
-                scroll.scrollNodeVerticallyIntoView(rep, innerHeight);
-              }
+              scroll.scrollWhenPressArrowKeys(arrowUp, rep, innerHeight);
             }
           }
         }
@@ -4834,9 +4823,6 @@ function Ace2Inner(){
         setIfNecessary(root.style, "height", "");
       }
     }
-    // if near edge, scroll to edge
-    var scrollX = scroll.getScrollX();
-    var scrollY = scroll.getScrollY();
     var win = outerWin;
     var r = 20;
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2937,17 +2937,24 @@ function Ace2Inner(){
 
   function isCaretAtTheTopOfViewport()
   {
-    var caretLinePosition = caretPosition.getPosition(); // get the position of the browser line
-    var viewportPosition = getViewPortTopBottom();
-    var viewportTop = viewportPosition.top;
-    var viewportBottom = viewportPosition.bottom;
-    var caretLineIsBelowViewportTop = caretLinePosition.bottom >= viewportTop;
-    var caretLineIsAboveViewportBottom = caretLinePosition.top < viewportBottom;
-    var caretLineIsInsideOfViewport = caretLineIsBelowViewportTop && caretLineIsAboveViewportBottom;
-    if (caretLineIsInsideOfViewport) {
-      var prevLineTop = caretPosition.getPositionTopOfPreviousBrowserLine(caretLinePosition, rep);
-      var previousLineIsAboveViewportTop = prevLineTop < viewportTop;
-      return previousLineIsAboveViewportTop;
+    var caretLine = rep.selStart[0];
+    var linePrevCaretLine = caretLine - 1;
+    var firstLineVisibleBeforeCaretLine = caretPosition.getPreviousVisibleLine(linePrevCaretLine, rep);
+    var caretLineIsPartiallyVisibleOnViewport = isLinePartiallyVisibleOnViewport(caretLine);
+    var lineBeforeCaretLineIsPartiallyVisibleOnViewport = isLinePartiallyVisibleOnViewport(firstLineVisibleBeforeCaretLine);
+    if (caretLineIsPartiallyVisibleOnViewport || lineBeforeCaretLineIsPartiallyVisibleOnViewport) {
+      var caretLinePosition = caretPosition.getPosition(); // get the position of the browser line
+      var viewportPosition = getViewPortTopBottom();
+      var viewportTop = viewportPosition.top;
+      var viewportBottom = viewportPosition.bottom;
+      var caretLineIsBelowViewportTop = caretLinePosition.bottom >= viewportTop;
+      var caretLineIsAboveViewportBottom = caretLinePosition.top < viewportBottom;
+      var caretLineIsInsideOfViewport = caretLineIsBelowViewportTop && caretLineIsAboveViewportBottom;
+      if (caretLineIsInsideOfViewport) {
+        var prevLineTop = caretPosition.getPositionTopOfPreviousBrowserLine(caretLinePosition, rep);
+        var previousLineIsAboveViewportTop = prevLineTop < viewportTop;
+        return previousLineIsAboveViewportTop;
+      }
     }
     return false;
   }
@@ -2984,10 +2991,13 @@ function Ace2Inner(){
     var linePosition = getLineEntryTopBottom(lineNode);
     var lineTop = linePosition.top;
     var lineBottom = linePosition.bottom;
-    var viewportBottom = getViewPortTopBottom().bottom;
-    var topOfLineIsAboveOfViewportBottom = lineTop < viewportBottom;
-    var bottomOfLineIsOnOrBelowOfViewportBottom = lineBottom >= viewportBottom;
-    return topOfLineIsAboveOfViewportBottom && bottomOfLineIsOnOrBelowOfViewportBottom;
+    var viewport = getViewPortTopBottom();
+    var viewportBottom = viewport.bottom;
+    var viewportTop = viewport.top;
+
+    return (topOfLineIsAboveOfViewportBottom && bottomOfLineIsOnOrBelowOfViewportBottom) ||
+      (topOfLineIsBelowViewportTop && topOfLineIsAboveViewportBottom) ||
+      (bottomOfLineIsAboveViewportBottom && bottomOfLineIsBelowViewportTop);
   }
 
   function doCreateDomLine(nonEmpty)

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2924,25 +2924,6 @@ function Ace2Inner(){
       // E.g., when there is only one line in the pad, this line(div) is the last line of
       // the viewport, but it is not in the bottom of the viewport, so it should not scroll.
       // This case only happens when it has a plugin of pagination, like ep_page_view
-      var edgeLinesVisibleOnViewport = getVisibleLineRange();
-      var lastLineVisibleOfViewport = edgeLinesVisibleOnViewport[1];
-
-      // it is possible that the last line visible is partially visible and user places
-      // the caret at the line before of this line
-
-
-      var caretIsInThelastLineVisibleOfViewport = rep.selEnd[0] >= lastLineVisibleOfViewport;
-      var caretIsInThelastButOneLineVisibleOfViewport = rep.selEnd[0] === lastLineVisibleOfViewport - 1;
-      var caretIsInTheLastLineOfViewport = caretIsInThelastLineVisibleOfViewport || caretIsInThelastButOneLineVisibleOfViewport;
-
-      // avoid scrolling when caret is at the last line of the pad but this line is not in the bottom
-      // of the pad. E.g. when a pad has only one line and the caret is on that line. Other scenario is when
-      // a pad has a min-height applied and the last line is above of the viewport and in a position above the
-      // min-height. In this case, it has space to scroll but it should not scroll because it scrolls only
-      // when a line is in the bottom of the viewport
-      var caretLineIsInTheBottomOfTheViewport = isCaretLineInTheBottomOfTheViewport(rep);
-
-      // avoid scrolling to the end of pad, when user press shortcut to select all (Cmd + A)
       var hasSelection = rep.selStart[0] !== rep.selEnd[0];
 
       // avoid scrolling when pad loads
@@ -2967,30 +2948,12 @@ function Ace2Inner(){
 
   function isCaretInTheLastLineOfViewport()
   {
-    var linePosition = caretPosition.getCaretLinePosition();
+    var linePosition = caretPosition.getPosition();
     var viewportBottom = getViewPortTopBottom().bottom;
 
-    // TODO make it better. Maybe this is Achiles heel. We use the current line height
-    // this can go wrong if the next line has a lower height
+    // here we assume that the next line has the same height of the caret line
     var nextLineBottom = linePosition.bottom + linePosition.height;
     return nextLineBottom > viewportBottom;
-  }
-
-  function isCaretLineInTheBottomOfTheViewport (rep) {
-    var caretlineIsInTheBottomOfViewport = false;
-    var lastLineNumber = rep.lines.length() - 1;
-    var caretLine = rep.selStart[0];
-    var lineAfterCaretLine = caretLine + 1;
-    if(lineAfterCaretLine < lastLineNumber) { // caret line is before the last line of the pad
-      var lineAfterCaretLineIsBelowOfViewport =  distanceToBottomOfViewport(rep, lineAfterCaretLine) < 0;
-      caretlineIsInTheBottomOfViewport = lineAfterCaretLineIsBelowOfViewport;
-    }else{ // caret line is the last line of the pad
-      var lastLineNodeHeight = rep.lines.atIndex(caretLine).lineNode.offsetHeight;
-      var distanceOfCaretLineToBottom = distanceToBottomOfViewport(rep, caretLine);
-      caretlineIsInTheBottomOfViewport = lastLineNodeHeight > distanceOfCaretLineToBottom;
-    }
-
-    return caretlineIsInTheBottomOfViewport;
   }
 
   // negative values means the line is below of the viewport bottom
@@ -5311,9 +5274,9 @@ function Ace2Inner(){
     // when the selection changes outside of the viewport the browser automatically scrolls the line
     // to inside of the viewport. Tested on IE, Firefox, Chrome in releases from 2015 until now
     // So, when the line scrolled gets outside of the viewport we let the browser handle it.
-    var linePosition = caretPosition.getCaretLinePosition();
+    var linePosition = caretPosition.getPosition();
     var win = outerWin;
-    if(linePosition){ // only scroll when pad is already loaded TODO BETTER COMMENTS
+    if(linePosition){
       var viewport = getViewPortTopBottom();
       var distanceOfTopOfViewport = linePosition.top - viewport.top;
       var distanceOfBottomOfViewport = viewport.bottom - linePosition.bottom;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2995,6 +2995,13 @@ function Ace2Inner(){
     var viewportBottom = viewport.bottom;
     var viewportTop = viewport.top;
 
+    var topOfLineIsAboveOfViewportBottom = lineTop < viewportBottom;
+    var bottomOfLineIsOnOrBelowOfViewportBottom = lineBottom >= viewportBottom;
+    var topOfLineIsBelowViewportTop = lineTop >= viewportTop;
+    var topOfLineIsAboveViewportBottom = lineTop <= viewportBottom;
+    var bottomOfLineIsAboveViewportBottom = lineBottom <= viewportBottom;
+    var bottomOfLineIsBelowViewportTop = lineBottom >= viewportTop;
+
     return (topOfLineIsAboveOfViewportBottom && bottomOfLineIsOnOrBelowOfViewportBottom) ||
       (topOfLineIsBelowViewportTop && topOfLineIsAboveViewportBottom) ||
       (bottomOfLineIsAboveViewportBottom && bottomOfLineIsBelowViewportTop);
@@ -4143,7 +4150,7 @@ function Ace2Inner(){
               if(arrowUpWasPressedInTheFirstLineOfTheViewport){
                 var win = outerWin;
                 var pixelsToScroll = getPixelsToScrollWhenUserPressesArrowUp();
-                // by default, the browser scrolls to the middle of the pad. To avoid the twist made
+                // by default, the browser scrolls to the middle of the viewport. To avoid the twist made
                 // when we apply a second scroll, we made it immediately (without animation)
                 scrollYPageWithoutAnimation(win, -pixelsToScroll);
               }else{
@@ -5430,10 +5437,10 @@ function Ace2Inner(){
   // By default, when user makes an edition in a line out of viewport, this line goes
   // to the edge of viewport. This function gets the extra pixels necessary to get the
   // caret line in a position X relative to Y% viewport.
-  function getPixelsRelativeToPercentageOfViewport(editionIsAboveOfViewport)
+  function getPixelsRelativeToPercentageOfViewport(aboveOfViewport)
   {
     var pixels = 0;
-    var scrollPercentageRelativeToViewport = getPercentageToScroll(editionIsAboveOfViewport);
+    var scrollPercentageRelativeToViewport = getPercentageToScroll(aboveOfViewport);
     if(scrollPercentageRelativeToViewport > 0 && scrollPercentageRelativeToViewport <= 1){
       pixels = parseInt(getInnerHeight() * scrollPercentageRelativeToViewport);
     }
@@ -5442,11 +5449,11 @@ function Ace2Inner(){
 
   // we use different percentages when change selection. It depends on if it is
   // either above the top or below the bottom of the page
-  function getPercentageToScroll(editionIsAboveOfViewport)
+  function getPercentageToScroll(aboveOfViewport)
   {
     var scrollSettings = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport;
     var percentageToScroll = scrollSettings.percentage.editionBelowViewport;
-    if(editionIsAboveOfViewport){
+    if(aboveOfViewport){
       percentageToScroll = scrollSettings.percentage.editionAboveViewport;
     }
     return percentageToScroll;
@@ -5473,7 +5480,6 @@ function Ace2Inner(){
   {
     if (!rep.selStart) return;
     fixView();
-    var focusLine = (rep.selFocusAtStart ? rep.selStart[0] : rep.selEnd[0]);
     scrollNodeVerticallyIntoView();
     if (!doesWrap)
     {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -82,7 +82,6 @@ function Ace2Inner(){
   var disposed = false;
   var editorInfo = parent.editorInfo;
 
-  var keyEmulatedByEtherpad = false;
 
   var iframe = window.frameElement;
   var outerWin = iframe.ace_outerWin;
@@ -3928,7 +3927,6 @@ function Ace2Inner(){
           //  - probably eliminates a few minor quirks
           fastIncorp(3);
           evt.preventDefault();
-          keyEmulatedByEtherpad = true;
           doDeleteKey(evt);
           specialHandled = true;
         }
@@ -3938,7 +3936,6 @@ function Ace2Inner(){
           // note that in mozilla we need to do an incorporation for proper return behavior anyway.
           fastIncorp(4);
           evt.preventDefault();
-          keyEmulatedByEtherpad = true;
           doReturnKey();
           //scrollSelectionIntoView();
           scheduler.setTimeout(function()
@@ -3972,7 +3969,6 @@ function Ace2Inner(){
           // tab
           fastIncorp(5);
           evt.preventDefault();
-          keyEmulatedByEtherpad = true;
           doTabKey(evt.shiftKey);
           //scrollSelectionIntoView();
           specialHandled = true;
@@ -4059,7 +4055,6 @@ function Ace2Inner(){
           // cmd-H (backspace)
           fastIncorp(20);
           evt.preventDefault();
-          keyEmulatedByEtherpad = true;
           doDeleteKey();
           specialHandled = true;
         }

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -6,9 +6,9 @@ exports.getPosition = function ()
   var rect, line;
   var editor = $('#innerdocbody')[0];
   var range = getSelectionRange();
-  var isSelectionInsideTheEditor = $(range.endContainer).closest('body')[0].id === 'innerdocbody';
+  var isSelectionInsideTheEditor = range && $(range.endContainer).closest('body')[0].id === 'innerdocbody';
 
-  if(range && isSelectionInsideTheEditor){
+  if(isSelectionInsideTheEditor){
     // when we have the caret in an empty line, e.g. a line with only a <br>,
     // getBoundingClientRect() returns all dimensions value as 0
     var selectionIsInTheBeginningOfLine = range.endOffset > 0;

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -66,5 +66,5 @@ function getSelectionRange()
    return selection.getRangeAt(0);
   } else {
    return null;
-   }
+  }
 }

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -1,0 +1,58 @@
+// TODO make it like etherpad default. No named functions, fix curly brackets
+exports.getCaretLinePosition = function () {
+  var editor = $('#innerdocbody')[0];
+  var range = getSelectionRange();
+  var rect, line;
+  if(range){
+    if (range.endOffset > 0 && (range.endContainer !== editor)) { // explain this first condition
+      clonedRange = range.cloneRange();
+      clonedRange.setStart(range.endContainer, range.endOffset);
+      clonedRange.setEnd(range.endContainer, range.endOffset);
+      rect = clonedRange.getBoundingClientRect();
+      line = {
+        bottom: rect.top + rect.height,
+        height: rect.height,
+        top: rect.top
+      }
+      clonedRange.detach();
+    }
+    // rect.height === 0, the element has no height so we have to create a element to
+    // measure the height
+    if(!rect || rect.height === 0){ // probably a <br> or one line char
+      clonedRange = range.cloneRange();
+
+      // avoid error with multiple lines selected and user presses shift
+      // why? Explain it!
+      clonedRange.setStart(range.endContainer, range.endOffset);
+      clonedRange.setEnd(range.endContainer, range.endOffset);
+
+      shadowCaret = $(document.createTextNode("|")); // create an element to have height
+
+      clonedRange.insertNode(shadowCaret[0]);
+      clonedRange.selectNode(shadowCaret[0]);
+
+      rect = clonedRange.getBoundingClientRect();
+      line = {
+        bottom: rect.top + rect.height,
+        height: rect.height,
+        top: rect.top
+      }
+      shadowCaret.remove();
+      clonedRange.detach();
+    }
+  }
+  return line;
+}
+
+var getSelectionRange = function(){
+  var selection;
+  if (!window.getSelection) {
+   return;
+  }
+  selection = window.getSelection();
+  if (selection.rangeCount > 0) {
+   return selection.getRangeAt(0);
+  } else {
+   return null;
+   }
+}

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -57,7 +57,7 @@ exports.getPosition = function ()
 
 exports.getPositionOfRepLineAtOffset = function (node, offset) {
   // it is not a text node, so we cannot make a selection
-  if (node.tagName === 'BR') {
+  if (node.tagName === 'BR' || node.tagName === 'EMPTY') {
     return getPositionOfElementOrSelection(node);
   }
 

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -193,6 +193,19 @@ function caretLineIsLastBrowserLineOfRepLine(caretLineTop, rep)
   return lastRootChildNodePosition.top === caretLineTop;
 }
 
+function getPreviousVisibleLine(line, rep)
+{
+  var firstLineOfPad = 0;
+  if (line <= firstLineOfPad) {
+    return firstLineOfPad;
+  }else if (isLineVisible(line,rep)) {
+    return line;
+  }else{
+    return getPreviousVisibleLine(line - 1, rep);
+  }
+}
+exports.getPreviousVisibleLine = getPreviousVisibleLine;
+
 function getNextVisibleLine(line, rep)
 {
   var lastLineOfThePad = rep.lines.length() - 1;

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -104,7 +104,7 @@ function caretLineIsFirstBrowserLine(caretLineTop, rep)
   var lineNode = rep.lines.atIndex(caretRepLine).lineNode;
   var firstRootNode = getFirstRootChildNode(lineNode);
 
-  // to get the position of the node we the position of the first char
+  // to get the position of the node we get the position of the first char
   var positionOfFirstRootNode = getPositionOfRepLineAtOffset(firstRootNode, 1);
   return positionOfFirstRootNode.top === caretLineTop;
 }

--- a/src/static/js/scroll.js
+++ b/src/static/js/scroll.js
@@ -36,6 +36,21 @@ Scroll.prototype.scrollWhenCaretIsInTheLastLineOfViewportWhenNecessary = functio
   }
 }
 
+Scroll.prototype.scrollWhenPressArrowKeys = function(arrowUp, rep, innerHeight)
+{
+  // if percentageScrollArrowUp is 0, let the scroll to be handled as default, put the previous
+  // rep line on the top of the viewport
+  if(this._arrowUpWasPressedInTheFirstLineOfTheViewport(arrowUp, rep)){
+    var pixelsToScroll = this._getPixelsToScrollWhenUserPressesArrowUp(innerHeight);
+
+    // by default, the browser scrolls to the middle of the viewport. To avoid the twist made
+    // when we apply a second scroll, we made it immediately (without animation)
+    this._scrollYPageWithoutAnimation(-pixelsToScroll);
+  }else{
+    this.scrollNodeVerticallyIntoView(rep, innerHeight);
+  }
+}
+
 // Some plugins might set a minimum height to the editor (ex: ep_page_view), so checking
 // if (caretLine() === rep.lines.length() - 1) is not enough. We need to check if there are
 // other lines after caretLine(), and all of them are out of viewport.
@@ -207,7 +222,7 @@ Scroll.prototype._getPercentageToScroll = function(aboveOfViewport)
   return percentageToScroll;
 }
 
-Scroll.prototype.getPixelsToScrollWhenUserPressesArrowUp = function(innerHeight)
+Scroll.prototype._getPixelsToScrollWhenUserPressesArrowUp = function(innerHeight)
 {
   var pixels = 0;
   var percentageToScrollUp = this.scrollSettings.percentageToScrollWhenUserPressesArrowUp;
@@ -223,11 +238,11 @@ Scroll.prototype._scrollYPage = function(pixelsToScroll)
   if(durationOfAnimationToShowFocusline){
     this._scrollYPageWithAnimation(pixelsToScroll, durationOfAnimationToShowFocusline);
   }else{
-    this.scrollYPageWithoutAnimation(pixelsToScroll);
+    this._scrollYPageWithoutAnimation(pixelsToScroll);
   }
 }
 
-Scroll.prototype.scrollYPageWithoutAnimation = function(pixelsToScroll)
+Scroll.prototype._scrollYPageWithoutAnimation = function(pixelsToScroll)
 {
   this.outerWin.scrollBy(0, pixelsToScroll);
 }
@@ -311,7 +326,7 @@ Scroll.prototype._getLineEntryTopBottom = function(entry, destObj)
   return obj;
 }
 
-Scroll.prototype.arrowUpWasPressedInTheFirstLineOfTheViewport = function(arrowUp, rep)
+Scroll.prototype._arrowUpWasPressedInTheFirstLineOfTheViewport = function(arrowUp, rep)
 {
   var percentageScrollArrowUp = this.scrollSettings.percentageToScrollWhenUserPressesArrowUp;
   return percentageScrollArrowUp && arrowUp && this._isCaretAtTheTopOfViewport(rep);

--- a/src/static/js/scroll.js
+++ b/src/static/js/scroll.js
@@ -1,0 +1,351 @@
+/*
+  This file handles scroll on edition or when user presses arrow keys.
+  In this file we have two representations of line (browser and rep line).
+  Rep Line = a line in the way is represented by Etherpad(rep) (each <div> is a line)
+  Browser Line = each vertical line. A <div> can be break into more than one
+  browser line.
+*/
+var caretPosition = require('/caretPosition');
+
+function Scroll(outerWin) {
+  // scroll settings
+  this.scrollSettings = parent.parent.clientVars.scrollWhenFocusLineIsOutOfViewport;
+
+  // DOM reference
+  this.outerWin = outerWin;
+  this.doc = this.outerWin.document;
+  this.rootDocument = parent.parent.document;
+}
+
+Scroll.prototype.scrollWhenCaretIsInTheLastLineOfViewportWhenNecessary = function (rep, isScrollableEvent, innerHeight)
+{
+  // are we placing the caret on the line at the bottom of viewport?
+  // And if so, do we need to scroll the editor, as defined on the settings.json?
+  var shouldScrollWhenCaretIsAtBottomOfViewport =  this.scrollSettings.scrollWhenCaretIsInTheLastLineOfViewport;
+  if (shouldScrollWhenCaretIsAtBottomOfViewport) {
+    // avoid scrolling when selection includes multiple lines -- user can potentially be selecting more lines
+    // than it fits on viewport
+    var multipleLinesSelected = rep.selStart[0] !== rep.selEnd[0];
+
+    // avoid scrolling when pad loads
+    if (isScrollableEvent && !multipleLinesSelected && this._isCaretAtTheBottomOfViewport(rep)) {
+      // when scrollWhenFocusLineIsOutOfViewport.percentage is 0, pixelsToScroll is 0
+      var pixelsToScroll = this._getPixelsRelativeToPercentageOfViewport(innerHeight);
+      this._scrollYPage(pixelsToScroll);
+    }
+  }
+}
+
+// Some plugins might set a minimum height to the editor (ex: ep_page_view), so checking
+// if (caretLine() === rep.lines.length() - 1) is not enough. We need to check if there are
+// other lines after caretLine(), and all of them are out of viewport.
+Scroll.prototype._isCaretAtTheBottomOfViewport = function(rep)
+{
+  // computing a line position using getBoundingClientRect() is expensive.
+  // (obs: getBoundingClientRect() is called on caretPosition.getPosition())
+  // To avoid that, we only call this function when it is possible that the
+  // caret is in the bottom of viewport
+  var caretLine = rep.selStart[0];
+  var lineAfterCaretLine = caretLine + 1;
+  var firstLineVisibleAfterCaretLine = caretPosition.getNextVisibleLine(lineAfterCaretLine, rep);
+  var caretLineIsPartiallyVisibleOnViewport = this._isLinePartiallyVisibleOnViewport(caretLine, rep);
+  var lineAfterCaretLineIsPartiallyVisibleOnViewport = this._isLinePartiallyVisibleOnViewport(firstLineVisibleAfterCaretLine, rep);
+  if (caretLineIsPartiallyVisibleOnViewport || lineAfterCaretLineIsPartiallyVisibleOnViewport) {
+    // check if the caret is in the bottom of the viewport
+    var caretLinePosition = caretPosition.getPosition();
+    var viewportBottom = this._getViewPortTopBottom().bottom;
+    var nextLineBottom = caretPosition.getBottomOfNextBrowserLine(caretLinePosition, rep);
+    var nextLineIsBelowViewportBottom = nextLineBottom > viewportBottom;
+    return nextLineIsBelowViewportBottom;
+  }
+  return false;
+}
+
+Scroll.prototype._isLinePartiallyVisibleOnViewport = function(lineNumber, rep)
+{
+  var lineNode = rep.lines.atIndex(lineNumber);
+  var linePosition = this._getLineEntryTopBottom(lineNode);
+  var lineTop = linePosition.top;
+  var lineBottom = linePosition.bottom;
+  var viewport = this._getViewPortTopBottom();
+  var viewportBottom = viewport.bottom;
+  var viewportTop = viewport.top;
+
+  var topOfLineIsAboveOfViewportBottom = lineTop < viewportBottom;
+  var bottomOfLineIsOnOrBelowOfViewportBottom = lineBottom >= viewportBottom;
+  var topOfLineIsBelowViewportTop = lineTop >= viewportTop;
+  var topOfLineIsAboveViewportBottom = lineTop <= viewportBottom;
+  var bottomOfLineIsAboveViewportBottom = lineBottom <= viewportBottom;
+  var bottomOfLineIsBelowViewportTop = lineBottom >= viewportTop;
+
+  return (topOfLineIsAboveOfViewportBottom && bottomOfLineIsOnOrBelowOfViewportBottom) ||
+    (topOfLineIsBelowViewportTop && topOfLineIsAboveViewportBottom) ||
+    (bottomOfLineIsAboveViewportBottom && bottomOfLineIsBelowViewportTop);
+}
+
+Scroll.prototype._getViewPortTopBottom = function()
+{
+  var theTop = this.getScrollY();
+  var doc = this.doc;
+  var height = doc.documentElement.clientHeight; // includes padding
+
+  // we have to get the exactly height of the viewport. So it has to subtract all the values which changes
+  // the viewport height (E.g. padding, position top)
+  var viewportExtraSpacesAndPosition = this._getEditorPositionTop() + this._getPaddingTopAddedWhenPageViewIsEnable();
+  return {
+    top: theTop,
+    bottom: (theTop + height - viewportExtraSpacesAndPosition)
+  };
+}
+
+Scroll.prototype._getEditorPositionTop = function()
+{
+  var editor = parent.document.getElementsByTagName('iframe');
+  var editorPositionTop = editor[0].offsetTop;
+  return editorPositionTop;
+}
+
+// ep_page_view adds padding-top, which makes the viewport smaller
+Scroll.prototype._getPaddingTopAddedWhenPageViewIsEnable = function()
+{
+  var aceOuter = this.rootDocument.getElementsByName("ace_outer");
+  var aceOuterPaddingTop = parseInt($(aceOuter).css("padding-top"));
+  return aceOuterPaddingTop;
+}
+
+Scroll.prototype._getScrollXY = function()
+{
+  var win = this.outerWin;
+  var odoc = this.doc;
+  if (typeof(win.pageYOffset) == "number")
+  {
+    return {
+      x: win.pageXOffset,
+      y: win.pageYOffset
+    };
+  }
+  var docel = odoc.documentElement;
+  if (docel && typeof(docel.scrollTop) == "number")
+  {
+    return {
+      x: docel.scrollLeft,
+      y: docel.scrollTop
+    };
+  }
+}
+
+Scroll.prototype.getScrollX = function()
+{
+  return this._getScrollXY().x;
+}
+
+Scroll.prototype.getScrollY = function()
+{
+  return this._getScrollXY().y;
+}
+
+Scroll.prototype.setScrollX = function(x)
+{
+  this.outerWin.scrollTo(x, this.getScrollY());
+}
+
+Scroll.prototype.setScrollY = function(y)
+{
+  this.outerWin.scrollTo(this.getScrollX(), y);
+}
+
+Scroll.prototype.setScrollXY = function(x, y)
+{
+  this.outerWin.scrollTo(x, y);
+}
+
+Scroll.prototype._isCaretAtTheTopOfViewport = function(rep)
+{
+  var caretLine = rep.selStart[0];
+  var linePrevCaretLine = caretLine - 1;
+  var firstLineVisibleBeforeCaretLine = caretPosition.getPreviousVisibleLine(linePrevCaretLine, rep);
+  var caretLineIsPartiallyVisibleOnViewport = this._isLinePartiallyVisibleOnViewport(caretLine, rep);
+  var lineBeforeCaretLineIsPartiallyVisibleOnViewport = this._isLinePartiallyVisibleOnViewport(firstLineVisibleBeforeCaretLine, rep);
+  if (caretLineIsPartiallyVisibleOnViewport || lineBeforeCaretLineIsPartiallyVisibleOnViewport) {
+    var caretLinePosition = caretPosition.getPosition(); // get the position of the browser line
+    var viewportPosition = this._getViewPortTopBottom();
+    var viewportTop = viewportPosition.top;
+    var viewportBottom = viewportPosition.bottom;
+    var caretLineIsBelowViewportTop = caretLinePosition.bottom >= viewportTop;
+    var caretLineIsAboveViewportBottom = caretLinePosition.top < viewportBottom;
+    var caretLineIsInsideOfViewport = caretLineIsBelowViewportTop && caretLineIsAboveViewportBottom;
+    if (caretLineIsInsideOfViewport) {
+      var prevLineTop = caretPosition.getPositionTopOfPreviousBrowserLine(caretLinePosition, rep);
+      var previousLineIsAboveViewportTop = prevLineTop < viewportTop;
+      return previousLineIsAboveViewportTop;
+    }
+  }
+  return false;
+}
+
+// By default, when user makes an edition in a line out of viewport, this line goes
+// to the edge of viewport. This function gets the extra pixels necessary to get the
+// caret line in a position X relative to Y% viewport.
+Scroll.prototype._getPixelsRelativeToPercentageOfViewport = function(innerHeight, aboveOfViewport)
+{
+  var pixels = 0;
+  var scrollPercentageRelativeToViewport = this._getPercentageToScroll(aboveOfViewport);
+  if(scrollPercentageRelativeToViewport > 0 && scrollPercentageRelativeToViewport <= 1){
+    pixels = parseInt(innerHeight * scrollPercentageRelativeToViewport);
+  }
+  return pixels;
+}
+
+// we use different percentages when change selection. It depends on if it is
+// either above the top or below the bottom of the page
+Scroll.prototype._getPercentageToScroll = function(aboveOfViewport)
+{
+  var percentageToScroll = this.scrollSettings.percentage.editionBelowViewport;
+  if(aboveOfViewport){
+    percentageToScroll = this.scrollSettings.percentage.editionAboveViewport;
+  }
+  return percentageToScroll;
+}
+
+Scroll.prototype.getPixelsToScrollWhenUserPressesArrowUp = function(innerHeight)
+{
+  var pixels = 0;
+  var percentageToScrollUp = this.scrollSettings.percentageToScrollWhenUserPressesArrowUp;
+  if(percentageToScrollUp > 0 && percentageToScrollUp <= 1){
+    pixels = parseInt(innerHeight * percentageToScrollUp);
+  }
+  return pixels;
+}
+
+Scroll.prototype._scrollYPage = function(pixelsToScroll)
+{
+  var durationOfAnimationToShowFocusline = this.scrollSettings.duration;
+  if(durationOfAnimationToShowFocusline){
+    this._scrollYPageWithAnimation(pixelsToScroll, durationOfAnimationToShowFocusline);
+  }else{
+    this.scrollYPageWithoutAnimation(pixelsToScroll);
+  }
+}
+
+Scroll.prototype.scrollYPageWithoutAnimation = function(pixelsToScroll)
+{
+  this.outerWin.scrollBy(0, pixelsToScroll);
+}
+
+Scroll.prototype._scrollYPageWithAnimation = function(pixelsToScroll, durationOfAnimationToShowFocusline)
+{
+  var outerDocBody = this.doc.getElementById("outerdocbody");
+
+  // it works on later versions of Chrome
+  var $outerDocBody = $(outerDocBody);
+  this._triggerScrollWithAnimation($outerDocBody, pixelsToScroll, durationOfAnimationToShowFocusline);
+
+  // it works on Firefox and earlier versions of Chrome
+  var $outerDocBodyParent = $outerDocBody.parent();
+  this._triggerScrollWithAnimation($outerDocBodyParent, pixelsToScroll, durationOfAnimationToShowFocusline);
+}
+
+// using a custom queue and clearing it, we avoid creating a queue of scroll animations. So if this function
+// is called twice quickly, only the last one runs.
+Scroll.prototype._triggerScrollWithAnimation = function($elem, pixelsToScroll, durationOfAnimationToShowFocusline)
+{
+  // clear the queue of animation
+  $elem.stop("scrollanimation");
+  $elem.animate({
+    scrollTop: '+=' + pixelsToScroll
+  }, {
+    duration: durationOfAnimationToShowFocusline,
+    queue: "scrollanimation"
+  }).dequeue("scrollanimation");
+}
+
+// scrollAmountWhenFocusLineIsOutOfViewport is set to 0 (default), scroll it the minimum distance
+// needed to be completely in view. If the value is greater than 0 and less than or equal to 1,
+// besides of scrolling the minimum needed to be visible, it scrolls additionally
+// (viewport height * scrollAmountWhenFocusLineIsOutOfViewport) pixels
+Scroll.prototype.scrollNodeVerticallyIntoView = function(rep, innerHeight)
+{
+  var viewport = this._getViewPortTopBottom();
+  var isPartOfRepLineOutOfViewport = this._partOfRepLineIsOutOfViewport(viewport, rep);
+
+  // when the selection changes outside of the viewport the browser automatically scrolls the line
+  // to inside of the viewport. Tested on IE, Firefox, Chrome in releases from 2015 until now
+  // So, when the line scrolled gets outside of the viewport we let the browser handle it.
+  var linePosition = caretPosition.getPosition();
+  if(linePosition){
+    var distanceOfTopOfViewport = linePosition.top - viewport.top;
+    var distanceOfBottomOfViewport = viewport.bottom - linePosition.bottom;
+    var caretIsAboveOfViewport = distanceOfTopOfViewport < 0;
+    var caretIsBelowOfViewport = distanceOfBottomOfViewport < 0;
+    if(caretIsAboveOfViewport){
+      var pixelsToScroll = distanceOfTopOfViewport - this._getPixelsRelativeToPercentageOfViewport(innerHeight, true);
+      this._scrollYPage(pixelsToScroll);
+    }else if(caretIsBelowOfViewport){
+      var pixelsToScroll = -distanceOfBottomOfViewport + this._getPixelsRelativeToPercentageOfViewport(innerHeight);
+      this._scrollYPage(pixelsToScroll);
+    }else{
+      this.scrollWhenCaretIsInTheLastLineOfViewportWhenNecessary(rep, true, innerHeight);
+    }
+  }
+}
+
+Scroll.prototype._partOfRepLineIsOutOfViewport = function(viewportPosition, rep)
+{
+  var focusLine = (rep.selFocusAtStart ? rep.selStart[0] : rep.selEnd[0]);
+  var line = rep.lines.atIndex(focusLine);
+  var linePosition = this._getLineEntryTopBottom(line);
+  var lineIsAboveOfViewport = linePosition.top < viewportPosition.top;
+  var lineIsBelowOfViewport = linePosition.bottom > viewportPosition.bottom;
+
+  return lineIsBelowOfViewport || lineIsAboveOfViewport;
+}
+
+Scroll.prototype._getLineEntryTopBottom = function(entry, destObj)
+{
+  var dom = entry.lineNode;
+  var top = dom.offsetTop;
+  var height = dom.offsetHeight;
+  var obj = (destObj || {});
+  obj.top = top;
+  obj.bottom = (top + height);
+  return obj;
+}
+
+Scroll.prototype.arrowUpWasPressedInTheFirstLineOfTheViewport = function(arrowUp, rep)
+{
+  var percentageScrollArrowUp = this.scrollSettings.percentageToScrollWhenUserPressesArrowUp;
+  return percentageScrollArrowUp && arrowUp && this._isCaretAtTheTopOfViewport(rep);
+}
+
+Scroll.prototype.getVisibleLineRange = function(rep)
+{
+  var viewport = this._getViewPortTopBottom();
+  //console.log("viewport top/bottom: %o", viewport);
+  var obj = {};
+  var self = this;
+  var start = rep.lines.search(function(e)
+  {
+    return self._getLineEntryTopBottom(e, obj).bottom > viewport.top;
+  });
+  var end = rep.lines.search(function(e)
+  {
+    // return the first line that the top position is greater or equal than
+    // the viewport. That is the first line that is below the viewport bottom.
+    // So the line that is in the bottom of the viewport is the very previous one.
+    return self._getLineEntryTopBottom(e, obj).top >= viewport.bottom;
+  });
+  if (end < start) end = start; // unlikely
+  // top.console.log(start+","+(end -1));
+  return [start, end - 1];
+}
+
+Scroll.prototype.getVisibleCharRange = function(rep)
+{
+  var lineRange = this.getVisibleLineRange(rep);
+  return [rep.lines.offsetOfIndex(lineRange[0]), rep.lines.offsetOfIndex(lineRange[1])];
+}
+
+exports.init = function(outerWin)
+{
+  return new Scroll(outerWin);
+}

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -66,6 +66,34 @@ describe('scroll when focus line is out of viewport', function () {
     });
   });
 
+  context('when user presses arrow up on the first line of the viewport', function(){
+    context('and percentageToScrollWhenUserPressesArrowUp is set to 0.3', function () {
+      var lineOnTopOfViewportWhenThePadIsScrolledDown;
+      before(function (done) {
+        setPercentageToScrollWhenUserPressesArrowUp(0.3);
+
+        // we need some room to make the scroll up
+        scrollEditorToBottomOfPad();
+        lineOnTopOfViewportWhenThePadIsScrolledDown = 93;
+        placeCaretAtTheEndOfLine(lineOnTopOfViewportWhenThePadIsScrolledDown);
+        setTimeout(function() {
+          // warning: even pressing up arrow, the caret does not change of position
+          pressAndReleaseUpArrow();
+          done();
+        }, 1000);
+      });
+
+      it('keeps the focus line scrolled 30% of the top of the viewport', function (done) {
+        // default behavior is to put the line in the top of viewport, but as
+        // PercentageToScrollWhenUserPressesArrowUp is set to 0.3, we have an extra 30% of lines scrolled
+        // (3 lines, which are the 30% of the 10 that are visible on viewport)
+        var firstLineOfViewport = getFirstLineVisibileOfViewport();
+        expect(firstLineOfViewport).to.be(lineOnTopOfViewportWhenThePadIsScrolledDown - 3);
+        done();
+      })
+    });
+  });
+
   context('when user edits the last line of viewport', function(){
     context('and scroll percentage config is set to 0 on settings.json', function(){
       var lastLineOfViewportBeforeEnter = 10;
@@ -338,6 +366,7 @@ describe('scroll when focus line is out of viewport', function () {
   var ENTER = 13;
   var BACKSPACE = 8;
   var LEFT_ARROW = 37;
+  var UP_ARROW = 38;
   var RIGHT_ARROW = 39;
   var LINES_ON_VIEWPORT = 10;
   var WIDTH_OF_EDITOR_RESIZED = 100;
@@ -513,6 +542,11 @@ describe('scroll when focus line is out of viewport', function () {
     pressKey(BACKSPACE);
   };
 
+  var pressAndReleaseUpArrow = function() {
+    pressKey(UP_ARROW);
+    releaseKey(UP_ARROW);
+  };
+
   var pressAndReleaseRightArrow = function() {
     pressKey(RIGHT_ARROW);
     releaseKey(RIGHT_ARROW);
@@ -581,6 +615,10 @@ describe('scroll when focus line is out of viewport', function () {
 
   var setScrollPercentageWhenFocusLineIsOutOfViewport = function(value) {
     helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage = value;
+  };
+
+  var setPercentageToScrollWhenUserPressesArrowUp = function (value) {
+    helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentageToScrollWhenUserPressesArrowUp = value;
   };
 
   var scrollWhenPlaceCaretInTheLastLineOfViewport = function() {

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -3,6 +3,7 @@ describe('scroll when focus line is out of viewport', function () {
     helper.newPad(function(){
       cleanPad(function(){
         forceUseMonospacedFont();
+        scrollWhenPlaceCaretInTheLastLineOfViewport();
         createPadWithSeveralLines(function(){
           resizeEditorHeight();
           done();
@@ -580,6 +581,11 @@ describe('scroll when focus line is out of viewport', function () {
 
   var setScrollPercentageWhenFocusLineIsOutOfViewport = function(value) {
     helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage = value;
+  };
+
+  var scrollWhenPlaceCaretInTheLastLineOfViewport = function() {
+    var scrollSettings = helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport;
+    scrollSettings.scrollWhenCaretIsInTheLastLineOfViewport = true;
   };
 
   var getLinePositionOnViewport = function(lineNumber) {

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -17,7 +17,7 @@ describe('scroll when focus line is out of viewport', function () {
     context('and scroll percentage config is set to 0.2 on settings.json', function(){
       var lineCloseOfTopOfPad = 10;
       before(function (done) {
-        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2);
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2, true);
         scrollEditorToBottomOfPad();
 
         placeCaretInTheBeginningOfLine(lineCloseOfTopOfPad, function(){ // place caret in the 10th line
@@ -99,7 +99,7 @@ describe('scroll when focus line is out of viewport', function () {
       var lastLineOfViewportBeforeEnter = 10;
       before(function () {
         // the default value
-        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+        resetScrollPercentageWhenFocusLineIsOutOfViewport();
 
         // make sure the last line on viewport is the 10th one
         scrollEditorToTopOfPad();
@@ -178,7 +178,7 @@ describe('scroll when focus line is out of viewport', function () {
       var lineCloseToBottomOfPad = 50;
       before(function () {
         // we force the line edited to be above the top of the viewport
-        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2); // set scroll jump to 20%
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2, true); // set scroll jump to 20%
         scrollEditorToTopOfPad();
         placeCaretAtTheEndOfLine(lineCloseToBottomOfPad);
         scrollEditorToBottomOfPad();
@@ -201,7 +201,7 @@ describe('scroll when focus line is out of viewport', function () {
     context('and scroll percentage config is set to 0 on settings.json', function(){
       before(function (done) {
         // reset to the default value
-        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+        resetScrollPercentageWhenFocusLineIsOutOfViewport();
 
         placeCaretInTheBeginningOfLine(0, function(){ // reset caret position
           scrollEditorToTopOfPad();
@@ -613,12 +613,24 @@ describe('scroll when focus line is out of viewport', function () {
     helper.padChrome$.window.clientVars.padOptions.useMonospaceFont = true;
   };
 
-  var setScrollPercentageWhenFocusLineIsOutOfViewport = function(value) {
-    helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage = value;
+  var setScrollPercentageWhenFocusLineIsOutOfViewport = function(value, editionAboveViewport) {
+    var scrollSettings = helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport;
+    if (editionAboveViewport) {
+      scrollSettings.percentage.editionAboveViewport = value;
+    }else{
+      scrollSettings.percentage.editionBelowViewport = value;
+    }
+  };
+
+  var resetScrollPercentageWhenFocusLineIsOutOfViewport = function() {
+    var scrollSettings = helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport;
+    scrollSettings.percentage.editionAboveViewport = 0;
+    scrollSettings.percentage.editionBelowViewport = 0;
   };
 
   var setPercentageToScrollWhenUserPressesArrowUp = function (value) {
-    helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentageToScrollWhenUserPressesArrowUp = value;
+    var scrollSettings = helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport;
+    scrollSettings.percentageToScrollWhenUserPressesArrowUp = value;
   };
 
   var scrollWhenPlaceCaretInTheLastLineOfViewport = function() {

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -93,7 +93,7 @@ describe('scroll when focus line is out of viewport', function () {
         // make sure the last line on viewport is the 10th one
         scrollEditorToTopOfPad();
         placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
-        pressEnter();
+        pressBackspace();
       });
 
       it('scrolls 30% of viewport up', function (done) {
@@ -217,7 +217,7 @@ describe('scroll when focus line is out of viewport', function () {
 
   // This is a special case. When user is selecting a text with arrow down or arrow left we have
   // to keep the last line selected on focus
-  context('when the first line selected is out of the viewport and user presses shift + arrow down', function(){
+  context('when the first line selected is out of the viewport and user presses shift arrow down', function(){
     var lastLineOfPad = 99;
     before(function (done) {
       scrollEditorToTopOfPad();
@@ -335,7 +335,7 @@ describe('scroll when focus line is out of viewport', function () {
   var BOTTOM_OF_PAGE = 5000; // we use a big value to force the page to be scrolled all the way down
   var LINES_OF_PAD = 100;
   var ENTER = 13;
-  var BACKSPACE = 9;
+  var BACKSPACE = 8;
   var LEFT_ARROW = 37;
   var RIGHT_ARROW = 39;
   var LINES_ON_VIEWPORT = 10;

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -1,0 +1,593 @@
+describe('scroll when focus line is out of viewport', function () {
+  before(function (done) {
+    helper.newPad(function(){
+      cleanPad(function(){
+        forceUseMonospacedFont();
+        createPadWithSeveralLines(function(){
+          resizeEditorHeight();
+          done();
+        });
+      });
+    });
+    this.timeout(20000);
+  });
+
+  context('when user presses any arrow keys on a line above the viewport', function(){
+    context('and scroll percentage config is set to 0.2 on settings.json', function(){
+      var lineCloseOfTopOfPad = 10;
+      before(function (done) {
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2);
+        scrollEditorToBottomOfPad();
+
+        placeCaretInTheBeginningOfLine(lineCloseOfTopOfPad, function(){ // place caret in the 10th line
+          // warning: even pressing right arrow, the caret does not change of position
+          // the column where the caret is, it has not importance, only the line
+          pressAndReleaseRightArrow();
+          done();
+        });
+      });
+
+      it('keeps the focus line scrolled 20% from the top of the viewport', function (done) {
+        // default behavior is to put the line in the top of viewport, but as
+        // scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.2, we have an extra 20% of lines scrolled
+        // (2 lines, which are the 20% of the 10 that are visible on viewport)
+        var firstLineOfViewport = getFirstLineVisibileOfViewport();
+        expect(lineCloseOfTopOfPad).to.be(firstLineOfViewport + 2);
+        done();
+      });
+    });
+  });
+
+  context('when user presses any arrow keys on a line below the viewport', function(){
+    context('and scroll percentage config is set to 0.7 on settings.json', function(){
+      var lineCloseToBottomOfPad = 50;
+      before(function (done) {
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.7);
+
+        // firstly, scroll to make the lineCloseToBottomOfPad visible. After that, scroll to make it out of viewport
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lineCloseToBottomOfPad); // place caret in the 50th line
+        setTimeout(function() {
+          // warning: even pressing right arrow, the caret does not change of position
+          pressAndReleaseLeftArrow();
+          done();
+        }, 1000);
+      });
+
+      it('keeps the focus line scrolled 70% from the bottom of the viewport', function (done) {
+        // default behavior is to put the line in the top of viewport, but as
+        // scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.7, we have an extra 70% of lines scrolled
+        // (7 lines, which are the 70% of the 10 that are visible on viewport)
+        var lastLineOfViewport = getLastLineVisibleOfViewport();
+        expect(lineCloseToBottomOfPad).to.be(lastLineOfViewport - 7);
+        done();
+      });
+    });
+  });
+
+  context('when user edits the last line of viewport', function(){
+    context('and scroll percentage config is set to 0 on settings.json', function(){
+      var lastLineOfViewportBeforeEnter = 10;
+      before(function () {
+        // the default value
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+
+        // make sure the last line on viewport is the 10th one
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
+        pressEnter();
+      });
+
+      it('keeps the focus line on the bottom of the viewport', function (done) {
+        var lastLineOfViewportAfterEnter = getLastLineVisibleOfViewport();
+        expect(lastLineOfViewportAfterEnter).to.be(lastLineOfViewportBeforeEnter + 1);
+        done();
+      });
+    });
+
+    context('and scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.3', function(){ // this value is arbitrary
+      var lastLineOfViewportBeforeEnter = 9;
+      before(function () {
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.3);
+
+        // make sure the last line on viewport is the 10th one
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
+        pressEnter();
+      });
+
+      it('scrolls 30% of viewport up', function (done) {
+        var lastLineOfViewportAfterEnter = getLastLineVisibleOfViewport();
+        // default behavior is to scroll one line at the bottom of viewport, but as
+        // scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.3, we have an extra 30% of lines scrolled
+        // (3 lines, which are the 30% of the 10 that are visible on viewport)
+        expect(lastLineOfViewportAfterEnter).to.be(lastLineOfViewportBeforeEnter + 3);
+        done();
+      });
+    });
+
+    context('and it is set to a value that overflow the interval [0, 1]', function(){
+      var lastLineOfViewportBeforeEnter = 10;
+      before(function(){
+        var scrollPercentageWhenFocusLineIsOutOfViewport = 1.5;
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lastLineOfViewportBeforeEnter);
+        setScrollPercentageWhenFocusLineIsOutOfViewport(scrollPercentageWhenFocusLineIsOutOfViewport);
+        pressEnter();
+      });
+
+      it('keeps the default behavior of moving the focus line on the bottom of the viewport', function (done) {
+        var lastLineOfViewportAfterEnter = getLastLineVisibleOfViewport();
+        expect(lastLineOfViewportAfterEnter).to.be(lastLineOfViewportBeforeEnter + 1);
+        done();
+      });
+    });
+  });
+
+  context('when user edits a line above the viewport', function(){
+    context('and scroll percentage config is set to 0 on settings.json', function(){
+      var lineCloseOfTopOfPad = 10;
+      before(function () {
+        // the default value
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+
+        // firstly, scroll to make the lineCloseOfTopOfPad visible. After that, scroll to make it out of viewport
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lineCloseOfTopOfPad); // place caret in the 10th line
+        scrollEditorToBottomOfPad();
+        pressBackspace(); // edit the line where the caret is, which is above the viewport
+      });
+
+      it('keeps the focus line on the top of the viewport', function (done) {
+        var firstLineOfViewportAfterEnter = getFirstLineVisibileOfViewport();
+        expect(firstLineOfViewportAfterEnter).to.be(lineCloseOfTopOfPad);
+        done();
+      });
+    });
+
+    context('and scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.2', function(){ // this value is arbitrary
+      var lineCloseToBottomOfPad = 50;
+      before(function () {
+        // we force the line edited to be above the top of the viewport
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.2); // set scroll jump to 20%
+        scrollEditorToTopOfPad();
+        placeCaretAtTheEndOfLine(lineCloseToBottomOfPad);
+        scrollEditorToBottomOfPad();
+        pressBackspace(); // edit line
+      });
+
+      it('scrolls 20% of viewport down', function (done) {
+        // default behavior is to scroll one line at the top of viewport, but as
+        // scrollPercentageWhenFocusLineIsOutOfViewport is set to 0.2, we have an extra 20% of lines scrolled
+        // (2 lines, which are the 20% of the 10 that are visible on viewport)
+        var firstLineVisibileOfViewport = getFirstLineVisibileOfViewport();
+        expect(lineCloseToBottomOfPad).to.be(firstLineVisibileOfViewport + 2);
+        done();
+      });
+    });
+  });
+
+  context('when user places the caret at the last line visible of viewport', function(){
+    var lastLineVisible;
+    context('and scroll percentage config is set to 0 on settings.json', function(){
+      before(function (done) {
+        // reset to the default value
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0);
+
+        placeCaretInTheBeginningOfLine(0, function(){ // reset caret position
+          scrollEditorToTopOfPad();
+          lastLineVisible = getLastLineVisibleOfViewport();
+          placeCaretInTheBeginningOfLine(lastLineVisible, done); // place caret in the 9th line
+        });
+
+      });
+
+      it('does not scroll', function(done){
+        setTimeout(function() {
+          var lastLineOfViewport = getLastLineVisibleOfViewport();
+          var lineDoesNotScroll = lastLineOfViewport === lastLineVisible;
+          expect(lineDoesNotScroll).to.be(true);
+          done();
+        }, 1000);
+      });
+    });
+    context('and scroll percentage config is set to 0.5 on settings.json', function(){
+      before(function (done) {
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.5);
+        scrollEditorToTopOfPad();
+        placeCaretInTheBeginningOfLine(0, function(){ // reset caret position
+          // this timeout inside a callback is ugly but it necessary to give time to aceSelectionChange
+          // realizes that the selection has been changed
+          setTimeout(function() {
+            lastLineVisible = getLastLineVisibleOfViewport();
+            placeCaretInTheBeginningOfLine(lastLineVisible, done); // place caret in the 9th line
+          }, 1000);
+        });
+      });
+
+      it('scrolls line to 50% of the viewport', function(done){
+        helper.waitFor(function(){
+          var lastLineOfViewport = getLastLineVisibleOfViewport();
+          var lastLinesScrolledFiveLinesUp = lastLineOfViewport - 5 === lastLineVisible;
+          return lastLinesScrolledFiveLinesUp;
+        }).done(done);
+      });
+    });
+  });
+
+  // This is a special case. When user is selecting a text with arrow down or arrow left we have
+  // to keep the last line selected on focus
+  context('when the first line selected is out of the viewport and user presses shift + arrow down', function(){
+    var lastLineOfPad = 99;
+    before(function (done) {
+      scrollEditorToTopOfPad();
+
+      // make a selection bigger than the viewport height
+      var $firstLineOfSelection = getLine(0);
+      var $lastLineOfSelection = getLine(lastLineOfPad);
+      var lengthOfLastLine = $lastLineOfSelection.text().length;
+      helper.selectLines($firstLineOfSelection, $lastLineOfSelection, 0, lengthOfLastLine);
+
+      // place the last line selected on the viewport
+      scrollEditorToBottomOfPad();
+
+      // press a key to make the selection goes down
+      // although we can't simulate the extending of selection. It's possible to send a key event
+      // which is captured on ace2_inner scroll function.
+      pressAndReleaseLeftArrow(true);
+      done();
+    });
+
+    it('keeps the last line selected on focus', function (done) {
+      var lastLineOfSelectionIsVisible = isLineOnViewport(lastLineOfPad);
+      expect(lastLineOfSelectionIsVisible).to.be(true);
+      done();
+    });
+  });
+
+  // In this scenario we avoid the bouncing scroll. E.g Let's suppose we have a big line that is
+  // the size of the viewport, and its top is above the viewport. When user presses '<-', this line
+  // will scroll down because the top is out of the viewport. When it scrolls down, the bottom of
+  // line gets below the viewport so when user presses '<-' again it scrolls up to make the bottom
+  // of line visible. If user presses arrow keys more than one time, the editor will keep scrolling up and down
+  context('when the line height is bigger than the scroll amount percentage * viewport height', function(){
+    var scrollOfEditorBeforePressKey;
+    var BIG_LINE_NUMBER = 0;
+    var MIDDLE_OF_BIG_LINE = 51;
+    before(function (done) {
+      createPadWithALineHigherThanViewportHeight(this, BIG_LINE_NUMBER, function(){
+        setScrollPercentageWhenFocusLineIsOutOfViewport(0.5); // set any value to force scroll to outside to viewport
+        var $bigLine = getLine(BIG_LINE_NUMBER);
+
+        // each line has about 5 chars, we place the caret in the middle of the line
+        helper.selectLines($bigLine, $bigLine, MIDDLE_OF_BIG_LINE, MIDDLE_OF_BIG_LINE);
+
+        scrollEditorToLeaveTopAndBottomOfBigLineOutOfViewport($bigLine);
+        scrollOfEditorBeforePressKey = getEditorScroll();
+
+        // press a key to force to scroll
+        pressAndReleaseRightArrow();
+        done();
+      });
+    });
+
+    // reset pad to the original text
+    after(function (done) {
+      this.timeout(5000);
+      cleanPad(function(){
+        createPadWithSeveralLines(function(){
+          resetEditorWidth();
+          done();
+        });
+      });
+    });
+
+    // as the editor.line is inside of the viewport, it should not scroll
+    it('should not scroll', function (done) {
+      var scrollOfEditorAfterPressKey = getEditorScroll();
+      expect(scrollOfEditorAfterPressKey).to.be(scrollOfEditorBeforePressKey);
+      done();
+    });
+  });
+
+  // Some plugins, for example the ep_page_view, change the editor dimensions. This plugin, for example,
+  // adds padding-top to the ace_outer, which changes the viewport height
+  describe('integration with plugins which changes the margin of editor', function(){
+    context('when editor dimensions changes', function(){
+      before(function () {
+        // reset the size of editor. Now we show more than 10 lines as in the other tests
+        resetResizeOfEditorHeight();
+        scrollEditorToTopOfPad();
+
+        // height of the editor viewport
+        var editorHeight = getEditorHeight();
+
+        // add a big padding-top, 50% of the viewport
+        var paddingTopOfAceOuter = editorHeight/2;
+        var chrome$ = helper.padChrome$;
+        var $outerIframe = chrome$('iframe');
+        $outerIframe.css('padding-top', paddingTopOfAceOuter);
+
+        // we set a big value to check if the scroll is made
+        setScrollPercentageWhenFocusLineIsOutOfViewport(1);
+      });
+
+      context('and user places the caret in the last line visible of the pad', function(){
+        var lastLineVisible;
+        beforeEach(function (done) {
+          lastLineVisible = getLastLineVisibleOfViewport();
+          placeCaretInTheBeginningOfLine(lastLineVisible, done);
+        });
+
+        it('scrolls the line where caret is', function(done){
+          helper.waitFor(function(){
+            var firstLineVisibileOfViewport = getFirstLineVisibileOfViewport();
+            var linesScrolled = firstLineVisibileOfViewport !== 0;
+            return linesScrolled;
+          }).done(done);
+        });
+      });
+    });
+  });
+
+  /* ********************* Helper functions/constants ********************* */
+  var TOP_OF_PAGE = 0;
+  var BOTTOM_OF_PAGE = 5000; // we use a big value to force the page to be scrolled all the way down
+  var LINES_OF_PAD = 100;
+  var ENTER = 13;
+  var BACKSPACE = 9;
+  var LEFT_ARROW = 37;
+  var RIGHT_ARROW = 39;
+  var LINES_ON_VIEWPORT = 10;
+  var WIDTH_OF_EDITOR_RESIZED = 100;
+  var LONG_TEXT_CHARS = 100;
+
+  var cleanPad = function(callback) {
+    var inner$ = helper.padInner$;
+    var $padContent = inner$('#innerdocbody');
+    $padContent.html('');
+
+    // wait for Etherpad to re-create first line
+    helper.waitFor(function(){
+      var lineNumber = inner$('div').length;
+      return lineNumber === 1;
+    }, 2000).done(callback);
+  };
+
+  var createPadWithSeveralLines = function(done) {
+    var line = '<span>a</span><br>';
+    var $firstLine = helper.padInner$('div').first();
+    var lines = line.repeat(LINES_OF_PAD); //arbitrary number, we need to create lines that is over the viewport
+    $firstLine.html(lines);
+
+    helper.waitFor(function(){
+      var linesCreated = helper.padInner$('div').length;
+      return linesCreated === LINES_OF_PAD;
+    }, 4000).done(done);
+  };
+
+  var createPadWithALineHigherThanViewportHeight = function(test, line, done) {
+    var viewportHeight = 160; //10 lines * 16px (height of line)
+    test.timeout(5000);
+    cleanPad(function(){
+      // make the editor smaller to make test easier
+      // with that width the each line has about 5 chars
+      resizeEditorWidth();
+
+      // we create a line with 100 chars, which makes about 20 lines
+      setLongTextOnLine(line);
+      helper.waitFor(function () {
+        var $firstLine = getLine(line);
+
+        var heightOfLine = $firstLine.get(0).getBoundingClientRect().height;
+        return heightOfLine >= viewportHeight;
+      }, 4000).done(done);
+    });
+  };
+
+  var setLongTextOnLine = function(line) {
+    var $line = getLine(line);
+    var longText = 'a'.repeat(LONG_TEXT_CHARS);
+    $line.html(longText);
+  };
+
+  // resize the editor to make the tests easier
+  var resizeEditorHeight = function() {
+    var chrome$ = helper.padChrome$;
+    chrome$('#editorcontainer').css('height', getSizeOfViewport());
+  };
+
+  // this makes about 5 chars per line
+  var resizeEditorWidth = function() {
+    var chrome$ = helper.padChrome$;
+    chrome$('#editorcontainer').css('width', WIDTH_OF_EDITOR_RESIZED);
+  };
+
+  var resetResizeOfEditorHeight = function() {
+    var chrome$ = helper.padChrome$;
+    chrome$('#editorcontainer').css('height', '');
+  };
+
+  var resetEditorWidth = function () {
+    var chrome$ = helper.padChrome$;
+    chrome$('#editorcontainer').css('width', '');
+  };
+
+  var getEditorHeight = function() {
+    var chrome$ = helper.padChrome$;
+    var $editor = chrome$('#editorcontainer');
+    var editorHeight = $editor.get(0).clientHeight;
+    return editorHeight;
+  };
+
+  var getSizeOfViewport = function() {
+    return getLinePositionOnViewport(LINES_ON_VIEWPORT) - getLinePositionOnViewport(0);
+  };
+
+  var scrollPageTo = function(value) {
+    var outer$ = helper.padOuter$;
+    var $ace_outer = outer$('#outerdocbody').parent();
+    $ace_outer.parent().scrollTop(value);
+  };
+
+  var scrollEditorToTopOfPad = function() {
+    scrollPageTo(TOP_OF_PAGE);
+  };
+
+  var scrollEditorToBottomOfPad = function() {
+    scrollPageTo(BOTTOM_OF_PAGE);
+  };
+
+  var scrollEditorToLeaveTopAndBottomOfBigLineOutOfViewport = function ($bigLine) {
+    var lineHeight = $bigLine.get(0).getBoundingClientRect().height;
+    var middleOfLine = lineHeight/2;
+    scrollPageTo(middleOfLine);
+  };
+
+  var getLine = function(lineNum) {
+    var inner$ = helper.padInner$;
+    var $line = inner$('div').eq(lineNum);
+    return $line;
+  };
+
+  var placeCaretAtTheEndOfLine = function(lineNum) {
+    var $targetLine = getLine(lineNum);
+    var lineLength = $targetLine.text().length;
+    helper.selectLines($targetLine, $targetLine, lineLength, lineLength);
+  };
+
+  var placeCaretInTheBeginningOfLine = function(lineNum, cb) {
+    var $targetLine = getLine(lineNum);
+    helper.selectLines($targetLine, $targetLine, 0, 0);
+    helper.waitFor(function() {
+      var $lineWhereCaretIs = getLineWhereCaretIs();
+      return $targetLine.get(0) === $lineWhereCaretIs.get(0);
+    }).done(cb);
+  };
+
+  var getLineWhereCaretIs = function() {
+    var inner$ = helper.padInner$;
+    var nodeWhereCaretIs = inner$.document.getSelection().anchorNode;
+    var $lineWhereCaretIs = $(nodeWhereCaretIs).closest('div');
+    return $lineWhereCaretIs;
+  };
+
+  var getFirstLineVisibileOfViewport = function() {
+    return _.find(_.range(0, LINES_OF_PAD - 1), isLineOnViewport);
+  };
+
+  var getLastLineVisibleOfViewport = function() {
+    return _.find(_.range(LINES_OF_PAD - 1, 0, -1), isLineOnViewport);
+  };
+
+  var pressKey = function(keyCode, shiftIsPressed){
+    var inner$ = helper.padInner$;
+    var evtType;
+    if(inner$(window)[0].bowser.firefox || inner$(window)[0].bowser.modernIE){ // if it's a mozilla or IE
+      evtType = 'keypress';
+    }else{
+      evtType = 'keydown';
+    }
+    var e = inner$.Event(evtType);
+    e.shiftKey = shiftIsPressed;
+    e.keyCode = keyCode;
+    e.which = keyCode; // etherpad listens to 'which'
+    inner$('#innerdocbody').trigger(e);
+  };
+
+  var releaseKey = function(keyCode){
+    var inner$ = helper.padInner$;
+    var evtType = 'keyup';
+    var e = inner$.Event(evtType);
+    e.keyCode = keyCode;
+    e.which = keyCode; // etherpad listens to 'which'
+    inner$('#innerdocbody').trigger(e);
+  };
+
+  var pressEnter = function() {
+    pressKey(ENTER);
+  };
+
+  var pressBackspace = function() {
+    pressKey(BACKSPACE);
+  };
+
+  var pressAndReleaseRightArrow = function() {
+    pressKey(RIGHT_ARROW);
+    releaseKey(RIGHT_ARROW);
+  };
+
+  var pressAndReleaseLeftArrow = function(shiftIsPressed) {
+    pressKey(LEFT_ARROW, shiftIsPressed);
+    releaseKey(LEFT_ARROW);
+  };
+
+  var isLineOnViewport = function(lineNumber) {
+    // in the function scrollNodeVerticallyIntoView from ace2_inner.js, iframePadTop is used to calculate
+    // how much scroll is needed. Although the name refers to padding-top, this value is not set on the
+    // padding-top.
+    var iframePadTop = 8;
+    var $line = getLine(lineNumber);
+    var linePosition = $line.get(0).getBoundingClientRect();
+
+    // position relative to the current viewport
+    var linePositionTopOnViewport = linePosition.top - getEditorScroll() + iframePadTop;
+    var linePositionBottomOnViewport = linePosition.bottom - getEditorScroll();
+
+    var lineBellowTop = linePositionBottomOnViewport > 0;
+    var lineAboveBottom = linePositionTopOnViewport < getClientHeightVisible();
+    var isVisible = lineBellowTop && lineAboveBottom;
+
+    return isVisible;
+  };
+
+  var getEditorScroll = function () {
+    var outer$ = helper.padOuter$;
+    var scrollTopFirefox = outer$('#outerdocbody').parent().scrollTop(); // works only on firefox
+    var scrollTop = outer$('#outerdocbody').scrollTop() || scrollTopFirefox;
+    return scrollTop;
+  };
+
+  // clientHeight includes padding, so we have to subtract it and consider only the visible viewport
+  var getClientHeightVisible = function () {
+    var outer$ = helper.padOuter$;
+    var $ace_outer = outer$('#outerdocbody').parent();
+    var ace_outerHeight = $ace_outer.get(0).clientHeight;
+    var ace_outerPaddingTop = getIntValueOfCSSProperty($ace_outer, 'padding-top');
+    var paddingAddedWhenPageViewIsEnable = getPaddingAddedWhenPageViewIsEnable();
+    var clientHeight = ace_outerHeight - ( ace_outerPaddingTop + paddingAddedWhenPageViewIsEnable);
+
+    return clientHeight;
+  };
+
+  // ep_page_view changes the dimensions of the editor. We have to guarantee
+  // the viewport height is calculated right
+  var getPaddingAddedWhenPageViewIsEnable = function () {
+    var chrome$ = helper.padChrome$;
+    var $outerIframe = chrome$('iframe');
+    var paddingAddedWhenPageViewIsEnable = parseInt($outerIframe.css('padding-top'));
+    return paddingAddedWhenPageViewIsEnable;
+  };
+
+  var getIntValueOfCSSProperty = function($element, property){
+    var valueString = $element.css(property);
+    return parseInt(valueString) || 0;
+  };
+
+  var forceUseMonospacedFont = function () {
+    helper.padChrome$.window.clientVars.padOptions.useMonospaceFont = true;
+  };
+
+  var setScrollPercentageWhenFocusLineIsOutOfViewport = function(value) {
+    helper.padChrome$.window.clientVars.scrollWhenFocusLineIsOutOfViewport.percentage = value;
+  };
+
+  var getLinePositionOnViewport = function(lineNumber) {
+    var $line = getLine(lineNumber);
+    var linePosition = $line.get(0).getBoundingClientRect();
+
+    // position relative to the current viewport
+    return linePosition.top - getEditorScroll();
+  };
+});
+

--- a/tests/frontend/specs/scroll.js
+++ b/tests/frontend/specs/scroll.js
@@ -74,7 +74,7 @@ describe('scroll when focus line is out of viewport', function () {
 
         // we need some room to make the scroll up
         scrollEditorToBottomOfPad();
-        lineOnTopOfViewportWhenThePadIsScrolledDown = 93;
+        lineOnTopOfViewportWhenThePadIsScrolledDown = 91;
         placeCaretAtTheEndOfLine(lineOnTopOfViewportWhenThePadIsScrolledDown);
         setTimeout(function() {
           // warning: even pressing up arrow, the caret does not change of position


### PR DESCRIPTION
By default, when there is an edition of a line, which is out of the
viewport, Etherpad scrolls the minimum necessary to make this line
visible. This makes that the line stays either on the top or the bottom
of the viewport. With this PR, we add a setting to make possible to
scroll to a position x% pixels from the viewport. Besides of that, we
add a setting to make an animation of this scroll and allow to scroll if the 
caret is at the last line of the viewport. Both of them are optional.
If nothing is changed on settings.json the Etherpad default behavior is
kept.
_Etherpad Default_
![](https://cloud.githubusercontent.com/assets/4945372/22115088/df7675ca-de52-11e6-8cbe-6d53af44ce7c.gif)

_Google Docs_
![](https://cloud.githubusercontent.com/assets/4945372/22113272/d93180c0-de4c-11e6-8ade-f98623ff88f5.gif)

_Microsoft Word_
![](https://cloud.githubusercontent.com/assets/4945372/22115435/1d244d06-de54-11e6-97c8-91d9dc8c1ea8.gif)

This PR has been used/tested for one year or so in production. 
We've tested this PR on differents browsers versions, some of them
![screen shot 2017-11-28 at 11 09 45 am](https://user-images.githubusercontent.com/4945372/33321399-aed5bdce-d42c-11e7-9e86-bca2de66f78c.png)

ps: When there is a selection and user either presses arrow keys or does an edition, the default behavior of browser is kept. 