### PR TITLE
Try/catch to skip invalid JSON in dirtyDB

### DIFF
--- a/bin/dirty-db-cleaner.py
+++ b/bin/dirty-db-cleaner.py
@@ -31,8 +31,11 @@ with open(dirtydb_input, 'r') as fd:
     print 'Reading %s' % dirtydb_input
     for line in fd:
         lines += 1
-        data = json.loads(line)
-        dirtydb[data['key']] = line
+        try:
+            data = json.loads(line)
+            dirtydb[data['key']] = line
+        except:
+            print("Skipping invalid JSON!")
         if lines % 10000 == 0:
             sys.stderr.write('.')
 print


### PR DESCRIPTION
I noticed, that a dirtyDB can end up having invalid lines of JSON. Sadly this will also break this little clean'up tool. The patch just ignored invalid JSON.
