### PR TITLE
Fix line-wrapping in WebKit

### DIFF
--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -43,7 +43,7 @@ body.grayedout { background-color: #eee !important }
 }
 
 body.doesWrap {
-  /* white-space: pre-wrap; */
+  white-space: pre-wrap;
 
   /*
     Must be pre-wrap to keep trailing spaces. Otherwise you get a zombie caret,


### PR DESCRIPTION
Re-add `white-space: pre-wrap;` to `body.doesWrap` (This possibly breaks older versions of Mozilla browsers, but makes etherpad-lite documents more readable on iOS devices).

Fixes #3270
