### PR TITLE
url encode pad name

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -177,7 +177,7 @@
             function go2Name()
             {
                 var padname = document.getElementById("padname").value;
-                padname.length > 0 ? window.location = "p/" + padname : alert("Please enter a name")
+                padname.length > 0 ? window.location = "p/" + encodeURIComponent(padname.trim()) : alert("Please enter a name")
             }
 
             function go2Random()


### PR DESCRIPTION
URL encode entered pad names to allow special characters, which are currently causing some unexpected behaviour.

Some examples:
`test.html?q=abc` - currently creates a pad with the name `test.html`
`test.html/abc` - results in the error `Cannot GET /p/test.html/abc`
