### PR TITLE
[chore] Allow debug mode on node versions >= 6.3

### DIFF
--- a/bin/debugRun.sh
+++ b/bin/debugRun.sh
@@ -11,18 +11,10 @@ fi
 #Prepare the environment
 bin/installDeps.sh || exit 1
 
-hash node-inspector > /dev/null 2>&1 || { 
-  echo "You need to install node-inspector to run the tests!" >&2
-  echo "You can install it with npm" >&2
-  echo "Run: npm install -g node-inspector" >&2
-  exit 1 
-}
+echo "If you are new to debugging Node.js with Chrome DevTools, take a look at this page:"
+echo "https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27"
+echo "Open 'chrome://inspect' on Chrome to start debugging."
 
-node-inspector &
-
-echo "If you are new to node-inspector, take a look at this video: https://youtu.be/AOnK3NVnxL8"
-
-node --debug node_modules/ep_etherpad-lite/node/server.js $*
-
-#Kill node-inspector before ending 
-kill $!
+#Use 0.0.0.0 to allow external connections to the debugger
+#(ex: running Etherpad on a docker container). Use default port # (9229)
+node --inspect=0.0.0.0:9229 node_modules/ep_etherpad-lite/node/server.js $*


### PR DESCRIPTION
I've tried to install `node-inspector` using Node 8 and it looks like it is not supported. 

According to the [documentation of that tool](https://www.npmjs.com/package/node-inspector):

> Since version 6.3, Node.js provides a built-in DevTools-based debugger which mostly deprecates Node Inspector (...). The built-in debugger (...) provides certain advanced features (...) that are too difficult to implement in Node Inspector.

As [we require nodejs >= 6.9.0](https://github.com/ether/etherpad-lite#requirements), and as [`node-inspector` only works on Chrome and Opera](https://www.npmjs.com/package/node-inspector#debug), it looks like a good approach to remove the dependency of that tool and use Chrome DevTools directly. Besides, [there are other tools available](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients) for debugging, if Chrome is not an option.

This PR also allow external connections to the inspector, so Etherpad instances running on containers can also be debugged. [There are obviously some risks to leave that opened on public IPs](https://nodejs.org/en/docs/guides/debugging-getting-started/#exposing-the-debug-port-publicly-is-unsafe), but I assumed no instance would run on debug mode for the final user.