### PR TITLE
installDeps: no need to download jquery at starting time. Remove curl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ git clone https://github.com/ether/etherpad-lite.git && cd etherpad-lite && bin/
 ```
 
 ## GNU/Linux and other UNIX-like systems
-You'll need gzip, git, curl, libssl develop libraries, python and gcc.  
-- *For Debian/Ubuntu*: `apt install gzip git curl python libssl-dev pkg-config build-essential`  
-- *For Fedora/CentOS*: `yum install gzip git curl python openssl-devel && yum groupinstall "Development Tools"`
-- *For FreeBSD*: `portinstall node, npm, curl, git (optional)`
+You'll need gzip, git, libssl develop libraries, python and gcc.
+- *For Debian/Ubuntu*: `apt install gzip git python libssl-dev pkg-config build-essential`
+- *For Fedora/CentOS*: `yum install gzip git python openssl-devel && yum groupinstall "Development Tools"`
+- *For FreeBSD*: `portinstall node, npm, git (optional)`
 
 Additionally, you'll need [node.js](https://nodejs.org) installed (minimum required Node version: **6.9.0**).
 Ideally, the latest stable version is preferred. Please note that the packages offered on some operating systems are outdated. In those cases, we recommend installing nodejs from official archives or compiling it from source (avoiding yum/apt).

--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -56,20 +56,6 @@ if [ -d "../bin" ]; then
   cd "../"
 fi
 
-#Is gnu-grep (ggrep) installed on SunOS (Solaris)
-if [ $(uname) = "SunOS" ]; then
-  hash ggrep > /dev/null 2>&1 || {
-    echo "Please install ggrep (pkg install gnu-grep)" >&2
-    exit 1
-  }
-fi
-
-#Is curl installed?
-hash curl > /dev/null 2>&1 || {
-  echo "Please install curl" >&2
-  exit 1
-}
-
 #Is node installed?
 #Not checking io.js, default installation creates a symbolic link to node
 hash node > /dev/null 2>&1 || {
@@ -119,25 +105,6 @@ echo "Ensure that all dependencies are up to date...  If this is the first time 
   rm -rf src/node_modules
   exit 1
 }
-
-echo "Ensure jQuery is downloaded and up to date..."
-DOWNLOAD_JQUERY="true"
-NEEDED_VERSION="1.9.1"
-if [ -f "src/static/js/jquery.js" ]; then
-  if [ $(uname) = "SunOS" ]; then
-    VERSION=$(head -n 3 src/static/js/jquery.js | ggrep -o "v[0-9]\.[0-9]\(\.[0-9]\)\?")
-  else
-    VERSION=$(head -n 3 src/static/js/jquery.js | grep -o "v[0-9]\.[0-9]\(\.[0-9]\)\?")
-  fi
-
-  if [ ${VERSION#v} = $NEEDED_VERSION ]; then
-    DOWNLOAD_JQUERY="false"
-  fi
-fi
-
-if [ $DOWNLOAD_JQUERY = "true" ]; then
-  curl -lo src/static/js/jquery.js https://code.jquery.com/jquery-$NEEDED_VERSION.js || exit 1
-fi
 
 #Remove all minified data to force node creating it new
 echo "Clearing minified cache..."


### PR DESCRIPTION
… dependency

In installDeps.sh we have a bunch of code (from 2011) that checks for the
existence of jQuery and eventually downloads it, but since 1239ce7f2848 (year
2012) jquery is vendorized in /src/static/js/jquery.js.

Also, stop mentioning curl as a dependency in the README.md

Fixes #3494