### PR TITLE
Use keydown instead of keypress on Firefox.

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3708,8 +3708,8 @@ function Ace2Inner(){
       return; // This stops double enters in Opera but double Tabs still show on single tab keypress, adding keyCode == 9 to this doesn't help as the event is fired twice
     }
     var specialHandled = false;
-    var isTypeForSpecialKey = ((browser.msie || browser.safari || browser.chrome) ? (type == "keydown") : (type == "keypress"));
-    var isTypeForCmdKey = ((browser.msie || browser.safari || browser.chrome) ? (type == "keydown") : (type == "keypress"));
+    var isTypeForSpecialKey = ((browser.msie || browser.safari || browser.chrome || browser.firefox) ? (type == "keydown") : (type == "keypress"));
+    var isTypeForCmdKey = ((browser.msie || browser.safari || browser.chrome || browser.firefox) ? (type == "keydown") : (type == "keypress"));
     var stopped = false;
 
     inCallStackIfNecessary("handleKeyEvent", function()


### PR DESCRIPTION
This related with issue #3383.

Firefox will not fire the keypress when target key is the non-printable keys. (like Enter / Tab / Delete... etc) For detail, see https://bugzilla.mozilla.org/show_bug.cgi?id=1440189.

This behavior is same as safari / chrome, So etherpad-lite will not need to special handling of these key when UA is Firefox. This PR will use keydown event when target key is no-printable keys.