### PR TITLE
Fix bug with cleanRun.sh

### DIFF
--- a/bin/cleanRun.sh
+++ b/bin/cleanRun.sh
@@ -38,4 +38,4 @@ bin/installDeps.sh $* || exit 1
 echo "Started Etherpad..."
 
 SCRIPTPATH=`pwd -P`
-node $SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js $*
+node "${$SCRIPTPATH}/node_modules/ep_etherpad-lite/node/server.js" $*


### PR DESCRIPTION
Now works if the output of `pwd` has a space in it.