### PR TITLE
Upgrade Ueberdb2 to 0.3.7 to fix #3348

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -17,7 +17,7 @@
                       "etherpad-require-kernel" : "1.0.9",
                       "resolve"                 : "1.1.7",
                       "socket.io"               : "1.7.3",
-                      "ueberdb2"                : "0.3.6",
+                      "ueberdb2"                : "0.3.7",
                       "express"                 : "4.13.4",
                       "express-session"         : "1.13.0",
                       "cookie-parser"           : "1.3.4",


### PR DESCRIPTION
Upgrade Ueberdb2 to 0.3.7 to fix https://github.com/ether/etherpad-lite/issues/3348