### PR TITLE
Update settings.json.template

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -45,12 +45,14 @@
                  },
 
   /* An Example of MySQL Configuration
+     See https://github.com/ether/etherpad-lite/wiki/How-to-use-Etherpad-Lite-with-MySQL
+   
    "dbType" : "mysql",
    "dbSettings" : {
                     "user"    : "root",
                     "host"    : "localhost",
                     "password": "",
-                    "database": "store",
+                    "database": "etherpad_lite_db",
                     "charset" : "utf8mb4"
                   },
   */

--- a/settings.json.template
+++ b/settings.json.template
@@ -49,9 +49,9 @@
    
    "dbType" : "mysql",
    "dbSettings" : {
-                    "user"    : "root",
+                    "user"    : "etherpaduser",
                     "host"    : "localhost",
-                    "password": "",
+                    "password": "PASSWORD",
                     "database": "etherpad_lite_db",
                     "charset" : "utf8mb4"
                   },


### PR DESCRIPTION
Harmonizing the database name.

"store" is the table name - not to be used here!

Database name must not contain "-", but can contain "_".

See https://github.com/ether/etherpad-lite/wiki/How-to-use-Etherpad-Lite-with-MySQL