### PR TITLE
Fix misparse of port when binding Unix socket

### DIFF
--- a/src/node/hooks/express/static.js
+++ b/src/node/hooks/express/static.js
@@ -17,11 +17,12 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 
   // Setup middleware that will package JavaScript files served by minify for
   // CommonJS loader on the client-side.
+  // Hostname "invalid.invalid" is a dummy value to allow parsing as a URI.
   var jsServer = new (Yajsml.Server)({
     rootPath: 'javascripts/src/'
-  , rootURI: 'http://localhost:' + settings.port + '/static/js/'
+  , rootURI: 'http://invalid.invalid/static/js/'
   , libraryPath: 'javascripts/lib/'
-  , libraryURI: 'http://localhost:' + settings.port + '/static/plugins/'
+  , libraryURI: 'http://invalid.invalid/static/plugins/'
   , requestURIs: minify.requestURIs // Loop-back is causing problems, this is a workaround.
   });
 

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -264,7 +264,8 @@ function getAceFile(callback) {
     async.forEach(founds, function (item, callback) {
       var filename = item.match(/"([^"]*)"/)[1];
 
-      var baseURI = 'http://localhost:' + settings.port;
+      // Hostname "invalid.invalid" is a dummy value to allow parsing as a URI.
+      var baseURI = 'http://invalid.invalid';
       var resourceURI = baseURI + path.normalize(path.join('/static/', filename));
       resourceURI = resourceURI.replace(/\\/g, '/'); // Windows (safe generally?)
 


### PR DESCRIPTION
The hostname:port of URIs used in Minify are currently bogus and refer to localhost only for historical reasons; there's no reason to retain them and omitting them avoids generating an invalid URI when "port" is not an integer.

For context: settings.port is passed to express's `listen`, which treats it as a filename for a Unix domain socket if it doesn't look like a port number. This is useful for starting a server to be reverse-proxied on a multi-user system without requiring fuss around port numbers or authentication.

Currently, etherpad-lite runs without error when configured to listen on a Unix domain socket; however, when a pad is accessed, the client JS fails with "Uncaught Error: The module at "ep_etherpad-lite/static/js/rjquery" does not exist." due to `pad.js` and `ace2_common.js` being generated incorrectly:

when the port is actually a path e.g. `"etherpad.sock"`, the generated URIs are of the form `"http://localhost:etherpad.sock/static/js/rjquery.js"`. Accordingly, the file searched for is `:etherpad.sock/static/js/rjquery.js`, rather than the expected `static/js/rjquery.js`. Since such a file doesn't exist, the required code doesn't get included in the bundle.

A workaround is to remove the reference to the port. In my patch, I've also replaced extraneous references to `localhost` with `invalid.invalid` to hopefully save future readers a wild goose chase looking the requests being made over the loopback interface before understanding the significance of the comment on `requestURIs`...