### PR TITLE
unable to convert with running soffice process

### DIFF
--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -63,6 +63,7 @@ function doConvertTask(task, callback) {
         '--invisible',
         '--nologo',
         '--nolockcheck',
+        '-env:UserInstallation=file:///tmp/LibreOffice_Conversion_${USER}',
         '--writer',
         '--convert-to', task.type,
         task.srcFile,

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -60,10 +60,10 @@ function doConvertTask(task, callback) {
     function(callback) {
       var soffice = spawn(settings.soffice, [
         '--headless',
-        '--invisible',
-        '--nologo',
-        '--nolockcheck',
-        '-env:UserInstallation=file:///tmp/LibreOffice_Conversion_${USER}',
+       //'--invisible',
+        //'--nologo',
+        //'--nolockcheck',
+        '-env:UserInstallation=file://'+tmpDir+'/LibreOffice_Conversion_${USER}',
         '--writer',
         '--convert-to', task.type,
         task.srcFile,


### PR DESCRIPTION
needed to add this parameter, because soffice already ran in headless mode for a different purpose
found here https://stackoverflow.com/questions/30349542/command-libreoffice-headless-convert-to-pdf-test-docx-outdir-pdf-is-not
Env: Ubuntu Server 14.04.5
LibreOffice 4.2.8.2 420m0(Build:2)