### PR TITLE
migrateDirtyDBtoRealDB: memory and buffer  #2214

### DIFF
--- a/bin/migrateDirtyDBtoRealDB.js
+++ b/bin/migrateDirtyDBtoRealDB.js
@@ -16,6 +16,7 @@ require("ep_etherpad-lite/node_modules/npm").load({}, function(er,npm) {
   var log4js = require("../src/node_modules/log4js");
   var dbWrapperSettings = {
       "cache": "0",         // The cache slows things down when you're mostly writing.
+      "writeInterval": 0    // Write directly to the database, don't buffer
   };
   var db = new ueberDB.database(settings.dbType, settings.dbSettings, dbWrapperSettings, log4js.getLogger("ueberDB"));
 

--- a/bin/migrateDirtyDBtoRealDB.js
+++ b/bin/migrateDirtyDBtoRealDB.js
@@ -6,6 +6,10 @@ require("ep_etherpad-lite/node_modules/npm").load({}, function(er,npm) {
   // to work with a real database.  Please make a backup of your dirty.db
   // file before using this script, just to be safe.
 
+  // It might be necessary to run the script using more memory:
+  // `node --max-old-space-size=4096 bin/migrateDirtyDBtoRealDB.js`
+
+
   var settings = require("ep_etherpad-lite/node/utils/Settings");
   var dirty = require("../src/node_modules/dirty")('var/dirty.db');
   var ueberDB = require("../src/node_modules/ueberdb2");


### PR DESCRIPTION
`bin/migrateDirtyDBtoRealDB.js`

---

(my) solution for #2214:

* the script ran out of memory -> added comment to give the script more memory in 4a41241
* ueberDB never write to the actual database -> disable write buffer in 055642e, write to the db directly

---

Since this is a maintenance script, there are no tests. I hope that's indented/alright. 