### PR TITLE
fix for python3

### DIFF
--- a/bin/dirty-db-cleaner.py
+++ b/bin/dirty-db-cleaner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env PYTHONUNBUFFERED=1 python2
+#!/usr/bin/env PYTHONUNBUFFERED=1 python
 #
 # Created by Bjarni R. Einarsson, placed in the public domain. Go wild!
 #
@@ -12,23 +12,23 @@ try:
     assert(os.path.exists(dirtydb_input))
     assert(not os.path.exists(dirtydb_output))
 except:
-    print 
-    print 'Usage: %s /path/to/dirty.db' % sys.argv[0]
-    print 
-    print 'Note: Will create a file named dirty.db.new in the same folder,'
-    print '      please make sure permissions are OK and a file by that'
-    print '      name does not exist already. This script works by omitting'
-    print '      duplicate lines from the dirty.db file, keeping only the'
-    print '      last (latest) instance. No revision data should be lost,'
-    print '      but be careful, make backups. If it breaks you get to keep'
-    print '      both pieces!'
-    print
+    print() 
+    print('Usage: %s /path/to/dirty.db' % sys.argv[0])
+    print() 
+    print('Note: Will create a file named dirty.db.new in the same folder,')
+    print('      please make sure permissions are OK and a file by that')
+    print('      name does not exist already. This script works by omitting')
+    print('      duplicate lines from the dirty.db file, keeping only the')
+    print('      last (latest) instance. No revision data should be lost,')
+    print('      but be careful, make backups. If it breaks you get to keep')
+    print('      both pieces!')
+    print()
     sys.exit(1)
 
 dirtydb = {}
 lines = 0
 with open(dirtydb_input, 'r') as fd:
-    print 'Reading %s' % dirtydb_input
+    print('Reading %s' % dirtydb_input)
     for line in fd:
         lines += 1
         try:
@@ -38,11 +38,11 @@ with open(dirtydb_input, 'r') as fd:
             print("Skipping invalid JSON!")
         if lines % 10000 == 0:
             sys.stderr.write('.')
-print
-print 'OK, found %d unique keys in %d lines' % (len(dirtydb), lines)
+print()
+print('OK, found %d unique keys in %d lines' % (len(dirtydb), lines))
 
 with open(dirtydb_output, 'w') as fd:
-    for data in dirtydb.values():
+    for data in list(dirtydb.values()):
         fd.write(data)
 
-print 'Wrote data to %s. All done!' % dirtydb_output
+print('Wrote data to %s. All done!' % dirtydb_output)


### PR DESCRIPTION
This changes the dirty-db-cleaner script to be python 2/3 agnostic.