### PR TITLE
tests: make sure author is switched on authorship test

### DIFF
--- a/tests/frontend/specs/authorship_of_editions.js
+++ b/tests/frontend/specs/authorship_of_editions.js
@@ -41,6 +41,10 @@ describe('author of pad edition', function() {
             // Reload pad, to make changes as a second user. Need a timeout here to make sure
             // all changes were saved before reloading
             setTimeout(function() {
+              // Expire cookie, so author is changed after reloading the pad.
+              // See https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Example_4_Reset_the_previous_cookie
+              helper.padChrome$.document.cookie = 'token=foo;expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+
               helper.newPad(done, padId);
             }, 1000);
           });


### PR DESCRIPTION
Original implementation of authorship test assumed a simple pad reload would switch the author -- and it actually did on Chrome. But other browsers might keep the author id on cookie.

To force the author switch, expire the cookie before reloading the pad.

Fixes: #3435