### PR TITLE
Unix domain socket support.

### DIFF
--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -5,17 +5,11 @@ var fs = require('fs');
 var path = require('path');
 var npm = require("npm/lib/npm.js");
 var  _ = require("underscore");
-var errorHandling = require("./express/errorhandling");
+require('systemd');
 require('autoquit');
 
 var server;
 var serverName;
-
-/*
- * Check here,
- * https://cgit.freedesktop.org/systemd/systemd/tree/src/systemd/sd-daemon.h
- */
-var systemdListenFDStart = 3;
 
 exports.createServer = function () {
   console.log("Report bugs at https://github.com/ether/etherpad-lite/issues")
@@ -23,21 +17,6 @@ exports.createServer = function () {
   serverName = "Etherpad " + settings.getGitCommit() + " (http://etherpad.org)";
   
   console.log("Your Etherpad version is " + settings.getEpVersion() + " (" + settings.getGitCommit() + ")");
-
-  if(settings.unixSocketActivation) {
-    if(!parseInt(process.env.LISTEN_FDS, 10)) {
-      console.error('No listen file descriptors provided by Systemd. It seems like Etherpad was not invoked by Systemd.');
-      errorHandling.gracefulShutdown();
-    }
-
-    if (parseInt(process.env.LISTEN_FDS, 10) < 1) {
-      console.error('No listen file descriptors provided by Systemd.');
-      errorHandling.gracefulShutdown();
-    } else if (parseInt(process.env.LISTEN_FDS, 10) > 1) {
-      console.error('Too many file descriptors provided by Systemd. Only one file descriptor expected.');
-      errorHandling.gracefulShutdown();
-    }
-  }
 
   exports.restartServer();
 
@@ -133,6 +112,6 @@ exports.restartServer = function () {
      * { timeOut: <TIMEOUT_IN_SECONDS> }
      */
     server.autoQuit();
-    server.listen({fd: systemdListenFDStart});
+    server.listen('systemd');
   }
 }

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -56,6 +56,11 @@ exports.ip = "0.0.0.0";
 exports.port = process.env.PORT || 9001;
 
 /**
+ * Enable or disable UNIX domain socket support.
+ */
+exports.unixSocketActivation = false;
+
+/**
  * Should we suppress Error messages from being in Pad Contents
  */
 exports.suppressErrorsInPadText = false;
@@ -497,5 +502,3 @@ exports.reloadSettings = function reloadSettings() {
 
 // initially load settings
 exports.reloadSettings();
-
-

--- a/src/package.json
+++ b/src/package.json
@@ -44,6 +44,7 @@
                       "measured"                : "1.1.0",
                       "mocha"                   : "2.4.5",
                       "supertest"               : "1.2.0",
+                      "systemd"                 : "0.3.1",
                       "autoquit"                : "0.1.6"
                      },
   "bin":             { "etherpad-lite": "./node/server.js" },

--- a/src/package.json
+++ b/src/package.json
@@ -43,7 +43,8 @@
                       "jsonminify"              : "0.4.1",
                       "measured"                : "1.1.0",
                       "mocha"                   : "2.4.5",
-                      "supertest"               : "1.2.0"
+                      "supertest"               : "1.2.0",
+                      "autoquit"                : "0.1.6"
                      },
   "bin":             { "etherpad-lite": "./node/server.js" },
   "devDependencies": {


### PR DESCRIPTION
Based on this [issue](https://github.com/ether/etherpad-lite/issues/3299) this PR tries to add a new feature with which Etherpad Lite can be reached locally with a UNIX domain socket and also enable Systemd socket activation. The implementation adds a new dependency to the **autoquit** module.

To test the implementation:

1. Enable the **unixSocketActivation** configuration option.

2. Add Systemd service and socket files,

- Service File (/etc/systemd/system/etherpad-lite.service)
```
[Unit]
Description=Etherpad Lite, the collaborative editor.
After=syslog.target network.target
Requires=etherpad-lite.socket

[Service]
Type=simple
User=<USER>
Group=<GROUP>
WorkingDirectory=<INSTALL_DIRECTORY>
ExecStart=<NODEJS_BIN_PATH> <INSTALL_DIRECTORY>/src/node/server.js
StandardOutput=syslog
StandardError=syslog
SyslogIdentifier=etherpad-lite
Restart=no

[Install]
WantedBy=multi-user.target
```

- Socket File (/etc/systemd/system/etherpad-lite.socket)
```
[Unit]
Description=Etherpad Lite socket for UNIX socket activation.
PartOf=etherpad-lite.service

[Socket]
ListenStream=/tmp/etherpad-lite.socket
Accept=False

[Install]
WantedBy=sockets.target
```

3. Enable the socket with the following commands,

```
sudo systemctl --system daemon-reload
```
```
sudo systemctl start etherpad-lite.socket
```

4. Test Etherpad Lite functionalities,

- HTTP GET request

```
curl --unix-socket /tmp/etherpad-lite.socket -X GET http:/
```

- HTTP REST API: Create a pad

```
curl --unix-socket /tmp/etherpad-lite.socket \
-d '{"apikey":"<API_KEY>", "padID":"<PAD_ID>", "text": "<TEXT>"}' \
-H "Content-Type: application/json" \
-X POST http:/api/1/createPad
```

- HTTP REST API: Set text of the created pad

```
curl --unix-socket /tmp/etherpad-lite.socket \
-d '{"apikey":"<API_KEY>", "padID":"<PAD_ID>", "text": "<TEXT>"}' \
-H "Content-Type: application/json" \
-X POST http:/api/1/setText
```

- HTTP REST API: Get text from the created pad

```
curl --unix-socket /tmp/etherpad-lite.socket \
-d '{"apikey":"<API_KEY>", "padID":"<PAD_ID>"}' \
-H "Content-Type: application/json" \
-X POST http:/api/1/getText
```
