### PR TITLE
specify python version in shebang

### DIFF
--- a/bin/dirty-db-cleaner.py
+++ b/bin/dirty-db-cleaner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env PYTHONUNBUFFERED=1 python2
 #
 # Created by Bjarni R. Einarsson, placed in the public domain. Go wild!
 #


### PR DESCRIPTION
This would fail e.g. on Archlinux otherwise