### PR TITLE
Don't send COMMIT-MESSAGE when socketio connection is not active

### DIFF
--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -181,20 +181,26 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
     }
 
     var sentMessage = false;
-    var userChangesData = editor.prepareUserChangeset();
-    if (userChangesData.changeset)
-    {
-      lastCommitTime = t;
-      state = "COMMITTING";
-      stateMessage = {
-        type: "USER_CHANGES",
-        baseRev: rev,
-        changeset: userChangesData.changeset,
-        apool: userChangesData.apool
-      };
-      sendMessage(stateMessage);
-      sentMessage = true;
-      callbacks.onInternalAction("commitPerformed");
+    if (getSocket().realConnected) {
+        var userChangesData = editor.prepareUserChangeset();
+        if (userChangesData.changeset)
+        {
+          lastCommitTime = t;
+          state = "COMMITTING";
+          stateMessage = {
+            type: "USER_CHANGES",
+            baseRev: rev,
+            changeset: userChangesData.changeset,
+            apool: userChangesData.apool
+          };
+          sendMessage(stateMessage);
+          sentMessage = true;
+          callbacks.onInternalAction("commitPerformed");
+        }
+    }
+    else {
+        // run again in a few seconds, to check if there was a reconnection attempt
+        setTimeout(wrapRecordingErrors("setTimeout(handleUserChanges)", handleUserChanges), 1000);
     }
 
     if (sentMessage)

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -201,15 +201,19 @@ function handshake()
   });
 
   socket.once('connect', function () {
+    // Setup our own connected flag since socketio one doesn't work accurately
+    socket.realConnected = true;
     sendClientReady(false);
   });
 
   socket.on('reconnect', function () {
+    socket.realConnected = true;
     pad.collabClient.setChannelState("CONNECTED");
     pad.sendClientReady(true);
   });
 
   socket.on('reconnecting', function() {
+    socket.realConnected = false;
     pad.collabClient.setChannelState("RECONNECTING");
   });
 


### PR DESCRIPTION
**BUG:**
If socket.io connection is lost and user is entering some input in the pad at the same time, then pad becomes unresponsive and shows a 'Disconnect modal' after few sec even after the socket.io connection is reestablished. 
+
Data entered in the pad during the loss of connection won't be sent to the server

**SOLUTION:**
Check if socket.io connection is active before sending any COMMIT-MESSAGE to the server. If not, wait for few sec before retrying to send the COMMIT-MESSAGE to the server.