### PR TITLE
Add --writer option to soffice convert command

### DIFF
--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -63,6 +63,7 @@ function doConvertTask(task, callback) {
         '--invisible',
         '--nologo',
         '--nolockcheck',
+        '--writer',
         '--convert-to', task.type,
         task.srcFile,
         '--outdir', tmpDir


### PR DESCRIPTION
If you edit `src/templates/export_html.html` to remove the `<meta name="changedby" content="Etherpad">` tag[1], PDF export with soffice has a bug: the first word of the pad is deleted and a blank page is inserted as first page (the pad's text begins on the second page).
The `--writer` soffice option avoids that bug.

[1] you may want to delete that tag since it is inserted as a comment in .doc or .odt soffice export.