### PR TITLE
Call authentication hooks before default basic authentication.

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -36,13 +36,16 @@ exports.basicAuth = function (req, res, next) {
       var userpass = new Buffer(req.headers.authorization.split(' ')[1], 'base64').toString().split(":")
       var username = userpass.shift();
       var password = userpass.join(':');
-
-      if (settings.users[username] != undefined && settings.users[username].password == password) {
-        settings.users[username].username = username;
-        req.session.user = settings.users[username];
-        return cb(true);
-      }
-      return hooks.aCallFirst("authenticate", {req: req, res:res, next:next, username: username, password: password}, hookResultMangle(cb));
+      var fallback = function(success) {
+        if (success) return cb(true);
+        if (settings.users[username] != undefined && settings.users[username].password == password) {
+          settings.users[username].username = username;
+          req.session.user = settings.users[username];
+          return cb(true);
+        }
+        return cb(false);
+      };
+      return hooks.aCallFirst("authenticate", {req: req, res:res, next:next, username: username, password: password}, hookResultMangle(fallback));
     }
     hooks.aCallFirst("authenticate", {req: req, res:res, next:next}, hookResultMangle(cb));
   }


### PR DESCRIPTION
This allows authenticators to do any extra session setup for a given user,
even if their username/password happens to match settings.json.