### PR TITLE
set authorColors in HTML exports

### DIFF
--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -29,6 +29,7 @@ var _encodeWhitespace = require('./ExportHelper')._encodeWhitespace;
 function getPadHTML(pad, revNum, callback)
 {
   var atext = pad.atext;
+  var authorColors;
   var html;
   async.waterfall([
   // fetch revision atext
@@ -49,12 +50,24 @@ function getPadHTML(pad, revNum, callback)
     }
   },
 
+    //get the authorColor table
+  function(callback){
+    pad.getAllAuthorColors(function(err, _authorColors){
+      if(err){
+        return callback(err);
+      }
+
+      authorColors = _authorColors;
+      callback();
+    });
+  },
+
   // convert atext to html
 
 
   function (callback)
   {
-    html = getHTMLFromAtext(pad, atext);
+    html = getHTMLFromAtext(pad, atext, authorColors);
     callback(null);
   }],
   // run final callback


### PR DESCRIPTION
This patch unconditionally adds colours to HTML exports by filling in the `authorColors` object which is not currently supplied to `getHTMLFromAtext()` during export (but is when the same function is used to produce an HTML diff).

If I knew how to make this optional I would.   The patch is shown here in case it can be merged as is, or for reference for other people that I know would like this functionality.