### PR TITLE
Document --credentials, --apikey and --sessionkey; remove -k (duplicate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If cloning to a subdirectory within another project, you may need to do the foll
 # Next Steps
 
 ## Tweak the settings
-You can initially modify the settings in `settings.json`. (If you need to handle multiple settings files, you can pass the path to a settings file to `bin/run.sh` using the `-s|--settings` option. This allows you to run multiple Etherpad instances from the same installation.)  Once you have access to your /admin section settings can be modified through the web browser.
+You can initially modify the settings in `settings.json`. (If you need to handle multiple settings files, you can pass the path to a settings file to `bin/run.sh` using the `-s|--settings` option. This allows you to run multiple Etherpad instances from the same installation. Similarly '--credentials' can be used to give an settings override file, '--apikey' to give a different APIKEY.txt file and '--sessionkey' to give a non-default SESSIONKEY.txt.)  Once you have access to your /admin section settings can be modified through the web browser.
 
 You should use a dedicated database such as "mysql", if you are planning on using etherpad-in a production environment, since the "dirtyDB" database driver is only for testing and/or development purposes.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ If cloning to a subdirectory within another project, you may need to do the foll
 # Next Steps
 
 ## Tweak the settings
-You can initially modify the settings in `settings.json`. (If you need to handle multiple settings files, you can pass the path to a settings file to `bin/run.sh` using the `-s|--settings` option. This allows you to run multiple Etherpad instances from the same installation. Similarly '--credentials' can be used to give an settings override file, '--apikey' to give a different APIKEY.txt file and '--sessionkey' to give a non-default SESSIONKEY.txt.)  Once you have access to your /admin section settings can be modified through the web browser.
+You can modify the settings in `settings.json`.
+If you need to handle multiple settings files, you can pass the path to a settings file to `bin/run.sh` using the `-s|--settings` option: this allows you to run multiple Etherpad instances from the same installation.
+Similarly, `--credentials` can be used to give a settings override file, `--apikey` to give a different APIKEY.txt file and `--sessionkey` to give a non-default SESSIONKEY.txt.
+Once you have access to your /admin section settings can be modified through the web browser.
 
 You should use a dedicated database such as "mysql", if you are planning on using etherpad-in a production environment, since the "dirtyDB" database driver is only for testing and/or development purposes.
 

--- a/src/node/utils/Cli.js
+++ b/src/node/utils/Cli.js
@@ -40,12 +40,12 @@ for ( var i = 0; i < argv.length; i++ ) {
   }
 
   // Override location of settings.json file
-  if ( prevArg == '--sessionkey' || prevArg == '-k' ) {
+  if ( prevArg == '--sessionkey' ) {
     exports.argv.sessionkey = arg;
   }
 
   // Override location of settings.json file
-  if ( prevArg == '--apikey' || prevArg == '-k' ) {
+  if ( prevArg == '--apikey' ) {
     exports.argv.apikey = arg;
   }
 


### PR DESCRIPTION
This pull requests adds some basic documentation for --credentials, --apikey and --sessionkey.
It removes the -k option, as it is currently used for both apikey and sessionkey.