### PR TITLE
Resolve relative paths deterministically

### DIFF
--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-
+var absolutePaths = require('../utils/AbsolutePaths');
 var ERR = require("async-stacktrace");
 var fs = require("fs");
 var api = require("../db/API");
@@ -31,7 +31,7 @@ var apiHandlerLogger = log4js.getLogger('APIHandler');
 
 //ensure we have an apikey
 var apikey = null;
-var apikeyFilename = argv.apikey || "./APIKEY.txt";
+var apikeyFilename = absolutePaths.makeAbsolute(argv.apikey || "./APIKEY.txt");
 try
 {
   apikey = fs.readFileSync(apikeyFilename,"utf8");

--- a/src/node/utils/AbsolutePaths.js
+++ b/src/node/utils/AbsolutePaths.js
@@ -114,3 +114,24 @@ exports.findEtherpadRoot = function() {
   absPathLogger.error(`To run, Etherpad has to identify an absolute base path. This is not: "${etherpadRoot}"`);
   process.exit(1);
 };
+
+/**
+ * Receives a filesystem path in input. If the path is absolute, returns it
+ * unchanged. If the path is relative, an absolute version of it is returned,
+ * built prepending exports.findEtherpadRoot() to it.
+ *
+ * @param  {string} somePath - an absolute or relative path
+ * @return {string} An absolute path. If the input path was already absolute,
+ *                  it is returned unchanged. Otherwise it is interpreted
+ *                  relative to exports.root.
+ */
+exports.makeAbsolute = function(somePath) {
+  if (path.isAbsolute(somePath)) {
+    return somePath;
+  }
+
+  const rewrittenPath = path.normalize(path.join(exports.findEtherpadRoot(), somePath));
+
+  absPathLogger.debug(`Relative path "${somePath}" can be rewritten to "${rewrittenPath}"`);
+  return rewrittenPath;
+};

--- a/src/node/utils/AbsolutePaths.js
+++ b/src/node/utils/AbsolutePaths.js
@@ -19,9 +19,16 @@
  */
 
 var log4js = require('log4js');
+var path = require('path');
 var _ = require('underscore');
 
 var absPathLogger = log4js.getLogger('AbsolutePaths');
+
+/*
+ * findEtherpadRoot() computes its value only on first invocation.
+ * Subsequent invocations are served from this variable.
+ */
+var etherpadRoot = null;
 
 /**
  * If stringArray's last elements are exactly equal to lastDesiredElements,
@@ -48,4 +55,62 @@ var popIfEndsWith = function(stringArray, lastDesiredElements) {
 
   absPathLogger.debug(`${stringArray.join(path.sep)} does not end with "${lastDesiredElements.join(path.sep)}"`);
   return false;
+};
+
+/**
+ * Heuristically computes the directory in which Etherpad is installed.
+ *
+ * All the relative paths have to be interpreted against this absolute base
+ * path. Since the Unix and Windows install have a different layout on disk,
+ * they are treated as two special cases.
+ *
+ * The path is computed only on first invocation. Subsequent invocations return
+ * a cached value.
+ *
+ * The cached value is stored in AbsolutePaths.etherpadRoot via a side effect.
+ *
+ * @return {string} The identified absolute base path. If such path cannot be
+ *                  identified, prints a log and exits the application.
+ */
+exports.findEtherpadRoot = function() {
+  if (etherpadRoot !== null) {
+    return etherpadRoot;
+  }
+
+  const findRoot = require('find-root');
+  const foundRoot = findRoot(__dirname);
+
+  var directoriesToStrip;
+  if (process.platform === 'win32') {
+    /*
+     * Given the structure of our Windows package, foundRoot's value
+     * will be the following on win32:
+     *
+     *   <BASE_DIR>\node_modules\ep_etherpad-lite
+     */
+    directoriesToStrip = ['node_modules', 'ep_etherpad-lite'];
+  } else {
+    /*
+     * On Unix platforms, foundRoot's value will be:
+     *
+     *   <BASE_DIR>\src
+     */
+    directoriesToStrip = ['src'];
+  }
+
+  const maybeEtherpadRoot = popIfEndsWith(foundRoot.split(path.sep), directoriesToStrip);
+  if (maybeEtherpadRoot === false) {
+    absPathLogger.error(`Could not identity Etherpad base path in this ${process.platform} installation in "${foundRoot}"`);
+    process.exit(1);
+  }
+
+  //  SIDE EFFECT on this module-level variable
+  etherpadRoot = maybeEtherpadRoot.join(path.sep);
+
+  if (path.isAbsolute(etherpadRoot)) {
+    return etherpadRoot;
+  }
+
+  absPathLogger.error(`To run, Etherpad has to identify an absolute base path. This is not: "${etherpadRoot}"`);
+  process.exit(1);
 };

--- a/src/node/utils/AbsolutePaths.js
+++ b/src/node/utils/AbsolutePaths.js
@@ -1,0 +1,23 @@
+/**
+ * Library for deterministic relative filename expansion for Etherpad.
+ */
+
+/*
+ * 2018 - muxator
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var log4js = require('log4js');
+
+var absPathLogger = log4js.getLogger('AbsolutePaths');

--- a/src/node/utils/AbsolutePaths.js
+++ b/src/node/utils/AbsolutePaths.js
@@ -19,5 +19,33 @@
  */
 
 var log4js = require('log4js');
+var _ = require('underscore');
 
 var absPathLogger = log4js.getLogger('AbsolutePaths');
+
+/**
+ * If stringArray's last elements are exactly equal to lastDesiredElements,
+ * returns a copy in which those last elements are popped, or false otherwise.
+ *
+ * @param {string[]} stringArray - The input array.
+ * @param {string[]} lastDesiredElements - The elements to remove from the end
+ *                   of the input array.
+ * @return {string[]|boolean} The shortened array, or false if there was no
+ *                            overlap.
+ */
+var popIfEndsWith = function(stringArray, lastDesiredElements) {
+  if (stringArray.length <= lastDesiredElements.length) {
+    absPathLogger.debug(`In order to pop "${lastDesiredElements.join(path.sep)}" from "${stringArray.join(path.sep)}", it should contain at least ${lastDesiredElements.length + 1 } elements`);
+
+    return false;
+  }
+
+  const lastElementsFound = _.last(stringArray, lastDesiredElements.length);
+
+  if (_.isEqual(lastElementsFound, lastDesiredElements)) {
+    return _.initial(stringArray, lastDesiredElements.length);
+  }
+
+  absPathLogger.debug(`${stringArray.join(path.sep)} does not end with "${lastDesiredElements.join(path.sep)}"`);
+  return false;
+};

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -471,7 +471,7 @@ exports.reloadSettings = function reloadSettings() {
   }
 
   if (!exports.sessionKey) {
-    var sessionkeyFilename = argv.sessionkey || "./SESSIONKEY.txt";
+    var sessionkeyFilename = absolutePaths.makeAbsolute(argv.sessionkey || "./SESSIONKEY.txt");
     try {
       exports.sessionKey = fs.readFileSync(sessionkeyFilename,"utf8");
       console.info(`Session key loaded from: ${sessionkeyFilename}`);

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -341,20 +341,10 @@ exports.getEpVersion = function() {
 
 exports.reloadSettings = function reloadSettings() {
   // Discover where the settings file lives
-  var settingsFilename = argv.settings || "settings.json";
-
+  var settingsFilename = absolutePaths.makeAbsolute(argv.settings || "settings.json");
+  
   // Discover if a credential file exists
-  var credentialsFilename = argv.credentials || "credentials.json";
-
-  if (path.resolve(settingsFilename)===settingsFilename) {
-    settingsFilename = path.resolve(settingsFilename);
-  } else {
-    settingsFilename = path.resolve(path.join(exports.root, settingsFilename));
-  }
-
-  if (path.resolve(credentialsFilename)===credentialsFilename) {
-    credentialsFilename = path.resolve(credentialsFilename);
-  }
+  var credentialsFilename = absolutePaths.makeAbsolute(argv.credentials || "credentials.json");
 
   var settingsStr, credentialsStr;
   try{

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -499,7 +499,9 @@ exports.reloadSettings = function reloadSettings() {
     if(!exports.suppressErrorsInPadText){
       exports.defaultPadText = exports.defaultPadText + "\nWarning: " + dirtyWarning + suppressDisableMsg;
     }
-    console.warn(dirtyWarning);
+
+    exports.dbSettings.filename = absolutePaths.makeAbsolute(exports.dbSettings.filename);
+    console.warn(dirtyWarning + ` File location: ${exports.dbSettings.filename}`);
   }
 };
 

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+var absolutePaths = require('./AbsolutePaths');
 var fs = require("fs");
 var os = require("os");
 var path = require('path');
@@ -31,7 +32,8 @@ var suppressDisableMsg = " -- To suppress these warning messages change suppress
 var _ = require("underscore");
 
 /* Root path of the installation */
-exports.root = path.normalize(path.join(npm.dir, ".."));
+exports.root = absolutePaths.findEtherpadRoot();
+console.log(`All relative paths will be interpreted relative to the identified Etherpad base dir: ${exports.root}`);
 
 /**
  * The app title, visible e.g. in the browser window

--- a/src/package.json
+++ b/src/package.json
@@ -38,6 +38,7 @@
     "etherpad-yajsml": "0.0.2",
     "express": "4.16.3",
     "express-session": "1.15.6",
+    "find-root": "1.1.0",
     "formidable": "1.2.1",
     "graceful-fs": "4.1.3",
     "jsonminify": "0.4.1",


### PR DESCRIPTION
Every relative path in Etherpad is resolved against the current working directory, or against `npm.dir`, which in turn depends on it.

Because of this, running the same Etherpad instance from different places litters the file system, and can lead to unpredictable results.

Affected files fixed by this PR are:
- `settings.json`
- `SESSION.txt`
- `APIKEY.txt`
- `dirty.db`
- `credentials.json`

This change aims to unify the behaviour: a relative path is always passed to `AbsolutePaths.makeAbsolute()`, that rewrites it to a common directory, eventually.

The strategy for determining this common directory is purely heuristic, because Unix install and the win32 package have a different layout on disk.

Fixes #3466 (and other similar issues).