### PR TITLE
installDeps.sh: don't nuke all installed plugins on update

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -116,7 +116,6 @@ echo "Ensure that all dependencies are up to date...  If this is the first time 
   cd ep_etherpad-lite
   npm install --no-save --loglevel warn
 ) || {
-  rm -rf node_modules
   exit 1
 }
 


### PR DESCRIPTION
When this script is run after an update, and something fails during the npm
run, the installed plugins will also be deleted. This is probably not what is
intended here.