### PR TITLE
travis-ci: updated nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "lts/*"
 install:
   - "bin/installDeps.sh"
   - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"


### PR DESCRIPTION
should fix the current error
```
$ bin/installDeps.sh
Your npm version "2.15.1" is too old. npm 3.10.x or higher is required.

The command "bin/installDeps.sh" failed and exited with 1 during .
```