### PR TITLE
Fix line number display when plugin add padding-top (like ep_page_view)

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -5404,8 +5404,8 @@ function Ace2Inner(){
             // height is taken to be the top offset of the next line. If we
             // didn't do this special case, we would miss out on any top margin
             // included on the first line. The default stylesheet doesn't add
-            // extra margins, but plugins might.
-            h = b.nextSibling.offsetTop;
+            // extra margins/padding, but plugins might.
+            h = b.nextSibling.offsetTop - window.getComputedStyle(doc.body).getPropertyValue("padding-top");
           } else {
             h = b.nextSibling.offsetTop - b.offsetTop;
           }


### PR DESCRIPTION
Line numbering display was broken when using page view since https://github.com/ether/etherpad-lite/commit/a3765d97853ecfe3fa608cd3b191a33cabe311ec.

The first number took the line height plus 100px, due to ep_page_view padding-top CSS rule.

This fixes the problem.