### PR TITLE
Migrate from callbacks to async/await

### DIFF
--- a/bin/checkAllPads.js
+++ b/bin/checkAllPads.js
@@ -1,144 +1,133 @@
 /*
-  This is a debug tool. It checks all revisions for data corruption
-*/
+ * This is a debug tool. It checks all revisions for data corruption
+ */
 
-if(process.argv.length != 2)
-{
+if (process.argv.length != 2) {
   console.error("Use: node bin/checkAllPads.js");
   process.exit(1);
 }
 
-//initialize the variables
+// initialize the variables
 var db, settings, padManager;
-var npm = require("../src/node_modules/npm");
-var async = require("../src/node_modules/async");
+var npm = require('../src/node_modules/npm');
+var async = require('../src/node_modules/async');
 
-var Changeset = require("../src/static/js/Changeset");
+var Changeset = require('../src/static/js/Changeset');
 
 async.series([
-  //load npm
+  // load npm
   function(callback) {
     npm.load({}, callback);
   },
-  //load modules
+
+  // load modules
   function(callback) {
     settings = require('../src/node/utils/Settings');
     db = require('../src/node/db/DB');
 
-    //initialize the database
+    // initialize the database
     db.init(callback);
   },
-  //load pads
-  function (callback)
-  {
+
+  // load pads
+  function (callback) {
     padManager = require('../src/node/db/PadManager');
-    
-    padManager.listAllPads(function(err, res)
-    {
+
+    padManager.listAllPads(function(err, res) {
       padIds = res.padIDs;
       callback(err);
     });
   },
-  function (callback)
-  {
-    async.forEach(padIds, function(padId, callback)
-    {
-        padManager.getPad(padId, function(err, pad) {
+
+  function (callback) {
+    async.forEach(padIds, function(padId, callback) {
+      padManager.getPad(padId, function(err, pad) {
+        if (err) {
+          callback(err);
+        }
+
+        // check if the pad has a pool
+        if (pad.pool === undefined ) {
+          console.error("[" + pad.id + "] Missing attribute pool");
+          callback();
+
+          return;
+        }
+
+        // create an array with key kevisions
+        // key revisions always save the full pad atext
+        var head = pad.getHeadRevisionNumber();
+        var keyRevisions = [];
+        for (var i = 0; i < head; i += 100) {
+          keyRevisions.push(i);
+        }
+
+        // run through all key revisions
+        async.forEachSeries(keyRevisions, function(keyRev, callback) {
+          // create an array of revisions we need till the next keyRevision or the End
+          var revisionsNeeded = [];
+
+          for(var i = keyRev; i <= keyRev + 100 && i <= head; i++) {
+            revisionsNeeded.push(i);
+          }
+
+          // this array will hold all revision changesets
+          var revisions = [];
+
+          // run through all needed revisions and get them from the database
+          async.forEach(revisionsNeeded, function(revNum, callback) {
+            db.db.get("pad:" + pad.id + ":revs:" + revNum, function(err, revision) {
+              revisions[revNum] = revision;
+              callback(err);
+            });
+          },
+
+          function(err) {
             if (err) {
-                callback(err);
+              callback(err);
+              return;
             }
-   
-            //check if the pad has a pool
-            if(pad.pool === undefined )
-            {
-                console.error("[" + pad.id + "] Missing attribute pool");
+
+            // check if the revision exists
+            if (revisions[keyRev] == null) {
+              console.error("[" + pad.id + "] Missing revision " + keyRev);
+              callback();
+              return;
+            }
+
+            // check if there is a atext in the keyRevisions
+            if (revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
+              console.error("[" + pad.id + "] Missing atext in revision " + keyRev);
+              callback();
+              return;
+            }
+
+            var apool = pad.pool;
+            var atext = revisions[keyRev].meta.atext;
+
+            for(var i = keyRev + 1; i <= keyRev + 100 && i <= head; i++) {
+              try {
+                // console.log("[" + pad.id + "] check revision " + i);
+                var cs = revisions[i].changeset;
+                atext = Changeset.applyToAText(cs, atext, apool);
+              } catch(e) {
+                console.error("[" + pad.id + "] Bad changeset at revision " + i + " - " + e.message);
                 callback();
                 return;
+              }
             }
 
-            //create an array with key kevisions
-            //key revisions always save the full pad atext
-            var head = pad.getHeadRevisionNumber();
-            var keyRevisions = [];
-            for(var i=0;i<head;i+=100)
-            {
-                keyRevisions.push(i);
-            }
-            
-            //run trough all key revisions
-            async.forEachSeries(keyRevisions, function(keyRev, callback)
-            {
-                //create an array of revisions we need till the next keyRevision or the End
-                var revisionsNeeded = [];
-                for(var i=keyRev;i<=keyRev+100 && i<=head; i++)
-                {
-                    revisionsNeeded.push(i);
-                }
-                
-                //this array will hold all revision changesets
-                var revisions = [];
-                
-                //run trough all needed revisions and get them from the database
-                async.forEach(revisionsNeeded, function(revNum, callback)
-                {
-                    db.db.get("pad:"+pad.id+":revs:" + revNum, function(err, revision)
-                    {
-                        revisions[revNum] = revision;
-                        callback(err);
-                    });
-                }, function(err)
-                {
-                    if(err)
-                    {
-                        callback(err);
-                        return;
-                    }
-
-                    //check if the revision exists
-                    if (revisions[keyRev] == null) {
-                        console.error("[" + pad.id + "] Missing revision " + keyRev);
-                        callback();
-                        return;
-                    }
-                    
-                    //check if there is a atext in the keyRevisions
-                    if(revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined)
-                    {
-                        console.error("[" + pad.id + "] Missing atext in revision " + keyRev);
-                        callback();
-                        return;
-                    }
-                    
-                    var apool = pad.pool;
-                    var atext = revisions[keyRev].meta.atext;
-                    
-                    for(var i=keyRev+1;i<=keyRev+100 && i<=head; i++)
-                    {
-                        try
-                        {
-                            //console.log("[" + pad.id + "] check revision " + i);
-                            var cs = revisions[i].changeset;
-                            atext = Changeset.applyToAText(cs, atext, apool);
-                        }
-                        catch(e)
-                        {
-                            console.error("[" + pad.id + "] Bad changeset at revision " + i + " - " + e.message);
-                            callback();
-                            return;
-                        }
-                    }
-                    
-                    callback();
-                });
-            }, callback);
-        });
+            callback();
+          });
+        }, callback);
+      });
     }, callback);
   }
-], function (err)
-{
-  if(err) throw err;
-  else 
-  { 
+],
+function (err) {
+  if (err) {
+    throw err;
+  } else {
     console.log("finished");
     process.exit(0);
   }

--- a/bin/checkAllPads.js
+++ b/bin/checkAllPads.js
@@ -7,128 +7,88 @@ if (process.argv.length != 2) {
   process.exit(1);
 }
 
-// initialize the variables
-var db, settings, padManager;
-var npm = require('../src/node_modules/npm');
-var async = require('../src/node_modules/async');
+// load and initialize NPM
+let npm = require('../src/node_modules/npm');
+npm.load({}, async function() {
 
-var Changeset = require('../src/static/js/Changeset');
-
-async.series([
-  // load npm
-  function(callback) {
-    npm.load({}, callback);
-  },
-
-  // load modules
-  function(callback) {
-    settings = require('../src/node/utils/Settings');
-    db = require('../src/node/db/DB');
-
+  try {
     // initialize the database
-    db.init(callback);
-  },
+    let settings = require('../src/node/utils/Settings');
+    let db = require('../src/node/db/DB');
+    await db.init();
 
-  // load pads
-  function (callback) {
-    padManager = require('../src/node/db/PadManager');
+    // load modules
+    let Changeset = require('../src/static/js/Changeset');
+    let padManager = require('../src/node/db/PadManager');
 
-    padManager.listAllPads(function(err, res) {
-      padIds = res.padIDs;
-      callback(err);
-    });
-  },
+    // get all pads
+    let res = await padManager.listAllPads();
 
-  function (callback) {
-    async.forEach(padIds, function(padId, callback) {
-      padManager.getPad(padId, function(err, pad) {
-        if (err) {
-          callback(err);
+    for (let padId of res.padIDs) {
+
+      let pad = await padManager.getPad(padId);
+
+      // check if the pad has a pool
+      if (pad.pool === undefined) {
+        console.error("[" + pad.id + "] Missing attribute pool");
+        continue;
+      }
+
+      // create an array with key kevisions
+      // key revisions always save the full pad atext
+      let head = pad.getHeadRevisionNumber();
+      let keyRevisions = [];
+      for (let rev = 0; rev < head; rev += 100) {
+        keyRevisions.push(rev);
+      }
+
+      // run through all key revisions
+      for (let keyRev of keyRevisions) {
+
+        // create an array of revisions we need till the next keyRevision or the End
+        var revisionsNeeded = [];
+        for (let rev = keyRev ; rev <= keyRev + 100 && rev <= head; rev++) {
+          revisionsNeeded.push(rev);
         }
 
-        // check if the pad has a pool
-        if (pad.pool === undefined ) {
-          console.error("[" + pad.id + "] Missing attribute pool");
-          callback();
+        // this array will hold all revision changesets
+        var revisions = [];
 
-          return;
+        // run through all needed revisions and get them from the database
+        for (let revNum of revisionsNeeded) {
+           let revision = await db.get("pad:" + pad.id + ":revs:" + revNum);
+           revisions[revNum] = revision;
         }
 
-        // create an array with key kevisions
-        // key revisions always save the full pad atext
-        var head = pad.getHeadRevisionNumber();
-        var keyRevisions = [];
-        for (var i = 0; i < head; i += 100) {
-          keyRevisions.push(i);
+        // check if the revision exists
+        if (revisions[keyRev] == null) {
+          console.error("[" + pad.id + "] Missing revision " + keyRev);
+          continue;
         }
 
-        // run through all key revisions
-        async.forEachSeries(keyRevisions, function(keyRev, callback) {
-          // create an array of revisions we need till the next keyRevision or the End
-          var revisionsNeeded = [];
+        // check if there is a atext in the keyRevisions
+        if (revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
+          console.error("[" + pad.id + "] Missing atext in revision " + keyRev);
+          continue;
+        }
 
-          for(var i = keyRev; i <= keyRev + 100 && i <= head; i++) {
-            revisionsNeeded.push(i);
+        let apool = pad.pool;
+        let atext = revisions[keyRev].meta.atext;
+
+        for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
+          try {
+            let cs = revisions[rev].changeset;
+            atext = Changeset.applyToAText(cs, atext, apool);
+          } catch (e) {
+            console.error("[" + pad.id + "] Bad changeset at revision " + i + " - " + e.message);
           }
-
-          // this array will hold all revision changesets
-          var revisions = [];
-
-          // run through all needed revisions and get them from the database
-          async.forEach(revisionsNeeded, function(revNum, callback) {
-            db.db.get("pad:" + pad.id + ":revs:" + revNum, function(err, revision) {
-              revisions[revNum] = revision;
-              callback(err);
-            });
-          },
-
-          function(err) {
-            if (err) {
-              callback(err);
-              return;
-            }
-
-            // check if the revision exists
-            if (revisions[keyRev] == null) {
-              console.error("[" + pad.id + "] Missing revision " + keyRev);
-              callback();
-              return;
-            }
-
-            // check if there is a atext in the keyRevisions
-            if (revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
-              console.error("[" + pad.id + "] Missing atext in revision " + keyRev);
-              callback();
-              return;
-            }
-
-            var apool = pad.pool;
-            var atext = revisions[keyRev].meta.atext;
-
-            for(var i = keyRev + 1; i <= keyRev + 100 && i <= head; i++) {
-              try {
-                // console.log("[" + pad.id + "] check revision " + i);
-                var cs = revisions[i].changeset;
-                atext = Changeset.applyToAText(cs, atext, apool);
-              } catch(e) {
-                console.error("[" + pad.id + "] Bad changeset at revision " + i + " - " + e.message);
-                callback();
-                return;
-              }
-            }
-
-            callback();
-          });
-        }, callback);
-      });
-    }, callback);
-  }
-],
-function (err) {
-  if (err) {
-    throw err;
-  } else {
-    console.log("finished");
-    process.exit(0);
+        }
+      }
+      console.log("finished");
+      process.exit(0);
+    }
+  } catch (err) {
+    console.trace(err);
+    process.exit(1);
   }
 });

--- a/bin/checkPad.js
+++ b/bin/checkPad.js
@@ -1,140 +1,126 @@
 /*
-  This is a debug tool. It checks all revisions for data corruption
-*/
+ * This is a debug tool. It checks all revisions for data corruption
+ */
 
-if(process.argv.length != 3)
-{
+if (process.argv.length != 3) {
   console.error("Use: node bin/checkPad.js $PADID");
   process.exit(1);
 }
+
 //get the padID
 var padId = process.argv[2];
 
-//initialize the variables
+// initialize the variables
 var db, settings, padManager;
-var npm = require("../src/node_modules/npm");
-var async = require("../src/node_modules/async");
+var npm = require('../src/node_modules/npm');
+var async = require('../src/node_modules/async');
 
-var Changeset = require("ep_etherpad-lite/static/js/Changeset");
+var Changeset = require('ep_etherpad-lite/static/js/Changeset');
 
 async.series([
-  //load npm
+  // load npm
   function(callback) {
     npm.load({}, function(er) {
       callback(er);
-    })
+    });
   },
-  //load modules
+
+  // load modules
   function(callback) {
     settings = require('../src/node/utils/Settings');
     db = require('../src/node/db/DB');
 
-    //initialize the database
+    // initialize the database
     db.init(callback);
   },
-  //get the pad 
-  function (callback)
-  {
+
+  // get the pad
+  function (callback) {
     padManager = require('../src/node/db/PadManager');
-    
-    padManager.doesPadExists(padId, function(err, exists)
-    {
-      if(!exists)
-      {
+
+    padManager.doesPadExists(padId, function(err, exists) {
+      if (!exists) {
         console.error("Pad does not exist");
         process.exit(1);
       }
-      
-      padManager.getPad(padId, function(err, _pad)  
-      {
+
+      padManager.getPad(padId, function(err, _pad) {
         pad = _pad;
         callback(err);
       });
     });
   },
-  function (callback)
-  {    
-    //create an array with key revisions
-    //key revisions always save the full pad atext
+
+  function (callback) {
+    // create an array with key revisions
+    // key revisions always save the full pad atext
     var head = pad.getHeadRevisionNumber();
     var keyRevisions = [];
-    for(var i=0;i<head;i+=100)
-    {
+    for (var i = 0; i < head; i += 100) {
       keyRevisions.push(i);
     }
-    
-    //run trough all key revisions
-    async.forEachSeries(keyRevisions, function(keyRev, callback)
-    {
-      //create an array of revisions we need till the next keyRevision or the End
+
+    // run through all key revisions
+    async.forEachSeries(keyRevisions, function(keyRev, callback) {
+      // create an array of revisions we need till the next keyRevision or the End
       var revisionsNeeded = [];
-      for(var i=keyRev;i<=keyRev+100 && i<=head; i++)
-      {
+      for(var i = keyRev; i <= keyRev + 100 && i <= head; i++) {
         revisionsNeeded.push(i);
       }
-      
-      //this array will hold all revision changesets
+
+      // this array will hold all revision changesets
       var revisions = [];
-      
-      //run trough all needed revisions and get them from the database
-      async.forEach(revisionsNeeded, function(revNum, callback)
-      {
-        db.db.get("pad:"+padId+":revs:" + revNum, function(err, revision)
-        {
+
+      // run through all needed revisions and get them from the database
+      async.forEach(revisionsNeeded, function(revNum, callback) {
+        db.db.get("pad:" + padId + ":revs:" + revNum, function(err, revision) {
           revisions[revNum] = revision;
           callback(err);
         });
-      }, function(err)
-      {
-        if(err)
-        {
+      },
+      function(err) {
+        if (err) {
           callback(err);
           return;
         }
-        
-        //check if the pad has a pool
-        if(pad.pool === undefined )
-        {
+
+        // check if the pad has a pool
+        if (pad.pool === undefined) {
           console.error("Attribute pool is missing");
           process.exit(1);
         }
-        
-        //check if there is an atext in the keyRevisions
-        if(revisions[keyRev] === undefined || revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined)
-        {
+
+        // check if there is an atext in the keyRevisions
+        if (revisions[keyRev] === undefined || revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
           console.error("No atext in key revision " + keyRev);
           callback();
           return;
         }
-        
+
         var apool = pad.pool;
         var atext = revisions[keyRev].meta.atext;
-        
-        for(var i=keyRev+1;i<=keyRev+100 && i<=head; i++)
-        {
-          try
-          {
-            //console.log("check revision " + i);
+
+        for (var i = keyRev + 1; i <= keyRev + 100 && i <= head; i++) {
+          try {
+            // console.log("check revision " + i);
             var cs = revisions[i].changeset;
             atext = Changeset.applyToAText(cs, atext, apool);
-          }
-          catch(e)
-          {
+          } catch(e) {
             console.error("Bad changeset at revision " + i + " - " + e.message);
             callback();
             return;
           }
         }
-        
+
         callback();
       });
     }, callback);
   }
-], function (err)
-{
-  if(err) throw err;
-  else 
-  { 
+],
+function (err) {
+  if(err) {
+    throw err;
+  } else {
     console.log("finished");
     process.exit(0);
   }

--- a/bin/checkPad.js
+++ b/bin/checkPad.js
@@ -7,121 +7,89 @@ if (process.argv.length != 3) {
   process.exit(1);
 }
 
-//get the padID
-var padId = process.argv[2];
+// get the padID
+const padId = process.argv[2];
 
-// initialize the variables
-var db, settings, padManager;
-var npm = require('../src/node_modules/npm');
-var async = require('../src/node_modules/async');
+// load and initialize NPM;
+let npm = require('../src/node_modules/npm');
+npm.load({}, async function() {
 
-var Changeset = require('ep_etherpad-lite/static/js/Changeset');
+  try {
+    // initialize database
+    let settings = require('../src/node/utils/Settings');
+    let db = require('../src/node/db/DB');
+    await db.init();
 
-async.series([
-  // load npm
-  function(callback) {
-    npm.load({}, function(er) {
-      callback(er);
-    });
-  },
+    // load modules
+    let Changeset = require('ep_etherpad-lite/static/js/Changeset');
+    let padManager = require('../src/node/db/PadManager');
 
-  // load modules
-  function(callback) {
-    settings = require('../src/node/utils/Settings');
-    db = require('../src/node/db/DB');
+    let exists = await padManager.doesPadExists(padId);
+    if (!exists) {
+      console.error("Pad does not exist");
+      process.exit(1);
+    }
 
-    // initialize the database
-    db.init(callback);
-  },
+    // get the pad
+    let pad = await padManager.getPad(padId);
 
-  // get the pad
-  function (callback) {
-    padManager = require('../src/node/db/PadManager');
-
-    padManager.doesPadExists(padId, function(err, exists) {
-      if (!exists) {
-        console.error("Pad does not exist");
-        process.exit(1);
-      }
-
-      padManager.getPad(padId, function(err, _pad) {
-        pad = _pad;
-        callback(err);
-      });
-    });
-  },
-
-  function (callback) {
     // create an array with key revisions
     // key revisions always save the full pad atext
-    var head = pad.getHeadRevisionNumber();
-    var keyRevisions = [];
-    for (var i = 0; i < head; i += 100) {
-      keyRevisions.push(i);
+    let head = pad.getHeadRevisionNumber();
+    let keyRevisions = [];
+    for (let rev = 0; rev < head; rev += 100) {
+      keyRevisions.push(rev);
     }
 
     // run through all key revisions
-    async.forEachSeries(keyRevisions, function(keyRev, callback) {
+    for (let keyRev of keyRevisions) {
+
       // create an array of revisions we need till the next keyRevision or the End
-      var revisionsNeeded = [];
-      for(var i = keyRev; i <= keyRev + 100 && i <= head; i++) {
-        revisionsNeeded.push(i);
+      let revisionsNeeded = [];
+      for (let rev = keyRev; rev <= keyRev + 100 && rev <= head; rev++) {
+        revisionsNeeded.push(rev);
       }
 
       // this array will hold all revision changesets
       var revisions = [];
 
       // run through all needed revisions and get them from the database
-      async.forEach(revisionsNeeded, function(revNum, callback) {
-        db.db.get("pad:" + padId + ":revs:" + revNum, function(err, revision) {
-          revisions[revNum] = revision;
-          callback(err);
-        });
-      },
-      function(err) {
-        if (err) {
-          callback(err);
-          return;
+      for (let revNum of revisionsNeeded) {
+        let revision = await db.get("pad:" + padId + ":revs:" + revNum);
+        revisions[revNum] = revision;
+      }
+
+      // check if the pad has a pool
+      if (pad.pool === undefined ) {
+        console.error("Attribute pool is missing");
+        process.exit(1);
+      }
+
+      // check if there is an atext in the keyRevisions
+      if (revisions[keyRev] === undefined || revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
+        console.error("No atext in key revision " + keyRev);
+        continue;
+      }
+
+      let apool = pad.pool;
+      let atext = revisions[keyRev].meta.atext;
+
+      for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
+        try {
+          // console.log("check revision " + rev);
+          let cs = revisions[rev].changeset;
+          atext = Changeset.applyToAText(cs, atext, apool);
+        } catch(e) {
+          console.error("Bad changeset at revision " + rev + " - " + e.message);
+          continue;
         }
+      }
+      console.log("finished");
+      process.exit(0);
+    }
 
-        // check if the pad has a pool
-        if (pad.pool === undefined) {
-          console.error("Attribute pool is missing");
-          process.exit(1);
-        }
-
-        // check if there is an atext in the keyRevisions
-        if (revisions[keyRev] === undefined || revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
-          console.error("No atext in key revision " + keyRev);
-          callback();
-          return;
-        }
-
-        var apool = pad.pool;
-        var atext = revisions[keyRev].meta.atext;
-
-        for (var i = keyRev + 1; i <= keyRev + 100 && i <= head; i++) {
-          try {
-            // console.log("check revision " + i);
-            var cs = revisions[i].changeset;
-            atext = Changeset.applyToAText(cs, atext, apool);
-          } catch(e) {
-            console.error("Bad changeset at revision " + i + " - " + e.message);
-            callback();
-            return;
-          }
-        }
-
-        callback();
-      });
-    }, callback);
-  }
-],
-function (err) {
-  if(err) {
-    throw err;
-  } else {
-    console.log("finished");
-    process.exit(0);
+  } catch (e) {
+    console.trace(e);
+    process.exit(1);
   }
 });

--- a/bin/deletePad.js
+++ b/bin/deletePad.js
@@ -9,55 +9,33 @@ if (process.argv.length != 3) {
 }
 
 // get the padID
-var padId = process.argv[2];
+let padId = process.argv[2];
 
-var db, padManager, pad, settings;
-var neededDBValues = ["pad:"+padId];
+let npm = require('../src/node_modules/npm');
 
-var npm = require('../src/node_modules/npm');
-var async = require('../src/node_modules/async');
-
-async.series([
-  // load npm
-  function(callback) {
-    npm.load({}, function(er) {
-      if (er) {
-        console.error("Could not load NPM: " + er)
-        process.exit(1);
-      } else {
-        callback();
-      }
-    });
-  },
-
-  // load modules
-  function(callback) {
-    settings = require('../src/node/utils/Settings');
-    db = require('../src/node/db/DB');
-    callback();
-  },
-
-  // initialize the database
-  function (callback) {
-    db.init(callback);
-  },
-
-  // delete the pad and its links
-  function (callback) {
-    padManager = require('../src/node/db/PadManager');
-
-    padManager.removePad(padId, function(err){
-      callback(err);
-    });
-
-    callback();
+npm.load({}, async function(er) {
+  if (er) {
+    console.error("Could not load NPM: " + er)
+    process.exit(1);
   }
-],
-function (err) {
-  if(err) {
-    throw err;
-  } else {
+
+  try {
+    let settings = require('../src/node/utils/Settings');
+    let db = require('../src/node/db/DB');
+    await db.init();
+
+    padManager = require('../src/node/db/PadManager');
+    await padManager.removePad(padId);
+
     console.log("Finished deleting padId: " + padId);
-    process.exit();
+    process.exit(0);
+
+  } catch (e) {
+    if (err.name === "apierror") {
+      console.error(e);
+    } else {
+      console.trace(e);
+    }
+    process.exit(1);
   }
 });

--- a/bin/deletePad.js
+++ b/bin/deletePad.js
@@ -1,63 +1,63 @@
 /*
-  A tool for deleting pads from the CLI, because sometimes a brick is required to fix a window.
-*/
+ * A tool for deleting pads from the CLI, because sometimes a brick is required
+ * to fix a window.
+ */
 
-if(process.argv.length != 3)
-{
+if (process.argv.length != 3) {
   console.error("Use: node deletePad.js $PADID");
   process.exit(1);
 }
-//get the padID
+
+// get the padID
 var padId = process.argv[2];
 
 var db, padManager, pad, settings;
 var neededDBValues = ["pad:"+padId];
 
-var npm = require("../src/node_modules/npm");
-var async = require("../src/node_modules/async");
+var npm = require('../src/node_modules/npm');
+var async = require('../src/node_modules/async');
 
 async.series([
   // load npm
   function(callback) {
     npm.load({}, function(er) {
-      if(er)
-      {
+      if (er) {
         console.error("Could not load NPM: " + er)
         process.exit(1);
-      }
-      else
-      {
+      } else {
         callback();
       }
-    })
+    });
   },
+
   // load modules
   function(callback) {
     settings = require('../src/node/utils/Settings');
     db = require('../src/node/db/DB');
     callback();
   },
+
   // initialize the database
-  function (callback)
-  {
+  function (callback) {
     db.init(callback);
   },
+
   // delete the pad and its links
-  function (callback)
-  {
+  function (callback) {
     padManager = require('../src/node/db/PadManager');
-    
+
     padManager.removePad(padId, function(err){
       callback(err);
-    }); 
+    });
+
     callback();
   }
-], function (err)
-{
-  if(err) throw err;
-  else 
-  { 
-    console.log("Finished deleting padId: "+padId);
+],
+function (err) {
+  if(err) {
+    throw err;
+  } else {
+    console.log("Finished deleting padId: " + padId);
     process.exit();
   }
 });

--- a/bin/extractPadData.js
+++ b/bin/extractPadData.js
@@ -10,88 +10,66 @@ if (process.argv.length != 3) {
 }
 
 // get the padID
-var padId = process.argv[2];
+let padId = process.argv[2];
 
-var db, dirty, padManager, pad, settings;
-var neededDBValues = ["pad:"+padId];
+let npm = require('../src/node_modules/npm');
 
-var npm = require('../node_modules/ep_etherpad-lite/node_modules/npm');
-var async = require('../node_modules/ep_etherpad-lite/node_modules/async');
+npm.load({}, async function(er) {
+  if (er) {
+    console.error("Could not load NPM: " + er)
+    process.exit(1);
+  }
 
-async.series([
-  // load npm
-  function(callback) {
-    npm.load({}, function(er) {
-      if (er) {
-        console.error("Could not load NPM: " + er)
-        process.exit(1);
-      } else {
-        callback();
-      }
-    })
-  },
+  try {
+    // initialize database
+    let settings = require('../src/node/utils/Settings');
+    let db = require('../src/node/db/DB');
+    await db.init();
 
-  // load modules
-  function(callback) {
-    settings = require('../node_modules/ep_etherpad-lite/node/utils/Settings');
-    db = require('../node_modules/ep_etherpad-lite/node/db/DB');
-    dirty = require('../node_modules/ep_etherpad-lite/node_modules/ueberDB/node_modules/dirty')(padId + ".db");
-    callback();
-  },
+    // load extra modules
+    let dirtyDB = require('../src/node_modules/dirty');
+    let padManager = require('../src/node/db/PadManager');
+    let util = require('util');
 
-  // initialize the database
-  function (callback) {
-    db.init(callback);
-  },
+    // initialize output database
+    let dirty = dirtyDB(padId + '.db');
 
-  // get the pad
-  function (callback) {
-    padManager = require('../node_modules/ep_etherpad-lite/node/db/PadManager');
+    // Promise wrapped get and set function
+    let wrapped = db.db.db.wrappedDB;
+    let get = util.promisify(wrapped.get.bind(wrapped));
+    let set = util.promisify(dirty.set.bind(dirty));
 
-    padManager.getPad(padId, function(err, _pad) {
-      pad = _pad;
-      callback(err);
-    });
-  },
+    // array in which required key values will be accumulated
+    let neededDBValues = ['pad:' + padId];
 
-  function (callback) {
+    // get the actual pad object
+    let pad = await padManager.getPad(padId);
+
     // add all authors
-    var authors = pad.getAllAuthors();
-    for (var i = 0; i < authors.length; i++) {
-      neededDBValues.push('globalAuthor:' + authors[i]);
-    }
+    neededDBValues.push(...pad.getAllAuthors().map(author => 'globalAuthor:' + author));
 
     // add all revisions
-    var revHead = pad.head;
-    for (var i = 0; i <= revHead; i++) {
-      neededDBValues.push('pad:' + padId + ':revs:' + i);
+    for (let rev = 0; rev <= pad.head; ++rev) {
+      neededDBValues.push('pad:' + padId + ':revs:' + rev);
     }
 
-    // get all chat values
-    var chatHead = pad.chatHead;
-    for (var i = 0; i <= chatHead; i++) {
-      neededDBValues.push('pad:' + padId + ':chat:' + i);
+    // add all chat values
+    for (let chat = 0; chat <= pad.chatHead; ++chat) {
+      neededDBValues.push('pad:' + padId + ':chat:' + chat);
     }
 
-    // get and set all values
-    async.forEach(neededDBValues, function(dbkey, callback) {
-      db.db.db.wrappedDB.get(dbkey, function(err, dbvalue) {
-        if (err) { callback(err); return}
+    for (let dbkey of neededDBValues) {
+      let dbvalue = await get(dbkey);
+      if (dbvalue && typeof dbvalue !== 'object') {
+        dbvalue = JSON.parse(dbvalue);
+      }
+      await set(dbkey, dbvalue);
+    }
 
-        if (dbvalue && typeof dbvalue != 'object') {
-          dbvalue = JSON.parse(dbvalue); // if it's not json then parse it as json
-        }
-
-        dirty.set(dbkey, dbvalue, callback);
-      });
-    }, callback);
-  }
-],
-function (err) {
-  if (err) {
-    throw err;
-  } else {
-    console.log("finished");
-    process.exit();
+    console.log('finished');
+    process.exit(0);
+  } catch (er) {
+    console.error(er);
+    process.exit(1);
   }
 });

--- a/bin/extractPadData.js
+++ b/bin/extractPadData.js
@@ -1,109 +1,97 @@
 /*
-  This is a debug tool. It helps to extract all datas of a pad and move it from an productive environment and to a develop environment to reproduce bugs there. It outputs a dirtydb file
-*/
+ * This is a debug tool. It helps to extract all datas of a pad and move it from
+ * a productive environment and to a develop environment to reproduce bugs
+ * there. It outputs a dirtydb file
+ */
 
-if(process.argv.length != 3)
-{
+if (process.argv.length != 3) {
   console.error("Use: node extractPadData.js $PADID");
   process.exit(1);
 }
-//get the padID
+
+// get the padID
 var padId = process.argv[2];
 
 var db, dirty, padManager, pad, settings;
 var neededDBValues = ["pad:"+padId];
 
-var npm = require("../node_modules/ep_etherpad-lite/node_modules/npm");
-var async = require("../node_modules/ep_etherpad-lite/node_modules/async");
+var npm = require('../node_modules/ep_etherpad-lite/node_modules/npm');
+var async = require('../node_modules/ep_etherpad-lite/node_modules/async');
 
 async.series([
   // load npm
   function(callback) {
     npm.load({}, function(er) {
-      if(er)
-      {
+      if (er) {
         console.error("Could not load NPM: " + er)
         process.exit(1);
-      }
-      else
-      {
+      } else {
         callback();
       }
     })
   },
+
   // load modules
   function(callback) {
     settings = require('../node_modules/ep_etherpad-lite/node/utils/Settings');
     db = require('../node_modules/ep_etherpad-lite/node/db/DB');
-    dirty = require("../node_modules/ep_etherpad-lite/node_modules/ueberDB/node_modules/dirty")(padId + ".db");
+    dirty = require('../node_modules/ep_etherpad-lite/node_modules/ueberDB/node_modules/dirty')(padId + ".db");
     callback();
   },
-  //initialize the database
-  function (callback)
-  {
+
+  // initialize the database
+  function (callback) {
     db.init(callback);
   },
-  //get the pad 
-  function (callback)
-  {
+
+  // get the pad
+  function (callback) {
     padManager = require('../node_modules/ep_etherpad-lite/node/db/PadManager');
-    
-    padManager.getPad(padId, function(err, _pad)  
-    {
+
+    padManager.getPad(padId, function(err, _pad) {
       pad = _pad;
       callback(err);
     });
   },
-  function (callback)
-  {
-    //add all authors
-    var authors = pad.getAllAuthors();
-    for(var i=0;i<authors.length;i++)
-    {
-      neededDBValues.push("globalAuthor:" + authors[i]);
-    }
-    
-    //add all revisions
-    var revHead = pad.head;
-    for(var i=0;i<=revHead;i++)
-    {
-      neededDBValues.push("pad:"+padId+":revs:" + i);
-    }
-    
-    //get all chat values
-    var chatHead = pad.chatHead;
-    for(var i=0;i<=chatHead;i++)
-    {
-      neededDBValues.push("pad:"+padId+":chat:" + i);
-    }
-    
-    //get and set all values
-    async.forEach(neededDBValues, function(dbkey, callback)
-    {
-      db.db.db.wrappedDB.get(dbkey, function(err, dbvalue)
-      {
-        if(err) { callback(err); return}
 
-        if(dbvalue && typeof dbvalue != 'object'){
-          dbvalue=JSON.parse(dbvalue); // if it's not json then parse it as json
+  function (callback) {
+    // add all authors
+    var authors = pad.getAllAuthors();
+    for (var i = 0; i < authors.length; i++) {
+      neededDBValues.push('globalAuthor:' + authors[i]);
+    }
+
+    // add all revisions
+    var revHead = pad.head;
+    for (var i = 0; i <= revHead; i++) {
+      neededDBValues.push('pad:' + padId + ':revs:' + i);
+    }
+
+    // get all chat values
+    var chatHead = pad.chatHead;
+    for (var i = 0; i <= chatHead; i++) {
+      neededDBValues.push('pad:' + padId + ':chat:' + i);
+    }
+
+    // get and set all values
+    async.forEach(neededDBValues, function(dbkey, callback) {
+      db.db.db.wrappedDB.get(dbkey, function(err, dbvalue) {
+        if (err) { callback(err); return}
+
+        if (dbvalue && typeof dbvalue != 'object') {
+          dbvalue = JSON.parse(dbvalue); // if it's not json then parse it as json
         }
-        
+
         dirty.set(dbkey, dbvalue, callback);
       });
     }, callback);
   }
-], function (err)
-{
-  if(err) throw err;
-  else 
-  { 
+],
+function (err) {
+  if (err) {
+    throw err;
+  } else {
     console.log("finished");
     process.exit();
   }
 });
-
-//get the pad object
-//get all revisions of this pad
-//get all authors related to this pad
-//get the readonly link related to this pad
-//get the chat entries related to this pad

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -287,7 +287,7 @@ exports.setHTML = async function(padID, html)
 
   // add a new changeset with the new html to the pad
   try {
-    await importHtml.setPadHTML(pad, cleanText(html));
+    importHtml.setPadHTML(pad, cleanText(html));
   } catch (e) {
     throw new customError("HTML is malformed", "apierror");
   }

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -204,7 +204,7 @@ exports.getText = function(padID, rev, callback)
 
   // ensure this is not a negative number
   if (rev !== undefined && rev < 0) {
-    callback(new customError("rev is a negativ number", "apierror"));
+    callback(new customError("rev is a negative number", "apierror"));
     return;
   }
 
@@ -257,7 +257,7 @@ exports.setText = function(padID, text, callback)
 {
   // text is required
   if (typeof text != "string") {
-    callback(new customError("text is no string", "apierror"));
+    callback(new customError("text is not a string", "apierror"));
     return;
   }
 
@@ -286,7 +286,7 @@ exports.appendText = function(padID, text, callback)
 {
   // text is required
   if (typeof text != "string") {
-    callback(new customError("text is no string", "apierror"));
+    callback(new customError("text is not a string", "apierror"));
     return;
   }
 
@@ -376,7 +376,7 @@ exports.setHTML = function(padID, html, callback)
 {
   // html is required
   if (typeof html != "string") {
-    callback(new customError("html is no string", "apierror"));
+    callback(new customError("html is not a string", "apierror"));
     return;
   }
 
@@ -472,7 +472,7 @@ exports.appendChatMessage = function(padID, text, authorID, time, callback)
 {
   // text is required
   if (typeof text != "string") {
-    callback(new customError("text is no string", "apierror"));
+    callback(new customError("text is not a string", "apierror"));
     return;
   }
 
@@ -569,7 +569,7 @@ exports.saveRevision = function(padID, rev, callback)
 
   // ensure this is not a negative number
   if (rev !== undefined && rev < 0) {
-    callback(new customError("rev is a negativ number", "apierror"));
+    callback(new customError("rev is a negative number", "apierror"));
     return;
   }
 
@@ -694,7 +694,7 @@ exports.restoreRevision = function(padID, rev, callback)
 
   // ensure this is not a negative number
   if (rev !== undefined && rev < 0) {
-    callback(new customError("rev is a negativ number", "apierror"));
+    callback(new customError("rev is a negative number", "apierror"));
     return;
   }
 

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -192,7 +192,7 @@ Example returns:
 exports.getText = function(padID, rev, callback)
 {
   // check if rev is a number
-  if (rev !== undefined && typeof rev != "number") {
+  if (rev !== undefined && typeof rev !== "number") {
     // try to parse the number
     if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
@@ -256,7 +256,7 @@ Example returns:
 exports.setText = function(padID, text, callback)
 {
   // text is required
-  if (typeof text != "string") {
+  if (typeof text !== "string") {
     callback(new customError("text is not a string", "apierror"));
     return;
   }
@@ -285,7 +285,7 @@ Example returns:
 exports.appendText = function(padID, text, callback)
 {
   // text is required
-  if (typeof text != "string") {
+  if (typeof text !== "string") {
     callback(new customError("text is not a string", "apierror"));
     return;
   }
@@ -311,7 +311,7 @@ Example returns:
 */
 exports.getHTML = function(padID, rev, callback)
 {
-  if (rev !== undefined && typeof rev != "number") {
+  if (rev !== undefined && typeof rev !== "number") {
     if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
       return;
@@ -375,7 +375,7 @@ Example returns:
 exports.setHTML = function(padID, html, callback)
 {
   // html is required
-  if (typeof html != "string") {
+  if (typeof html !== "string") {
     callback(new customError("html is not a string", "apierror"));
     return;
   }
@@ -471,7 +471,7 @@ Example returns:
 exports.appendChatMessage = function(padID, text, authorID, time, callback)
 {
   // text is required
-  if (typeof text != "string") {
+  if (typeof text !== "string") {
     callback(new customError("text is not a string", "apierror"));
     return;
   }
@@ -557,7 +557,7 @@ Example returns:
 exports.saveRevision = function(padID, rev, callback)
 {
   // check if rev is a number
-  if (rev !== undefined && typeof rev != "number") {
+  if (rev !== undefined && typeof rev !== "number") {
     // try to parse the number
     if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
@@ -636,7 +636,7 @@ exports.createPad = function(padID, text, callback)
 {
   if (padID) {
     // ensure there is no $ in the padID
-    if (padID.indexOf("$") != -1) {
+    if (padID.indexOf("$") !== -1) {
       callback(new customError("createPad can't create group pads", "apierror"));
       return;
     }
@@ -682,7 +682,7 @@ exports.deletePad = function(padID, callback)
 exports.restoreRevision = function(padID, rev, callback)
 {
   // check if rev is a number
-  if (rev !== undefined && typeof rev != "number") {
+  if (rev !== undefined && typeof rev !== "number") {
     // try to parse the number
     if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
@@ -838,7 +838,7 @@ exports.getPadID = function(roID, callback)
   readOnlyManager.getPadId(roID, function(err, retrievedPadID) {
     if (ERR(err, callback)) return;
 
-    if (retrievedPadID == null) {
+    if (retrievedPadID === null) {
       callback(new customError("padID does not exist", "apierror"));
       return;
     }
@@ -858,7 +858,7 @@ Example returns:
 exports.setPublicStatus = function(padID, publicStatus, callback)
 {
   // ensure this is a group pad
-  if (padID && padID.indexOf("$") == -1) {
+  if (padID && padID.indexOf("$") === -1) {
     callback(new customError("You can only get/set the publicStatus of pads that belong to a group", "apierror"));
     return;
   }
@@ -868,7 +868,7 @@ exports.setPublicStatus = function(padID, publicStatus, callback)
     if (ERR(err, callback)) return;
 
     // convert string to boolean
-    if (typeof publicStatus == "string")
+    if (typeof publicStatus === "string")
       publicStatus = publicStatus == "true" ? true : false;
 
     // set the password
@@ -1045,7 +1045,7 @@ Example returns:
 */
 exports.createDiffHTML = function(padID, startRev, endRev, callback) {
   // check if startRev is a number
-  if (startRev !== undefined && typeof startRev != "number") {
+  if (startRev !== undefined && typeof startRev !== "number") {
     // try to parse the number
     if (isNaN(parseInt(startRev))) {
       callback({stop: "startRev is not a number"});
@@ -1056,7 +1056,7 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback) {
   }
 
   // check if endRev is a number
-  if (endRev !== undefined && typeof endRev != "number") {
+  if (endRev !== undefined && typeof endRev !== "number") {
     // try to parse the number
     if (isNaN(parseInt(endRev))) {
       callback({stop: "endRev is not a number"});
@@ -1119,13 +1119,13 @@ function is_int(value)
 // gets a pad safe
 function getPadSafe(padID, shouldExist, text, callback)
 {
-  if (typeof text == "function") {
+  if (typeof text === "function") {
     callback = text;
     text = null;
   }
 
   // check if padID is a string
-  if (typeof padID != "string") {
+  if (typeof padID !== "string") {
     callback(new customError("padID is not a string", "apierror"));
     return;
   }

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -103,11 +103,11 @@ Example returns:
 }
 
 */
-exports.getAttributePool = function (padID, callback) 
+exports.getAttributePool = function(padID, callback)
 {
-  getPadSafe(padID, true, function(err, pad)
-  {
+  getPadSafe(padID, true, function(err, pad) {
     if (ERR(err, callback)) return;
+
     callback(null, {pool: pad.pool});
   });
 }
@@ -128,11 +128,9 @@ Example returns:
 exports.getRevisionChangeset = function(padID, rev, callback)
 {
   // check if rev is a number
-  if (rev !== undefined && typeof rev !== "number")
-  {
+  if (rev !== undefined && typeof rev !== "number") {
     // try to parse the number
-    if (isNaN(parseInt(rev)))
-    {
+    if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
       return;
     }
@@ -141,49 +139,42 @@ exports.getRevisionChangeset = function(padID, rev, callback)
   }
 
   // ensure this is not a negative number
-  if (rev !== undefined && rev < 0)
-  {
+  if (rev !== undefined && rev < 0) {
     callback(new customError("rev is not a negative number", "apierror"));
     return;
   }
 
   // ensure this is not a float value
-  if (rev !== undefined && !is_int(rev))
-  {
+  if (rev !== undefined && !is_int(rev)) {
     callback(new customError("rev is a float value", "apierror"));
     return;
   }
 
   // get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
-    //the client asked for a special revision
-    if(rev !== undefined)
-    {
-      //check if this is a valid revision
-      if(rev > pad.getHeadRevisionNumber())
-      {
-        callback(new customError("rev is higher than the head revision of the pad","apierror"));
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
+    // the client asked for a special revision
+    if (rev !== undefined) {
+      // check if this is a valid revision
+      if (rev > pad.getHeadRevisionNumber()) {
+        callback(new customError("rev is higher than the head revision of the pad", "apierror"));
         return;
       }
-      
-      //get the changeset for this revision
-      pad.getRevisionChangeset(rev, function(err, changeset)
-      {
-        if(ERR(err, callback)) return;
-        
+
+      // get the changeset for this revision
+      pad.getRevisionChangeset(rev, function(err, changeset) {
+        if (ERR(err, callback)) return;
+
         callback(null, changeset);
       })
 
       return;
     }
 
-    //the client wants the latest changeset, lets return it to him
-    pad.getRevisionChangeset(pad.getHeadRevisionNumber(), function(err, changeset)
-    {
-      if(ERR(err, callback)) return;
+    // the client wants the latest changeset, lets return it to him
+    pad.getRevisionChangeset(pad.getHeadRevisionNumber(), function(err, changeset) {
+      if (ERR(err, callback)) return;
 
       callback(null, changeset);
     })
@@ -191,7 +182,7 @@ exports.getRevisionChangeset = function(padID, rev, callback)
 }
 
 /**
-getText(padID, [rev]) returns the text of a pad 
+getText(padID, [rev]) returns the text of a pad
 
 Example returns:
 
@@ -200,69 +191,61 @@ Example returns:
 */
 exports.getText = function(padID, rev, callback)
 {
-  //check if rev is a number
-  if(rev !== undefined && typeof rev != "number")
-  {
-    //try to parse the number
-    if(isNaN(parseInt(rev)))
-    {
+  // check if rev is a number
+  if (rev !== undefined && typeof rev != "number") {
+    // try to parse the number
+    if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
       return;
     }
 
     rev = parseInt(rev);
   }
-  
-  //ensure this is not a negativ number
-  if(rev !== undefined && rev < 0)
-  {
-    callback(new customError("rev is a negativ number","apierror"));
+
+  // ensure this is not a negative number
+  if (rev !== undefined && rev < 0) {
+    callback(new customError("rev is a negativ number", "apierror"));
     return;
   }
-  
-  //ensure this is not a float value
-  if(rev !== undefined && !is_int(rev))
-  {
-    callback(new customError("rev is a float value","apierror"));
+
+  // ensure this is not a float value
+  if (rev !== undefined && !is_int(rev)) {
+    callback(new customError("rev is a float value", "apierror"));
     return;
   }
-  
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
-    //the client asked for a special revision
-    if(rev !== undefined)
-    {
-      //check if this is a valid revision
-      if(rev > pad.getHeadRevisionNumber())
-      {
-        callback(new customError("rev is higher than the head revision of the pad","apierror"));
+
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
+    // the client asked for a special revision
+    if (rev !== undefined) {
+      // check if this is a valid revision
+      if (rev > pad.getHeadRevisionNumber()) {
+        callback(new customError("rev is higher than the head revision of the pad", "apierror"));
         return;
       }
-      
-      //get the text of this revision
-      pad.getInternalRevisionAText(rev, function(err, atext)
-      {
-        if(ERR(err, callback)) return;
-        
+
+      // get the text of this revision
+      pad.getInternalRevisionAText(rev, function(err, atext) {
+        if (ERR(err, callback)) return;
+
         var data = {text: atext.text};
-        
+
         callback(null, data);
       })
 
       return;
     }
 
-    //the client wants the latest text, lets return it to him
+    // the client wants the latest text, lets return it to him
     var padText = exportTxt.getTXTFromAtext(pad, pad.atext);
     callback(null, {"text": padText});
   });
 }
 
 /**
-setText(padID, text) sets the text of a pad 
+setText(padID, text) sets the text of a pad
 
 Example returns:
 
@@ -271,23 +254,21 @@ Example returns:
 {code: 1, message:"text too long", data: null}
 */
 exports.setText = function(padID, text, callback)
-{    
-  //text is required
-  if(typeof text != "string")
-  {
-    callback(new customError("text is no string","apierror"));
+{
+  // text is required
+  if (typeof text != "string") {
+    callback(new customError("text is no string", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
-    //set the text
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
+    // set the text
     pad.setText(text);
-    
-    //update the clients on the pad
+
+    // update the clients on the pad
     padMessageHandler.updatePadClients(pad, callback);
   });
 }
@@ -303,29 +284,25 @@ Example returns:
 */
 exports.appendText = function(padID, text, callback)
 {
-  //text is required
-  if(typeof text != "string")
-  {
-    callback(new customError("text is no string","apierror"));
+  // text is required
+  if (typeof text != "string") {
+    callback(new customError("text is no string", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
 
     pad.appendText(text);
 
-    //update the clients on the pad
+    // update the clients on the pad
     padMessageHandler.updatePadClients(pad, callback);
   });
 };
 
-
-
 /**
-getHTML(padID, [rev]) returns the html of a pad 
+getHTML(padID, [rev]) returns the html of a pad
 
 Example returns:
 
@@ -334,47 +311,39 @@ Example returns:
 */
 exports.getHTML = function(padID, rev, callback)
 {
-  if (rev !== undefined && typeof rev != "number")
-  {
-    if (isNaN(parseInt(rev)))
-    {
-      callback(new customError("rev is not a number","apierror"));
+  if (rev !== undefined && typeof rev != "number") {
+    if (isNaN(parseInt(rev))) {
+      callback(new customError("rev is not a number", "apierror"));
       return;
     }
 
     rev = parseInt(rev);
   }
 
-  if(rev !== undefined && rev < 0)
-  {
-     callback(new customError("rev is a negative number","apierror"));
+  if (rev !== undefined && rev < 0) {
+     callback(new customError("rev is a negative number", "apierror"));
      return;
   }
 
-  if(rev !== undefined && !is_int(rev))
-  {
-    callback(new customError("rev is a float value","apierror"));
+  if (rev !== undefined && !is_int(rev)) {
+    callback(new customError("rev is a float value", "apierror"));
     return;
   }
 
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
-    //the client asked for a special revision
-    if(rev !== undefined)
-    {
-      //check if this is a valid revision
-      if(rev > pad.getHeadRevisionNumber())
-      {
-        callback(new customError("rev is higher than the head revision of the pad","apierror"));
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
+    // the client asked for a special revision
+    if (rev !== undefined) {
+      // check if this is a valid revision
+      if (rev > pad.getHeadRevisionNumber()) {
+        callback(new customError("rev is higher than the head revision of the pad", "apierror"));
         return;
       }
-     
-      //get the html of this revision 
-      exportHtml.getPadHTML(pad, rev, function(err, html)
-      {
-          if(ERR(err, callback)) return;
+
+      // get the html of this revision
+      exportHtml.getPadHTML(pad, rev, function(err, html) {
+          if (ERR(err, callback)) return;
           html = "<!DOCTYPE HTML><html><body>" +html; // adds HTML head
           html += "</body></html>";
           var data = {html: html};
@@ -384,10 +353,9 @@ exports.getHTML = function(padID, rev, callback)
       return;
     }
 
-    //the client wants the latest text, lets return it to him
-    exportHtml.getPadHTML(pad, undefined, function (err, html)
-    {
-      if(ERR(err, callback)) return;
+    // the client wants the latest text, lets return it to him
+    exportHtml.getPadHTML(pad, undefined, function(err, html) {
+      if (ERR(err, callback)) return;
       html = "<!DOCTYPE HTML><html><body>" +html; // adds HTML head
       html += "</body></html>";
       var data = {html: html};
@@ -406,26 +374,24 @@ Example returns:
 */
 exports.setHTML = function(padID, html, callback)
 {
-  //html is required
-  if(typeof html != "string")
-  {
-    callback(new customError("html is no string","apierror"));
+  // html is required
+  if (typeof html != "string") {
+    callback(new customError("html is no string", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
 
     // add a new changeset with the new html to the pad
-    importHtml.setPadHTML(pad, cleanText(html), function(e){
-      if(e){
-        callback(new customError("HTML is malformed","apierror"));
+    importHtml.setPadHTML(pad, cleanText(html), function(e) {
+      if (e) {
+        callback(new customError("HTML is malformed", "apierror"));
         return;
       }
 
-      //update the clients on the pad
+      // update the clients on the pad
       padMessageHandler.updatePadClients(pad, callback);
     });
   });
@@ -449,54 +415,46 @@ Example returns:
 */
 exports.getChatHistory = function(padID, start, end, callback)
 {
-  if(start && end)
-  {
-    if(start < 0)
-    {
-      callback(new customError("start is below zero","apierror"));
+  if (start && end) {
+    if (start < 0) {
+      callback(new customError("start is below zero", "apierror"));
       return;
     }
-    if(end < 0)
-    {
-      callback(new customError("end is below zero","apierror"));
+    if (end < 0) {
+      callback(new customError("end is below zero", "apierror"));
       return;
     }
-    if(start > end)
-    {
-      callback(new customError("start is higher than end","apierror"));
+    if (start > end) {
+      callback(new customError("start is higher than end", "apierror"));
       return;
     }
   }
-  
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     var chatHead = pad.chatHead;
-    
+
     // fall back to getting the whole chat-history if a parameter is missing
-    if(!start || !end)
-    {
+    if (!start || !end) {
     start = 0;
     end = pad.chatHead;
     }
-    
-    if(start > chatHead)
-    {
-      callback(new customError("start is higher than the current chatHead","apierror"));
+
+    if (start > chatHead) {
+      callback(new customError("start is higher than the current chatHead", "apierror"));
       return;
     }
-    if(end > chatHead)
-    {
-      callback(new customError("end is higher than the current chatHead","apierror"));
+    if (end > chatHead) {
+      callback(new customError("end is higher than the current chatHead", "apierror"));
       return;
     }
-    
+
     // the the whole message-log and return it to the client
     pad.getChatMessages(start, end,
-      function(err, msgs)
-      {
-        if(ERR(err, callback)) return;
+      function(err, msgs) {
+        if (ERR(err, callback)) return;
         callback(null, {messages: msgs});
       });
   });
@@ -512,16 +470,14 @@ Example returns:
 */
 exports.appendChatMessage = function(padID, text, authorID, time, callback)
 {
-  //text is required
-  if(typeof text != "string")
-  {
-    callback(new customError("text is no string","apierror"));
+  // text is required
+  if (typeof text != "string") {
+    callback(new customError("text is no string", "apierror"));
     return;
   }
-  
+
   // if time is not an integer value
-  if(time === undefined || !is_int(time))
-  {
+  if (time === undefined || !is_int(time)) {
     // set time to current timestamp
     time = Date.now();
   }
@@ -537,7 +493,7 @@ exports.appendChatMessage = function(padID, text, authorID, time, callback)
 /*****************/
 
 /**
-getRevisionsCount(padID) returns the number of revisions of this pad 
+getRevisionsCount(padID) returns the number of revisions of this pad
 
 Example returns:
 
@@ -546,11 +502,10 @@ Example returns:
 */
 exports.getRevisionsCount = function(padID, callback)
 {
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     callback(null, {revisions: pad.getHeadRevisionNumber()});
   });
 }
@@ -565,10 +520,9 @@ Example returns:
 */
 exports.getSavedRevisionsCount = function(padID, callback)
 {
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
 
     callback(null, {savedRevisions: pad.getSavedRevisionsNumber()});
   });
@@ -584,10 +538,9 @@ Example returns:
 */
 exports.listSavedRevisions = function(padID, callback)
 {
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
 
     callback(null, {savedRevisions: pad.getSavedRevisionsList()});
   });
@@ -603,12 +556,10 @@ Example returns:
 */
 exports.saveRevision = function(padID, rev, callback)
 {
-  //check if rev is a number
-  if(rev !== undefined && typeof rev != "number")
-  {
-    //try to parse the number
-    if(isNaN(parseInt(rev)))
-    {
+  // check if rev is a number
+  if (rev !== undefined && typeof rev != "number") {
+    // try to parse the number
+    if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
       return;
     }
@@ -616,32 +567,27 @@ exports.saveRevision = function(padID, rev, callback)
     rev = parseInt(rev);
   }
 
-  //ensure this is not a negativ number
-  if(rev !== undefined && rev < 0)
-  {
-    callback(new customError("rev is a negativ number","apierror"));
+  // ensure this is not a negative number
+  if (rev !== undefined && rev < 0) {
+    callback(new customError("rev is a negativ number", "apierror"));
     return;
   }
 
-  //ensure this is not a float value
-  if(rev !== undefined && !is_int(rev))
-  {
-    callback(new customError("rev is a float value","apierror"));
+  // ensure this is not a float value
+  if (rev !== undefined && !is_int(rev)) {
+    callback(new customError("rev is a float value", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
 
-    //the client asked for a special revision
-    if(rev !== undefined)
-    {
-      //check if this is a valid revision
-      if(rev > pad.getHeadRevisionNumber())
-      {
-        callback(new customError("rev is higher than the head revision of the pad","apierror"));
+    // the client asked for a special revision
+    if (rev !== undefined) {
+      // check if this is a valid revision
+      if (rev > pad.getHeadRevisionNumber()) {
+        callback(new customError("rev is higher than the head revision of the pad", "apierror"));
         return;
       }
     } else {
@@ -649,7 +595,7 @@ exports.saveRevision = function(padID, rev, callback)
     }
 
     authorManager.createAuthor('API', function(err, author) {
-      if(ERR(err, callback)) return;
+      if (ERR(err, callback)) return;
 
       pad.addSavedRevision(rev, author.authorID, 'Saved through API call');
       callback();
@@ -667,19 +613,19 @@ Example returns:
 */
 exports.getLastEdited = function(padID, callback)
 {
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     pad.getLastEdit(function(err, value) {
-      if(ERR(err, callback)) return;
+      if (ERR(err, callback)) return;
       callback(null, {lastEdited: value});
     });
   });
 }
 
 /**
-createPad(padName [, text]) creates a new pad in this group 
+createPad(padName [, text]) creates a new pad in this group
 
 Example returns:
 
@@ -687,34 +633,30 @@ Example returns:
 {code: 1, message:"pad does already exist", data: null}
 */
 exports.createPad = function(padID, text, callback)
-{  
-  //ensure there is no $ in the padID
-  if(padID)
-  {
-    if(padID.indexOf("$") != -1)
-    {
-      callback(new customError("createPad can't create group pads","apierror"));
+{
+  if (padID) {
+    // ensure there is no $ in the padID
+    if (padID.indexOf("$") != -1) {
+      callback(new customError("createPad can't create group pads", "apierror"));
       return;
     }
 
-    //check for url special characters
-    if(padID.match(/(\/|\?|&|#)/))
-    {
-      callback(new customError("malformed padID: Remove special characters","apierror"));
+    // check for url special characters
+    if (padID.match(/(\/|\?|&|#)/)) {
+      callback(new customError("malformed padID: Remove special characters", "apierror"));
       return;
     }
   }
 
-  //create pad
-  getPadSafe(padID, false, text, function(err)
-  {
-    if(ERR(err, callback)) return;
+  // create pad
+  getPadSafe(padID, false, text, function(err) {
+    if (ERR(err, callback)) return;
     callback();
   });
 }
 
 /**
-deletePad(padID) deletes a pad 
+deletePad(padID) deletes a pad
 
 Example returns:
 
@@ -723,10 +665,9 @@ Example returns:
 */
 exports.deletePad = function(padID, callback)
 {
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     pad.remove(callback);
   });
 }
@@ -738,14 +679,12 @@ exports.deletePad = function(padID, callback)
  {code:0, message:"ok", data:null}
  {code: 1, message:"padID does not exist", data: null}
  */
-exports.restoreRevision = function (padID, rev, callback)
+exports.restoreRevision = function(padID, rev, callback)
 {
-  //check if rev is a number
-  if (rev !== undefined && typeof rev != "number")
-  {
-    //try to parse the number
-    if (isNaN(parseInt(rev)))
-    {
+  // check if rev is a number
+  if (rev !== undefined && typeof rev != "number") {
+    // try to parse the number
+    if (isNaN(parseInt(rev))) {
       callback(new customError("rev is not a number", "apierror"));
       return;
     }
@@ -753,51 +692,43 @@ exports.restoreRevision = function (padID, rev, callback)
     rev = parseInt(rev);
   }
 
-  //ensure this is not a negativ number
-  if (rev !== undefined && rev < 0)
-  {
+  // ensure this is not a negative number
+  if (rev !== undefined && rev < 0) {
     callback(new customError("rev is a negativ number", "apierror"));
     return;
   }
 
-  //ensure this is not a float value
-  if (rev !== undefined && !is_int(rev))
-  {
+  // ensure this is not a float value
+  if (rev !== undefined && !is_int(rev)) {
     callback(new customError("rev is a float value", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function (err, pad)
-  {
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
     if (ERR(err, callback)) return;
 
 
-    //check if this is a valid revision
-    if (rev > pad.getHeadRevisionNumber())
-    {
+    // check if this is a valid revision
+    if (rev > pad.getHeadRevisionNumber()) {
       callback(new customError("rev is higher than the head revision of the pad", "apierror"));
       return;
     }
 
-    pad.getInternalRevisionAText(rev, function (err, atext)
-    {
+    pad.getInternalRevisionAText(rev, function(err, atext) {
       if (ERR(err, callback)) return;
 
       var oldText = pad.text();
       atext.text += "\n";
-      function eachAttribRun(attribs, func)
-      {
+      function eachAttribRun(attribs, func) {
         var attribsIter = Changeset.opIterator(attribs);
         var textIndex = 0;
         var newTextStart = 0;
         var newTextEnd = atext.text.length;
-        while (attribsIter.hasNext())
-        {
+        while (attribsIter.hasNext()) {
           var op = attribsIter.next();
           var nextIndex = textIndex + op.chars;
-          if (!(nextIndex <= newTextStart || textIndex >= newTextEnd))
-          {
+          if (!(nextIndex <= newTextStart || textIndex >= newTextEnd)) {
             func(Math.max(newTextStart, textIndex), Math.min(newTextEnd, nextIndex), op.attribs);
           }
           textIndex = nextIndex;
@@ -808,29 +739,25 @@ exports.restoreRevision = function (padID, rev, callback)
       var builder = Changeset.builder(oldText.length);
 
       // assemble each line into the builder
-      eachAttribRun(atext.attribs, function (start, end, attribs)
-      {
+      eachAttribRun(atext.attribs, function(start, end, attribs) {
         builder.insert(atext.text.substring(start, end), attribs);
       });
 
       var lastNewlinePos = oldText.lastIndexOf('\n');
-      if (lastNewlinePos < 0)
-      {
+      if (lastNewlinePos < 0) {
         builder.remove(oldText.length - 1, 0);
-      } else
-      {
+      } else {
         builder.remove(lastNewlinePos, oldText.match(/\n/g).length - 1);
         builder.remove(oldText.length - lastNewlinePos - 1, 0);
       }
 
       var changeset = builder.toString();
 
-      //append the changeset
+      // append the changeset
       pad.appendRevision(changeset);
-      //
-      padMessageHandler.updatePadClients(pad, function ()
-      {
-      });
+
+      // update the clients on the pad
+      padMessageHandler.updatePadClients(pad, function() {});
       callback(null, null);
     });
 
@@ -838,7 +765,7 @@ exports.restoreRevision = function (padID, rev, callback)
 };
 
 /**
-copyPad(sourceID, destinationID[, force=false]) copies a pad. If force is true, 
+copyPad(sourceID, destinationID[, force=false]) copies a pad. If force is true,
   the destination will be overwritten if it exists.
 
 Example returns:
@@ -848,16 +775,15 @@ Example returns:
 */
 exports.copyPad = function(sourceID, destinationID, force, callback)
 {
-  getPadSafe(sourceID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+  getPadSafe(sourceID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     pad.copy(destinationID, force, callback);
   });
 }
 
 /**
-movePad(sourceID, destinationID[, force=false]) moves a pad. If force is true, 
+movePad(sourceID, destinationID[, force=false]) moves a pad. If force is true,
   the destination will be overwritten if it exists.
 
 Example returns:
@@ -867,18 +793,17 @@ Example returns:
 */
 exports.movePad = function(sourceID, destinationID, force, callback)
 {
-  getPadSafe(sourceID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+  getPadSafe(sourceID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     pad.copy(destinationID, force, function(err) {
-      if(ERR(err, callback)) return;
+      if (ERR(err, callback)) return;
       pad.remove(callback);
     });
   });
 }
 /**
-getReadOnlyLink(padID) returns the read only link of a pad 
+getReadOnlyLink(padID) returns the read only link of a pad
 
 Example returns:
 
@@ -887,15 +812,13 @@ Example returns:
 */
 exports.getReadOnlyID = function(padID, callback)
 {
-  //we don't need the pad object, but this function does all the security stuff for us
-  getPadSafe(padID, true, function(err)
-  {
-    if(ERR(err, callback)) return;
-    
-    //get the readonlyId
-    readOnlyManager.getReadOnlyId(padID, function(err, readOnlyId)
-    {
-      if(ERR(err, callback)) return;
+  // we don't need the pad object, but this function does all the security stuff for us
+  getPadSafe(padID, true, function(err) {
+    if (ERR(err, callback)) return;
+
+    // get the readonlyId
+    readOnlyManager.getReadOnlyId(padID, function(err, readOnlyId) {
+      if (ERR(err, callback)) return;
       callback(null, {readOnlyID: readOnlyId});
     });
   });
@@ -911,14 +834,12 @@ Example returns:
 */
 exports.getPadID = function(roID, callback)
 {
-  //get the PadId
-  readOnlyManager.getPadId(roID, function(err, retrievedPadID)
-  {
-    if(ERR(err, callback)) return;
+  // get the PadId
+  readOnlyManager.getPadId(roID, function(err, retrievedPadID) {
+    if (ERR(err, callback)) return;
 
-    if(retrievedPadID == null)
-    {
-      callback(new customError("padID does not exist","apierror"));
+    if (retrievedPadID == null) {
+      callback(new customError("padID does not exist", "apierror"));
       return;
     }
 
@@ -927,7 +848,7 @@ exports.getPadID = function(roID, callback)
 }
 
 /**
-setPublicStatus(padID, publicStatus) sets a boolean for the public status of a pad 
+setPublicStatus(padID, publicStatus) sets a boolean for the public status of a pad
 
 Example returns:
 
@@ -936,31 +857,29 @@ Example returns:
 */
 exports.setPublicStatus = function(padID, publicStatus, callback)
 {
-  //ensure this is a group pad
-  if(padID && padID.indexOf("$") == -1)
-  {
-    callback(new customError("You can only get/set the publicStatus of pads that belong to a group","apierror"));
+  // ensure this is a group pad
+  if (padID && padID.indexOf("$") == -1) {
+    callback(new customError("You can only get/set the publicStatus of pads that belong to a group", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
-    //convert string to boolean
-    if(typeof publicStatus == "string")
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
+    // convert string to boolean
+    if (typeof publicStatus == "string")
       publicStatus = publicStatus == "true" ? true : false;
-    
-    //set the password
+
+    // set the password
     pad.setPublicStatus(publicStatus);
-    
+
     callback();
   });
 }
 
 /**
-getPublicStatus(padID) return true of false 
+getPublicStatus(padID) return true of false
 
 Example returns:
 
@@ -969,24 +888,22 @@ Example returns:
 */
 exports.getPublicStatus = function(padID, callback)
 {
-  //ensure this is a group pad
-  if(padID && padID.indexOf("$") == -1)
-  {
-    callback(new customError("You can only get/set the publicStatus of pads that belong to a group","apierror"));
+  // ensure this is a group pad
+  if (padID && padID.indexOf("$") == -1) {
+    callback(new customError("You can only get/set the publicStatus of pads that belong to a group", "apierror"));
     return;
   }
-  
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     callback(null, {publicStatus: pad.getPublicStatus()});
   });
 }
 
 /**
-setPassword(padID, password) returns ok or a error message 
+setPassword(padID, password) returns ok or a error message
 
 Example returns:
 
@@ -995,27 +912,25 @@ Example returns:
 */
 exports.setPassword = function(padID, password, callback)
 {
-  //ensure this is a group pad
-  if(padID && padID.indexOf("$") == -1)
-  {
-    callback(new customError("You can only get/set the password of pads that belong to a group","apierror"));
+  // ensure this is a group pad
+  if (padID && padID.indexOf("$") == -1) {
+    callback(new customError("You can only get/set the password of pads that belong to a group", "apierror"));
     return;
   }
-  
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
-    //set the password
+
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
+    // set the password
     pad.setPassword(password == "" ? null : password);
-    
+
     callback();
   });
 }
 
 /**
-isPasswordProtected(padID) returns true or false 
+isPasswordProtected(padID) returns true or false
 
 Example returns:
 
@@ -1024,24 +939,22 @@ Example returns:
 */
 exports.isPasswordProtected = function(padID, callback)
 {
-  //ensure this is a group pad
-  if(padID && padID.indexOf("$") == -1)
-  {
-    callback(new customError("You can only get/set the password of pads that belong to a group","apierror"));
+  // ensure this is a group pad
+  if (padID && padID.indexOf("$") == -1) {
+    callback(new customError("You can only get/set the password of pads that belong to a group", "apierror"));
     return;
   }
 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     callback(null, {isPasswordProtected: pad.isPasswordProtected()});
   });
 }
 
 /**
-listAuthorsOfPad(padID) returns an array of authors who contributed to this pad 
+listAuthorsOfPad(padID) returns an array of authors who contributed to this pad
 
 Example returns:
 
@@ -1050,11 +963,10 @@ Example returns:
 */
 exports.listAuthorsOfPad = function(padID, callback)
 {
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
-    
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     callback(null, {authorIDs: pad.getAllAuthors()});
   });
 }
@@ -1082,8 +994,8 @@ Example returns:
 {code: 1, message:"padID does not exist"}
 */
 
-exports.sendClientsMessage = function (padID, msg, callback) {
-  getPadSafe(padID, true, function (err, pad) {
+exports.sendClientsMessage = function(padID, msg, callback) {
+  getPadSafe(padID, true, function(err, pad) {
     if (ERR(err, callback)) {
       return;
     }
@@ -1115,10 +1027,10 @@ Example returns:
 */
 exports.getChatHead = function(padID, callback)
 {
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(ERR(err, callback)) return;
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (ERR(err, callback)) return;
+
     callback(null, {chatHead: pad.chatHead});
   });
 }
@@ -1131,69 +1043,64 @@ Example returns:
 {"code":0,"message":"ok","data":{"html":"<style>\n.authora_HKIv23mEbachFYfH {background-color: #a979d9}\n.authora_n4gEeMLsv1GivNeh {background-color: #a9b5d9}\n.removed {text-decoration: line-through; -ms-filter:'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)'; filter: alpha(opacity=80); opacity: 0.8; }\n</style>Welcome to Etherpad!<br><br>This pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!<br><br>Get involved with Etherpad at <a href=\"http&#x3a;&#x2F;&#x2F;etherpad&#x2e;org\">http:&#x2F;&#x2F;etherpad.org</a><br><span class=\"authora_HKIv23mEbachFYfH\">aw</span><br><br>","authors":["a.HKIv23mEbachFYfH",""]}}
 {"code":4,"message":"no or wrong API Key","data":null}
 */
-exports.createDiffHTML = function(padID, startRev, endRev, callback){
-  //check if rev is a number
-  if(startRev !== undefined && typeof startRev != "number")
-  {
-    //try to parse the number
-    if(isNaN(parseInt(startRev)))
-    {
+exports.createDiffHTML = function(padID, startRev, endRev, callback) {
+  // check if startRev is a number
+  if (startRev !== undefined && typeof startRev != "number") {
+    // try to parse the number
+    if (isNaN(parseInt(startRev))) {
       callback({stop: "startRev is not a number"});
       return;
     }
 
     startRev = parseInt(startRev, 10);
   }
- 
-  //check if rev is a number
-  if(endRev !== undefined && typeof endRev != "number")
-  {
-    //try to parse the number
-    if(isNaN(parseInt(endRev)))
-    {
+
+  // check if endRev is a number
+  if (endRev !== undefined && typeof endRev != "number") {
+    // try to parse the number
+    if (isNaN(parseInt(endRev))) {
       callback({stop: "endRev is not a number"});
       return;
     }
 
     endRev = parseInt(endRev, 10);
   }
- 
-  //get the pad
-  getPadSafe(padID, true, function(err, pad)
-  {
-    if(err){
+
+  // get the pad
+  getPadSafe(padID, true, function(err, pad) {
+    if (err) {
       return callback(err);
     }
- 
+
     try {
       var padDiff = new PadDiff(pad, startRev, endRev);
     } catch(e) {
       return callback({stop:e.message});
     }
     var html, authors;
- 
+
     async.series([
-      function(callback){
-        padDiff.getHtml(function(err, _html){
-          if(err){
+      function(callback) {
+        padDiff.getHtml(function(err, _html) {
+          if (err) {
             return callback(err);
           }
- 
+
           html = _html;
           callback();
         });
       },
-      function(callback){
-        padDiff.getAuthors(function(err, _authors){
-          if(err){
+      function(callback) {
+        padDiff.getAuthors(function(err, _authors) {
+          if (err) {
             return callback(err);
           }
- 
+
           authors = _authors;
           callback();
         });
       }
-    ], function(err){
+    ], function(err) {
       callback(err, {html: html, authors: authors})
     });
   });
@@ -1203,53 +1110,44 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback){
 /** INTERNAL HELPER FUNCTIONS */
 /******************************/
 
-//checks if a number is an int
+// checks if a number is an int
 function is_int(value)
-{ 
+{
   return (parseFloat(value) == parseInt(value)) && !isNaN(value)
 }
 
-//gets a pad safe
+// gets a pad safe
 function getPadSafe(padID, shouldExist, text, callback)
 {
-  if(typeof text == "function")
-  {
+  if (typeof text == "function") {
     callback = text;
     text = null;
   }
 
-  //check if padID is a string
-  if(typeof padID != "string")
-  {
-    callback(new customError("padID is not a string","apierror"));
+  // check if padID is a string
+  if (typeof padID != "string") {
+    callback(new customError("padID is not a string", "apierror"));
     return;
   }
-  
-  //check if the padID maches the requirements
-  if(!padManager.isValidPadId(padID))
-  {
-    callback(new customError("padID did not match requirements","apierror"));
+
+  // check if the padID maches the requirements
+  if (!padManager.isValidPadId(padID)) {
+    callback(new customError("padID did not match requirements", "apierror"));
     return;
   }
-  
-  //check if the pad exists
-  padManager.doesPadExists(padID, function(err, exists)
-  {
-    if(ERR(err, callback)) return;
-    
-    //does not exist, but should
-    if(exists == false && shouldExist == true)
-    {
-      callback(new customError("padID does not exist","apierror"));
-    }
-    //does exists, but shouldn't
-    else if(exists == true && shouldExist == false)
-    {
-      callback(new customError("padID does already exist","apierror"));
-    }
-    //pad exists, let's get it
-    else
-    {
+
+  // check if the pad exists
+  padManager.doesPadExists(padID, function(err, exists) {
+    if (ERR(err, callback)) return;
+
+    // does not exist, but should
+    if (exists == false && shouldExist == true) {
+      callback(new customError("padID does not exist", "apierror"));
+    } else if (exists == true && shouldExist == false) {
+      // does exist, but shouldn't
+      callback(new customError("padID does already exist", "apierror"));
+    } else {
+      // pad exists, let's get it
       padManager.getPad(padID, text, callback);
     }
   });

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -33,6 +33,7 @@ var exportTxt = require("../utils/ExportTxt");
 var importHtml = require("../utils/ImportHtml");
 var cleanText = require("./Pad").cleanText;
 var PadDiff = require("../utils/padDiff");
+const thenify = require("thenify").withCallback;
 
 /**********************/
 /**GROUP FUNCTIONS*****/
@@ -103,14 +104,14 @@ Example returns:
 }
 
 */
-exports.getAttributePool = function(padID, callback)
+exports.getAttributePool = thenify(function(padID, callback)
 {
   getPadSafe(padID, true, function(err, pad) {
     if (ERR(err, callback)) return;
 
     callback(null, {pool: pad.pool});
   });
-}
+});
 
 /**
 getRevisionChangeset (padID, [rev])
@@ -125,7 +126,7 @@ Example returns:
 }
 
 */
-exports.getRevisionChangeset = function(padID, rev, callback)
+exports.getRevisionChangeset = thenify(function(padID, rev, callback)
 {
   // check if rev is a number
   if (rev !== undefined && typeof rev !== "number") {
@@ -179,7 +180,7 @@ exports.getRevisionChangeset = function(padID, rev, callback)
       callback(null, changeset);
     })
   });
-}
+});
 
 /**
 getText(padID, [rev]) returns the text of a pad
@@ -189,7 +190,7 @@ Example returns:
 {code: 0, message:"ok", data: {text:"Welcome Text"}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getText = function(padID, rev, callback)
+exports.getText = thenify(function(padID, rev, callback)
 {
   // check if rev is a number
   if (rev !== undefined && typeof rev !== "number") {
@@ -242,7 +243,7 @@ exports.getText = function(padID, rev, callback)
     var padText = exportTxt.getTXTFromAtext(pad, pad.atext);
     callback(null, {"text": padText});
   });
-}
+});
 
 /**
 setText(padID, text) sets the text of a pad
@@ -253,7 +254,7 @@ Example returns:
 {code: 1, message:"padID does not exist", data: null}
 {code: 1, message:"text too long", data: null}
 */
-exports.setText = function(padID, text, callback)
+exports.setText = thenify(function(padID, text, callback)
 {
   // text is required
   if (typeof text !== "string") {
@@ -271,7 +272,7 @@ exports.setText = function(padID, text, callback)
     // update the clients on the pad
     padMessageHandler.updatePadClients(pad, callback);
   });
-}
+});
 
 /**
 appendText(padID, text) appends text to a pad
@@ -282,7 +283,7 @@ Example returns:
 {code: 1, message:"padID does not exist", data: null}
 {code: 1, message:"text too long", data: null}
 */
-exports.appendText = function(padID, text, callback)
+exports.appendText = thenify(function(padID, text, callback)
 {
   // text is required
   if (typeof text !== "string") {
@@ -299,7 +300,7 @@ exports.appendText = function(padID, text, callback)
     // update the clients on the pad
     padMessageHandler.updatePadClients(pad, callback);
   });
-};
+});
 
 /**
 getHTML(padID, [rev]) returns the html of a pad
@@ -309,7 +310,7 @@ Example returns:
 {code: 0, message:"ok", data: {text:"Welcome <strong>Text</strong>"}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getHTML = function(padID, rev, callback)
+exports.getHTML = thenify(function(padID, rev, callback)
 {
   if (rev !== undefined && typeof rev !== "number") {
     if (isNaN(parseInt(rev))) {
@@ -362,7 +363,7 @@ exports.getHTML = function(padID, rev, callback)
       callback(null, data);
     });
   });
-}
+});
 
 /**
 setHTML(padID, html) sets the text of a pad based on HTML
@@ -372,7 +373,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.setHTML = function(padID, html, callback)
+exports.setHTML = thenify(function(padID, html, callback)
 {
   // html is required
   if (typeof html !== "string") {
@@ -395,7 +396,7 @@ exports.setHTML = function(padID, html, callback)
       padMessageHandler.updatePadClients(pad, callback);
     });
   });
-}
+});
 
 /******************/
 /**CHAT FUNCTIONS */
@@ -413,7 +414,7 @@ Example returns:
 
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getChatHistory = function(padID, start, end, callback)
+exports.getChatHistory = thenify(function(padID, start, end, callback)
 {
   if (start && end) {
     if (start < 0) {
@@ -458,7 +459,7 @@ exports.getChatHistory = function(padID, start, end, callback)
         callback(null, {messages: msgs});
       });
   });
-}
+});
 
 /**
 appendChatMessage(padID, text, authorID, time), creates a chat message for the pad id, time is a timestamp
@@ -468,7 +469,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.appendChatMessage = function(padID, text, authorID, time, callback)
+exports.appendChatMessage = thenify(function(padID, text, authorID, time, callback)
 {
   // text is required
   if (typeof text !== "string") {
@@ -486,7 +487,7 @@ exports.appendChatMessage = function(padID, text, authorID, time, callback)
   padMessageHandler.sendChatMessageToPadClients(time, authorID, text, padID);
 
   callback();
-}
+});
 
 /*****************/
 /**PAD FUNCTIONS */
@@ -500,7 +501,7 @@ Example returns:
 {code: 0, message:"ok", data: {revisions: 56}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getRevisionsCount = function(padID, callback)
+exports.getRevisionsCount = thenify(function(padID, callback)
 {
   // get the pad
   getPadSafe(padID, true, function(err, pad) {
@@ -508,7 +509,7 @@ exports.getRevisionsCount = function(padID, callback)
 
     callback(null, {revisions: pad.getHeadRevisionNumber()});
   });
-}
+});
 
 /**
 getSavedRevisionsCount(padID) returns the number of saved revisions of this pad
@@ -518,7 +519,7 @@ Example returns:
 {code: 0, message:"ok", data: {savedRevisions: 42}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getSavedRevisionsCount = function(padID, callback)
+exports.getSavedRevisionsCount = thenify(function(padID, callback)
 {
   // get the pad
   getPadSafe(padID, true, function(err, pad) {
@@ -526,7 +527,7 @@ exports.getSavedRevisionsCount = function(padID, callback)
 
     callback(null, {savedRevisions: pad.getSavedRevisionsNumber()});
   });
-}
+});
 
 /**
 listSavedRevisions(padID) returns the list of saved revisions of this pad
@@ -536,7 +537,7 @@ Example returns:
 {code: 0, message:"ok", data: {savedRevisions: [2, 42, 1337]}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.listSavedRevisions = function(padID, callback)
+exports.listSavedRevisions = thenify(function(padID, callback)
 {
   // get the pad
   getPadSafe(padID, true, function(err, pad) {
@@ -544,7 +545,7 @@ exports.listSavedRevisions = function(padID, callback)
 
     callback(null, {savedRevisions: pad.getSavedRevisionsList()});
   });
-}
+});
 
 /**
 saveRevision(padID) returns the list of saved revisions of this pad
@@ -554,7 +555,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.saveRevision = function(padID, rev, callback)
+exports.saveRevision = thenify(function(padID, rev, callback)
 {
   // check if rev is a number
   if (rev !== undefined && typeof rev !== "number") {
@@ -601,7 +602,7 @@ exports.saveRevision = function(padID, rev, callback)
       callback();
     });
   });
-}
+});
 
 /**
 getLastEdited(padID) returns the timestamp of the last revision of the pad
@@ -611,7 +612,7 @@ Example returns:
 {code: 0, message:"ok", data: {lastEdited: 1340815946602}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getLastEdited = function(padID, callback)
+exports.getLastEdited = thenify(function(padID, callback)
 {
   // get the pad
   getPadSafe(padID, true, function(err, pad) {
@@ -622,7 +623,7 @@ exports.getLastEdited = function(padID, callback)
       callback(null, {lastEdited: value});
     });
   });
-}
+});
 
 /**
 createPad(padName [, text]) creates a new pad in this group
@@ -632,7 +633,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"pad does already exist", data: null}
 */
-exports.createPad = function(padID, text, callback)
+exports.createPad = thenify(function(padID, text, callback)
 {
   if (padID) {
     // ensure there is no $ in the padID
@@ -653,7 +654,7 @@ exports.createPad = function(padID, text, callback)
     if (ERR(err, callback)) return;
     callback();
   });
-}
+});
 
 /**
 deletePad(padID) deletes a pad
@@ -663,14 +664,14 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.deletePad = function(padID, callback)
+exports.deletePad = thenify(function(padID, callback)
 {
   getPadSafe(padID, true, function(err, pad) {
     if (ERR(err, callback)) return;
 
     pad.remove(callback);
   });
-}
+});
 /**
  restoreRevision(padID, [rev]) Restores revision from past as new changeset
 
@@ -679,7 +680,7 @@ exports.deletePad = function(padID, callback)
  {code:0, message:"ok", data:null}
  {code: 1, message:"padID does not exist", data: null}
  */
-exports.restoreRevision = function(padID, rev, callback)
+exports.restoreRevision = thenify(function(padID, rev, callback)
 {
   // check if rev is a number
   if (rev !== undefined && typeof rev !== "number") {
@@ -762,7 +763,7 @@ exports.restoreRevision = function(padID, rev, callback)
     });
 
   });
-};
+});
 
 /**
 copyPad(sourceID, destinationID[, force=false]) copies a pad. If force is true,
@@ -773,14 +774,14 @@ Example returns:
 {code: 0, message:"ok", data: {padID: destinationID}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.copyPad = function(sourceID, destinationID, force, callback)
+exports.copyPad = thenify(function(sourceID, destinationID, force, callback)
 {
   getPadSafe(sourceID, true, function(err, pad) {
     if (ERR(err, callback)) return;
 
     pad.copy(destinationID, force, callback);
   });
-}
+});
 
 /**
 movePad(sourceID, destinationID[, force=false]) moves a pad. If force is true,
@@ -791,7 +792,7 @@ Example returns:
 {code: 0, message:"ok", data: {padID: destinationID}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.movePad = function(sourceID, destinationID, force, callback)
+exports.movePad = thenify(function(sourceID, destinationID, force, callback)
 {
   getPadSafe(sourceID, true, function(err, pad) {
     if (ERR(err, callback)) return;
@@ -801,7 +802,7 @@ exports.movePad = function(sourceID, destinationID, force, callback)
       pad.remove(callback);
     });
   });
-}
+});
 /**
 getReadOnlyLink(padID) returns the read only link of a pad
 
@@ -810,7 +811,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getReadOnlyID = function(padID, callback)
+exports.getReadOnlyID = thenify(function(padID, callback)
 {
   // we don't need the pad object, but this function does all the security stuff for us
   getPadSafe(padID, true, function(err) {
@@ -822,7 +823,7 @@ exports.getReadOnlyID = function(padID, callback)
       callback(null, {readOnlyID: readOnlyId});
     });
   });
-}
+});
 
 /**
 getPadID(roID) returns the padID of a pad based on the readonlyID(roID)
@@ -832,7 +833,7 @@ Example returns:
 {code: 0, message:"ok", data: {padID: padID}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getPadID = function(roID, callback)
+exports.getPadID = thenify(function(roID, callback)
 {
   // get the PadId
   readOnlyManager.getPadId(roID, function(err, retrievedPadID) {
@@ -845,7 +846,7 @@ exports.getPadID = function(roID, callback)
 
     callback(null, {padID: retrievedPadID});
   });
-}
+});
 
 /**
 setPublicStatus(padID, publicStatus) sets a boolean for the public status of a pad
@@ -855,7 +856,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.setPublicStatus = function(padID, publicStatus, callback)
+exports.setPublicStatus = thenify(function(padID, publicStatus, callback)
 {
   // ensure this is a group pad
   if (padID && padID.indexOf("$") === -1) {
@@ -876,7 +877,7 @@ exports.setPublicStatus = function(padID, publicStatus, callback)
 
     callback();
   });
-}
+});
 
 /**
 getPublicStatus(padID) return true of false
@@ -886,7 +887,7 @@ Example returns:
 {code: 0, message:"ok", data: {publicStatus: true}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getPublicStatus = function(padID, callback)
+exports.getPublicStatus = thenify(function(padID, callback)
 {
   // ensure this is a group pad
   if (padID && padID.indexOf("$") == -1) {
@@ -900,7 +901,7 @@ exports.getPublicStatus = function(padID, callback)
 
     callback(null, {publicStatus: pad.getPublicStatus()});
   });
-}
+});
 
 /**
 setPassword(padID, password) returns ok or a error message
@@ -910,7 +911,7 @@ Example returns:
 {code: 0, message:"ok", data: null}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.setPassword = function(padID, password, callback)
+exports.setPassword = thenify(function(padID, password, callback)
 {
   // ensure this is a group pad
   if (padID && padID.indexOf("$") == -1) {
@@ -927,7 +928,7 @@ exports.setPassword = function(padID, password, callback)
 
     callback();
   });
-}
+});
 
 /**
 isPasswordProtected(padID) returns true or false
@@ -937,7 +938,7 @@ Example returns:
 {code: 0, message:"ok", data: {passwordProtection: true}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.isPasswordProtected = function(padID, callback)
+exports.isPasswordProtected = thenify(function(padID, callback)
 {
   // ensure this is a group pad
   if (padID && padID.indexOf("$") == -1) {
@@ -951,7 +952,7 @@ exports.isPasswordProtected = function(padID, callback)
 
     callback(null, {isPasswordProtected: pad.isPasswordProtected()});
   });
-}
+});
 
 /**
 listAuthorsOfPad(padID) returns an array of authors who contributed to this pad
@@ -961,7 +962,7 @@ Example returns:
 {code: 0, message:"ok", data: {authorIDs : ["a.s8oes9dhwrvt0zif", "a.akf8finncvomlqva"]}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.listAuthorsOfPad = function(padID, callback)
+exports.listAuthorsOfPad = thenify(function(padID, callback)
 {
   // get the pad
   getPadSafe(padID, true, function(err, pad) {
@@ -969,7 +970,7 @@ exports.listAuthorsOfPad = function(padID, callback)
 
     callback(null, {authorIDs: pad.getAllAuthors()});
   });
-}
+});
 
 /**
 sendClientsMessage(padID, msg) sends a message to all clients connected to the
@@ -994,7 +995,7 @@ Example returns:
 {code: 1, message:"padID does not exist"}
 */
 
-exports.sendClientsMessage = function(padID, msg, callback) {
+exports.sendClientsMessage = thenify(function(padID, msg, callback) {
   getPadSafe(padID, true, function(err, pad) {
     if (ERR(err, callback)) {
       return;
@@ -1002,7 +1003,7 @@ exports.sendClientsMessage = function(padID, msg, callback) {
 
     padMessageHandler.handleCustomMessage(padID, msg, callback);
   } );
-}
+});
 
 /**
 checkToken() returns ok when the current api token is valid
@@ -1012,10 +1013,10 @@ Example returns:
 {"code":0,"message":"ok","data":null}
 {"code":4,"message":"no or wrong API Key","data":null}
 */
-exports.checkToken = function(callback)
+exports.checkToken = thenify(function(callback)
 {
   callback();
-}
+});
 
 /**
 getChatHead(padID) returns the chatHead (last number of the last chat-message) of the pad
@@ -1025,7 +1026,7 @@ Example returns:
 {code: 0, message:"ok", data: {chatHead: 42}}
 {code: 1, message:"padID does not exist", data: null}
 */
-exports.getChatHead = function(padID, callback)
+exports.getChatHead = thenify(function(padID, callback)
 {
   // get the pad
   getPadSafe(padID, true, function(err, pad) {
@@ -1033,7 +1034,7 @@ exports.getChatHead = function(padID, callback)
 
     callback(null, {chatHead: pad.chatHead});
   });
-}
+});
 
 /**
 createDiffHTML(padID, startRev, endRev) returns an object of diffs from 2 points in a pad
@@ -1043,7 +1044,7 @@ Example returns:
 {"code":0,"message":"ok","data":{"html":"<style>\n.authora_HKIv23mEbachFYfH {background-color: #a979d9}\n.authora_n4gEeMLsv1GivNeh {background-color: #a9b5d9}\n.removed {text-decoration: line-through; -ms-filter:'progid:DXImageTransform.Microsoft.Alpha(Opacity=80)'; filter: alpha(opacity=80); opacity: 0.8; }\n</style>Welcome to Etherpad!<br><br>This pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!<br><br>Get involved with Etherpad at <a href=\"http&#x3a;&#x2F;&#x2F;etherpad&#x2e;org\">http:&#x2F;&#x2F;etherpad.org</a><br><span class=\"authora_HKIv23mEbachFYfH\">aw</span><br><br>","authors":["a.HKIv23mEbachFYfH",""]}}
 {"code":4,"message":"no or wrong API Key","data":null}
 */
-exports.createDiffHTML = function(padID, startRev, endRev, callback) {
+exports.createDiffHTML = thenify(function(padID, startRev, endRev, callback) {
   // check if startRev is a number
   if (startRev !== undefined && typeof startRev !== "number") {
     // try to parse the number
@@ -1104,7 +1105,7 @@ exports.createDiffHTML = function(padID, startRev, endRev, callback) {
       callback(err, {html: html, authors: authors})
     });
   });
-}
+});
 
 /******************************/
 /** INTERNAL HELPER FUNCTIONS */

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -453,7 +453,7 @@ exports.saveRevision = async function(padID, rev)
     rev = pad.getHeadRevisionNumber();
   }
 
-  let author = authorManager.createAuthor('API');
+  let author = await authorManager.createAuthor('API');
   pad.addSavedRevision(rev, author.authorID, 'Saved through API call');
 }
 

--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -45,7 +45,7 @@ exports.doesAuthorExists = function(authorID, callback)
   db.get("globalAuthor:" + authorID, function(err, author) {
     if (ERR(err, callback)) return;
 
-    callback(null, author != null);
+    callback(null, author !== null);
   });
 }
 
@@ -98,7 +98,7 @@ function mapAuthorWithDBKey (mapperkey, mapper, callback)
   db.get(mapperkey + ":" + mapper, function(err, author) {
     if (ERR(err, callback)) return;
 
-    if (author == null) {
+    if (author === null) {
       // there is no author with this mapper, so create one
       exports.createAuthor(null, function(err, author) {
         if (ERR(err, callback)) return;
@@ -212,7 +212,7 @@ exports.listPadsOfAuthor = function(authorID, callback)
   db.get("globalAuthor:" + authorID, function(err, author) {
     if (ERR(err, callback)) return;
 
-    if (author == null) {
+    if (author === null) {
       // author does not exist
       callback(new customError("authorID does not exist", "apierror"));
 
@@ -242,7 +242,7 @@ exports.addPad = function(authorID, padID)
   // get the entry
   db.get("globalAuthor:" + authorID, function(err, author) {
     if (ERR(err)) return;
-    if (author == null) return;
+    if (author === null) return;
 
     if (author.padIDs == null) {
       // the entry doesn't exist so far, let's create it
@@ -266,9 +266,9 @@ exports.removePad = function(authorID, padID)
 {
   db.get("globalAuthor:" + authorID, function(err, author) {
     if (ERR(err)) return;
-    if (author == null) return;
+    if (author === null) return;
 
-    if (author.padIDs != null) {
+    if (author.padIDs !== null) {
       // remove pad from author
       delete author.padIDs[padID];
       db.set("globalAuthor:" + authorID, author);

--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -18,25 +18,33 @@
  * limitations under the License.
  */
 
-
 var ERR = require("async-stacktrace");
 var db = require("./DB").db;
 var customError = require("../utils/customError");
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 
-exports.getColorPalette = function(){
-  return ["#ffc7c7", "#fff1c7", "#e3ffc7", "#c7ffd5", "#c7ffff", "#c7d5ff", "#e3c7ff", "#ffc7f1", "#ffa8a8", "#ffe699", "#cfff9e", "#99ffb3", "#a3ffff", "#99b3ff", "#cc99ff", "#ff99e5", "#e7b1b1", "#e9dcAf", "#cde9af", "#bfedcc", "#b1e7e7", "#c3cdee", "#d2b8ea", "#eec3e6", "#e9cece", "#e7e0ca", "#d3e5c7", "#bce1c5", "#c1e2e2", "#c1c9e2", "#cfc1e2", "#e0bdd9", "#baded3", "#a0f8eb", "#b1e7e0", "#c3c8e4", "#cec5e2", "#b1d5e7", "#cda8f0", "#f0f0a8", "#f2f2a6", "#f5a8eb", "#c5f9a9", "#ececbb", "#e7c4bc", "#daf0b2", "#b0a0fd", "#bce2e7", "#cce2bb", "#ec9afe", "#edabbd", "#aeaeea", "#c4e7b1", "#d722bb", "#f3a5e7", "#ffa8a8", "#d8c0c5", "#eaaedd", "#adc6eb", "#bedad1", "#dee9af", "#e9afc2", "#f8d2a0", "#b3b3e6"];
+exports.getColorPalette = function() {
+  return [
+    "#ffc7c7", "#fff1c7", "#e3ffc7", "#c7ffd5", "#c7ffff", "#c7d5ff", "#e3c7ff", "#ffc7f1",
+    "#ffa8a8", "#ffe699", "#cfff9e", "#99ffb3", "#a3ffff", "#99b3ff", "#cc99ff", "#ff99e5",
+    "#e7b1b1", "#e9dcAf", "#cde9af", "#bfedcc", "#b1e7e7", "#c3cdee", "#d2b8ea", "#eec3e6",
+    "#e9cece", "#e7e0ca", "#d3e5c7", "#bce1c5", "#c1e2e2", "#c1c9e2", "#cfc1e2", "#e0bdd9",
+    "#baded3", "#a0f8eb", "#b1e7e0", "#c3c8e4", "#cec5e2", "#b1d5e7", "#cda8f0", "#f0f0a8",
+    "#f2f2a6", "#f5a8eb", "#c5f9a9", "#ececbb", "#e7c4bc", "#daf0b2", "#b0a0fd", "#bce2e7",
+    "#cce2bb", "#ec9afe", "#edabbd", "#aeaeea", "#c4e7b1", "#d722bb", "#f3a5e7", "#ffa8a8",
+    "#d8c0c5", "#eaaedd", "#adc6eb", "#bedad1", "#dee9af", "#e9afc2", "#f8d2a0", "#b3b3e6"
+  ];
 };
 
 /**
  * Checks if the author exists
  */
-exports.doesAuthorExists = function (authorID, callback)
+exports.doesAuthorExists = function(authorID, callback)
 {
-  //check if the database entry of this author exists
-  db.get("globalAuthor:" + authorID, function (err, author)
-  {
-    if(ERR(err, callback)) return;
+  // check if the database entry of this author exists
+  db.get("globalAuthor:" + authorID, function(err, author) {
+    if (ERR(err, callback)) return;
+
     callback(null, author != null);
   });
 }
@@ -46,12 +54,12 @@ exports.doesAuthorExists = function (authorID, callback)
  * @param {String} token The token
  * @param {Function} callback callback (err, author)
  */
-exports.getAuthor4Token = function (token, callback)
+exports.getAuthor4Token = function(token, callback)
 {
-  mapAuthorWithDBKey("token2author", token, function(err, author)
-  {
-    if(ERR(err, callback)) return;
-    //return only the sub value authorID
+  mapAuthorWithDBKey("token2author", token, function(err, author) {
+    if (ERR(err, callback)) return;
+
+    // return only the sub value authorID
     callback(null, author ? author.authorID : author);
   });
 }
@@ -62,17 +70,17 @@ exports.getAuthor4Token = function (token, callback)
  * @param {String} name The name of the author (optional)
  * @param {Function} callback callback (err, author)
  */
-exports.createAuthorIfNotExistsFor = function (authorMapper, name, callback)
+exports.createAuthorIfNotExistsFor = function(authorMapper, name, callback)
 {
-  mapAuthorWithDBKey("mapper2author", authorMapper, function(err, author)
-  {
-    if(ERR(err, callback)) return;
+  mapAuthorWithDBKey("mapper2author", authorMapper, function(err, author) {
+    if (ERR(err, callback)) return;
 
-    //set the name of this author
-    if(name)
+    if (name) {
+      // set the name of this author
       exports.setAuthorName(author.authorID, name);
+    }
 
-    //return the authorID
+    // return the authorID
     callback(null, author);
   });
 }
@@ -86,33 +94,30 @@ exports.createAuthorIfNotExistsFor = function (authorMapper, name, callback)
  */
 function mapAuthorWithDBKey (mapperkey, mapper, callback)
 {
-  //try to map to an author
-  db.get(mapperkey + ":" + mapper, function (err, author)
-  {
-    if(ERR(err, callback)) return;
+  // try to map to an author
+  db.get(mapperkey + ":" + mapper, function(err, author) {
+    if (ERR(err, callback)) return;
 
-    //there is no author with this mapper, so create one
-    if(author == null)
-    {
-      exports.createAuthor(null, function(err, author)
-      {
-        if(ERR(err, callback)) return;
+    if (author == null) {
+      // there is no author with this mapper, so create one
+      exports.createAuthor(null, function(err, author) {
+        if (ERR(err, callback)) return;
 
-        //create the token2author relation
+        // create the token2author relation
         db.set(mapperkey + ":" + mapper, author.authorID);
 
-        //return the author
+        // return the author
         callback(null, author);
       });
 
       return;
     }
 
-    //there is a author with this mapper
-    //update the timestamp of this author
+    // there is an author with this mapper
+    // update the timestamp of this author
     db.setSub("globalAuthor:" + author, ["timestamp"], Date.now());
 
-    //return the author
+    // return the author
     callback(null, {authorID: author});
   });
 }
@@ -123,13 +128,17 @@ function mapAuthorWithDBKey (mapperkey, mapper, callback)
  */
 exports.createAuthor = function(name, callback)
 {
-  //create the new author name
+  // create the new author name
   var author = "a." + randomString(16);
 
-  //create the globalAuthors db entry
-  var authorObj = {"colorId" : Math.floor(Math.random()*(exports.getColorPalette().length)), "name": name, "timestamp": Date.now()};
+  // create the globalAuthors db entry
+  var authorObj = {
+    "colorId": Math.floor(Math.random() * (exports.getColorPalette().length)),
+    "name": name,
+    "timestamp": Date.now()
+  };
 
-  //set the global author db entry
+  // set the global author db entry
   db.set("globalAuthor:" + author, authorObj);
 
   callback(null, {authorID: author});
@@ -140,19 +149,17 @@ exports.createAuthor = function(name, callback)
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, authorObj)
  */
-exports.getAuthor = function (author, callback)
+exports.getAuthor = function(author, callback)
 {
   db.get("globalAuthor:" + author, callback);
 }
-
-
 
 /**
  * Returns the color Id of the author
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, colorId)
  */
-exports.getAuthorColorId = function (author, callback)
+exports.getAuthorColorId = function(author, callback)
 {
   db.getSub("globalAuthor:" + author, ["colorId"], callback);
 }
@@ -163,7 +170,7 @@ exports.getAuthorColorId = function (author, callback)
  * @param {String} colorId The color id of the author
  * @param {Function} callback (optional)
  */
-exports.setAuthorColorId = function (author, colorId, callback)
+exports.setAuthorColorId = function(author, colorId, callback)
 {
   db.setSub("globalAuthor:" + author, ["colorId"], colorId, callback);
 }
@@ -173,7 +180,7 @@ exports.setAuthorColorId = function (author, colorId, callback)
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, name)
  */
-exports.getAuthorName = function (author, callback)
+exports.getAuthorName = function(author, callback)
 {
   db.getSub("globalAuthor:" + author, ["name"], callback);
 }
@@ -184,7 +191,7 @@ exports.getAuthorName = function (author, callback)
  * @param {String} name The name of the author
  * @param {Function} callback (optional)
  */
-exports.setAuthorName = function (author, name, callback)
+exports.setAuthorName = function(author, name, callback)
 {
   db.setSub("globalAuthor:" + author, ["name"], name, callback);
 }
@@ -194,33 +201,33 @@ exports.setAuthorName = function (author, name, callback)
  * @param {String} author The id of the author
  * @param {Function} callback (optional)
  */
-exports.listPadsOfAuthor = function (authorID, callback)
+exports.listPadsOfAuthor = function(authorID, callback)
 {
   /* There are two other places where this array is manipulated:
    * (1) When the author is added to a pad, the author object is also updated
    * (2) When a pad is deleted, each author of that pad is also updated
    */
-  //get the globalAuthor
-  db.get("globalAuthor:" + authorID, function(err, author)
-  {
-    if(ERR(err, callback)) return;
 
-    //author does not exists
-    if(author == null)
-    {
-      callback(new customError("authorID does not exist","apierror"))
+  // get the globalAuthor
+  db.get("globalAuthor:" + authorID, function(err, author) {
+    if (ERR(err, callback)) return;
+
+    if (author == null) {
+      // author does not exist
+      callback(new customError("authorID does not exist", "apierror"));
+
       return;
     }
 
-    //everything is fine, return the pad IDs
+    // everything is fine, return the pad IDs
     var pads = [];
-    if(author.padIDs != null)
-    {
-      for (var padId in author.padIDs)
-      {
+
+    if (author.padIDs != null) {
+      for (var padId in author.padIDs) {
         pads.push(padId);
       }
     }
+
     callback(null, {padIDs: pads});
   });
 }
@@ -230,24 +237,22 @@ exports.listPadsOfAuthor = function (authorID, callback)
  * @param {String} author The id of the author
  * @param {String} padID The id of the pad the author contributes to
  */
-exports.addPad = function (authorID, padID)
+exports.addPad = function(authorID, padID)
 {
-  //get the entry
-  db.get("globalAuthor:" + authorID, function(err, author)
-  {
-    if(ERR(err)) return;
-    if(author == null) return;
+  // get the entry
+  db.get("globalAuthor:" + authorID, function(err, author) {
+    if (ERR(err)) return;
+    if (author == null) return;
 
-    //the entry doesn't exist so far, let's create it
-    if(author.padIDs == null)
-    {
+    if (author.padIDs == null) {
+      // the entry doesn't exist so far, let's create it
       author.padIDs = {};
     }
 
-    //add the entry for this pad
-    author.padIDs[padID] = 1;// anything, because value is not used
+    // add the entry for this pad
+    author.padIDs[padID] = 1; // anything, because value is not used
 
-    //save the new element back
+    // save the new element back
     db.set("globalAuthor:" + authorID, author);
   });
 }
@@ -257,16 +262,14 @@ exports.addPad = function (authorID, padID)
  * @param {String} author The id of the author
  * @param {String} padID The id of the pad the author contributes to
  */
-exports.removePad = function (authorID, padID)
+exports.removePad = function(authorID, padID)
 {
-  db.get("globalAuthor:" + authorID, function (err, author)
-  {
-    if(ERR(err)) return;
-    if(author == null) return;
+  db.get("globalAuthor:" + authorID, function(err, author) {
+    if (ERR(err)) return;
+    if (author == null) return;
 
-    if(author.padIDs != null)
-    {
-      //remove pad from author
+    if (author.padIDs != null) {
+      // remove pad from author
       delete author.padIDs[padID];
       db.set("globalAuthor:" + authorID, author);
     }

--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -40,7 +40,7 @@ exports.getColorPalette = function() {
 /**
  * Checks if the author exists
  */
-exports.doesAuthorExists = thenify(function(authorID, callback)
+exports.doesAuthorExist = thenify(function(authorID, callback)
 {
   // check if the database entry of this author exists
   db.get("globalAuthor:" + authorID, function(err, author) {
@@ -49,6 +49,9 @@ exports.doesAuthorExists = thenify(function(authorID, callback)
     callback(null, author !== null);
   });
 });
+
+/* exported for backwards compatibility */
+exports.doesAuthorExists = exports.doesAuthorExist;
 
 /**
  * Returns the AuthorID for a token.

--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -21,7 +21,6 @@
 var db = require("./DB");
 var customError = require("../utils/customError");
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
-const thenify = require("thenify").withCallback;
 
 exports.getColorPalette = function() {
   return [

--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -144,12 +144,11 @@ exports.getAuthor = function(author)
 /**
  * Returns the color Id of the author
  * @param {String} author The id of the author
- * @param {Function} callback callback(err, colorId)
  */
-exports.getAuthorColorId = thenify(function(author, callback)
+exports.getAuthorColorId = function(author)
 {
-  db.db.getSub("globalAuthor:" + author, ["colorId"], callback);
-});
+  return db.getSub("globalAuthor:" + author, ["colorId"]);
+}
 
 /**
  * Sets the color Id of the author
@@ -164,12 +163,11 @@ exports.setAuthorColorId = function(author, colorId)
 /**
  * Returns the name of the author
  * @param {String} author The id of the author
- * @param {Function} callback callback(err, name)
  */
-exports.getAuthorName = thenify(function(author, callback)
+exports.getAuthorName = function(author)
 {
-  db.db.getSub("globalAuthor:" + author, ["name"], callback);
-});
+  return db.getSub("globalAuthor:" + author, ["name"]);
+}
 
 /**
  * Sets the name of the author

--- a/src/node/db/AuthorManager.js
+++ b/src/node/db/AuthorManager.js
@@ -22,6 +22,7 @@ var ERR = require("async-stacktrace");
 var db = require("./DB").db;
 var customError = require("../utils/customError");
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
+const thenify = require("thenify").withCallback;
 
 exports.getColorPalette = function() {
   return [
@@ -39,7 +40,7 @@ exports.getColorPalette = function() {
 /**
  * Checks if the author exists
  */
-exports.doesAuthorExists = function(authorID, callback)
+exports.doesAuthorExists = thenify(function(authorID, callback)
 {
   // check if the database entry of this author exists
   db.get("globalAuthor:" + authorID, function(err, author) {
@@ -47,14 +48,14 @@ exports.doesAuthorExists = function(authorID, callback)
 
     callback(null, author !== null);
   });
-}
+});
 
 /**
  * Returns the AuthorID for a token.
  * @param {String} token The token
  * @param {Function} callback callback (err, author)
  */
-exports.getAuthor4Token = function(token, callback)
+exports.getAuthor4Token = thenify(function(token, callback)
 {
   mapAuthorWithDBKey("token2author", token, function(err, author) {
     if (ERR(err, callback)) return;
@@ -62,7 +63,7 @@ exports.getAuthor4Token = function(token, callback)
     // return only the sub value authorID
     callback(null, author ? author.authorID : author);
   });
-}
+});
 
 /**
  * Returns the AuthorID for a mapper.
@@ -70,7 +71,7 @@ exports.getAuthor4Token = function(token, callback)
  * @param {String} name The name of the author (optional)
  * @param {Function} callback callback (err, author)
  */
-exports.createAuthorIfNotExistsFor = function(authorMapper, name, callback)
+exports.createAuthorIfNotExistsFor = thenify(function(authorMapper, name, callback)
 {
   mapAuthorWithDBKey("mapper2author", authorMapper, function(err, author) {
     if (ERR(err, callback)) return;
@@ -83,7 +84,7 @@ exports.createAuthorIfNotExistsFor = function(authorMapper, name, callback)
     // return the authorID
     callback(null, author);
   });
-}
+});
 
 /**
  * Returns the AuthorID for a mapper. We can map using a mapperkey,
@@ -126,7 +127,7 @@ function mapAuthorWithDBKey (mapperkey, mapper, callback)
  * Internal function that creates the database entry for an author
  * @param {String} name The name of the author
  */
-exports.createAuthor = function(name, callback)
+exports.createAuthor = thenify(function(name, callback)
 {
   // create the new author name
   var author = "a." + randomString(16);
@@ -142,27 +143,27 @@ exports.createAuthor = function(name, callback)
   db.set("globalAuthor:" + author, authorObj);
 
   callback(null, {authorID: author});
-}
+});
 
 /**
  * Returns the Author Obj of the author
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, authorObj)
  */
-exports.getAuthor = function(author, callback)
+exports.getAuthor = thenify(function(author, callback)
 {
   db.get("globalAuthor:" + author, callback);
-}
+});
 
 /**
  * Returns the color Id of the author
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, colorId)
  */
-exports.getAuthorColorId = function(author, callback)
+exports.getAuthorColorId = thenify(function(author, callback)
 {
   db.getSub("globalAuthor:" + author, ["colorId"], callback);
-}
+});
 
 /**
  * Sets the color Id of the author
@@ -170,20 +171,20 @@ exports.getAuthorColorId = function(author, callback)
  * @param {String} colorId The color id of the author
  * @param {Function} callback (optional)
  */
-exports.setAuthorColorId = function(author, colorId, callback)
+exports.setAuthorColorId = thenify(function(author, colorId, callback)
 {
   db.setSub("globalAuthor:" + author, ["colorId"], colorId, callback);
-}
+});
 
 /**
  * Returns the name of the author
  * @param {String} author The id of the author
  * @param {Function} callback callback(err, name)
  */
-exports.getAuthorName = function(author, callback)
+exports.getAuthorName = thenify(function(author, callback)
 {
   db.getSub("globalAuthor:" + author, ["name"], callback);
-}
+});
 
 /**
  * Sets the name of the author
@@ -191,17 +192,17 @@ exports.getAuthorName = function(author, callback)
  * @param {String} name The name of the author
  * @param {Function} callback (optional)
  */
-exports.setAuthorName = function(author, name, callback)
+exports.setAuthorName = thenify(function(author, name, callback)
 {
   db.setSub("globalAuthor:" + author, ["name"], name, callback);
-}
+});
 
 /**
  * Returns an array of all pads this author contributed to
  * @param {String} author The id of the author
  * @param {Function} callback (optional)
  */
-exports.listPadsOfAuthor = function(authorID, callback)
+exports.listPadsOfAuthor = thenify(function(authorID, callback)
 {
   /* There are two other places where this array is manipulated:
    * (1) When the author is added to a pad, the author object is also updated
@@ -230,7 +231,7 @@ exports.listPadsOfAuthor = function(authorID, callback)
 
     callback(null, {padIDs: pads});
   });
-}
+});
 
 /**
  * Adds a new pad to the list of contributions

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -1,5 +1,5 @@
 /**
- * The DB Module provides a database initalized with the settings 
+ * The DB Module provides a database initalized with the settings
  * provided by the settings module
  */
 
@@ -23,7 +23,7 @@ var ueberDB = require("ueberdb2");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
 
-//set database settings
+// set database settings
 var db = new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger("ueberDB"));
 
 /**
@@ -33,24 +33,19 @@ exports.db = null;
 
 /**
  * Initalizes the database with the settings provided by the settings module
- * @param {Function} callback 
+ * @param {Function} callback
  */
-exports.init = function(callback)
-{
-  //initalize the database async
-  db.init(function(err)
-  {
-    //there was an error while initializing the database, output it and stop 
-    if(err)
-    {
+exports.init = function(callback) {
+  // initalize the database async
+  db.init(function(err) {
+    if (err) {
+      // there was an error while initializing the database, output it and stop
       console.error("ERROR: Problem while initalizing the database");
       console.error(err.stack ? err.stack : err);
       process.exit(1);
-    }
-    //everything ok
-    else
-    {
-      exports.db = db;  
+    } else {
+      // everything ok
+      exports.db = db;
       callback(null);
     }
   });

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -35,7 +35,7 @@ exports.db = null;
  * Initalizes the database with the settings provided by the settings module
  * @param {Function} callback
  */
-exports.init = function(callback) {
+function init(callback) {
   // initalize the database async
   db.init(function(err) {
     if (err) {
@@ -49,4 +49,20 @@ exports.init = function(callback) {
       callback(null);
     }
   });
+}
+
+/**
+ * Initalizes the database with the settings provided by the settings module
+ * If the callback is not supplied a Promise is returned instead.
+ * @param {Function} callback
+ */
+exports.init = function(callback)
+{
+  if (callback === undefined) {
+    return new Promise(resolve => init(resolve));
+  } else if (typeof callback === "function") {
+    init(callback);
+  } else {
+    throw new TypeError("DB.init callback parameter");
+  }
 }

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -51,6 +51,19 @@ exports.init = function() {
           exports[fn] = util.promisify(db[fn].bind(db));
         });
 
+        // set up wrappers for get and getSub that can't return "undefined"
+        let get = exports.get;
+        exports.get = async function(key) {
+          let result = await get(key);
+          return (result === undefined) ? null : result;
+        };
+
+        let getSub = exports.getSub;
+        exports.getSub = async function(key, sub) {
+          let result = await getSub(key, sub);
+          return (result === undefined) ? null : result;
+        };
+
         // exposed for those callers that need the underlying raw API
         exports.db = db;
         resolve();

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -22,6 +22,7 @@
 var ueberDB = require("ueberdb2");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
+const thenify = require("thenify").withCallback;
 
 // set database settings
 var db = new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger("ueberDB"));
@@ -35,7 +36,7 @@ exports.db = null;
  * Initalizes the database with the settings provided by the settings module
  * @param {Function} callback
  */
-function init(callback) {
+exports.init = thenify(function (callback) {
   // initalize the database async
   db.init(function(err) {
     if (err) {
@@ -49,20 +50,4 @@ function init(callback) {
       callback(null);
     }
   });
-}
-
-/**
- * Initalizes the database with the settings provided by the settings module
- * If the callback is not supplied a Promise is returned instead.
- * @param {Function} callback
- */
-exports.init = function(callback)
-{
-  if (callback === undefined) {
-    return new Promise(resolve => init(resolve));
-  } else if (typeof callback === "function") {
-    init(callback);
-  } else {
-    throw new TypeError("DB.init callback parameter");
-  }
-}
+});

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -22,11 +22,10 @@
 var ueberDB = require("ueberdb2");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
-const thenify = require("thenify").withCallback;
 const util = require("util");
 
 // set database settings
-var db = new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger("ueberDB"));
+let db = new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger("ueberDB"));
 
 /**
  * The UeberDB Object that provides the database functions
@@ -37,24 +36,25 @@ exports.db = null;
  * Initalizes the database with the settings provided by the settings module
  * @param {Function} callback
  */
-exports.init = thenify(function (callback) {
+exports.init = function() {
   // initalize the database async
-  db.init(function(err) {
-    if (err) {
-      // there was an error while initializing the database, output it and stop
-      console.error("ERROR: Problem while initalizing the database");
-      console.error(err.stack ? err.stack : err);
-      process.exit(1);
-    } else {
-      // everything ok
-      exports.db = db;
+  return new Promise((resolve, reject) => {
+    db.init(function(err) {
+      if (err) {
+        // there was an error while initializing the database, output it and stop
+        console.error("ERROR: Problem while initalizing the database");
+        console.error(err.stack ? err.stack : err);
+        process.exit(1);
+      } else {
+        // everything ok, set up Promise-based methods
+        ['get', 'set', 'findKeys', 'getSub', 'setSub', 'remove', 'doShutdown'].forEach(fn => {
+          exports[fn] = util.promisify(db[fn].bind(db));
+        });
 
-      // set up Promise-based methods
-      ['get', 'set', 'findKeys', 'getSub', 'setSub', 'remove', 'doShutdown'].forEach(fn => {
-        exports[fn] = util.promisify(db[fn].bind(db));
-      });
-
-      callback(null);
-    }
+        // exposed for those callers that need the underlying raw API
+        exports.db = db;
+        resolve();
+      }
+    });
   });
-});
+}

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -23,6 +23,7 @@ var ueberDB = require("ueberdb2");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
 const thenify = require("thenify").withCallback;
+const util = require("util");
 
 // set database settings
 var db = new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger("ueberDB"));
@@ -47,6 +48,12 @@ exports.init = thenify(function (callback) {
     } else {
       // everything ok
       exports.db = db;
+
+      // set up Promise-based methods
+      ['get', 'set', 'findKeys', 'getSub', 'setSub', 'remove', 'doShutdown'].forEach(fn => {
+        exports[fn] = util.promisify(db[fn].bind(db));
+      });
+
       callback(null);
     }
   });

--- a/src/node/db/GroupManager.js
+++ b/src/node/db/GroupManager.js
@@ -18,13 +18,11 @@
  * limitations under the License.
  */
 
-var ERR = require("async-stacktrace");
 var customError = require("../utils/customError");
 var randomString = require('ep_etherpad-lite/static/js/pad_utils').randomString;
 var db = require("./DB");
 var padManager = require("./PadManager");
 var sessionManager = require("./SessionManager");
-const thenify = require("thenify").withCallback;
 
 exports.listAllGroups = async function()
 {
@@ -85,15 +83,13 @@ exports.deleteGroup = async function(groupID)
   await db.set("groups", newGroups);
 }
 
-// @TODO: this is the only function still called with a callback
-exports.doesGroupExist = thenify(function(groupID, callback)
+exports.doesGroupExist = async function(groupID)
 {
   // try to get the group entry
-  db.db.get("group:" + groupID, function (err, group) {
-    if (ERR(err, callback)) return;
-    callback(null, group != null);
-  });
-});
+  let group = await db.get("group:" + groupID);
+
+  return (group != null);
+}
 
 exports.createGroup = async function()
 {

--- a/src/node/db/GroupManager.js
+++ b/src/node/db/GroupManager.js
@@ -199,7 +199,7 @@ exports.createGroupIfNotExistsFor = function(groupMapper, callback)
 {
   // ensure mapper is optional
   if (typeof groupMapper != "string") {
-    callback(new customError("groupMapper is no string", "apierror"));
+    callback(new customError("groupMapper is not a string", "apierror"));
     return;
   }
 

--- a/src/node/db/GroupManager.js
+++ b/src/node/db/GroupManager.js
@@ -17,7 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
 
 var ERR = require("async-stacktrace");
 var customError = require("../utils/customError");
@@ -29,117 +28,112 @@ var sessionManager = require("./SessionManager");
 
 exports.listAllGroups = function(callback) {
   db.get("groups", function (err, groups) {
-    if(ERR(err, callback)) return;
-    
-    // there are no groups
-    if(groups == null) {
+    if (ERR(err, callback)) return;
+
+    if (groups == null) {
+      // there are no groups
       callback(null, {groupIDs: []});
+
       return;
     }
-    
+
     var groupIDs = [];
-    for ( var groupID in groups ) {
+    for (var groupID in groups) {
       groupIDs.push(groupID);
     }
     callback(null, {groupIDs: groupIDs});
   });
 }
- 
+
 exports.deleteGroup = function(groupID, callback)
 {
   var group;
 
   async.series([
-    //ensure group exists 
-    function (callback)
-    {
-      //try to get the group entry
-      db.get("group:" + groupID, function (err, _group)
-      {
-        if(ERR(err, callback)) return;
-        
-        //group does not exist
-        if(_group == null)
-        {
-          callback(new customError("groupID does not exist","apierror"));
+    // ensure group exists
+    function (callback) {
+      // try to get the group entry
+      db.get("group:" + groupID, function (err, _group) {
+        if (ERR(err, callback)) return;
+
+        if (_group == null) {
+          // group does not exist
+          callback(new customError("groupID does not exist", "apierror"));
           return;
         }
 
-        //group exists, everything is fine
+        // group exists, everything is fine
         group = _group;
         callback();
       });
     },
-    //iterate trough all pads of this groups and delete them
-    function(callback)
-    {
-      //collect all padIDs in an array, that allows us to use async.forEach
+
+    // iterate through all pads of this group and delete them
+    function(callback) {
+      // collect all padIDs in an array, that allows us to use async.forEach
       var padIDs = [];
-      for(var i in group.pads)
-      {
+      for(var i in group.pads) {
         padIDs.push(i);
       }
-      
-      //loop trough all pads and delete them 
-      async.forEach(padIDs, function(padID, callback)
-      {
-        padManager.getPad(padID, function(err, pad)
-        {
-          if(ERR(err, callback)) return;
-          
+
+      // loop through all pads and delete them
+      async.forEach(padIDs, function(padID, callback) {
+        padManager.getPad(padID, function(err, pad) {
+          if (ERR(err, callback)) return;
+
           pad.remove(callback);
         });
       }, callback);
     },
-    //iterate trough group2sessions and delete all sessions
+
+    // iterate through group2sessions and delete all sessions
     function(callback)
     {
-      //try to get the group entry
-      db.get("group2sessions:" + groupID, function (err, group2sessions)
-      {
-        if(ERR(err, callback)) return;
-        
-        //skip if there is no group2sessions entry
-        if(group2sessions == null) {callback(); return}
-        
-        //collect all sessions in an array, that allows us to use async.forEach
+      // try to get the group entry
+      db.get("group2sessions:" + groupID, function (err, group2sessions) {
+        if (ERR(err, callback)) return;
+
+        // skip if there is no group2sessions entry
+        if (group2sessions == null) { callback(); return }
+
+        // collect all sessions in an array, that allows us to use async.forEach
         var sessions = [];
-        for(var i in group2sessions.sessionsIDs)
-        {
+        for (var i in group2sessions.sessionsIDs) {
           sessions.push(i);
         }
-        
-        //loop trough all sessions and delete them 
-        async.forEach(sessions, function(session, callback)
-        {
+
+        // loop through all sessions and delete them
+        async.forEach(sessions, function(session, callback) {
           sessionManager.deleteSession(session, callback);
         }, callback);
       });
     },
-    //remove group and group2sessions entry
-    function(callback)
-    {
+
+    // remove group and group2sessions entry
+    function(callback) {
       db.remove("group2sessions:" + groupID);
       db.remove("group:" + groupID);
       callback();
     },
-    //unlist the group
-    function(callback)
-    {
+
+    // unlist the group
+    function(callback) {
       exports.listAllGroups(function(err, groups) {
-        if(ERR(err, callback)) return;
+        if (ERR(err, callback)) return;
         groups = groups? groups.groupIDs : [];
 
-        // it's not listed
-        if(groups.indexOf(groupID) == -1) {
+        if (groups.indexOf(groupID) == -1) {
+          // it's not listed
           callback();
+
           return;
         }
 
+        // remove from the list
         groups.splice(groups.indexOf(groupID), 1);
-        
-        // store empty groupe list
-        if(groups.length == 0) {
+
+        // store empty group list
+        if (groups.length == 0) {
           db.set("groups", {});
           callback();
           return;
@@ -150,50 +144,51 @@ exports.deleteGroup = function(groupID, callback)
         async.forEach(groups, function(group, cb) {
           newGroups[group] = 1;
           cb();
-        },function() {
+        },
+        function() {
           db.set("groups", newGroups);
           callback();
         });
       });
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
+  ],
+  function(err) {
+    if (ERR(err, callback)) return;
     callback();
   });
 }
- 
+
 exports.doesGroupExist = function(groupID, callback)
 {
-  //try to get the group entry
-  db.get("group:" + groupID, function (err, group)
-  {
-    if(ERR(err, callback)) return;
+  // try to get the group entry
+  db.get("group:" + groupID, function (err, group) {
+    if (ERR(err, callback)) return;
     callback(null, group != null);
   });
 }
 
 exports.createGroup = function(callback)
 {
-  //search for non existing groupID
+  // search for non existing groupID
   var groupID = "g." + randomString(16);
-  
-  //create the group
+
+  // create the group
   db.set("group:" + groupID, {pads: {}});
-  
-  //list the group
+
+  // list the group
   exports.listAllGroups(function(err, groups) {
-    if(ERR(err, callback)) return;
+    if (ERR(err, callback)) return;
+
     groups = groups? groups.groupIDs : [];
-    
     groups.push(groupID);
-    
+
     // regenerate group list
     var newGroups = {};
     async.forEach(groups, function(group, cb) {
       newGroups[group] = 1;
       cb();
-    },function() {
+    },
+    function() {
       db.set("groups", newGroups);
       callback(null, {groupID: groupID});
     });
@@ -202,129 +197,121 @@ exports.createGroup = function(callback)
 
 exports.createGroupIfNotExistsFor = function(groupMapper, callback)
 {
-  //ensure mapper is optional
-  if(typeof groupMapper != "string")
-  {
-    callback(new customError("groupMapper is no string","apierror"));
+  // ensure mapper is optional
+  if (typeof groupMapper != "string") {
+    callback(new customError("groupMapper is no string", "apierror"));
     return;
   }
-  
-  //try to get a group for this mapper
-  db.get("mapper2group:"+groupMapper, function(err, groupID)
-  {
+
+  // try to get a group for this mapper
+  db.get("mapper2group:" + groupMapper, function(err, groupID) {
     function createGroupForMapper(cb) {
-      exports.createGroup(function(err, responseObj)
-      {
-        if(ERR(err, cb)) return;
-        
-        //create the mapper entry for this group
-        db.set("mapper2group:"+groupMapper, responseObj.groupID);
-        
+      exports.createGroup(function(err, responseObj) {
+        if (ERR(err, cb)) return;
+
+        // create the mapper entry for this group
+        db.set("mapper2group:" + groupMapper, responseObj.groupID);
+
         cb(null, responseObj);
       });
     }
 
-    if(ERR(err, callback)) return;
-     
-    // there is a group for this mapper
-    if(groupID) {
+    if (ERR(err, callback)) return;
+
+    if (groupID) {
+      // there is a group for this mapper
       exports.doesGroupExist(groupID, function(err, exists) {
-        if(ERR(err, callback)) return;
-        if(exists) return callback(null, {groupID: groupID});
+        if (ERR(err, callback)) return;
+
+        if (exists) return callback(null, {groupID: groupID});
 
         // hah, the returned group doesn't exist, let's create one
         createGroupForMapper(callback)
-      })
+      });
 
       return;
     }
 
-    //there is no group for this mapper, let's create a group
+    // there is no group for this mapper, let's create a group
     createGroupForMapper(callback)
   });
 }
 
 exports.createGroupPad = function(groupID, padName, text, callback)
 {
-  //create the padID
+  // create the padID
   var padID = groupID + "$" + padName;
 
   async.series([
-    //ensure group exists 
-    function (callback)
-    {
-      exports.doesGroupExist(groupID, function(err, exists)
-      {
-        if(ERR(err, callback)) return;
-        
-        //group does not exist
-        if(exists == false)
-        {
-          callback(new customError("groupID does not exist","apierror"));
+    // ensure group exists
+    function (callback) {
+      exports.doesGroupExist(groupID, function(err, exists) {
+        if (ERR(err, callback)) return;
+
+        if (exists == false) {
+          // group does not exist
+          callback(new customError("groupID does not exist", "apierror"));
           return;
         }
 
-        //group exists, everything is fine
+        // group exists, everything is fine
         callback();
       });
     },
-    //ensure pad does not exists
-    function (callback)
-    {
-      padManager.doesPadExists(padID, function(err, exists)
-      {
-        if(ERR(err, callback)) return;
-        
-        //pad exists already
-        if(exists == true)
-        {
-          callback(new customError("padName does already exist","apierror"));
+
+    // ensure pad doesn't exist already
+    function (callback) {
+      padManager.doesPadExists(padID, function(err, exists) {
+        if (ERR(err, callback)) return;
+
+        if (exists == true) {
+          // pad exists already
+          callback(new customError("padName does already exist", "apierror"));
           return;
         }
 
-        //pad does not exist, everything is fine
+        // pad does not exist, everything is fine
         callback();
       });
     },
-    //create the pad
-    function (callback)
-    {
-      padManager.getPad(padID, text, function(err)
-      {
-        if(ERR(err, callback)) return;
+
+    // create the pad
+    function (callback) {
+      padManager.getPad(padID, text, function(err) {
+        if (ERR(err, callback)) return;
+
         callback();
       });
     },
-    //create an entry in the group for this pad
-    function (callback)
-    {
+
+    // create an entry in the group for this pad
+    function (callback) {
       db.setSub("group:" + groupID, ["pads", padID], 1);
       callback();
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
+  ],
+  function(err) {
+    if (ERR(err, callback)) return;
+
     callback(null, {padID: padID});
   });
 }
 
 exports.listPads = function(groupID, callback)
 {
-  exports.doesGroupExist(groupID, function(err, exists)
-  {
-    if(ERR(err, callback)) return;
-    
-    //group does not exist
-    if(exists == false)
-    {
-      callback(new customError("groupID does not exist","apierror"));
+  exports.doesGroupExist(groupID, function(err, exists) {
+    if (ERR(err, callback)) return;
+
+    // ensure the group exists
+    if (exists == false) {
+      callback(new customError("groupID does not exist", "apierror"));
       return;
     }
 
-    //group exists, let's get the pads
-    db.getSub("group:" + groupID, ["pads"], function(err, result)
-    {
-      if(ERR(err, callback)) return;
+    // group exists, let's get the pads
+    db.getSub("group:" + groupID, ["pads"], function(err, result) {
+      if (ERR(err, callback)) return;
+
       var pads = [];
       for ( var padId in result ) {
         pads.push(padId);

--- a/src/node/db/GroupManager.js
+++ b/src/node/db/GroupManager.js
@@ -25,8 +25,9 @@ var db = require("./DB").db;
 var async = require("async");
 var padManager = require("./PadManager");
 var sessionManager = require("./SessionManager");
+const thenify = require("thenify").withCallback;
 
-exports.listAllGroups = function(callback) {
+exports.listAllGroups = thenify(function(callback) {
   db.get("groups", function (err, groups) {
     if (ERR(err, callback)) return;
 
@@ -43,9 +44,9 @@ exports.listAllGroups = function(callback) {
     }
     callback(null, {groupIDs: groupIDs});
   });
-}
+});
 
-exports.deleteGroup = function(groupID, callback)
+exports.deleteGroup = thenify(function(groupID, callback)
 {
   var group;
 
@@ -158,18 +159,18 @@ exports.deleteGroup = function(groupID, callback)
     if (ERR(err, callback)) return;
     callback();
   });
-}
+});
 
-exports.doesGroupExist = function(groupID, callback)
+exports.doesGroupExist = thenify(function(groupID, callback)
 {
   // try to get the group entry
   db.get("group:" + groupID, function (err, group) {
     if (ERR(err, callback)) return;
     callback(null, group != null);
   });
-}
+});
 
-exports.createGroup = function(callback)
+exports.createGroup = thenify(function(callback)
 {
   // search for non existing groupID
   var groupID = "g." + randomString(16);
@@ -195,9 +196,9 @@ exports.createGroup = function(callback)
       callback(null, {groupID: groupID});
     });
   });
-}
+});
 
-exports.createGroupIfNotExistsFor = function(groupMapper, callback)
+exports.createGroupIfNotExistsFor = thenify(function(groupMapper, callback)
 {
   // ensure mapper is optional
   if (typeof groupMapper !== "string") {
@@ -237,9 +238,9 @@ exports.createGroupIfNotExistsFor = function(groupMapper, callback)
     // there is no group for this mapper, let's create a group
     createGroupForMapper(callback)
   });
-}
+});
 
-exports.createGroupPad = function(groupID, padName, text, callback)
+exports.createGroupPad = thenify(function(groupID, padName, text, callback)
 {
   // create the padID
   var padID = groupID + "$" + padName;
@@ -297,9 +298,9 @@ exports.createGroupPad = function(groupID, padName, text, callback)
 
     callback(null, {padID: padID});
   });
-}
+});
 
-exports.listPads = function(groupID, callback)
+exports.listPads = thenify(function(groupID, callback)
 {
   exports.doesGroupExist(groupID, function(err, exists) {
     if (ERR(err, callback)) return;
@@ -321,4 +322,4 @@ exports.listPads = function(groupID, callback)
       callback(null, {padIDs: pads});
     });
   });
-}
+});

--- a/src/node/db/GroupManager.js
+++ b/src/node/db/GroupManager.js
@@ -122,7 +122,9 @@ exports.deleteGroup = function(groupID, callback)
         if (ERR(err, callback)) return;
         groups = groups? groups.groupIDs : [];
 
-        if (groups.indexOf(groupID) === -1) {
+        let index = groups.indexOf(groupID);
+
+        if (index === -1) {
           // it's not listed
           callback();
 
@@ -130,7 +132,7 @@ exports.deleteGroup = function(groupID, callback)
         }
 
         // remove from the list
-        groups.splice(groups.indexOf(groupID), 1);
+        groups.splice(index, 1);
 
         // store empty group list
         if (groups.length == 0) {

--- a/src/node/db/GroupManager.js
+++ b/src/node/db/GroupManager.js
@@ -122,7 +122,7 @@ exports.deleteGroup = function(groupID, callback)
         if (ERR(err, callback)) return;
         groups = groups? groups.groupIDs : [];
 
-        if (groups.indexOf(groupID) == -1) {
+        if (groups.indexOf(groupID) === -1) {
           // it's not listed
           callback();
 
@@ -198,7 +198,7 @@ exports.createGroup = function(callback)
 exports.createGroupIfNotExistsFor = function(groupMapper, callback)
 {
   // ensure mapper is optional
-  if (typeof groupMapper != "string") {
+  if (typeof groupMapper !== "string") {
     callback(new customError("groupMapper is not a string", "apierror"));
     return;
   }
@@ -248,7 +248,7 @@ exports.createGroupPad = function(groupID, padName, text, callback)
       exports.doesGroupExist(groupID, function(err, exists) {
         if (ERR(err, callback)) return;
 
-        if (exists == false) {
+        if (!exists) {
           // group does not exist
           callback(new customError("groupID does not exist", "apierror"));
           return;
@@ -303,7 +303,7 @@ exports.listPads = function(groupID, callback)
     if (ERR(err, callback)) return;
 
     // ensure the group exists
-    if (exists == false) {
+    if (!exists) {
       callback(new customError("groupID does not exist", "apierror"));
       return;
     }

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -18,6 +18,7 @@ var readOnlyManager = require("./ReadOnlyManager");
 var crypto = require("crypto");
 var randomString = require("../utils/randomstring");
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+const thenify = require("thenify").withCallback;
 
 // serialization/deserialization attributes
 var attributeBlackList = ["id"];
@@ -131,22 +132,22 @@ Pad.prototype.saveToDatabase = function saveToDatabase() {
 }
 
 // get time of last edit (changeset application)
-Pad.prototype.getLastEdit = function getLastEdit(callback) {
+Pad.prototype.getLastEdit = thenify(function getLastEdit(callback) {
   var revNum = this.getHeadRevisionNumber();
   db.getSub("pad:" + this.id + ":revs:" + revNum, ["meta", "timestamp"], callback);
-}
+});
 
-Pad.prototype.getRevisionChangeset = function getRevisionChangeset(revNum, callback) {
+Pad.prototype.getRevisionChangeset = thenify(function getRevisionChangeset(revNum, callback) {
   db.getSub("pad:" + this.id + ":revs:" + revNum, ["changeset"], callback);
-};
+});
 
-Pad.prototype.getRevisionAuthor = function getRevisionAuthor(revNum, callback) {
+Pad.prototype.getRevisionAuthor = thenify(function getRevisionAuthor(revNum, callback) {
   db.getSub("pad:" + this.id + ":revs:" + revNum, ["meta", "author"], callback);
-};
+});
 
-Pad.prototype.getRevisionDate = function getRevisionDate(revNum, callback) {
+Pad.prototype.getRevisionDate = thenify(function getRevisionDate(revNum, callback) {
   db.getSub("pad:" + this.id + ":revs:" + revNum, ["meta", "timestamp"], callback);
-};
+});
 
 Pad.prototype.getAllAuthors = function getAllAuthors() {
   var authors = [];
@@ -160,7 +161,7 @@ Pad.prototype.getAllAuthors = function getAllAuthors() {
   return authors;
 };
 
-Pad.prototype.getInternalRevisionAText = function getInternalRevisionAText(targetRev, callback) {
+Pad.prototype.getInternalRevisionAText = thenify(function getInternalRevisionAText(targetRev, callback) {
   var _this = this;
 
   var keyRev = this.getKeyRevisionNumber(targetRev);
@@ -228,13 +229,13 @@ Pad.prototype.getInternalRevisionAText = function getInternalRevisionAText(targe
     if (ERR(err, callback)) return;
     callback(null, atext);
   });
-};
+});
 
-Pad.prototype.getRevision = function getRevisionChangeset(revNum, callback) {
+Pad.prototype.getRevision = thenify(function getRevisionChangeset(revNum, callback) {
   db.get("pad:" + this.id + ":revs:" + revNum, callback);
-};
+});
 
-Pad.prototype.getAllAuthorColors = function getAllAuthorColors(callback) {
+Pad.prototype.getAllAuthorColors = thenify(function getAllAuthorColors(callback) {
   var authors = this.getAllAuthors();
   var returnTable = {};
   var colorPalette = authorManager.getColorPalette();
@@ -254,7 +255,7 @@ Pad.prototype.getAllAuthorColors = function getAllAuthorColors(callback) {
   function(err) {
     callback(err, returnTable);
   });
-};
+});
 
 Pad.prototype.getValidRevisionRange = function getValidRevisionRange(startRev, endRev) {
   startRev = parseInt(startRev, 10);
@@ -325,7 +326,7 @@ Pad.prototype.appendChatMessage = function appendChatMessage(text, userId, time)
   this.saveToDatabase();
 };
 
-Pad.prototype.getChatMessage = function getChatMessage(entryNum, callback) {
+Pad.prototype.getChatMessage = thenify(function getChatMessage(entryNum, callback) {
   var _this = this;
   var entry;
 
@@ -359,9 +360,9 @@ Pad.prototype.getChatMessage = function getChatMessage(entryNum, callback) {
     if (ERR(err, callback)) return;
     callback(null, entry);
   });
-};
+});
 
-Pad.prototype.getChatMessages = function getChatMessages(start, end, callback) {
+Pad.prototype.getChatMessages = thenify(function getChatMessages(start, end, callback) {
   // collect the numbers of chat entries and in which order we need them
   var neededEntries = [];
   var order = 0;
@@ -398,9 +399,9 @@ Pad.prototype.getChatMessages = function getChatMessages(start, end, callback) {
 
     callback(null, cleanedEntries);
   });
-};
+});
 
-Pad.prototype.init = function init(text, callback) {
+Pad.prototype.init = thenify(function init(text, callback) {
   var _this = this;
 
   // replace text with default text if text isn't set
@@ -432,9 +433,9 @@ Pad.prototype.init = function init(text, callback) {
     hooks.callAll("padLoad", { 'pad': _this });
     callback(null);
   });
-};
+});
 
-Pad.prototype.copy = function copy(destinationID, force, callback) {
+Pad.prototype.copy = thenify(function copy(destinationID, force, callback) {
   var sourceID = this.id;
   var _this = this;
   var destGroupID;
@@ -581,9 +582,9 @@ Pad.prototype.copy = function copy(destinationID, force, callback) {
     if (ERR(err, callback)) return;
     callback(null, { padID: destinationID });
   });
-};
+});
 
-Pad.prototype.remove = function remove(callback) {
+Pad.prototype.remove = thenify(function remove(callback) {
   var padID = this.id;
   var _this = this;
 
@@ -676,7 +677,7 @@ Pad.prototype.remove = function remove(callback) {
     if (ERR(err, callback)) return;
     callback();
   });
-};
+});
 
 // set in db
 Pad.prototype.setPublicStatus = function setPublicStatus(publicStatus) {

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -169,9 +169,8 @@ Pad.prototype.getInternalRevisionAText = async function getInternalRevisionAText
 
   // get all needed data out of the database
 
-  // get the atext of the key revision
-  let _atext = await db.getSub("pad:" + this.id + ":revs:" + keyRev, ["meta", "atext"]);
-  let atext = Changeset.cloneAText(_atext);
+  // start to get the atext of the key revision
+  let p_atext = db.getSub("pad:" + this.id + ":revs:" + keyRev, ["meta", "atext"]);
 
   // get all needed changesets
   let changesets = [];
@@ -180,6 +179,10 @@ Pad.prototype.getInternalRevisionAText = async function getInternalRevisionAText
       changesets[item] = changeset;
     });
   }));
+
+  // we should have the atext by now
+  let atext = await p_atext;
+  atext = Changeset.cloneAText(atext);
 
   // apply all changesets to the key changeset
   let apool = this.apool();
@@ -455,7 +458,10 @@ Pad.prototype.remove = async function remove() {
   // kick everyone from this pad
   padMessageHandler.kickSessionsFromPad(padID);
 
-  // delete all relations
+  // delete all relations - the original code used async.parallel but
+  // none of the operations except getting the group depended on callbacks
+  // so the database operations here are just started and then left to
+  // run to completion
  
   // is it a group pad? -> delete the entry of this pad in the group
   if (padID.indexOf("$") >= 0) {

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -19,6 +19,7 @@ var crypto = require("crypto");
 var randomString = require("../utils/randomstring");
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
 const thenify = require("thenify").withCallback;
+const nodeify = require("nodeify");
 
 // serialization/deserialization attributes
 var attributeBlackList = ["id"];
@@ -621,7 +622,12 @@ Pad.prototype.remove = thenify(function remove(callback) {
 
         // remove the readonly entries
         function(callback) {
-          readOnlyManager.getReadOnlyId(padID, function(err, readonlyID) {
+          // @TODO - temporary until surrounding code is Promisified
+          function getReadOnlyId(padID, callback) {
+            return nodeify(readOnlyManager.getReadOnlyId(padID), callback);
+          }
+
+          getReadOnlyId(padID, function(err, readonlyID) {
             if (ERR(err, callback)) return;
 
             db.remove("pad2readonly:" + padID);

--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -22,6 +22,7 @@ var ERR = require("async-stacktrace");
 var customError = require("../utils/customError");
 var Pad = require("../db/Pad").Pad;
 var db = require("./DB").db;
+const thenify = require("thenify").withCallback;
 
 /**
  * A cache of all loaded Pads.
@@ -53,7 +54,7 @@ var padList = {
   list: [],
   sorted : false,
   initiated: false,
-  init: function(cb) {
+  init: thenify(function(cb) {
     db.findKeys("pad:*", "*:*:*", function(err, dbData) {
       if (ERR(err, cb)) return;
 
@@ -68,18 +69,18 @@ var padList = {
     });
 
     return this;
-  },
-  load: function(cb) {
+  }),
+  load: thenify(function(cb) {
     if (this.initiated) {
       cb && cb();
     } else {
       this.init(cb);
     }
-  },
+  }),
   /**
    * Returns all pads in alphabetical order as array.
    */
-  getPads: function(cb) {
+  getPads: thenify(function(cb) {
     this.load(function() {
       if (!padList.sorted) {
         padList.list = padList.list.sort();
@@ -88,7 +89,7 @@ var padList = {
 
       cb && cb(padList.list);
     })
-  },
+  }),
   addPad: function(name) {
     if (!this.initiated) return;
 
@@ -125,7 +126,7 @@ var padIdTransforms = [
  * @param id A String with the id of the pad
  * @param {Function} callback
  */
-exports.getPad = function(id, text, callback)
+exports.getPad = thenify(function(id, text, callback)
 {
   // check if this is a valid padId
   if (!exports.isValidPadId(id)) {
@@ -177,17 +178,17 @@ exports.getPad = function(id, text, callback)
     padList.addPad(id);
     callback(null, pad);
   });
-}
+});
 
-exports.listAllPads = function(cb)
+exports.listAllPads = thenify(function(cb)
 {
   padList.getPads(function(list) {
     cb && cb(null, {padIDs: list});
   });
-}
+});
 
 // checks if a pad exists
-exports.doesPadExists = function(padId, callback)
+exports.doesPadExists = thenify(function(padId, callback)
 {
   db.get("pad:" + padId, function(err, value) {
     if (ERR(err, callback)) return;
@@ -198,10 +199,10 @@ exports.doesPadExists = function(padId, callback)
       callback(null, false);
     }
   });
-}
+});
 
 // returns a sanitized padId, respecting legacy pad id formats
-exports.sanitizePadId = function(padId, callback) {
+function sanitizePadId(padId, callback) {
   var transform_index = arguments[2] || 0;
 
   // we're out of possible transformations, so just return it
@@ -228,8 +229,17 @@ exports.sanitizePadId = function(padId, callback) {
     }
 
     // check the next transform
-    exports.sanitizePadId(transformedPadId, callback, transform_index);
+    sanitizePadId(transformedPadId, callback, transform_index);
   });
+}
+
+// sanitizePadId can't use thenify: single arg callback
+exports.sanitizePadId = function(padId, callback) {
+  if (callback) {
+    return sanitizePadId(padId, callback);
+  } else {
+    return new Promise(resolve => sanitizePadId(padId, resolve));
+  }
 }
 
 exports.isValidPadId = function(padId)

--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -23,7 +23,7 @@ var customError = require("../utils/customError");
 var Pad = require("../db/Pad").Pad;
 var db = require("./DB").db;
 
-/** 
+/**
  * A cache of all loaded Pads.
  *
  * Provides "get" and "set" functions,
@@ -35,12 +35,11 @@ var db = require("./DB").db;
  * that's defined somewhere more sensible.
  */
 var globalPads = {
-    get: function (name) { return this[':'+name]; },
-    set: function (name, value) 
-    {
+    get: function(name) { return this[':'+name]; },
+    set: function(name, value) {
       this[':'+name] = value;
     },
-    remove: function (name) {
+    remove: function(name) {
       delete this[':'+name];
     }
 };
@@ -54,56 +53,63 @@ var padList = {
   list: [],
   sorted : false,
   initiated: false,
-  init: function(cb)
-  {
-    db.findKeys("pad:*", "*:*:*", function(err, dbData)
-    {
-      if(ERR(err, cb)) return;
-      if(dbData != null){
+  init: function(cb) {
+    db.findKeys("pad:*", "*:*:*", function(err, dbData) {
+      if (ERR(err, cb)) return;
+
+      if (dbData != null) {
         padList.initiated = true
-        dbData.forEach(function(val){
+        dbData.forEach(function(val) {
           padList.addPad(val.replace(/pad:/,""),false);
         });
-        cb && cb()
+
+        cb && cb();
       }
     });
+
     return this;
   },
   load: function(cb) {
-    if(this.initiated) cb && cb()
-    else this.init(cb)
+    if (this.initiated) {
+      cb && cb();
+    } else {
+      this.init(cb);
+    }
   },
   /**
    * Returns all pads in alphabetical order as array.
    */
-  getPads: function(cb){
+  getPads: function(cb) {
     this.load(function() {
-      if(!padList.sorted){
+      if (!padList.sorted) {
         padList.list = padList.list.sort();
         padList.sorted = true;
       }
+
       cb && cb(padList.list);
     })
   },
-  addPad: function(name)
-  {
-    if(!this.initiated) return;
-    if(this.list.indexOf(name) == -1){
+  addPad: function(name) {
+    if (!this.initiated) return;
+
+    if (this.list.indexOf(name) == -1) {
       this.list.push(name);
-      this.sorted=false;
+      this.sorted = false;
     }
   },
-  removePad: function(name)
-  {
-    if(!this.initiated) return;
+  removePad: function(name) {
+    if (!this.initiated) return;
+
     var index = this.list.indexOf(name);
-    if(index>-1){
-      this.list.splice(index,1);
-      this.sorted=false;
+
+    if (index > -1) {
+      this.list.splice(index, 1);
+      this.sorted = false;
     }
   }
 };
-//initialises the allknowing data structure
+
+// initialises the all-knowing data structure
 
 /**
  * An array of padId transformations. These represent changes in pad name policy over
@@ -117,58 +123,56 @@ var padIdTransforms = [
 /**
  * Returns a Pad Object with the callback
  * @param id A String with the id of the pad
- * @param {Function} callback 
+ * @param {Function} callback
  */
 exports.getPad = function(id, text, callback)
-{    
-  //check if this is a valid padId
-  if(!exports.isValidPadId(id))
-  {
-    callback(new customError(id + " is not a valid padId","apierror"));
+{
+  // check if this is a valid padId
+  if (!exports.isValidPadId(id)) {
+    callback(new customError(id + " is not a valid padId", "apierror"));
+
     return;
   }
-  
-  //make text an optional parameter
-  if(typeof text == "function")
-  {
+
+  // make text an optional parameter
+  if (typeof text == "function") {
     callback = text;
     text = null;
   }
-  
-  //check if this is a valid text
-  if(text != null)
-  {
-    //check if text is a string
-    if(typeof text != "string")
-    {
-      callback(new customError("text is not a string","apierror"));
+
+  // check if this is a valid text
+  if (text != null) {
+    // check if text is a string
+    if (typeof text != "string") {
+      callback(new customError("text is not a string", "apierror"));
+
       return;
     }
-    
-    //check if text is less than 100k chars
-    if(text.length > 100000)
-    {
-      callback(new customError("text must be less than 100k chars","apierror"));
+
+    // check if text is less than 100k chars
+    if (text.length > 100000) {
+      callback(new customError("text must be less than 100k chars", "apierror"));
+
       return;
     }
   }
-  
+
   var pad = globalPads.get(id);
-  
-  //return pad if its already loaded
-  if(pad != null)
-  {
+
+  // return pad if it's already loaded
+  if (pad != null) {
     callback(null, pad);
+
     return;
   }
 
-  //try to load pad
+  // try to load pad
   pad = new Pad(id);
 
-  //initalize the pad
-  pad.init(text, function(err)
-  {
-    if(ERR(err, callback)) return;
+  // initalize the pad
+  pad.init(text, function(err) {
+    if (ERR(err, callback)) return;
+
     globalPads.set(id, pad);
     padList.addPad(id);
     callback(null, pad);
@@ -182,49 +186,48 @@ exports.listAllPads = function(cb)
   });
 }
 
-//checks if a pad exists
+// checks if a pad exists
 exports.doesPadExists = function(padId, callback)
 {
-  db.get("pad:"+padId, function(err, value)
-  {
-    if(ERR(err, callback)) return;
-    if(value != null && value.atext){
+  db.get("pad:" + padId, function(err, value) {
+    if (ERR(err, callback)) return;
+
+    if (value != null && value.atext) {
       callback(null, true);
-    }
-    else
-    {
-      callback(null, false); 
+    } else {
+      callback(null, false);
     }
   });
 }
 
-//returns a sanitized padId, respecting legacy pad id formats
+// returns a sanitized padId, respecting legacy pad id formats
 exports.sanitizePadId = function(padId, callback) {
   var transform_index = arguments[2] || 0;
-  //we're out of possible transformations, so just return it
-  if(transform_index >= padIdTransforms.length)
-  {
+
+  // we're out of possible transformations, so just return it
+  if (transform_index >= padIdTransforms.length) {
     callback(padId);
+
     return;
   }
 
-  //check if padId exists
-  exports.doesPadExists(padId, function(junk, exists)
-  {
-    if(exists)
-    {
+  // check if padId exists
+  exports.doesPadExists(padId, function(junk, exists) {
+    if (exists) {
       callback(padId);
+
       return;
     }
 
-    //get the next transformation *that's different*
+    // get the next transformation *that's different*
     var transformedPadId = padId;
-    while(transformedPadId == padId && transform_index < padIdTransforms.length)
-    {
+
+    while(transformedPadId == padId && transform_index < padIdTransforms.length) {
       transformedPadId = padId.replace(padIdTransforms[transform_index][0], padIdTransforms[transform_index][1]);
       transform_index += 1;
     }
-    //check the next transform
+
+    // check the next transform
     exports.sanitizePadId(transformedPadId, callback, transform_index);
   });
 }
@@ -237,13 +240,13 @@ exports.isValidPadId = function(padId)
 /**
  * Removes the pad from database and unloads it.
  */
-exports.removePad = function(padId){
-  db.remove("pad:"+padId);
+exports.removePad = function(padId) {
+  db.remove("pad:" + padId);
   exports.unloadPad(padId);
   padList.removePad(padId);
 }
 
-//removes a pad from the cache
+// removes a pad from the cache
 exports.unloadPad = function(padId)
 {
   globalPads.remove(padId);

--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -188,7 +188,7 @@ exports.listAllPads = thenify(function(cb)
 });
 
 // checks if a pad exists
-exports.doesPadExists = thenify(function(padId, callback)
+exports.doesPadExist = thenify(function(padId, callback)
 {
   db.get("pad:" + padId, function(err, value) {
     if (ERR(err, callback)) return;
@@ -200,6 +200,9 @@ exports.doesPadExists = thenify(function(padId, callback)
     }
   });
 });
+
+// alias for backwards compatibility
+exports.doesPadExists = exports.doesPadExist;
 
 // returns a sanitized padId, respecting legacy pad id formats
 function sanitizePadId(padId, callback) {

--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -18,11 +18,9 @@
  * limitations under the License.
  */
 
-var ERR = require("async-stacktrace");
 var customError = require("../utils/customError");
 var Pad = require("../db/Pad").Pad;
-var db = require("./DB").db;
-const thenify = require("thenify").withCallback;
+var db = require("./DB");
 
 /**
  * A cache of all loaded Pads.
@@ -114,59 +112,43 @@ let padList = {
  * @param id A String with the id of the pad
  * @param {Function} callback
  */
-exports.getPad = thenify(function(id, text, callback)
+exports.getPad = async function(id, text)
 {
   // check if this is a valid padId
   if (!exports.isValidPadId(id)) {
-    callback(new customError(id + " is not a valid padId", "apierror"));
-
-    return;
-  }
-
-  // make text an optional parameter
-  if (typeof text == "function") {
-    callback = text;
-    text = null;
+    throw new customError(id + " is not a valid padId", "apierror");
   }
 
   // check if this is a valid text
   if (text != null) {
     // check if text is a string
     if (typeof text != "string") {
-      callback(new customError("text is not a string", "apierror"));
-
-      return;
+      throw new customError("text is not a string", "apierror");
     }
 
     // check if text is less than 100k chars
     if (text.length > 100000) {
-      callback(new customError("text must be less than 100k chars", "apierror"));
-
-      return;
+      throw new customError("text must be less than 100k chars", "apierror");
     }
   }
 
-  var pad = globalPads.get(id);
+  let pad = globalPads.get(id);
 
   // return pad if it's already loaded
   if (pad != null) {
-    callback(null, pad);
-
-    return;
+    return pad;
   }
 
   // try to load pad
   pad = new Pad(id);
 
   // initalize the pad
-  pad.init(text, function(err) {
-    if (ERR(err, callback)) return;
+  await pad.init(text);
+  globalPads.set(id, pad);
+  padList.addPad(id);
 
-    globalPads.set(id, pad);
-    padList.addPad(id);
-    callback(null, pad);
-  });
-});
+  return pad;
+}
 
 exports.listAllPads = async function()
 {
@@ -176,18 +158,12 @@ exports.listAllPads = async function()
 }
 
 // checks if a pad exists
-exports.doesPadExist = thenify(function(padId, callback)
+exports.doesPadExist = async function(padId)
 {
-  db.get("pad:" + padId, function(err, value) {
-    if (ERR(err, callback)) return;
+  let value = await db.get("pad:" + padId);
 
-    if (value != null && value.atext) {
-      callback(null, true);
-    } else {
-      callback(null, false);
-    }
-  });
-});
+  return (value != null && value.atext);
+}
 
 // alias for backwards compatibility
 exports.doesPadExists = exports.doesPadExist;

--- a/src/node/db/ReadOnlyManager.js
+++ b/src/node/db/ReadOnlyManager.js
@@ -29,43 +29,40 @@ var randomString = require("../utils/randomstring");
  * @param {String} padId the id of the pad
  */
 exports.getReadOnlyId = function (padId, callback)
-{  
+{
   var readOnlyId;
-  
+
   async.waterfall([
-    //check if there is a pad2readonly entry
-    function(callback)
-    {
+    // check if there is a pad2readonly entry
+    function(callback) {
       db.get("pad2readonly:" + padId, callback);
     },
-    function(dbReadOnlyId, callback)
-    {
-      //there is no readOnly Entry in the database, let's create one
-      if(dbReadOnlyId == null)
-      {
+
+    function(dbReadOnlyId, callback) {
+      if (dbReadOnlyId == null) {
+        // there is no readOnly Entry in the database, let's create one
         readOnlyId = "r." + randomString(16);
-        
+
         db.set("pad2readonly:" + padId, readOnlyId);
         db.set("readonly2pad:" + readOnlyId, padId);
-      }
-      //there is a readOnly Entry in the database, let's take this one
-      else
-      {
+      } else {
+        // there is a readOnly Entry in the database, let's take this one
         readOnlyId = dbReadOnlyId;
       }
-      
+
       callback();
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
-    //return the results
+  ],
+  function(err) {
+    if (ERR(err, callback)) return;
+
+    // return the results
     callback(null, readOnlyId);
   })
 }
 
 /**
- * returns a the padId for a read only id
+ * returns the padId for a read only id
  * @param {String} readOnlyId read only id
  */
 exports.getPadId = function(readOnlyId, callback)
@@ -74,20 +71,21 @@ exports.getPadId = function(readOnlyId, callback)
 }
 
 /**
- * returns a the padId and readonlyPadId in an object for any id
+ * returns the padId and readonlyPadId in an object for any id
  * @param {String} padIdOrReadonlyPadId read only id or real pad id
  */
 exports.getIds = function(id, callback) {
-  if (id.indexOf("r.") == 0)
+  if (id.indexOf("r.") == 0) {
     exports.getPadId(id, function (err, value) {
-      if(ERR(err, callback)) return;
+      if (ERR(err, callback)) return;
+
       callback(null, {
         readOnlyPadId: id,
         padId: value, // Might be null, if this is an unknown read-only id
         readonly: true
       });
     });
-  else
+  } else {
     exports.getReadOnlyId(id, function (err, value) {
       callback(null, {
         readOnlyPadId: value,
@@ -95,4 +93,5 @@ exports.getIds = function(id, callback) {
         readonly: false
       });
     });
+  }
 }

--- a/src/node/db/ReadOnlyManager.js
+++ b/src/node/db/ReadOnlyManager.js
@@ -23,12 +23,13 @@ var ERR = require("async-stacktrace");
 var db = require("./DB").db;
 var async = require("async");
 var randomString = require("../utils/randomstring");
+const thenify = require("thenify").withCallback;
 
 /**
  * returns a read only id for a pad
  * @param {String} padId the id of the pad
  */
-exports.getReadOnlyId = function (padId, callback)
+exports.getReadOnlyId = thenify(function (padId, callback)
 {
   var readOnlyId;
 
@@ -59,22 +60,22 @@ exports.getReadOnlyId = function (padId, callback)
     // return the results
     callback(null, readOnlyId);
   })
-}
+});
 
 /**
  * returns the padId for a read only id
  * @param {String} readOnlyId read only id
  */
-exports.getPadId = function(readOnlyId, callback)
+exports.getPadId = thenify(function(readOnlyId, callback)
 {
   db.get("readonly2pad:" + readOnlyId, callback);
-}
+});
 
 /**
  * returns the padId and readonlyPadId in an object for any id
  * @param {String} padIdOrReadonlyPadId read only id or real pad id
  */
-exports.getIds = function(id, callback) {
+exports.getIds = thenify(function(id, callback) {
   if (id.indexOf("r.") == 0) {
     exports.getPadId(id, function (err, value) {
       if (ERR(err, callback)) return;
@@ -94,4 +95,4 @@ exports.getIds = function(id, callback) {
       });
     });
   }
-}
+});

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -62,7 +62,7 @@ exports.checkAccess = function(padID, sessionCookie, token, password, callback)
     }
   } else {
     // a session is not required, so we'll check if it's a public pad
-    if (padID.indexOf("$") == -1) {
+    if (padID.indexOf("$") === -1) {
       // it's not a group pad, means we can grant access
 
       // get author for this token
@@ -225,17 +225,17 @@ exports.checkAccess = function(padID, sessionCookie, token, password, callback)
 
           // --> grant access
           statusObject = { accessStatus: "grant", authorID: sessionAuthor };
-        } else if (isPasswordProtected && passwordStatus == "correct") {
+        } else if (isPasswordProtected && passwordStatus === "correct") {
           // - the pad is password protected and password is correct
 
           // --> grant access
           statusObject = { accessStatus: "grant", authorID: sessionAuthor };
-        } else if (isPasswordProtected && passwordStatus == "wrong") {
+        } else if (isPasswordProtected && passwordStatus === "wrong") {
           // - the pad is password protected but wrong password given
 
           // --> deny access, ask for new password and tell them that the password is wrong
           statusObject = { accessStatus: "wrongPassword" };
-        } else if (isPasswordProtected && passwordStatus == "notGiven") {
+        } else if (isPasswordProtected && passwordStatus === "notGiven") {
           // - the pad is password protected but no password given
 
           // --> ask for password
@@ -261,17 +261,17 @@ exports.checkAccess = function(padID, sessionCookie, token, password, callback)
         if (isPublic && !isPasswordProtected) {
           // --> grant access, with author of token
           statusObject = {accessStatus: "grant", authorID: tokenAuthor};
-        } else if (isPublic && isPasswordProtected && passwordStatus == "correct") {
+        } else if (isPublic && isPasswordProtected && passwordStatus === "correct") {
           // - it's public and password protected and password is correct
 
           // --> grant access, with author of token
           statusObject = {accessStatus: "grant", authorID: tokenAuthor};
-        } else if (isPublic && isPasswordProtected && passwordStatus == "wrong") {
+        } else if (isPublic && isPasswordProtected && passwordStatus === "wrong") {
           // - it's public and the pad is password protected but wrong password given
 
           // --> deny access, ask for new password and tell them that the password is wrong
           statusObject = {accessStatus: "wrongPassword"};
-        } else if (isPublic && isPasswordProtected && passwordStatus == "notGiven") {
+        } else if (isPublic && isPasswordProtected && passwordStatus === "notGiven") {
           // - it's public and the pad is password protected but no password given
 
           // --> ask for password

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 var ERR = require("async-stacktrace");
 var async = require("async");
 var authorManager = require("./AuthorManager");
@@ -34,59 +33,57 @@ var authLogger = log4js.getLogger("auth");
  * @param padID the pad the user wants to access
  * @param sessionCookie the session the user has (set via api)
  * @param token the token of the author (randomly generated at client side, used for public pads)
- * @param password the password the user has given to access this pad, can be null 
+ * @param password the password the user has given to access this pad, can be null
  * @param callback will be called with (err, {accessStatus: grant|deny|wrongPassword|needPassword, authorID: a.xxxxxx})
- */ 
-exports.checkAccess = function (padID, sessionCookie, token, password, callback)
-{ 
+ */
+exports.checkAccess = function(padID, sessionCookie, token, password, callback)
+{
   var statusObject;
-  
-  if(!padID) {
+
+  if (!padID) {
     callback(null, {accessStatus: "deny"});
     return;
   }
 
   // allow plugins to deny access
   var deniedByHook = hooks.callAll("onAccessCheck", {'padID': padID, 'password': password, 'token': token, 'sessionCookie': sessionCookie}).indexOf(false) > -1;
-  if(deniedByHook)
-  {
+  if (deniedByHook) {
     callback(null, {accessStatus: "deny"});
     return;
   }
 
-  // a valid session is required (api-only mode)
-  if(settings.requireSession)
-  {
-    // without sessionCookie, access is denied
-    if(!sessionCookie)
-    {
+  if (settings.requireSession) {
+    // a valid session is required (api-only mode)
+    if (!sessionCookie) {
+      // without sessionCookie, access is denied
       callback(null, {accessStatus: "deny"});
+
       return;
     }
-  }
-  // a session is not required, so we'll check if it's a public pad
-  else
-  {
-    // it's not a group pad, means we can grant access
-    if(padID.indexOf("$") == -1)
-    {
-      //get author for this token
-      authorManager.getAuthor4Token(token, function(err, author)
-      {
-        if(ERR(err, callback)) return;
-        
+  } else {
+    // a session is not required, so we'll check if it's a public pad
+    if (padID.indexOf("$") == -1) {
+      // it's not a group pad, means we can grant access
+
+      // get author for this token
+      authorManager.getAuthor4Token(token, function(err, author) {
+        if (ERR(err, callback)) return;
+
         // assume user has access
-        statusObject = {accessStatus: "grant", authorID: author};
-        // user can't create pads
-        if(settings.editOnly)
-        {
+        statusObject = { accessStatus: "grant", authorID: author };
+
+        if (settings.editOnly) {
+          // user can't create pads
+
           // check if pad exists
-          padManager.doesPadExists(padID, function(err, exists)
-          {
-            if(ERR(err, callback)) return;
-            
-            // pad doesn't exist - user can't have access
-            if(!exists) statusObject.accessStatus = "deny";
+          padManager.doesPadExists(padID, function(err, exists) {
+            if (ERR(err, callback)) return;
+
+            if (!exists) {
+              // pad doesn't exist - user can't have access
+              statusObject.accessStatus = "deny";
+            }
+
             // grant or deny access, with author of token
             callback(null, statusObject);
           });
@@ -98,12 +95,12 @@ exports.checkAccess = function (padID, sessionCookie, token, password, callback)
         // grant access, with author of token
         callback(null, statusObject);
       });
-      
-      //don't continue
+
+      // don't continue
       return;
     }
   }
-   
+
   var groupID = padID.split("$")[0];
   var padExists = false;
   var validSession = false;
@@ -114,216 +111,193 @@ exports.checkAccess = function (padID, sessionCookie, token, password, callback)
   var passwordStatus = password == null ? "notGiven" : "wrong"; // notGiven, correct, wrong
 
   async.series([
-    //get basic informations from the database 
-    function(callback)
-    {
+    // get basic informations from the database
+    function(callback) {
       async.parallel([
-        //does pad exists
-        function(callback)
-        {
-          padManager.doesPadExists(padID, function(err, exists)
-          {
-            if(ERR(err, callback)) return;
+        // does pad exist
+        function(callback) {
+          padManager.doesPadExists(padID, function(err, exists) {
+            if (ERR(err, callback)) return;
+
             padExists = exists;
             callback();
           });
         },
-        //get information about all sessions contained in this cookie
-        function(callback)
-        {
-          if (!sessionCookie)
-          {
+
+        // get information about all sessions contained in this cookie
+        function(callback) {
+          if (!sessionCookie) {
             callback();
             return;
           }
-          
+
           var sessionIDs = sessionCookie.split(',');
-          async.forEach(sessionIDs, function(sessionID, callback)
-          {
-            sessionManager.getSessionInfo(sessionID, function(err, sessionInfo)
-            {
-              //skip session if it doesn't exist
-              if(err && err.message == "sessionID does not exist")
-              {
+
+          async.forEach(sessionIDs, function(sessionID, callback) {
+            sessionManager.getSessionInfo(sessionID, function(err, sessionInfo) {
+              // skip session if it doesn't exist
+              if (err && err.message == "sessionID does not exist") {
                 authLogger.debug("Auth failed: unknown session");
                 callback();
+
                 return;
               }
-              
-              if(ERR(err, callback)) return;
-              
+
+              if (ERR(err, callback)) return;
+
               var now = Math.floor(Date.now()/1000);
-              
-              //is it for this group?
-              if(sessionInfo.groupID != groupID)
-              {
+
+              // is it for this group?
+              if (sessionInfo.groupID != groupID) {
                 authLogger.debug("Auth failed: wrong group");
                 callback();
+
                 return;
               }
-              
-              //is validUntil still ok?
-              if(sessionInfo.validUntil <= now)
-              {
+
+              // is validUntil still ok?
+              if (sessionInfo.validUntil <= now) {
                 authLogger.debug("Auth failed: validUntil");
                 callback();
+
                 return;
               }
-              
+
               // There is a valid session
               validSession = true;
               sessionAuthor = sessionInfo.authorID;
-              
+
               callback();
             });
           }, callback);
         },
-        //get author for token
-        function(callback)
-        {
-          //get author for this token
-          authorManager.getAuthor4Token(token, function(err, author)
-          {
-            if(ERR(err, callback)) return;
+
+        // get author for token
+        function(callback) {
+          // get author for this token
+          authorManager.getAuthor4Token(token, function(err, author) {
+            if (ERR(err, callback)) return;
+
             tokenAuthor = author;
             callback();
           });
         }
       ], callback);
     },
-    //get more informations of this pad, if avaiable
-    function(callback)
-    {
-      //skip this if the pad doesn't exists
-      if(padExists == false) 
-      {
+
+    // get more informations of this pad, if avaiable
+    function(callback) {
+      // skip this if the pad doesn't exist
+      if (padExists == false) {
         callback();
+
         return;
       }
-      
-      padManager.getPad(padID, function(err, pad)
-      {
-        if(ERR(err, callback)) return;
-        
-        //is it a public pad?
+
+      padManager.getPad(padID, function(err, pad) {
+        if (ERR(err, callback)) return;
+
+        // is it a public pad?
         isPublic = pad.getPublicStatus();
-        
-        //is it password protected?
+
+        // is it password protected?
         isPasswordProtected = pad.isPasswordProtected();
-        
-        //is password correct?
-        if(isPasswordProtected && password && pad.isCorrectPassword(password))
-        {
+
+        // is password correct?
+        if (isPasswordProtected && password && pad.isCorrectPassword(password)) {
           passwordStatus = "correct";
         }
-        
+
         callback();
       });
     },
-    function(callback)
-    {
-      //- a valid session for this group is avaible AND pad exists
-      if(validSession && padExists)
-      {
-        //- the pad is not password protected
-        if(!isPasswordProtected)
-        {
-          //--> grant access
-          statusObject = {accessStatus: "grant", authorID: sessionAuthor};
-        }
-        //- the setting to bypass password validation is set
-        else if(settings.sessionNoPassword)
-        {
-          //--> grant access
-          statusObject = {accessStatus: "grant", authorID: sessionAuthor};
-        }
-        //- the pad is password protected and password is correct
-        else if(isPasswordProtected && passwordStatus == "correct")
-        {
-          //--> grant access
-          statusObject = {accessStatus: "grant", authorID: sessionAuthor};
-        }
-        //- the pad is password protected but wrong password given
-        else if(isPasswordProtected && passwordStatus == "wrong")
-        {
-          //--> deny access, ask for new password and tell them that the password is wrong
-          statusObject = {accessStatus: "wrongPassword"};
-        }
-        //- the pad is password protected but no password given
-        else if(isPasswordProtected && passwordStatus == "notGiven")
-        {
-          //--> ask for password
-          statusObject = {accessStatus: "needPassword"};
-        }
-        else
-        {
+
+    function(callback) {
+      if (validSession && padExists) {
+        // - a valid session for this group is avaible AND pad exists
+        if (!isPasswordProtected) {
+          // - the pad is not password protected
+
+          // --> grant access
+          statusObject = { accessStatus: "grant", authorID: sessionAuthor };
+        } else if (settings.sessionNoPassword) {
+          // - the setting to bypass password validation is set
+
+          // --> grant access
+          statusObject = { accessStatus: "grant", authorID: sessionAuthor };
+        } else if (isPasswordProtected && passwordStatus == "correct") {
+          // - the pad is password protected and password is correct
+
+          // --> grant access
+          statusObject = { accessStatus: "grant", authorID: sessionAuthor };
+        } else if (isPasswordProtected && passwordStatus == "wrong") {
+          // - the pad is password protected but wrong password given
+
+          // --> deny access, ask for new password and tell them that the password is wrong
+          statusObject = { accessStatus: "wrongPassword" };
+        } else if (isPasswordProtected && passwordStatus == "notGiven") {
+          // - the pad is password protected but no password given
+
+          // --> ask for password
+          statusObject = { accessStatus: "needPassword" };
+        } else {
           throw new Error("Ops, something wrong happend");
         }
-      } 
-      //- a valid session for this group avaible but pad doesn't exists
-      else if(validSession && !padExists)
-      {
-        //--> grant access
+      } else if (validSession && !padExists) {
+        // - a valid session for this group avaible but pad doesn't exist
+
+        // --> grant access
         statusObject = {accessStatus: "grant", authorID: sessionAuthor};
-        //--> deny access if user isn't allowed to create the pad
-        if(settings.editOnly)
-        {
+
+        if (settings.editOnly) {
+          // --> deny access if user isn't allowed to create the pad
           authLogger.debug("Auth failed: valid session & pad does not exist");
           statusObject.accessStatus = "deny";
         }
-      }
-      // there is no valid session avaiable AND pad exists
-      else if(!validSession && padExists)
-      {
-        //-- its public and not password protected
-        if(isPublic && !isPasswordProtected)
-        {
-          //--> grant access, with author of token
+      } else if (!validSession && padExists) {
+        // there is no valid session avaiable AND pad exists
+
+        // -- it's public and not password protected
+        if (isPublic && !isPasswordProtected) {
+          // --> grant access, with author of token
           statusObject = {accessStatus: "grant", authorID: tokenAuthor};
-        }
-        //- its public and password protected and password is correct
-        else if(isPublic && isPasswordProtected && passwordStatus == "correct")
-        {
-          //--> grant access, with author of token
+        } else if (isPublic && isPasswordProtected && passwordStatus == "correct") {
+          // - it's public and password protected and password is correct
+
+          // --> grant access, with author of token
           statusObject = {accessStatus: "grant", authorID: tokenAuthor};
-        }
-        //- its public and the pad is password protected but wrong password given 
-        else if(isPublic && isPasswordProtected && passwordStatus == "wrong")
-        {
-          //--> deny access, ask for new password and tell them that the password is wrong
+        } else if (isPublic && isPasswordProtected && passwordStatus == "wrong") {
+          // - it's public and the pad is password protected but wrong password given
+
+          // --> deny access, ask for new password and tell them that the password is wrong
           statusObject = {accessStatus: "wrongPassword"};
-        }
-        //- its public and the pad is password protected but no password given
-        else if(isPublic && isPasswordProtected && passwordStatus == "notGiven")
-        {
-          //--> ask for password
+        } else if (isPublic && isPasswordProtected && passwordStatus == "notGiven") {
+          // - it's public and the pad is password protected but no password given
+
+          // --> ask for password
           statusObject = {accessStatus: "needPassword"};
-        }
-        //- its not public
-        else if(!isPublic)
-        {
+        } else if (!isPublic) {
+          // - it's not public
+
           authLogger.debug("Auth failed: invalid session & pad is not public");
-          //--> deny access
+          // --> deny access
           statusObject = {accessStatus: "deny"};
-        }
-        else
-        {
+        } else {
           throw new Error("Ops, something wrong happend");
         }
-      }    
-      // there is no valid session avaiable AND pad doesn't exists
-      else
-      {
-         authLogger.debug("Auth failed: invalid session & pad does not exist");
-         //--> deny access
-         statusObject = {accessStatus: "deny"};
+      } else {
+        // there is no valid session avaiable AND pad doesn't exist
+        authLogger.debug("Auth failed: invalid session & pad does not exist");
+        // --> deny access
+        statusObject = {accessStatus: "deny"};
       }
-      
+
       callback();
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
+  ],
+  function(err) {
+    if (ERR(err, callback)) return;
+
     callback(null, statusObject);
   });
 };

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -25,7 +25,6 @@ var sessionManager = require("./SessionManager");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
 var authLogger = log4js.getLogger("auth");
-const thenify = require("thenify").withCallback;
 
 /**
  * This function controlls the access to a pad, it checks if the user can access a pad.

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -27,6 +27,7 @@ var sessionManager = require("./SessionManager");
 var settings = require("../utils/Settings");
 var log4js = require('log4js');
 var authLogger = log4js.getLogger("auth");
+const thenify = require("thenify").withCallback;
 
 /**
  * This function controlls the access to a pad, it checks if the user can access a pad.
@@ -36,7 +37,7 @@ var authLogger = log4js.getLogger("auth");
  * @param password the password the user has given to access this pad, can be null
  * @param callback will be called with (err, {accessStatus: grant|deny|wrongPassword|needPassword, authorID: a.xxxxxx})
  */
-exports.checkAccess = function(padID, sessionCookie, token, password, callback)
+exports.checkAccess = thenify(function(padID, sessionCookie, token, password, callback)
 {
   var statusObject;
 
@@ -300,4 +301,4 @@ exports.checkAccess = function(padID, sessionCookie, token, password, callback)
 
     callback(null, statusObject);
   });
-};
+});

--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -21,160 +21,106 @@
 var ERR = require("async-stacktrace");
 var customError = require("../utils/customError");
 var randomString = require("../utils/randomstring");
-var db = require("./DB").db;
-var async = require("async");
+var db = require("./DB");
 var groupManager = require("./GroupManager");
 var authorManager = require("./AuthorManager");
 const thenify = require("thenify").withCallback;
 
-exports.doesSessionExist = thenify(function(sessionID, callback)
+exports.doesSessionExist = async function(sessionID)
 {
   //check if the database entry of this session exists
-  db.get("session:" + sessionID, function (err, session)
-  {
-    if(ERR(err, callback)) return;
-    callback(null, session != null);
-  });
-});
+  let session = await db.get("session:" + sessionID);
+  return (session !== null);
+}
 
 /**
  * Creates a new session between an author and a group
  */
-exports.createSession = thenify(function(groupID, authorID, validUntil, callback)
+exports.createSession = async function(groupID, authorID, validUntil)
 {
-  var sessionID;
+  // check if the group exists
+  let groupExists = await groupManager.doesGroupExist(groupID);
+  if (!groupExists) {
+    throw new customError("groupID does not exist", "apierror");
+  }
 
-  async.series([
-    // check if the group exists
-    function(callback)
-    {
-      groupManager.doesGroupExist(groupID, function(err, exists)
-      {
-        if(ERR(err, callback)) return;
+  // check if the author exists
+  let authorExists = await authorManager.doesAuthorExist(authorID);
+  if (!authorExists) {
+    throw new customError("authorID does not exist", "apierror");
+  }
 
-        // group does not exist
-        if (exists == false) {
-          callback(new customError("groupID does not exist", "apierror"));
-        } else {
-          // everything is fine, continue
-          callback();
-        }
-      });
-    },
+  // try to parse validUntil if it's not a number
+  if (typeof validUntil !== "number") {
+    validUntil = parseInt(validUntil);
+  }
 
-    // check if the author exists
-    function(callback)
-    {
-      authorManager.doesAuthorExists(authorID, function(err, exists)
-      {
-        if(ERR(err, callback)) return;
+  // check it's a valid number
+  if (isNaN(validUntil)) {
+    throw new customError("validUntil is not a number", "apierror");
+  }
 
-        if (exists == false) {
-          // author does not exist
-          callback(new customError("authorID does not exist", "apierror"));
-        } else {
-          // everything is fine, continue
-          callback();
-        }
-      });
-    },
+  // ensure this is not a negative number
+  if (validUntil < 0) {
+    throw new customError("validUntil is a negative number", "apierror");
+  }
 
-    // check validUntil and create the session db entry
-    function(callback)
-    {
-      // check if rev is a number
-      if (typeof validUntil != "number")
-      {
-        // try to parse the number
-        if (isNaN(parseInt(validUntil))) {
-          callback(new customError("validUntil is not a number", "apierror"));
-          return;
-        }
+  // ensure this is not a float value
+  if (!is_int(validUntil)) {
+    throw new customError("validUntil is a float value", "apierror");
+  }
 
-        validUntil = parseInt(validUntil);
-      }
+  // check if validUntil is in the future
+  if (validUntil < Math.floor(Date.now() / 1000)) {
+    throw new customError("validUntil is in the past", "apierror");
+  }
 
-      // ensure this is not a negative number
-      if (validUntil < 0) {
-        callback(new customError("validUntil is a negative number", "apierror"));
-        return;
-      }
+  // generate sessionID
+  let sessionID = "s." + randomString(16);
 
-      // ensure this is not a float value
-      if (!is_int(validUntil)) {
-        callback(new customError("validUntil is a float value", "apierror"));
-        return;
-      }
+  // set the session into the database
+  await db.set("session:" + sessionID, {"groupID": groupID, "authorID": authorID, "validUntil": validUntil});
 
-      // check if validUntil is in the future
-      if (Math.floor(Date.now()/1000) > validUntil) {
-        callback(new customError("validUntil is in the past", "apierror"));
-        return;
-      }
+  // get the entry
+  let group2sessions = await db.get("group2sessions:" + groupID);
 
-      // generate sessionID
-      sessionID = "s." + randomString(16);
+  /*
+   * In some cases, the db layer could return "undefined" as well as "null".
+   * Thus, it is not possible to perform strict null checks on group2sessions.
+   * In a previous version of this code, a strict check broke session
+   * management.
+   *
+   * See: https://github.com/ether/etherpad-lite/issues/3567#issuecomment-468613960
+   */
+  if (!group2sessions || !group2sessions.sessionIDs) {
+    // the entry doesn't exist so far, let's create it
+    group2sessions = {sessionIDs : {}};
+  }
 
-      // set the session into the database
-      db.set("session:" + sessionID, {"groupID": groupID, "authorID": authorID, "validUntil": validUntil});
+  // add the entry for this session
+  group2sessions.sessionIDs[sessionID] = 1;
 
-      callback();
-    },
+  // save the new element back
+  await db.set("group2sessions:" + groupID, group2sessions);
 
-    // set the group2sessions entry
-    function(callback)
-    {
-      // get the entry
-      db.get("group2sessions:" + groupID, function(err, group2sessions)
-      {
-        if(ERR(err, callback)) return;
+  // get the author2sessions entry
+  let author2sessions = await db.get("author2sessions:" + authorID);
 
-        if (group2sessions == null || group2sessions.sessionIDs == null) {
-          // the entry doesn't exist so far, let's create it
-          group2sessions = {sessionIDs : {}};
-        }
+  if (author2sessions == null || author2sessions.sessionIDs == null) {
+    // the entry doesn't exist so far, let's create it
+    author2sessions = {sessionIDs : {}};
+  }
 
-        // add the entry for this session
-        group2sessions.sessionIDs[sessionID] = 1;
+  // add the entry for this session
+  author2sessions.sessionIDs[sessionID] = 1;
 
-        // save the new element back
-        db.set("group2sessions:" + groupID, group2sessions);
+  //save the new element back
+  await db.set("author2sessions:" + authorID, author2sessions);
 
-        callback();
-      });
-    },
+  return { sessionID };
+}
 
-    // set the author2sessions entry
-    function(callback)
-    {
-      // get the entry
-      db.get("author2sessions:" + authorID, function(err, author2sessions)
-      {
-        if(ERR(err, callback)) return;
-
-        if (author2sessions == null || author2sessions.sessionIDs == null) {
-          // the entry doesn't exist so far, let's create it
-          author2sessions = {sessionIDs : {}};
-        }
-
-        // add the entry for this session
-        author2sessions.sessionIDs[sessionID] = 1;
-
-        //save the new element back
-        db.set("author2sessions:" + authorID, author2sessions);
-
-        callback();
-      });
-    }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
-
-    // return error and sessionID
-    callback(null, {sessionID: sessionID});
-  })
-});
-
+// @TODO once external dependencies are using Promises
 exports.getSessionInfo = thenify(function(sessionID, callback)
 {
   // check if the database entry of this session exists
@@ -195,160 +141,86 @@ exports.getSessionInfo = thenify(function(sessionID, callback)
 /**
  * Deletes a session
  */
-exports.deleteSession = thenify(function(sessionID, callback)
+exports.deleteSession = async function(sessionID)
 {
-  var authorID, groupID;
-  var group2sessions, author2sessions;
+  // ensure that the session exists
+  let session = await db.get("session:" + sessionID);
+  if (session == null) {
+    throw new customError("sessionID does not exist", "apierror");
+  }
 
-  async.series([
-    function(callback)
-    {
-      // get the session entry
-      db.get("session:" + sessionID, function (err, session)
-      {
-        if(ERR(err, callback)) return;
+  // everything is fine, use the sessioninfos
+  let groupID = session.groupID;
+  let authorID = session.authorID;
 
-        if (session == null) {
-          // session does not exist
-          callback(new customError("sessionID does not exist", "apierror"))
-        } else {
-          // everything is fine, use the sessioninfos
-          authorID = session.authorID;
-          groupID = session.groupID;
+  // get the group2sessions and author2sessions entries
+  let group2sessions = await db.get("group2sessions:" + groupID);
+  let author2sessions = await db.get("author2sessions:" + authorID);
 
-          callback();
-        }
-      });
-    },
+  // remove the session
+  await db.remove("session:" + sessionID);
 
-    // get the group2sessions entry
-    function(callback)
-    {
-      db.get("group2sessions:" + groupID, function (err, _group2sessions)
-      {
-        if(ERR(err, callback)) return;
-        group2sessions = _group2sessions;
-        callback();
-      });
-    },
+  // remove session from group2sessions
+  if (group2sessions != null) { // Maybe the group was already deleted
+    delete group2sessions.sessionIDs[sessionID];
+    await db.set("group2sessions:" + groupID, group2sessions);
+  }
 
-    // get the author2sessions entry
-    function(callback)
-    {
-      db.get("author2sessions:" + authorID, function (err, _author2sessions)
-      {
-        if(ERR(err, callback)) return;
-        author2sessions = _author2sessions;
-        callback();
-      });
-    },
+  // remove session from author2sessions
+  if (author2sessions != null) { // Maybe the author was already deleted
+    delete author2sessions.sessionIDs[sessionID];
+    await db.set("author2sessions:" + authorID, author2sessions);
+  }
+}
 
-    // remove the values from the database
-    function(callback)
-    {
-      //remove the session
-      db.remove("session:" + sessionID);
-
-      // remove session from group2sessions
-      if(group2sessions != null) { // Maybe the group was already deleted
-          delete group2sessions.sessionIDs[sessionID];
-          db.set("group2sessions:" + groupID, group2sessions);
-      }
-
-      // remove session from author2sessions
-      if(author2sessions != null) { // Maybe the author was already deleted
-          delete author2sessions.sessionIDs[sessionID];
-          db.set("author2sessions:" + authorID, author2sessions);
-      }
-
-      callback();
-    }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
-    callback();
-  })
-});
-
-exports.listSessionsOfGroup = thenify(function(groupID, callback)
+exports.listSessionsOfGroup = async function(groupID)
 {
-  groupManager.doesGroupExist(groupID, function(err, exists)
-  {
-    if(ERR(err, callback)) return;
+  // check that the group exists
+  let exists = await groupManager.doesGroupExist(groupID);
+  if (!exists) {
+    throw new customError("groupID does not exist", "apierror");
+  }
 
-    if (exists == false) {
-      // group does not exist
-      callback(new customError("groupID does not exist", "apierror"));
-    } else {
-      // everything is fine, continue
-      listSessionsWithDBKey("group2sessions:" + groupID, callback);
-    }
-  });
-});
+  let sessions = await listSessionsWithDBKey("group2sessions:" + groupID);
+  return sessions;
+}
 
-exports.listSessionsOfAuthor = thenify(function(authorID, callback)
+exports.listSessionsOfAuthor = async function(authorID)
 {
-  authorManager.doesAuthorExists(authorID, function(err, exists)
-  {
-    if(ERR(err, callback)) return;
+  // check that the author exists
+  let exists = await authorManager.doesAuthorExist(authorID)
+  if (!exists) {
+    throw new customError("authorID does not exist", "apierror");
+  }
 
-    if (exists == false) {
-      // group does not exist
-      callback(new customError("authorID does not exist", "apierror"));
-    } else {
-      // everything is fine, continue
-      listSessionsWithDBKey("author2sessions:" + authorID, callback);
-    }
-  });
-});
+  let sessions = await listSessionsWithDBKey("author2sessions:" + authorID);
+  return sessions;
+}
 
 // this function is basically the code listSessionsOfAuthor and listSessionsOfGroup has in common
-function listSessionsWithDBKey (dbkey, callback)
+// required to return null rather than an empty object if there are none
+async function listSessionsWithDBKey(dbkey, callback)
 {
-  var sessions;
+  // get the group2sessions entry
+  let sessionObject = await db.get(dbkey);
+  let sessions = sessionObject ? sessionObject.sessionIDs : null;
 
-  async.series([
-    function(callback)
-    {
-      // get the group2sessions entry
-      db.get(dbkey, function(err, sessionObject)
-      {
-        if(ERR(err, callback)) return;
-        sessions = sessionObject ? sessionObject.sessionIDs : null;
-        callback();
-      });
-    },
-
-    function(callback)
-    {
-      // collect all sessionIDs in an arrary
-      var sessionIDs = [];
-      for (var i in sessions)
-      {
-        sessionIDs.push(i);
+  // iterate through the sessions and get the sessioninfos
+  for (let sessionID in sessions) {
+    try {
+      let sessionInfo = await exports.getSessionInfo(sessionID);
+      sessions[sessionID] = sessionInfo;
+    } catch (err) {
+      if (err == "apierror: sessionID does not exist") {
+        console.warn(`Found bad session ${sessionID} in ${dbkey}`);
+        sessions[sessionID] = null;
+      } else {
+        throw err;
       }
-
-      // iterate through the sessions and get the sessioninfos
-      async.forEach(sessionIDs, function(sessionID, callback)
-      {
-        exports.getSessionInfo(sessionID, function(err, sessionInfo)
-        {
-          if (err == "apierror: sessionID does not exist") {
-            console.warn(`Found bad session ${sessionID} in ${dbkey}`);
-          } else if(ERR(err, callback)) {
-            return;
-          }
-
-          sessions[sessionID] = sessionInfo;
-          callback();
-        });
-      }, callback);
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
-    callback(null, sessions);
-  });
+  }
+
+  return sessions;
 }
 
 // checks if a number is an int

--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -24,7 +24,7 @@ var randomString = require("../utils/randomstring");
 var db = require("./DB").db;
 var async = require("async");
 var groupManager = require("./GroupManager");
-var authorMangager = require("./AuthorManager");
+var authorManager = require("./AuthorManager");
 
 exports.doesSessionExist = function(sessionID, callback)
 {
@@ -64,7 +64,7 @@ exports.createSession = function(groupID, authorID, validUntil, callback)
     // check if the author exists
     function(callback)
     {
-      authorMangager.doesAuthorExists(authorID, function(err, exists)
+      authorManager.doesAuthorExists(authorID, function(err, exists)
       {
         if(ERR(err, callback)) return;
 
@@ -287,7 +287,7 @@ exports.listSessionsOfGroup = function(groupID, callback)
 
 exports.listSessionsOfAuthor = function(authorID, callback)
 {
-  authorMangager.doesAuthorExists(authorID, function(err, exists)
+  authorManager.doesAuthorExists(authorID, function(err, exists)
   {
     if(ERR(err, callback)) return;
 

--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -25,8 +25,9 @@ var db = require("./DB").db;
 var async = require("async");
 var groupManager = require("./GroupManager");
 var authorManager = require("./AuthorManager");
+const thenify = require("thenify").withCallback;
 
-exports.doesSessionExist = function(sessionID, callback)
+exports.doesSessionExist = thenify(function(sessionID, callback)
 {
   //check if the database entry of this session exists
   db.get("session:" + sessionID, function (err, session)
@@ -34,12 +35,12 @@ exports.doesSessionExist = function(sessionID, callback)
     if(ERR(err, callback)) return;
     callback(null, session != null);
   });
-}
+});
 
 /**
  * Creates a new session between an author and a group
  */
-exports.createSession = function(groupID, authorID, validUntil, callback)
+exports.createSession = thenify(function(groupID, authorID, validUntil, callback)
 {
   var sessionID;
 
@@ -172,9 +173,9 @@ exports.createSession = function(groupID, authorID, validUntil, callback)
     // return error and sessionID
     callback(null, {sessionID: sessionID});
   })
-}
+});
 
-exports.getSessionInfo = function(sessionID, callback)
+exports.getSessionInfo = thenify(function(sessionID, callback)
 {
   // check if the database entry of this session exists
   db.get("session:" + sessionID, function (err, session)
@@ -189,12 +190,12 @@ exports.getSessionInfo = function(sessionID, callback)
       callback(null, session);
     }
   });
-}
+});
 
 /**
  * Deletes a session
  */
-exports.deleteSession = function(sessionID, callback)
+exports.deleteSession = thenify(function(sessionID, callback)
 {
   var authorID, groupID;
   var group2sessions, author2sessions;
@@ -267,9 +268,9 @@ exports.deleteSession = function(sessionID, callback)
     if(ERR(err, callback)) return;
     callback();
   })
-}
+});
 
-exports.listSessionsOfGroup = function(groupID, callback)
+exports.listSessionsOfGroup = thenify(function(groupID, callback)
 {
   groupManager.doesGroupExist(groupID, function(err, exists)
   {
@@ -283,9 +284,9 @@ exports.listSessionsOfGroup = function(groupID, callback)
       listSessionsWithDBKey("group2sessions:" + groupID, callback);
     }
   });
-}
+});
 
-exports.listSessionsOfAuthor = function(authorID, callback)
+exports.listSessionsOfAuthor = thenify(function(authorID, callback)
 {
   authorManager.doesAuthorExists(authorID, function(err, exists)
   {
@@ -299,7 +300,7 @@ exports.listSessionsOfAuthor = function(authorID, callback)
       listSessionsWithDBKey("author2sessions:" + authorID, callback);
     }
   });
-}
+});
 
 // this function is basically the code listSessionsOfAuthor and listSessionsOfGroup has in common
 function listSessionsWithDBKey (dbkey, callback)

--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -95,7 +95,7 @@ exports.createSession = function(groupID, authorID, validUntil, callback)
 
       // ensure this is not a negative number
       if (validUntil < 0) {
-        callback(new customError("validUntil is a negativ number", "apierror"));
+        callback(new customError("validUntil is a negative number", "apierror"));
         return;
       }
 

--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -23,7 +23,7 @@ var customError = require("../utils/customError");
 var randomString = require("../utils/randomstring");
 var db = require("./DB").db;
 var async = require("async");
-var groupMangager = require("./GroupManager");
+var groupManager = require("./GroupManager");
 var authorMangager = require("./AuthorManager");
 
 exports.doesSessionExist = function(sessionID, callback)
@@ -47,7 +47,7 @@ exports.createSession = function(groupID, authorID, validUntil, callback)
     // check if the group exists
     function(callback)
     {
-      groupMangager.doesGroupExist(groupID, function(err, exists)
+      groupManager.doesGroupExist(groupID, function(err, exists)
       {
         if(ERR(err, callback)) return;
 
@@ -271,7 +271,7 @@ exports.deleteSession = function(sessionID, callback)
 
 exports.listSessionsOfGroup = function(groupID, callback)
 {
-  groupMangager.doesGroupExist(groupID, function(err, exists)
+  groupManager.doesGroupExist(groupID, function(err, exists)
   {
     if(ERR(err, callback)) return;
 

--- a/src/node/db/SessionStore.js
+++ b/src/node/db/SessionStore.js
@@ -1,4 +1,4 @@
- /* 
+/*
  * Stores session data in the database
  * Source; https://github.com/edy-b/SciFlowWriter/blob/develop/available_plugins/ep_sciflowwriter/db/DirtyStore.js
  * This is not used for authors that are created via the API at current
@@ -13,11 +13,12 @@ var SessionStore = module.exports = function SessionStore() {};
 
 SessionStore.prototype.__proto__ = Store.prototype;
 
-SessionStore.prototype.get = function(sid, fn){
+SessionStore.prototype.get = function(sid, fn) {
   messageLogger.debug('GET ' + sid);
+
   var self = this;
-  db.get("sessionstorage:" + sid, function (err, sess)
-  {
+
+  db.get("sessionstorage:" + sid, function(err, sess) {
     if (sess) {
       sess.cookie.expires = 'string' == typeof sess.cookie.expires ? new Date(sess.cookie.expires) : sess.cookie.expires;
       if (!sess.cookie.expires || new Date() < sess.cookie.expires) {
@@ -31,26 +32,30 @@ SessionStore.prototype.get = function(sid, fn){
   });
 };
 
-SessionStore.prototype.set = function(sid, sess, fn){
+SessionStore.prototype.set = function(sid, sess, fn) {
   messageLogger.debug('SET ' + sid);
+
   db.set("sessionstorage:" + sid, sess);
-  process.nextTick(function(){
-    if(fn) fn();
+  process.nextTick(function() {
+    if (fn) fn();
   });
 };
 
-SessionStore.prototype.destroy = function(sid, fn){
+SessionStore.prototype.destroy = function(sid, fn) {
   messageLogger.debug('DESTROY ' + sid);
+
   db.remove("sessionstorage:" + sid);
-  process.nextTick(function(){
-    if(fn) fn();
+  process.nextTick(function() {
+    if (fn) fn();
   });
 };
 
-SessionStore.prototype.all = function(fn){
+SessionStore.prototype.all = function(fn) {
   messageLogger.debug('ALL');
+
   var sessions = [];
-  db.forEach(function(key, value){
+
+  db.forEach(function(key, value) {
     if (key.substr(0,15) === "sessionstorage:") {
       sessions.push(value);
     }
@@ -58,20 +63,23 @@ SessionStore.prototype.all = function(fn){
   fn(null, sessions);
 };
 
-SessionStore.prototype.clear = function(fn){
+SessionStore.prototype.clear = function(fn) {
   messageLogger.debug('CLEAR');
-  db.forEach(function(key, value){
+
+  db.forEach(function(key, value) {
     if (key.substr(0,15) === "sessionstorage:") {
       db.db.remove("session:" + key);
     }
   });
-  if(fn) fn();
+  if (fn) fn();
 };
 
-SessionStore.prototype.length = function(fn){
+SessionStore.prototype.length = function(fn) {
   messageLogger.debug('LENGTH');
+
   var i = 0;
-  db.forEach(function(key, value){
+
+  db.forEach(function(key, value) {
     if (key.substr(0,15) === "sessionstorage:") {
       i++;
     }

--- a/src/node/db/SessionStore.js
+++ b/src/node/db/SessionStore.js
@@ -36,18 +36,18 @@ SessionStore.prototype.set = function(sid, sess, fn) {
   messageLogger.debug('SET ' + sid);
 
   db.set("sessionstorage:" + sid, sess);
-  process.nextTick(function() {
-    if (fn) fn();
-  });
+  if (fn) {
+    process.nextTick(fn);
+  }
 };
 
 SessionStore.prototype.destroy = function(sid, fn) {
   messageLogger.debug('DESTROY ' + sid);
 
   db.remove("sessionstorage:" + sid);
-  process.nextTick(function() {
-    if (fn) fn();
-  });
+  if (fn) {
+    process.nextTick(fn);
+  }
 };
 
 SessionStore.prototype.all = function(fn) {

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -188,7 +188,7 @@ exports.handle = function(apiVersion, functionName, fields, req, res)
   // check the api key!
   fields["apikey"] = fields["apikey"] || fields["api_key"];
 
-  if (fields["apikey"] != apikey.trim()) {
+  if (fields["apikey"] !== apikey.trim()) {
     res.statusCode = 401;
     res.send({code: 4, message: "no or wrong API Key", data: null});
     return;

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -19,18 +19,20 @@
  * limitations under the License.
  */
 
-var ERR = require("async-stacktrace");
 var exporthtml = require("../utils/ExportHtml");
 var exporttxt = require("../utils/ExportTxt");
 var exportEtherpad = require("../utils/ExportEtherpad");
-var async = require("async");
 var fs = require("fs");
 var settings = require('../utils/Settings');
 var os = require('os');
 var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");
 var TidyHtml = require('../utils/TidyHtml');
+const util = require("util");
 
-var convertor = null;
+const fsp_writeFile = util.promisify(fs.writeFile);
+const fsp_unlink = util.promisify(fs.unlink);
+
+let convertor = null;
 
 // load abiword only if it is enabled
 if (settings.abiword != null) {
@@ -47,122 +49,92 @@ const tempDirectory = os.tmpdir();
 /**
  * do a requested export
  */
-exports.doExport = function(req, res, padId, type)
+async function doExport(req, res, padId, type)
 {
   var fileName = padId;
 
   // allow fileName to be overwritten by a hook, the type type is kept static for security reasons
-  hooks.aCallFirst("exportFileName", padId,
-    function(err, hookFileName){
-      // if fileName is set then set it to the padId, note that fileName is returned as an array.
-      if (hookFileName.length) {
-       fileName = hookFileName;
-      }
+  let hookFileName = await hooks.aCallFirst("exportFileName", padId);
 
-      // tell the browser that this is a downloadable file
-      res.attachment(fileName + "." + type);
+  // if fileName is set then set it to the padId, note that fileName is returned as an array.
+  if (hookFileName.length) {
+    fileName = hookFileName;
+  }
 
-      // if this is a plain text export, we can do this directly
-      // We have to over engineer this because tabs are stored as attributes and not plain text
-      if (type == "etherpad") {
-        exportEtherpad.getPadRaw(padId, function(err, pad) {
-          if (!err) {
-            res.send(pad);
-            // return;
-          }
-        });
-      } else if (type == "txt") {
-        exporttxt.getPadTXTDocument(padId, req.params.rev, function(err, txt) {
-          if (!err) {
-            res.send(txt);
-          }
-        });
-      } else {
-        var html;
-        var randNum;
-        var srcFile, destFile;
+  // tell the browser that this is a downloadable file
+  res.attachment(fileName + "." + type);
 
-        async.series([
-          // render the html document
-          function(callback) {
-            exporthtml.getPadHTMLDocument(padId, req.params.rev, function(err, _html) {
-              if (ERR(err, callback)) return;
-              html = _html;
-              callback();
-            });
-          },
+  // if this is a plain text export, we can do this directly
+  // We have to over engineer this because tabs are stored as attributes and not plain text
+  if (type === "etherpad") {
+    let pad = await exportEtherpad.getPadRaw(padId);
+    res.send(pad);
+  } else if (type === "txt") {
+    let txt = await exporttxt.getPadTXTDocument(padId, req.params.rev);
+    res.send(txt);
+  } else {
+    // render the html document
+    let html = await exporthtml.getPadHTMLDocument(padId, req.params.rev);
 
-          // decide what to do with the html export
-          function(callback) {
-            // if this is a html export, we can send this from here directly
-            if (type == "html") {
-              // do any final changes the plugin might want to make
-              hooks.aCallFirst("exportHTMLSend", html, function(err, newHTML) {
-                if (newHTML.length) html = newHTML;
-                res.send(html);
-                callback("stop");
-              });
-            } else {
-              // write the html export to a file
-              randNum = Math.floor(Math.random()*0xFFFFFFFF);
-              srcFile = tempDirectory + "/etherpad_export_" + randNum + ".html";
-              fs.writeFile(srcFile, html, callback);
-            }
-          },
+    // decide what to do with the html export
 
-          // Tidy up the exported HTML
-          function(callback) {
-            // ensure html can be collected by the garbage collector
-            html = null;
-
-            TidyHtml.tidy(srcFile, callback);
-          },
-
-          // send the convert job to the convertor (abiword, libreoffice, ..)
-          function(callback) {
-            destFile = tempDirectory + "/etherpad_export_" + randNum + "." + type;
-
-            // Allow plugins to overwrite the convert in export process
-            hooks.aCallAll("exportConvert", { srcFile: srcFile, destFile: destFile, req: req, res: res }, function(err, result) {
-              if (!err && result.length > 0) {
-                // console.log("export handled by plugin", destFile);
-                handledByPlugin = true;
-                callback();
-              } else {
-                convertor.convertFile(srcFile, destFile, type, callback);
-              }
-            });
-
-          },
-
-          // send the file
-          function(callback) {
-            res.sendFile(destFile, null, callback);
-          },
-
-          // clean up temporary files
-          function(callback) {
-            async.parallel([
-              function(callback) {
-                fs.unlink(srcFile, callback);
-              },
-              function(callback) {
-                // 100ms delay to accommodate for slow windows fs
-                if (os.type().indexOf("Windows") > -1) {
-                  setTimeout(function() {
-                    fs.unlink(destFile, callback);
-                  }, 100);
-                } else {
-                  fs.unlink(destFile, callback);
-                }
-              }
-            ], callback);
-          }
-        ],
-        function(err) {
-          if (err && err != "stop") ERR(err);
-        })
-      }
+    // if this is a html export, we can send this from here directly
+    if (type === "html") {
+      // do any final changes the plugin might want to make
+      let newHTML = await hooks.aCallFirst("exportHTMLSend", html);
+      if (newHTML.length) html = newHTML;
+      res.send(html);
+      throw "stop";
     }
-  );
-};
+
+    // else write the html export to a file
+    let randNum = Math.floor(Math.random()*0xFFFFFFFF);
+    let srcFile = tempDirectory + "/etherpad_export_" + randNum + ".html";
+    await fsp_writeFile(srcFile, html);
+
+    // Tidy up the exported HTML
+    // ensure html can be collected by the garbage collector
+    html = null;
+    await TidyHtml.tidy(srcFile);
+
+    // send the convert job to the convertor (abiword, libreoffice, ..)
+    let destFile = tempDirectory + "/etherpad_export_" + randNum + "." + type;
+
+    // Allow plugins to overwrite the convert in export process
+    let result = await hooks.aCallAll("exportConvert", { srcFile, destFile, req, res });
+    if (result.length > 0) {
+      // console.log("export handled by plugin", destFile);
+      handledByPlugin = true;
+    } else {
+      // @TODO no Promise interface for convertors (yet)
+      await new Promise((resolve, reject) => {
+        convertor.convertFile(srcFile, destFile, type, function(err) {
+          err ?  reject("convertFailed") : resolve();
+        });
+      });
+    }
+
+    // send the file
+    let sendFile = util.promisify(res.sendFile);
+    await res.sendFile(destFile, null);
+
+    // clean up temporary files
+    await fsp_unlink(srcFile);
+
+    // 100ms delay to accommodate for slow windows fs
+    if (os.type().indexOf("Windows") > -1) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
+    await fsp_unlink(destFile);
+  }
+}
+
+exports.doExport = function(req, res, padId, type)
+{
+  doExport(req, res, padId, type).catch(err => {
+    if (err !== "stop") {
+      throw err;
+    }
+  });
+}

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -151,7 +151,7 @@ exports.doImport = function(req, res, padId)
       padManager.getPad(padId, function(err, _pad) {
         var headCount = _pad.head;
         if (headCount >= 10) {
-          apiLogger.warn("Direct database Import attempt of a pad that already has content, we wont be doing this");
+          apiLogger.warn("Direct database Import attempt of a pad that already has content, we won't be doing this");
           return callback("padHasData");
         }
 

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -37,29 +37,30 @@ var ERR = require("async-stacktrace")
 var convertor = null;
 var exportExtension = "htm";
 
-//load abiword only if its enabled and if soffice is disabled
-if(settings.abiword != null && settings.soffice === null)
+// load abiword only if it is enabled and if soffice is disabled
+if (settings.abiword != null && settings.soffice === null) {
   convertor = require("../utils/Abiword");
+}
 
-//load soffice only if its enabled
-if(settings.soffice != null) {
+// load soffice only if it is enabled
+if (settings.soffice != null) {
   convertor = require("../utils/LibreOffice");
   exportExtension = "html";
 }
 
 const tmpDirectory = os.tmpdir();
-  
+
 /**
  * do a requested import
- */ 
+ */
 exports.doImport = function(req, res, padId)
 {
   var apiLogger = log4js.getLogger("ImportHandler");
 
-  //pipe to a file
-  //convert file to html via abiword or soffice
-  //set html in the pad
-  
+  // pipe to a file
+  // convert file to html via abiword or soffice
+  // set html in the pad
+
   var srcFile, destFile
     , pad
     , text
@@ -68,69 +69,74 @@ exports.doImport = function(req, res, padId)
     , useConvertor;
 
   var randNum = Math.floor(Math.random()*0xFFFFFFFF);
-  
+
   // setting flag for whether to use convertor or not
   useConvertor = (convertor != null);
 
   async.series([
-    //save the uploaded file to /tmp
+    // save the uploaded file to /tmp
     function(callback) {
       var form = new formidable.IncomingForm();
       form.keepExtensions = true;
       form.uploadDir = tmpDirectory;
-      
-      form.parse(req, function(err, fields, files) { 
-        //the upload failed, stop at this point
-        if(err || files.file === undefined) {
-          if(err) console.warn("Uploading Error: " + err.stack);
+
+      form.parse(req, function(err, fields, files) {
+        if (err || files.file === undefined) {
+          // the upload failed, stop at this point
+          if (err) {
+            console.warn("Uploading Error: " + err.stack);
+          }
           callback("uploadFailed");
 
           return;
         }
 
-        //everything ok, continue
-        //save the path of the uploaded file
+        // everything ok, continue
+        // save the path of the uploaded file
         srcFile = files.file.path;
         callback();
       });
     },
-    
-    //ensure this is a file ending we know, else we change the file ending to .txt
-    //this allows us to accept source code files like .c or .java
+
+    // ensure this is a file ending we know, else we change the file ending to .txt
+    // this allows us to accept source code files like .c or .java
     function(callback) {
       var fileEnding = path.extname(srcFile).toLowerCase()
         , knownFileEndings = [".txt", ".doc", ".docx", ".pdf", ".odt", ".html", ".htm", ".etherpad", ".rtf"]
         , fileEndingKnown = (knownFileEndings.indexOf(fileEnding) > -1);
-      
-      //if the file ending is known, continue as normal
-      if(fileEndingKnown) {
+
+      // if the file ending is known, continue as normal
+      if (fileEndingKnown) {
         callback();
-        
+
         return;
       }
 
-      //we need to rename this file with a .txt ending
-      if(settings.allowUnknownFileEnds === true){
+      // we need to rename this file with a .txt ending
+      if (settings.allowUnknownFileEnds === true) {
         var oldSrcFile = srcFile;
-        srcFile = path.join(path.dirname(srcFile),path.basename(srcFile, fileEnding)+".txt");
+        srcFile = path.join(path.dirname(srcFile), path.basename(srcFile, fileEnding) + ".txt");
         fs.rename(oldSrcFile, srcFile, callback);
-      }else{
+      } else {
         console.warn("Not allowing unknown file type to be imported", fileEnding);
         callback("uploadFailed");
       }
     },
-    function(callback){
+
+    function(callback) {
       destFile = path.join(tmpDirectory, "etherpad_import_" + randNum + "." + exportExtension);
 
       // Logic for allowing external Import Plugins
-      hooks.aCallAll("import", {srcFile: srcFile, destFile: destFile}, function(err, result){
-        if(ERR(err, callback)) return callback();
-        if(result.length > 0){ // This feels hacky and wrong..
+      hooks.aCallAll("import", { srcFile: srcFile, destFile: destFile }, function(err, result) {
+        if (ERR(err, callback)) return callback();
+
+        if (result.length > 0) { // This feels hacky and wrong..
           importHandledByPlugin = true;
         }
         callback();
       });
     },
+
     function(callback) {
       var fileEnding = path.extname(srcFile).toLowerCase()
       var fileIsNotEtherpad = (fileEnding !== ".etherpad");
@@ -141,23 +147,24 @@ exports.doImport = function(req, res, padId)
         return;
       }
 
-      // we do this here so we can see if the pad has quit ea few edits
-      padManager.getPad(padId, function(err, _pad){
+      // we do this here so we can see if the pad has quite a few edits
+      padManager.getPad(padId, function(err, _pad) {
         var headCount = _pad.head;
-        if(headCount >= 10){
-          apiLogger.warn("Direct database Import attempt of a pad that already has content, we wont be doing this")
+        if (headCount >= 10) {
+          apiLogger.warn("Direct database Import attempt of a pad that already has content, we wont be doing this");
           return callback("padHasData");
         }
 
-        fs.readFile(srcFile, "utf8", function(err, _text){
+        fs.readFile(srcFile, "utf8", function(err, _text) {
           directDatabaseAccess = true;
-          importEtherpad.setPadRaw(padId, _text, function(err){
+          importEtherpad.setPadRaw(padId, _text, function(err) {
             callback();
           });
         });
       });
     },
-    //convert file to html
+
+    // convert file to html if necessary
     function(callback) {
       if (importHandledByPlugin || directDatabaseAccess) {
         callback();
@@ -168,18 +175,20 @@ exports.doImport = function(req, res, padId)
       var fileEnding = path.extname(srcFile).toLowerCase();
       var fileIsHTML = (fileEnding === ".html" || fileEnding === ".htm");
       var fileIsTXT = (fileEnding === ".txt");
+
       if (fileIsTXT) useConvertor = false; // Don't use convertor for text files
+
       // See https://github.com/ether/etherpad-lite/issues/2572
       if (fileIsHTML || (useConvertor === false)) {
         // if no convertor only rename
         fs.rename(srcFile, destFile, callback);
-        
+
         return;
       }
 
       convertor.convertFile(srcFile, destFile, exportExtension, function(err) {
-        //catch convert errors
-        if(err) {
+        // catch convert errors
+        if (err) {
           console.warn("Converting Error:", err);
           return callback("convertFailed");
         }
@@ -187,7 +196,7 @@ exports.doImport = function(req, res, padId)
         callback();
       });
     },
-    
+
     function(callback) {
       if (useConvertor || directDatabaseAccess) {
         callback();
@@ -216,17 +225,17 @@ exports.doImport = function(req, res, padId)
         callback();
       });
     },
-        
-    //get the pad object
+
+    // get the pad object
     function(callback) {
-      padManager.getPad(padId, function(err, _pad){
-        if(ERR(err, callback)) return;
+      padManager.getPad(padId, function(err, _pad) {
+        if (ERR(err, callback)) return;
         pad = _pad;
         callback();
       });
     },
-    
-    //read the text
+
+    // read the text
     function(callback) {
       if (directDatabaseAccess) {
         callback();
@@ -234,43 +243,46 @@ exports.doImport = function(req, res, padId)
         return;
       }
 
-      fs.readFile(destFile, "utf8", function(err, _text){
-        if(ERR(err, callback)) return;
+      fs.readFile(destFile, "utf8", function(err, _text) {
+        if (ERR(err, callback)) return;
         text = _text;
         // Title needs to be stripped out else it appends it to the pad..
         text = text.replace("<title>", "<!-- <title>");
         text = text.replace("</title>","</title>-->");
 
-        //node on windows has a delay on releasing of the file lock.  
-        //We add a 100ms delay to work around this
-        if(os.type().indexOf("Windows") > -1){
+        // node on windows has a delay on releasing of the file lock.
+        // We add a 100ms delay to work around this
+        if (os.type().indexOf("Windows") > -1) {
            setTimeout(function() {callback();}, 100);
         } else {
           callback();
         }
       });
     },
-    
-    //change text of the pad and broadcast the changeset
+
+    // change text of the pad and broadcast the changeset
     function(callback) {
-      if(!directDatabaseAccess){
+      if (!directDatabaseAccess) {
         var fileEnding = path.extname(srcFile).toLowerCase();
         if (importHandledByPlugin || useConvertor || fileEnding == ".htm" || fileEnding == ".html") {
           importHtml.setPadHTML(pad, text, function(e){
-            if(e) apiLogger.warn("Error importing, possibly caused by malformed HTML");
+            if (e) {
+              apiLogger.warn("Error importing, possibly caused by malformed HTML");
+            }
           });
         } else {
           pad.setText(text);
         }
       }
 
-      // Load the Pad into memory then brodcast updates to all clients
+      // Load the Pad into memory then broadcast updates to all clients
       padManager.unloadPad(padId);
-      padManager.getPad(padId, function(err, _pad){
+      padManager.getPad(padId, function(err, _pad) {
         var pad = _pad;
         padManager.unloadPad(padId);
+
         // direct Database Access means a pad user should perform a switchToPad
-        // and not attempt to recieve updated pad data..
+        // and not attempt to receive updated pad data
         if (directDatabaseAccess) {
           callback();
 
@@ -283,8 +295,8 @@ exports.doImport = function(req, res, padId)
       });
 
     },
-    
-    //clean up temporary files
+
+    // clean up temporary files
     function(callback) {
       if (directDatabaseAccess) {
         callback();
@@ -308,17 +320,16 @@ exports.doImport = function(req, res, padId)
     }
   ], function(err) {
     var status = "ok";
-    
-    //check for known errors and replace the status
-    if(err == "uploadFailed" || err == "convertFailed" || err == "padHasData")
-    {
+
+    // check for known errors and replace the status
+    if (err == "uploadFailed" || err == "convertFailed" || err == "padHasData") {
       status = err;
       err = null;
     }
 
     ERR(err);
 
-    //close the connection
+    // close the connection
     res.send(
       "<head> \
         <script type='text/javascript' src='../../static/js/jquery.js'></script> \
@@ -331,4 +342,3 @@ exports.doImport = function(req, res, padId)
     );
   });
 }
-

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -20,10 +20,8 @@
  * limitations under the License.
  */
 
-var ERR = require("async-stacktrace")
-  , padManager = require("../db/PadManager")
+var padManager = require("../db/PadManager")
   , padMessageHandler = require("./PadMessageHandler")
-  , async = require("async")
   , fs = require("fs")
   , path = require("path")
   , settings = require('../utils/Settings')
@@ -32,10 +30,16 @@ var ERR = require("async-stacktrace")
   , importHtml = require("../utils/ImportHtml")
   , importEtherpad = require("../utils/ImportEtherpad")
   , log4js = require("log4js")
-  , hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks.js");
+  , hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks.js")
+  , util = require("util");
 
-var convertor = null;
-var exportExtension = "htm";
+let fsp_exists = util.promisify(fs.exists);
+let fsp_rename = util.promisify(fs.rename);
+let fsp_readFile = util.promisify(fs.readFile);
+let fsp_unlink = util.promisify(fs.unlink)
+
+let convertor = null;
+let exportExtension = "htm";
 
 // load abiword only if it is enabled and if soffice is disabled
 if (settings.abiword != null && settings.soffice === null) {
@@ -53,292 +57,213 @@ const tmpDirectory = os.tmpdir();
 /**
  * do a requested import
  */
-exports.doImport = function(req, res, padId)
+async function doImport(req, res, padId)
 {
   var apiLogger = log4js.getLogger("ImportHandler");
 
   // pipe to a file
   // convert file to html via abiword or soffice
   // set html in the pad
-
-  var srcFile, destFile
-    , pad
-    , text
-    , importHandledByPlugin
-    , directDatabaseAccess
-    , useConvertor;
-
   var randNum = Math.floor(Math.random()*0xFFFFFFFF);
 
   // setting flag for whether to use convertor or not
-  useConvertor = (convertor != null);
+  let useConvertor = (convertor != null);
 
-  async.series([
-    // save the uploaded file to /tmp
-    function(callback) {
-      var form = new formidable.IncomingForm();
-      form.keepExtensions = true;
-      form.uploadDir = tmpDirectory;
+  let form = new formidable.IncomingForm();
+  form.keepExtensions = true;
+  form.uploadDir = tmpDirectory;
 
-      form.parse(req, function(err, fields, files) {
-        if (err || files.file === undefined) {
-          // the upload failed, stop at this point
-          if (err) {
-            console.warn("Uploading Error: " + err.stack);
-          }
-          callback("uploadFailed");
-
-          return;
+  // locally wrapped Promise, since form.parse requires a callback
+  let srcFile = await new Promise((resolve, reject) => {
+    form.parse(req, function(err, fields, files) {
+      if (err || files.file === undefined) {
+        // the upload failed, stop at this point
+        if (err) {
+          console.warn("Uploading Error: " + err.stack);
         }
-
-        // everything ok, continue
-        // save the path of the uploaded file
-        srcFile = files.file.path;
-        callback();
-      });
-    },
-
-    // ensure this is a file ending we know, else we change the file ending to .txt
-    // this allows us to accept source code files like .c or .java
-    function(callback) {
-      var fileEnding = path.extname(srcFile).toLowerCase()
-        , knownFileEndings = [".txt", ".doc", ".docx", ".pdf", ".odt", ".html", ".htm", ".etherpad", ".rtf"]
-        , fileEndingKnown = (knownFileEndings.indexOf(fileEnding) > -1);
-
-      // if the file ending is known, continue as normal
-      if (fileEndingKnown) {
-        callback();
-
-        return;
+        reject("uploadFailed");
       }
+      resolve(files.file.path);
+    });
+  });
 
+  // ensure this is a file ending we know, else we change the file ending to .txt
+  // this allows us to accept source code files like .c or .java
+  let fileEnding = path.extname(srcFile).toLowerCase()
+    , knownFileEndings = [".txt", ".doc", ".docx", ".pdf", ".odt", ".html", ".htm", ".etherpad", ".rtf"]
+    , fileEndingUnknown = (knownFileEndings.indexOf(fileEnding) < 0);
+
+  if (fileEndingUnknown) {
+    // the file ending is not known
+
+    if (settings.allowUnknownFileEnds === true) {
       // we need to rename this file with a .txt ending
-      if (settings.allowUnknownFileEnds === true) {
-        var oldSrcFile = srcFile;
-        srcFile = path.join(path.dirname(srcFile), path.basename(srcFile, fileEnding) + ".txt");
-        fs.rename(oldSrcFile, srcFile, callback);
-      } else {
-        console.warn("Not allowing unknown file type to be imported", fileEnding);
-        callback("uploadFailed");
-      }
-    },
+      let oldSrcFile = srcFile;
 
-    function(callback) {
-      destFile = path.join(tmpDirectory, "etherpad_import_" + randNum + "." + exportExtension);
+      srcFile = path.join(path.dirname(srcFile), path.basename(srcFile, fileEnding) + ".txt");
+      await fs.rename(oldSrcFile, srcFile);
+    } else {
+      console.warn("Not allowing unknown file type to be imported", fileEnding);
+      throw "uploadFailed";
+    }
+  }
 
-      // Logic for allowing external Import Plugins
-      hooks.aCallAll("import", { srcFile: srcFile, destFile: destFile }, function(err, result) {
-        if (ERR(err, callback)) return callback();
+  let destFile = path.join(tmpDirectory, "etherpad_import_" + randNum + "." + exportExtension);
 
-        if (result.length > 0) { // This feels hacky and wrong..
-          importHandledByPlugin = true;
-        }
-        callback();
-      });
-    },
+  // Logic for allowing external Import Plugins
+  let result = await hooks.aCallAll("import", { srcFile, destFile });
+  let importHandledByPlugin = (result.length > 0);  // This feels hacky and wrong..
 
-    function(callback) {
-      var fileEnding = path.extname(srcFile).toLowerCase()
-      var fileIsNotEtherpad = (fileEnding !== ".etherpad");
+  let fileIsEtherpad = (fileEnding === ".etherpad");
+  let fileIsHTML = (fileEnding === ".html" || fileEnding === ".htm");
+  let fileIsTXT = (fileEnding === ".txt");
 
-      if (fileIsNotEtherpad) {
-        callback();
+  let directDatabaseAccess = false;
 
-        return;
-      }
+  if (fileIsEtherpad) {
+    // we do this here so we can see if the pad has quite a few edits
+    let _pad = await padManager.getPad(padId);
+    let headCount = _pad.head;
 
-      // we do this here so we can see if the pad has quite a few edits
-      padManager.getPad(padId, function(err, _pad) {
-        var headCount = _pad.head;
-        if (headCount >= 10) {
-          apiLogger.warn("Direct database Import attempt of a pad that already has content, we won't be doing this");
-          return callback("padHasData");
-        }
+    if (headCount >= 10) {
+      apiLogger.warn("Direct database Import attempt of a pad that already has content, we won't be doing this");
+      throw "padHasData";
+    }
 
-        fs.readFile(srcFile, "utf8", function(err, _text) {
-          directDatabaseAccess = true;
-          importEtherpad.setPadRaw(padId, _text, function(err) {
-            callback();
-          });
+    const fsp_readFile = util.promisify(fs.readFile);
+    let _text = await fsp_readFile(srcFile, "utf8");
+    directDatabaseAccess = true;
+    await importEtherpad.setPadRaw(padId, _text);
+  }
+
+  // convert file to html if necessary
+  if (!importHandledByPlugin && !directDatabaseAccess) {
+    if (fileIsTXT) {
+      // Don't use convertor for text files
+      useConvertor = false;
+    }
+
+    // See https://github.com/ether/etherpad-lite/issues/2572
+    if (fileIsHTML || !useConvertor) {
+      // if no convertor only rename
+      fs.renameSync(srcFile, destFile);
+    } else {
+      // @TODO - no Promise interface for convertors (yet)
+      await new Promise((resolve, reject) => {
+        convertor.convertFile(srcFile, destFile, exportExtension, function(err) {
+          // catch convert errors
+          if (err) {
+            console.warn("Converting Error:", err);
+            reject("convertFailed");
+          }
+          resolve();
         });
       });
-    },
-
-    // convert file to html if necessary
-    function(callback) {
-      if (importHandledByPlugin || directDatabaseAccess) {
-        callback();
-
-        return;
-      }
-
-      var fileEnding = path.extname(srcFile).toLowerCase();
-      var fileIsHTML = (fileEnding === ".html" || fileEnding === ".htm");
-      var fileIsTXT = (fileEnding === ".txt");
-
-      if (fileIsTXT) useConvertor = false; // Don't use convertor for text files
-
-      // See https://github.com/ether/etherpad-lite/issues/2572
-      if (fileIsHTML || (useConvertor === false)) {
-        // if no convertor only rename
-        fs.rename(srcFile, destFile, callback);
-
-        return;
-      }
-
-      convertor.convertFile(srcFile, destFile, exportExtension, function(err) {
-        // catch convert errors
-        if (err) {
-          console.warn("Converting Error:", err);
-          return callback("convertFailed");
-        }
-
-        callback();
-      });
-    },
-
-    function(callback) {
-      if (useConvertor || directDatabaseAccess) {
-        callback();
-
-        return;
-      }
-
-      // Read the file with no encoding for raw buffer access.
-      fs.readFile(destFile, function(err, buf) {
-        if (err) throw err;
-        var isAscii = true;
-        // Check if there are only ascii chars in the uploaded file
-        for (var i=0, len=buf.length; i<len; i++) {
-          if (buf[i] > 240) {
-            isAscii=false;
-            break;
-          }
-        }
-
-        if (!isAscii) {
-          callback("uploadFailed");
-
-          return;
-        }
-
-        callback();
-      });
-    },
-
-    // get the pad object
-    function(callback) {
-      padManager.getPad(padId, function(err, _pad) {
-        if (ERR(err, callback)) return;
-        pad = _pad;
-        callback();
-      });
-    },
-
-    // read the text
-    function(callback) {
-      if (directDatabaseAccess) {
-        callback();
-
-        return;
-      }
-
-      fs.readFile(destFile, "utf8", function(err, _text) {
-        if (ERR(err, callback)) return;
-        text = _text;
-        // Title needs to be stripped out else it appends it to the pad..
-        text = text.replace("<title>", "<!-- <title>");
-        text = text.replace("</title>","</title>-->");
-
-        // node on windows has a delay on releasing of the file lock.
-        // We add a 100ms delay to work around this
-        if (os.type().indexOf("Windows") > -1) {
-           setTimeout(function() {callback();}, 100);
-        } else {
-          callback();
-        }
-      });
-    },
-
-    // change text of the pad and broadcast the changeset
-    function(callback) {
-      if (!directDatabaseAccess) {
-        var fileEnding = path.extname(srcFile).toLowerCase();
-        if (importHandledByPlugin || useConvertor || fileEnding == ".htm" || fileEnding == ".html") {
-          importHtml.setPadHTML(pad, text, function(e){
-            if (e) {
-              apiLogger.warn("Error importing, possibly caused by malformed HTML");
-            }
-          });
-        } else {
-          pad.setText(text);
-        }
-      }
-
-      // Load the Pad into memory then broadcast updates to all clients
-      padManager.unloadPad(padId);
-      padManager.getPad(padId, function(err, _pad) {
-        var pad = _pad;
-        padManager.unloadPad(padId);
-
-        // direct Database Access means a pad user should perform a switchToPad
-        // and not attempt to receive updated pad data
-        if (directDatabaseAccess) {
-          callback();
-
-          return;
-        }
-
-        // @TODO: not waiting for updatePadClients to finish
-        padMessageHandler.updatePadClients(pad);
-        callback();
-      });
-
-    },
-
-    // clean up temporary files
-    function(callback) {
-      if (directDatabaseAccess) {
-        callback();
-
-        return;
-      }
-
-      try {
-         fs.unlinkSync(srcFile);
-      } catch (e) {
-         console.log(e);
-      }
-
-      try {
-         fs.unlinkSync(destFile);
-      } catch (e) {
-         console.log(e);
-      }
-
-      callback();
     }
-  ], function(err) {
-    var status = "ok";
+  }
 
+  if (!useConvertor && !directDatabaseAccess) {
+    // Read the file with no encoding for raw buffer access.
+    let buf = await fsp_readFile(destFile);
+
+    // Check if there are only ascii chars in the uploaded file
+    let isAscii = ! Array.prototype.some.call(buf, c => (c > 240));
+
+    if (!isAscii) {
+      throw "uploadFailed";
+    }
+  }
+
+  // get the pad object
+  let pad = await padManager.getPad(padId);
+
+  // read the text
+  let text;
+
+  if (!directDatabaseAccess) {
+    text = await fsp_readFile(destFile, "utf8");
+
+    // Title needs to be stripped out else it appends it to the pad..
+    text = text.replace("<title>", "<!-- <title>");
+    text = text.replace("</title>","</title>-->");
+
+    // node on windows has a delay on releasing of the file lock.
+    // We add a 100ms delay to work around this
+    if (os.type().indexOf("Windows") > -1){
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+
+  // change text of the pad and broadcast the changeset
+  if (!directDatabaseAccess) {
+    if (importHandledByPlugin || useConvertor || fileIsHTML) {
+      try {
+        importHtml.setPadHTML(pad, text);
+      } catch (e) {
+        apiLogger.warn("Error importing, possibly caused by malformed HTML");
+      }
+    } else {
+      pad.setText(text);
+    }
+  }
+
+  // Load the Pad into memory then broadcast updates to all clients
+  padManager.unloadPad(padId);
+  pad = await padManager.getPad(padId);
+  padManager.unloadPad(padId);
+
+  // direct Database Access means a pad user should perform a switchToPad
+  // and not attempt to receive updated pad data
+  if (!directDatabaseAccess) {
+    // tell clients to update
+    await padMessageHandler.updatePadClients(pad);
+  }
+
+  if (!directDatabaseAccess) {
+    // clean up temporary files
+
+    /*
+     * TODO: directly delete the file and handle the eventual error. Checking
+     * before for existence is prone to race conditions, and does not handle any
+     * errors anyway.
+     */
+    if (await fsp_exists(srcFile)) {
+      fsp_unlink(srcFile);
+    }
+
+    if (await fsp_exists(destFile)) {
+      fsp_unlink(destFile);
+    }
+  }
+
+  return directDatabaseAccess;
+}
+
+exports.doImport = function (req, res, padId)
+{
+  let status = "ok";
+  let directDatabaseAccess;
+
+  doImport(req, res, padId).then(result => {
+    directDatabaseAccess = result;
+  }).catch(err => {
     // check for known errors and replace the status
     if (err == "uploadFailed" || err == "convertFailed" || err == "padHasData") {
       status = err;
-      err = null;
+    } else {
+      throw err;
     }
-
-    ERR(err);
-
-    // close the connection
-    res.send(
-      "<head> \
-        <script type='text/javascript' src='../../static/js/jquery.js'></script> \
-      </head> \
-      <script> \
-        $(window).load(function(){ \
-          var impexp = window.parent.padimpexp.handleFrameCall('" + directDatabaseAccess +"', '" + status + "'); \
-        }) \
-      </script>"
-    );
   });
+
+  // close the connection
+  res.send(
+    "<head> \
+      <script type='text/javascript' src='../../static/js/jquery.js'></script> \
+    </head> \
+    <script> \
+      $(window).load(function(){ \
+        var impexp = window.parent.padimpexp.handleFrameCall('" + directDatabaseAccess +"', '" + status + "'); \
+      }) \
+    </script>"
+  );
 }

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -289,9 +289,9 @@ exports.doImport = function(req, res, padId)
           return;
         }
 
-        padMessageHandler.updatePadClients(pad, function(){
-          callback();
-        });
+        // @TODO: not waiting for updatePadClients to finish
+        padMessageHandler.updatePadClients(pad);
+        callback();
       });
 
     },

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -457,7 +457,7 @@ function handleGetChatMessages(client, message)
   var count = end - start;
 
   if (count < 0 || count > 100) {
-    messageLogger.warn("Dropped message, GetChatMessages Message, client requested invalid amout of messages!");
+    messageLogger.warn("Dropped message, GetChatMessages Message, client requested invalid amount of messages!");
     return;
   }
 

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -19,8 +19,6 @@
  */
 
 
-var ERR = require("async-stacktrace");
-var async = require("async");
 var padManager = require("../db/PadManager");
 var Changeset = require("ep_etherpad-lite/static/js/Changeset");
 var AttributePool = require("ep_etherpad-lite/static/js/AttributePool");
@@ -38,7 +36,6 @@ var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks.js");
 var channels = require("channels");
 var stats = require('../stats');
 var remoteAddress = require("../utils/RemoteAddress").remoteAddress;
-const thenify = require("thenify").withCallback;
 const nodeify = require("nodeify");
 
 /**
@@ -62,16 +59,14 @@ stats.gauge('totalUsers', function() {
 /**
  * A changeset queue per pad that is processed by handleUserChanges()
  */
-var padChannels = new channels.channels(handleUserChangesCB);
-
-function handleUserChangesCB(data, callback) {
+var padChannels = new channels.channels(function(data, callback) {
   return nodeify(handleUserChanges(data), callback);
-}
+});
 
 /**
  * Saves the Socket class we need to send and receive data from the client
  */
-var socketio;
+let socketio;
 
 /**
  * This Method is called by server.js to tell the message handler on which socket it should send
@@ -115,17 +110,17 @@ exports.kickSessionsFromPad = function(padID)
  * Handles the disconnection of a user
  * @param client the client that leaves
  */
-exports.handleDisconnect = function(client)
+exports.handleDisconnect = async function(client)
 {
   stats.meter('disconnects').mark();
 
   // save the padname of this session
-  var session = sessioninfos[client.id];
+  let session = sessioninfos[client.id];
 
   // if this connection was already etablished with a handshake, send a disconnect message to the others
   if (session && session.author) {
     // Get the IP address from our persistant object
-    var ip = remoteAddress[client.id];
+    let ip = remoteAddress[client.id];
 
     // Anonymize the IP address if IP logging is disabled
     if (settings.disableIPlogging) {
@@ -135,29 +130,27 @@ exports.handleDisconnect = function(client)
     accessLogger.info('[LEAVE] Pad "' + session.padId + '": Author "' + session.author + '" on client ' + client.id + ' with IP "' + ip + '" left the pad');
 
     // get the author color out of the db
-    authorManager.getAuthorColorId(session.author, function(err, color) {
-      ERR(err);
+    let color = await authorManager.getAuthorColorId(session.author);
 
-      // prepare the notification for the other users on the pad, that this user left
-      var messageToTheOtherUsers = {
-        "type": "COLLABROOM",
-        "data": {
-          type: "USER_LEAVE",
-          userInfo: {
-            "ip": "127.0.0.1",
-            "colorId": color,
-            "userAgent": "Anonymous",
-            "userId": session.author
-          }
+    // prepare the notification for the other users on the pad, that this user left
+    let messageToTheOtherUsers = {
+      "type": "COLLABROOM",
+      "data": {
+        type: "USER_LEAVE",
+        userInfo: {
+          "ip": "127.0.0.1",
+          "colorId": color,
+          "userAgent": "Anonymous",
+          "userId": session.author
         }
-      };
+      }
+    };
 
-      // Go through all user that are still on the pad, and send them the USER_LEAVE message
-      client.broadcast.to(session.padId).json.send(messageToTheOtherUsers);
+    // Go through all user that are still on the pad, and send them the USER_LEAVE message
+    client.broadcast.to(session.padId).json.send(messageToTheOtherUsers);
 
-      // Allow plugins to hook into users leaving the pad
-      hooks.callAll("userLeave", session);
-    });
+    // Allow plugins to hook into users leaving the pad
+    hooks.callAll("userLeave", session);
   }
 
   // Delete the sessioninfos entrys of this session
@@ -179,7 +172,7 @@ exports.handleMessage = async function(client, message)
     return;
   }
 
-  var thisSession = sessioninfos[client.id];
+  let thisSession = sessioninfos[client.id];
 
   if (!thisSession) {
     messageLogger.warn("Dropped message from an unknown connection.")
@@ -248,7 +241,7 @@ exports.handleMessage = async function(client, message)
 
   /*
    * In a previous version of this code, an "if (message)" wrapped the
-   * following async.series().
+   * following series of async calls  [now replaced with await calls]
    * This ugly "!Boolean(message)" is a lame way to exactly negate the truthy
    * condition and replace it with an early return, while being sure to leave
    * the original behaviour unchanged.
@@ -310,15 +303,13 @@ exports.handleMessage = async function(client, message)
  * @param client the client that send this message
  * @param message the message from the client
  */
-function handleSaveRevisionMessage(client, message){
+async function handleSaveRevisionMessage(client, message)
+{
   var padId = sessioninfos[client.id].padId;
   var userId = sessioninfos[client.id].author;
 
-  padManager.getPad(padId, function(err, pad) {
-    if (ERR(err)) return;
-
-    pad.addSavedRevision(pad.head, userId);
-  });
+  let pad = await padManager.getPad(padId);
+  pad.addSavedRevision(pad.head, userId);
 }
 
 /**
@@ -328,7 +319,7 @@ function handleSaveRevisionMessage(client, message){
  * @param msg {Object} the message we're sending
  * @param sessionID {string} the socketIO session to which we're sending this message
  */
-exports.handleCustomObjectMessage = async function(msg, sessionID) {
+exports.handleCustomObjectMessage = function(msg, sessionID) {
   if (msg.data.type === "CUSTOM") {
     if (sessionID){
       // a sessionID is targeted: directly to this sessionID
@@ -346,9 +337,9 @@ exports.handleCustomObjectMessage = async function(msg, sessionID) {
  * @param padID {Pad} the pad to which we're sending this message
  * @param msgString {String} the message we're sending
  */
-exports.handleCustomMessage = thenify(function(padID, msgString, cb) {
-  var time = Date.now();
-  var msg = {
+exports.handleCustomMessage = function(padID, msgString) {
+  let time = Date.now();
+  let msg = {
     type: 'COLLABROOM',
     data: {
       type: msgString,
@@ -356,9 +347,7 @@ exports.handleCustomMessage = thenify(function(padID, msgString, cb) {
     }
   };
   socketio.sockets.in(padID).json.send(msg);
-
-  cb(null, {});
-});
+}
 
 /**
  * Handles a Chat Message
@@ -382,55 +371,24 @@ function handleChatMessage(client, message)
  * @param text the text of the chat message
  * @param padId the padId to send the chat message to
  */
-exports.sendChatMessageToPadClients = function(time, userId, text, padId) {
-  var pad;
-  var userName;
+exports.sendChatMessageToPadClients = async function(time, userId, text, padId)
+{
+  // get the pad
+  let pad = await padManager.getPad(padId);
 
-  async.series([
-    // get the pad
-    function(callback) {
-      padManager.getPad(padId, function(err, _pad) {
-        if (ERR(err, callback)) return;
+  // get the author
+  let userName = await authorManager.getAuthorName(userId);
 
-        pad = _pad;
-        callback();
-      });
-    },
+  // save the chat message
+  pad.appendChatMessage(text, userId, time);
 
-    function(callback) {
-      authorManager.getAuthorName(userId, function(err, _userName) {
-        if (ERR(err, callback)) return;
+  let msg = {
+    type: "COLLABROOM",
+    data: { type: "CHAT_MESSAGE", userId, userName, time, text }
+  };
 
-        userName = _userName;
-        callback();
-      });
-    },
-
-    // save the chat message and broadcast it
-    function(callback) {
-      // save the chat message
-      pad.appendChatMessage(text, userId, time);
-
-      var msg = {
-        type: "COLLABROOM",
-        data: {
-                type: "CHAT_MESSAGE",
-                userId: userId,
-                userName: userName,
-                time: time,
-                text: text
-              }
-      };
-
-      // broadcast the chat message to everyone on the pad
-      socketio.sockets.in(padId).json.send(msg);
-
-      callback();
-    }
-  ],
-  function(err) {
-    ERR(err);
-  });
+  // broadcast the chat message to everyone on the pad
+  socketio.sockets.in(padId).json.send(msg);
 }
 
 /**
@@ -438,7 +396,7 @@ exports.sendChatMessageToPadClients = function(time, userId, text, padId) {
  * @param client the client that send this message
  * @param message the message from the client
  */
-function handleGetChatMessages(client, message)
+async function handleGetChatMessages(client, message)
 {
   if (message.data.start == null) {
     messageLogger.warn("Dropped message, GetChatMessages Message has no start!");
@@ -450,45 +408,29 @@ function handleGetChatMessages(client, message)
     return;
   }
 
-  var start = message.data.start;
-  var end = message.data.end;
-  var count = end - start;
+  let start = message.data.start;
+  let end = message.data.end;
+  let count = end - start;
 
   if (count < 0 || count > 100) {
     messageLogger.warn("Dropped message, GetChatMessages Message, client requested invalid amount of messages!");
     return;
   }
 
-  var padId = sessioninfos[client.id].padId;
-  var pad;
+  let padId = sessioninfos[client.id].padId;
+  let pad = await padManager.getPad(padId);
 
-  async.series([
-    // get the pad
-    function(callback) {
-      padManager.getPad(padId, function(err, _pad) {
-        if (ERR(err, callback)) return;
+  let chatMessages = await pad.getChatMessages(start, end);
+  let infoMsg = {
+    type: "COLLABROOM",
+    data: {
+      type: "CHAT_MESSAGES",
+      messages: chatMessages
+    }
+  };
 
-        pad = _pad;
-        callback();
-      });
-    },
-
-    function(callback) {
-      pad.getChatMessages(start, end, function(err, chatMessages) {
-        if (ERR(err, callback)) return;
-
-        var infoMsg = {
-          type: "COLLABROOM",
-          data: {
-            type: "CHAT_MESSAGES",
-            messages: chatMessages
-          }
-        };
-
-        // send the messages back to the client
-        client.json.send(infoMsg);
-      });
-    }]);
+  // send the messages back to the client
+  client.json.send(infoMsg);
 }
 
 /**
@@ -763,13 +705,13 @@ async function handleUserChanges(data)
   stopWatch.end();
 }
 
-exports.updatePadClients = thenify(function(pad, callback)
+exports.updatePadClients = async function(pad)
 {
   // skip this if no-one is on this pad
-  var roomClients = _getRoomClients(pad.id);
+  let roomClients = _getRoomClients(pad.id);
 
   if (roomClients.length == 0) {
-    return callback();
+    return;
   }
 
   // since all clients usually get the same set of changesets, store them in local cache
@@ -778,69 +720,54 @@ exports.updatePadClients = thenify(function(pad, callback)
   // BEFORE first result will be landed to our cache object. The solution is to replace parallel processing
   // via async.forEach with sequential for() loop. There is no real benefits of running this in parallel,
   // but benefit of reusing cached revision object is HUGE
-  var revCache = {};
+  let revCache = {};
 
   // go through all sessions on this pad
-  async.forEach(roomClients, function(client, callback){
-    var sid = client.id;
-    // https://github.com/caolan/async#whilst
+  for (let client of roomClients) {
+    let sid = client.id;
+
     // send them all new changesets
-    async.whilst(
-      function() { return sessioninfos[sid] && sessioninfos[sid].rev < pad.getHeadRevisionNumber()},
-      function(callback)
-      {
-        var r = sessioninfos[sid].rev + 1;
+    while (sessioninfos[sid] && sessioninfos[sid].rev < pad.getHeadRevisionNumber()) {
+      let r = sessioninfos[sid].rev + 1;
+      let revision = revCache[r];
+      if (!revision) {
+        revision = await pad.getRevision(r);
+        revCache[r] = revision;
+      }
 
-        async.waterfall([
-          function(callback) {
-            if(revCache[r]) {
-              callback(null, revCache[r]);
-            } else {
-              pad.getRevision(r, callback);
-            }
-          },
+      let author = revision.meta.author,
+          revChangeset = revision.changeset,
+          currentTime = revision.meta.timestamp;
 
-          function(revision, callback) {
-            revCache[r] = revision;
+      // next if session has not been deleted
+      if (sessioninfos[sid] == null) {
+        continue;
+      }
 
-            var author = revision.meta.author,
-                revChangeset = revision.changeset,
-                currentTime = revision.meta.timestamp;
+      if (author == sessioninfos[sid].author) {
+        client.json.send({ "type": "COLLABROOM", "data":{ type: "ACCEPT_COMMIT", newRev: r }});
+      } else {
+        let forWire = Changeset.prepareForWire(revChangeset, pad.pool);
+        let wireMsg = {"type": "COLLABROOM",
+                       "data": { type:"NEW_CHANGES",
+                                 newRev:r,
+                                 changeset: forWire.translated,
+                                 apool: forWire.pool,
+                                 author: author,
+                                 currentTime: currentTime,
+                                 timeDelta: currentTime - sessioninfos[sid].time
+                               }};
 
-            // next if session has not been deleted
-            if (sessioninfos[sid] == null) {
-              return callback(null);
-            }
+        client.json.send(wireMsg);
+      }
 
-            if (author == sessioninfos[sid].author) {
-              client.json.send({"type":"COLLABROOM","data":{type:"ACCEPT_COMMIT", newRev:r}});
-            } else {
-              var forWire = Changeset.prepareForWire(revChangeset, pad.pool);
-              var wireMsg = {"type":"COLLABROOM",
-                             "data":{type:"NEW_CHANGES",
-                                     newRev:r,
-                                     changeset: forWire.translated,
-                                     apool: forWire.pool,
-                                     author: author,
-                                     currentTime: currentTime,
-                                     timeDelta: currentTime - sessioninfos[sid].time
-                                    }};
-
-              client.json.send(wireMsg);
-            }
-
-            if (sessioninfos[sid]) {
-              sessioninfos[sid].time = currentTime;
-              sessioninfos[sid].rev = r;
-            }
-            callback(null);
-          }
-        ], callback);
-      },
-      callback
-    );
-  },callback);
-});
+      if (sessioninfos[sid]) {
+        sessioninfos[sid].time = currentTime;
+        sessioninfos[sid].rev = r;
+      }
+    }
+  }
+}
 
 /**
  * Copied from the Etherpad Source Code. Don't know what this method does excatly...
@@ -893,12 +820,12 @@ function _correctMarkersInPad(atext, apool) {
 function handleSwitchToPad(client, message)
 {
   // clear the session and leave the room
-  var currentSession = sessioninfos[client.id];
-  var padId = currentSession.padId;
-  var roomClients = _getRoomClients(padId);
+  let currentSession = sessioninfos[client.id];
+  let padId = currentSession.padId;
+  let roomClients = _getRoomClients(padId);
 
-  async.forEach(roomClients, function(client, callback) {
-    var sinfo = sessioninfos[client.id];
+  roomClients.forEach(client => {
+    let sinfo = sessioninfos[client.id];
     if (sinfo && sinfo.author == currentSession.author) {
       // fix user's counter, works on page refresh or if user closes browser window and then rejoins
       sessioninfos[client.id] = {};

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -61,7 +61,7 @@ stats.gauge('totalUsers', function() {
 /**
  * A changeset queue per pad that is processed by handleUserChanges()
  */
-var padChannels = new channels.channels(handleUserChanges);
+var padChannels = new channels.channels(thenify(handleUserChanges));
 
 /**
  * Saves the Socket class we need to send and receive data from the client
@@ -330,7 +330,7 @@ function handleSaveRevisionMessage(client, message){
  * @param msg {Object} the message we're sending
  * @param sessionID {string} the socketIO session to which we're sending this message
  */
-exports.handleCustomObjectMessage = function(msg, sessionID, cb) {
+exports.handleCustomObjectMessage = thenify(function(msg, sessionID, cb) {
   if (msg.data.type === "CUSTOM") {
     if (sessionID){
       // a sessionID is targeted: directly to this sessionID
@@ -341,7 +341,8 @@ exports.handleCustomObjectMessage = function(msg, sessionID, cb) {
     }
   }
   cb(null, {});
-}
+});
+
 
 /**
  * Handles a custom message (sent via HTTP API request)
@@ -349,7 +350,7 @@ exports.handleCustomObjectMessage = function(msg, sessionID, cb) {
  * @param padID {Pad} the pad to which we're sending this message
  * @param msgString {String} the message we're sending
  */
-exports.handleCustomMessage = function(padID, msgString, cb) {
+exports.handleCustomMessage = thenify(function(padID, msgString, cb) {
   var time = Date.now();
   var msg = {
     type: 'COLLABROOM',
@@ -361,7 +362,7 @@ exports.handleCustomMessage = function(padID, msgString, cb) {
   socketio.sockets.in(padID).json.send(msg);
 
   cb(null, {});
-}
+});
 
 /**
  * Handles a Chat Message

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -54,8 +54,8 @@ exports.sessioninfos = sessioninfos;
 
 // Measure total amount of users
 stats.gauge('totalUsers', function() {
-  return Object.keys(socketio.sockets.sockets).length
-})
+  return Object.keys(socketio.sockets.sockets).length;
+});
 
 /**
  * A changeset queue per pad that is processed by handleUserChanges()
@@ -63,7 +63,7 @@ stats.gauge('totalUsers', function() {
 var padChannels = new channels.channels(handleUserChanges);
 
 /**
- * Saves the Socket class we need to send and recieve data from the client
+ * Saves the Socket class we need to send and receive data from the client
  */
 var socketio;
 
@@ -84,7 +84,7 @@ exports.handleConnect = function(client)
 {
   stats.meter('connects').mark();
 
-  //Initalize sessioninfos for this new session
+  // Initalize sessioninfos for this new session
   sessioninfos[client.id]={};
 }
 
@@ -97,11 +97,11 @@ exports.kickSessionsFromPad = function(padID)
   if(typeof socketio.sockets['clients'] !== 'function')
    return;
 
-  //skip if there is nobody on this pad
+  // skip if there is nobody on this pad
   if(_getRoomClients(padID).length == 0)
     return;
 
-  //disconnect everyone from this pad
+  // disconnect everyone from this pad
   socketio.sockets.in(padID).json.send({disconnect:"deleted"});
 }
 
@@ -113,29 +113,26 @@ exports.handleDisconnect = function(client)
 {
   stats.meter('disconnects').mark();
 
-  //save the padname of this session
+  // save the padname of this session
   var session = sessioninfos[client.id];
 
-  //if this connection was already etablished with a handshake, send a disconnect message to the others
-  if(session && session.author)
-  {
-
+  // if this connection was already etablished with a handshake, send a disconnect message to the others
+  if (session && session.author) {
     // Get the IP address from our persistant object
     var ip = remoteAddress[client.id];
 
     // Anonymize the IP address if IP logging is disabled
-    if(settings.disableIPlogging) {
+    if (settings.disableIPlogging) {
       ip = 'ANONYMOUS';
     }
 
-    accessLogger.info('[LEAVE] Pad "'+session.padId+'": Author "'+session.author+'" on client '+client.id+' with IP "'+ip+'" left the pad')
+    accessLogger.info('[LEAVE] Pad "' + session.padId + '": Author "' + session.author + '" on client ' + client.id + ' with IP "' + ip + '" left the pad');
 
-    //get the author color out of the db
-    authorManager.getAuthorColorId(session.author, function(err, color)
-    {
+    // get the author color out of the db
+    authorManager.getAuthorColorId(session.author, function(err, color) {
       ERR(err);
 
-      //prepare the notification for the other users on the pad, that this user left
+      // prepare the notification for the other users on the pad, that this user left
       var messageToTheOtherUsers = {
         "type": "COLLABROOM",
         "data": {
@@ -149,7 +146,7 @@ exports.handleDisconnect = function(client)
         }
       };
 
-      //Go trough all user that are still on the pad, and send them the USER_LEAVE message
+      // Go through all user that are still on the pad, and send them the USER_LEAVE message
       client.broadcast.to(session.padId).json.send(messageToTheOtherUsers);
 
       // Allow plugins to hook into users leaving the pad
@@ -157,7 +154,7 @@ exports.handleDisconnect = function(client)
     });
   }
 
-  //Delete the sessioninfos entrys of this session
+  // Delete the sessioninfos entrys of this session
   delete sessioninfos[client.id];
 }
 
@@ -168,23 +165,24 @@ exports.handleDisconnect = function(client)
  */
 exports.handleMessage = function(client, message)
 {
-  if(message == null)
-  {
+  if (message == null) {
     return;
   }
-  if(!message.type)
-  {
+
+  if (!message.type) {
     return;
   }
-  var thisSession = sessioninfos[client.id]
-  if(!thisSession) {
+
+  var thisSession = sessioninfos[client.id];
+
+  if (!thisSession) {
     messageLogger.warn("Dropped message from an unknown connection.")
     return;
   }
 
-  var handleMessageHook = function(callback){
+  var handleMessageHook = function(callback) {
     // Allow plugins to bypass the readonly message blocker
-    hooks.aCallAll("handleMessageSecurity", { client: client, message: message }, function ( err, messages ) {
+    hooks.aCallAll("handleMessageSecurity", { client: client, message: message }, function( err, messages ) {
       if(ERR(err, callback)) return;
       _.each(messages, function(newMessage){
         if ( newMessage === true ) {
@@ -196,7 +194,7 @@ exports.handleMessage = function(client, message)
     var dropMessage = false;
     // Call handleMessage hook. If a plugin returns null, the message will be dropped. Note that for all messages
     // handleMessage will be called, even if the client is not authorized
-    hooks.aCallAll("handleMessage", { client: client, message: message }, function ( err, messages ) {
+    hooks.aCallAll("handleMessage", { client: client, message: message }, function( err, messages ) {
       if(ERR(err, callback)) return;
       _.each(messages, function(newMessage){
         if ( newMessage === null ) {
@@ -210,18 +208,18 @@ exports.handleMessage = function(client, message)
 
   }
 
-  var finalHandler = function () {
-    //Check what type of message we get and delegate to the other methodes
-    if(message.type == "CLIENT_READY") {
+  var finalHandler = function() {
+    // Check what type of message we get and delegate to the other methods
+    if (message.type == "CLIENT_READY") {
       handleClientReady(client, message);
-    } else if(message.type == "CHANGESET_REQ") {
+    } else if (message.type == "CHANGESET_REQ") {
       handleChangesetRequest(client, message);
     } else if(message.type == "COLLABROOM") {
       if (thisSession.readonly) {
         messageLogger.warn("Dropped message, COLLABROOM for readonly pad");
       } else if (message.data.type == "USER_CHANGES") {
         stats.counter('pendingEdits').inc()
-        padChannels.emit(message.padId, {client: client, message: message});// add to pad queue
+        padChannels.emit(message.padId, {client: client, message: message}); // add to pad queue
       } else if (message.data.type == "USERINFO_UPDATE") {
         handleUserInfoUpdate(client, message);
       } else if (message.data.type == "CHAT_MESSAGE") {
@@ -242,7 +240,7 @@ exports.handleMessage = function(client, message)
     } else {
       messageLogger.warn("Dropped message, unknown Message Type " + message.type);
     }
-  };
+  }
 
   /*
    * In a previous version of this code, an "if (message)" wrapped the
@@ -259,11 +257,11 @@ exports.handleMessage = function(client, message)
 
   async.series([
     handleMessageHook,
-    //check permissions
-    function(callback)
-    {
+
+    // check permissions
+    function(callback) {
       // client tried to auth for the first time (first msg from the client)
-      if(message.type == "CLIENT_READY") {
+      if (message.type == "CLIENT_READY") {
         createSessionInfo(client, message);
       }
 
@@ -274,31 +272,27 @@ exports.handleMessage = function(client, message)
       // FIXME: Allow to override readwrite access with readonly
 
       // Simulate using the load testing tool
-      if(!sessioninfos[client.id].auth){
+      if (!sessioninfos[client.id].auth) {
         console.error("Auth was never applied to a session.  If you are using the stress-test tool then restart Etherpad and the Stress test tool.")
         return;
       }
 
       var auth = sessioninfos[client.id].auth;
-      var checkAccessCallback = function(err, statusObject)
-      {
-        if(ERR(err, callback)) return;
+      var checkAccessCallback = function(err, statusObject) {
+        if (ERR(err, callback)) return;
 
-        //access was granted
-        if(statusObject.accessStatus == "grant")
-        {
+        if (statusObject.accessStatus == "grant") {
+          // access was granted
           callback();
-        }
-        //no access, send the client a message that tell him why
-        else
-        {
+        } else {
+          // no access, send the client a message that tells him why
           client.json.send({accessStatus: statusObject.accessStatus})
         }
       };
 
-      //check if pad is requested via readOnly
+      // check if pad is requested via readOnly
       if (auth.padID.indexOf("r.") === 0) {
-        //Pad is readOnly, first get the real Pad ID
+        // Pad is readOnly, first get the real Pad ID
         readOnlyManager.getPadId(auth.padID, function(err, value) {
           ERR(err);
           securityManager.checkAccess(value, auth.sessionID, auth.token, auth.password, checkAccessCallback);
@@ -321,32 +315,32 @@ function handleSaveRevisionMessage(client, message){
   var padId = sessioninfos[client.id].padId;
   var userId = sessioninfos[client.id].author;
 
-  padManager.getPad(padId, function(err, pad)
-  {
-    if(ERR(err)) return;
+  padManager.getPad(padId, function(err, pad) {
+    if (ERR(err)) return;
 
     pad.addSavedRevision(pad.head, userId);
   });
 }
 
 /**
- * Handles a custom message, different to the function below as it handles objects not strings and you can
- * direct the message to specific sessionID
+ * Handles a custom message, different to the function below as it handles
+ * objects not strings and you can direct the message to specific sessionID
  *
  * @param msg {Object} the message we're sending
  * @param sessionID {string} the socketIO session to which we're sending this message
  */
-exports.handleCustomObjectMessage = function (msg, sessionID, cb) {
-  if(msg.data.type === "CUSTOM"){
-    if(sessionID){ // If a sessionID is targeted then send directly to this sessionID
-      socketio.sockets.socket(sessionID).json.send(msg); // send a targeted message
-    }else{
-      socketio.sockets.in(msg.data.payload.padId).json.send(msg); // broadcast to all clients on this pad
+exports.handleCustomObjectMessage = function(msg, sessionID, cb) {
+  if (msg.data.type === "CUSTOM") {
+    if (sessionID){
+      // a sessionID is targeted: directly to this sessionID
+      socketio.sockets.socket(sessionID).json.send(msg);
+    } else {
+      // broadcast to all clients on this pad
+      socketio.sockets.in(msg.data.payload.padId).json.send(msg);
     }
   }
   cb(null, {});
 }
-
 
 /**
  * Handles a custom message (sent via HTTP API request)
@@ -354,7 +348,7 @@ exports.handleCustomObjectMessage = function (msg, sessionID, cb) {
  * @param padID {Pad} the pad to which we're sending this message
  * @param msgString {String} the message we're sending
  */
-exports.handleCustomMessage = function (padID, msgString, cb) {
+exports.handleCustomMessage = function(padID, msgString, cb) {
   var time = Date.now();
   var msg = {
     type: 'COLLABROOM',
@@ -390,34 +384,33 @@ function handleChatMessage(client, message)
  * @param text the text of the chat message
  * @param padId the padId to send the chat message to
  */
-exports.sendChatMessageToPadClients = function (time, userId, text, padId) {
+exports.sendChatMessageToPadClients = function(time, userId, text, padId) {
   var pad;
   var userName;
 
   async.series([
-    //get the pad
-    function(callback)
-    {
-      padManager.getPad(padId, function(err, _pad)
-      {
-        if(ERR(err, callback)) return;
+    // get the pad
+    function(callback) {
+      padManager.getPad(padId, function(err, _pad) {
+        if (ERR(err, callback)) return;
+
         pad = _pad;
         callback();
       });
     },
-    function(callback)
-    {
-      authorManager.getAuthorName(userId, function(err, _userName)
-      {
-        if(ERR(err, callback)) return;
+
+    function(callback) {
+      authorManager.getAuthorName(userId, function(err, _userName) {
+        if (ERR(err, callback)) return;
+
         userName = _userName;
         callback();
       });
     },
-    //save the chat message and broadcast it
-    function(callback)
-    {
-      //save the chat message
+
+    // save the chat message and broadcast it
+    function(callback) {
+      // save the chat message
       pad.appendChatMessage(text, userId, time);
 
       var msg = {
@@ -431,13 +424,13 @@ exports.sendChatMessageToPadClients = function (time, userId, text, padId) {
               }
       };
 
-      //broadcast the chat message to everyone on the pad
+      // broadcast the chat message to everyone on the pad
       socketio.sockets.in(padId).json.send(msg);
 
       callback();
     }
-  ], function(err)
-  {
+  ],
+  function(err) {
     ERR(err);
   });
 }
@@ -449,13 +442,12 @@ exports.sendChatMessageToPadClients = function (time, userId, text, padId) {
  */
 function handleGetChatMessages(client, message)
 {
-  if(message.data.start == null)
-  {
+  if (message.data.start == null) {
     messageLogger.warn("Dropped message, GetChatMessages Message has no start!");
     return;
   }
-  if(message.data.end == null)
-  {
+
+  if (message.data.end == null) {
     messageLogger.warn("Dropped message, GetChatMessages Message has no start!");
     return;
   }
@@ -464,8 +456,7 @@ function handleGetChatMessages(client, message)
   var end = message.data.end;
   var count = end - start;
 
-  if(count < 0 || count > 100)
-  {
+  if (count < 0 || count > 100) {
     messageLogger.warn("Dropped message, GetChatMessages Message, client requested invalid amout of messages!");
     return;
   }
@@ -474,21 +465,19 @@ function handleGetChatMessages(client, message)
   var pad;
 
   async.series([
-    //get the pad
-    function(callback)
-    {
-      padManager.getPad(padId, function(err, _pad)
-      {
-        if(ERR(err, callback)) return;
+    // get the pad
+    function(callback) {
+      padManager.getPad(padId, function(err, _pad) {
+        if (ERR(err, callback)) return;
+
         pad = _pad;
         callback();
       });
     },
-    function(callback)
-    {
-      pad.getChatMessages(start, end, function(err, chatMessages)
-      {
-        if(ERR(err, callback)) return;
+
+    function(callback) {
+      pad.getChatMessages(start, end, function(err, chatMessages) {
+        if (ERR(err, callback)) return;
 
         var infoMsg = {
           type: "COLLABROOM",
@@ -511,14 +500,13 @@ function handleGetChatMessages(client, message)
  */
 function handleSuggestUserName(client, message)
 {
-  //check if all ok
-  if(message.data.payload.newName == null)
-  {
+  // check if all ok
+  if (message.data.payload.newName == null) {
     messageLogger.warn("Dropped message, suggestUserName Message has no newName!");
     return;
   }
-  if(message.data.payload.unnamedId == null)
-  {
+
+  if (message.data.payload.unnamedId == null) {
     messageLogger.warn("Dropped message, suggestUserName Message has no unnamedId!");
     return;
   }
@@ -526,10 +514,10 @@ function handleSuggestUserName(client, message)
   var padId = sessioninfos[client.id].padId;
   var roomClients = _getRoomClients(padId);
 
-  //search the author and send him this message
+  // search the author and send him this message
   roomClients.forEach(function(client) {
     var session = sessioninfos[client.id];
-    if(session && session.author == message.data.payload.unnamedId) {
+    if (session && session.author == message.data.payload.unnamedId) {
       client.json.send(message);
     }
   });
@@ -542,37 +530,35 @@ function handleSuggestUserName(client, message)
  */
 function handleUserInfoUpdate(client, message)
 {
-  //check if all ok
-  if(message.data.userInfo == null)
-  {
+  // check if all ok
+  if (message.data.userInfo == null) {
     messageLogger.warn("Dropped message, USERINFO_UPDATE Message has no userInfo!");
     return;
   }
-  if(message.data.userInfo.colorId == null)
-  {
+
+  if (message.data.userInfo.colorId == null) {
     messageLogger.warn("Dropped message, USERINFO_UPDATE Message has no colorId!");
     return;
   }
 
   // Check that we have a valid session and author to update.
   var session = sessioninfos[client.id];
-  if(!session || !session.author || !session.padId)
-  {
+  if (!session || !session.author || !session.padId) {
     messageLogger.warn("Dropped message, USERINFO_UPDATE Session not ready." + message.data);
     return;
   }
 
-  //Find out the author name of this session
+  // Find out the author name of this session
   var author = session.author;
 
   // Check colorId is a Hex color
   var isColor  = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i.test(message.data.userInfo.colorId) // for #f00 (Thanks Smamatti)
-  if(!isColor){
+  if (!isColor) {
     messageLogger.warn("Dropped message, USERINFO_UPDATE Color is malformed." + message.data);
     return;
   }
 
-  //Tell the authorManager about the new attributes
+  // Tell the authorManager about the new attributes
   authorManager.setAuthorColorId(author, message.data.userInfo.colorId);
   authorManager.setAuthorName(author, message.data.userInfo.name);
 
@@ -585,7 +571,7 @@ function handleUserInfoUpdate(client, message)
       type: "USER_NEWINFO",
       userInfo: {
         userId: author,
-        //set a null name, when there is no name set. cause the client wants it null
+        // set a null name, when there is no name set. cause the client wants it null
         name: message.data.userInfo.name || null,
         colorId: message.data.userInfo.colorId,
         userAgent: "Anonymous",
@@ -594,7 +580,7 @@ function handleUserInfoUpdate(client, message)
     }
   };
 
-  //Send the other clients on the pad the update message
+  // Send the other clients on the pad the update message
   client.broadcast.to(padId).json.send(infoMsg);
 }
 
@@ -621,34 +607,34 @@ function handleUserChanges(data, cb)
   stats.counter('pendingEdits').dec()
 
   // Make sure all required fields are present
-  if(message.data.baseRev == null)
-  {
+  if (message.data.baseRev == null) {
     messageLogger.warn("Dropped message, USER_CHANGES Message has no baseRev!");
     return cb();
   }
-  if(message.data.apool == null)
-  {
+
+  if (message.data.apool == null) {
     messageLogger.warn("Dropped message, USER_CHANGES Message has no apool!");
     return cb();
   }
-  if(message.data.changeset == null)
-  {
+
+  if (message.data.changeset == null) {
     messageLogger.warn("Dropped message, USER_CHANGES Message has no changeset!");
     return cb();
   }
-  //TODO: this might happen with other messages too => find one place to copy the session
-  //and always use the copy. atm a message will be ignored if the session is gone even
-  //if the session was valid when the message arrived in the first place
-  if(!sessioninfos[client.id])
-  {
+
+  // TODO: this might happen with other messages too => find one place to copy the session
+  // and always use the copy. atm a message will be ignored if the session is gone even
+  // if the session was valid when the message arrived in the first place
+  if (!sessioninfos[client.id]) {
     messageLogger.warn("Dropped message, disconnect happened in the mean time");
     return cb();
   }
 
-  //get all Vars we need
+  // get all Vars we need
   var baseRev = message.data.baseRev;
   var wireApool = (new AttributePool()).fromJsonable(message.data.apool);
   var changeset = message.data.changeset;
+
   // The client might disconnect between our callbacks. We should still
   // finish processing the changeset, so keep a reference to the session.
   var thisSession = sessioninfos[client.id];
@@ -659,31 +645,29 @@ function handleUserChanges(data, cb)
   var stopWatch = stats.timer('edits').start();
 
   async.series([
-    //get the pad
-    function(callback)
-    {
-      padManager.getPad(thisSession.padId, function(err, value)
-      {
-        if(ERR(err, callback)) return;
+    // get the pad
+    function(callback) {
+      padManager.getPad(thisSession.padId, function(err, value) {
+        if (ERR(err, callback)) return;
+
         pad = value;
         callback();
       });
     },
-    //create the changeset
-    function(callback)
-    {
-      //ex. _checkChangesetAndPool
 
-      try
-      {
+    // create the changeset
+    function(callback) {
+      // ex. _checkChangesetAndPool
+
+      try {
         // Verify that the changeset has valid syntax and is in canonical form
         Changeset.checkRep(changeset);
 
         // Verify that the attribute indexes used in the changeset are all
         // defined in the accompanying attribute pool.
         Changeset.eachAttribNumber(changeset, function(n) {
-          if (! wireApool.getAttrib(n)) {
-            throw new Error("Attribute pool is missing attribute "+n+" for changeset "+changeset);
+          if (!wireApool.getAttrib(n)) {
+            throw new Error("Attribute pool is missing attribute " + n + " for changeset " + changeset);
           }
         });
 
@@ -693,102 +677,105 @@ function handleUserChanges(data, cb)
         while(iterator.hasNext()) {
           op = iterator.next()
 
-          //+ can add text with attribs
-          //= can change or add attribs
-          //- can have attribs, but they are discarded and don't show up in the attribs - but do show up in the  pool
+          // + can add text with attribs
+          // = can change or add attribs
+          // - can have attribs, but they are discarded and don't show up in the attribs - but do show up in the  pool
 
           op.attribs.split('*').forEach(function(attr) {
-            if(!attr) return
+            if (!attr) return;
+
             attr = wireApool.getAttrib(attr)
-            if(!attr) return
-            //the empty author is used in the clearAuthorship functionality so this should be the only exception
-            if('author' == attr[0] && (attr[1] != thisSession.author && attr[1] != '')) throw new Error("Trying to submit changes as another author in changeset "+changeset);
-          })
+            if (!attr) return;
+
+            // the empty author is used in the clearAuthorship functionality so this should be the only exception
+            if ('author' == attr[0] && (attr[1] != thisSession.author && attr[1] != '')) {
+              throw new Error("Trying to submit changes as another author in changeset " + changeset);
+            }
+          });
         }
 
-        //ex. adoptChangesetAttribs
+        // ex. adoptChangesetAttribs
 
-        //Afaik, it copies the new attributes from the changeset, to the global Attribute Pool
+        // Afaik, it copies the new attributes from the changeset, to the global Attribute Pool
         changeset = Changeset.moveOpsToNewPool(changeset, wireApool, pad.pool);
-      }
-      catch(e)
-      {
+      } catch(e) {
         // There is an error in this changeset, so just refuse it
         client.json.send({disconnect:"badChangeset"});
         stats.meter('failedChangesets').mark();
         return callback(new Error("Can't apply USER_CHANGES, because "+e.message));
       }
 
-      //ex. applyUserChanges
+      // ex. applyUserChanges
       apool = pad.pool;
       r = baseRev;
 
       // The client's changeset might not be based on the latest revision,
       // since other clients are sending changes at the same time.
       // Update the changeset so that it can be applied to the latest revision.
-      //https://github.com/caolan/async#whilst
+      // https://github.com/caolan/async#whilst
       async.whilst(
         function() { return r < pad.getHeadRevisionNumber(); },
         function(callback)
         {
           r++;
 
-          pad.getRevisionChangeset(r, function(err, c)
-          {
-            if(ERR(err, callback)) return;
+          pad.getRevisionChangeset(r, function(err, c) {
+            if (ERR(err, callback)) return;
 
             // At this point, both "c" (from the pad) and "changeset" (from the
             // client) are relative to revision r - 1. The follow function
             // rebases "changeset" so that it is relative to revision r
             // and can be applied after "c".
-            try
-            {
+            try {
               // a changeset can be based on an old revision with the same changes in it
               // prevent eplite from accepting it TODO: better send the client a NEW_CHANGES
               // of that revision
-              if(baseRev+1 == r && c == changeset) {
+              if (baseRev + 1 == r && c == changeset) {
                 client.json.send({disconnect:"badChangeset"});
                 stats.meter('failedChangesets').mark();
+
                 return callback(new Error("Won't apply USER_CHANGES, because it contains an already accepted changeset"));
               }
+
               changeset = Changeset.follow(c, changeset, false, apool);
-            }catch(e){
+            } catch(e) {
               client.json.send({disconnect:"badChangeset"});
               stats.meter('failedChangesets').mark();
+
               return callback(new Error("Can't apply USER_CHANGES, because "+e.message));
             }
 
-            if ((r - baseRev) % 200 == 0) { // don't let the stack get too deep
+            if ((r - baseRev) % 200 == 0) {
+              // don't let the stack get too deep
               async.nextTick(callback);
             } else {
               callback(null);
             }
           });
         },
-        //use the callback of the series function
+
+        // use the callback of the series function
         callback
       );
     },
-    //do correction changesets, and send it to all users
-    function (callback)
-    {
+
+    // do correction changesets, and send it to all users
+    function(callback) {
       var prevText = pad.text();
 
-      if (Changeset.oldLen(changeset) != prevText.length)
-      {
+      if (Changeset.oldLen(changeset) != prevText.length) {
         client.json.send({disconnect:"badChangeset"});
         stats.meter('failedChangesets').mark();
+
         return callback(new Error("Can't apply USER_CHANGES "+changeset+" with oldLen " + Changeset.oldLen(changeset) + " to document of length " + prevText.length));
       }
 
-      try
-      {
+      try {
         pad.appendRevision(changeset, thisSession.author);
-      }
-      catch(e)
-      {
+      } catch(e) {
         client.json.send({disconnect:"badChangeset"});
         stats.meter('failedChangesets').mark();
+
         return callback(e)
       }
 
@@ -809,21 +796,25 @@ function handleUserChanges(data, cb)
       });
       callback();
     }
-  ], function(err)
-  {
+  ],
+  function(err) {
     stopWatch.end()
     cb();
-    if(err) console.warn(err.stack || err)
+
+    if(err) {
+      console.warn(err.stack || err);
+    }
   });
 }
 
 exports.updatePadClients = function(pad, callback)
 {
-  //skip this step if noone is on this pad
+  // skip this if no-one is on this pad
   var roomClients = _getRoomClients(pad.id);
 
-  if(roomClients.length==0)
+  if (roomClients.length == 0) {
     return callback();
+  }
 
   // since all clients usually get the same set of changesets, store them in local cache
   // to remove unnecessary roundtrip to the datalayer
@@ -833,26 +824,27 @@ exports.updatePadClients = function(pad, callback)
   // but benefit of reusing cached revision object is HUGE
   var revCache = {};
 
-  //go trough all sessions on this pad
+  // go through all sessions on this pad
   async.forEach(roomClients, function(client, callback){
     var sid = client.id;
-    //https://github.com/caolan/async#whilst
-    //send them all new changesets
+    // https://github.com/caolan/async#whilst
+    // send them all new changesets
     async.whilst(
-      function (){ return sessioninfos[sid] && sessioninfos[sid].rev < pad.getHeadRevisionNumber()},
+      function() { return sessioninfos[sid] && sessioninfos[sid].rev < pad.getHeadRevisionNumber()},
       function(callback)
       {
         var r = sessioninfos[sid].rev + 1;
 
         async.waterfall([
           function(callback) {
-            if(revCache[r])
+            if(revCache[r]) {
               callback(null, revCache[r]);
-            else
+            } else {
               pad.getRevision(r, callback);
+            }
           },
-          function(revision, callback)
-          {
+
+          function(revision, callback) {
             revCache[r] = revision;
 
             var author = revision.meta.author,
@@ -860,15 +852,13 @@ exports.updatePadClients = function(pad, callback)
                 currentTime = revision.meta.timestamp;
 
             // next if session has not been deleted
-            if(sessioninfos[sid] == null)
+            if (sessioninfos[sid] == null) {
               return callback(null);
-
-            if(author == sessioninfos[sid].author)
-            {
-              client.json.send({"type":"COLLABROOM","data":{type:"ACCEPT_COMMIT", newRev:r}});
             }
-            else
-            {
+
+            if (author == sessioninfos[sid].author) {
+              client.json.send({"type":"COLLABROOM","data":{type:"ACCEPT_COMMIT", newRev:r}});
+            } else {
               var forWire = Changeset.prepareForWire(revChangeset, pad.pool);
               var wireMsg = {"type":"COLLABROOM",
                              "data":{type:"NEW_CHANGES",
@@ -882,7 +872,8 @@ exports.updatePadClients = function(pad, callback)
 
               client.json.send(wireMsg);
             }
-            if(sessioninfos[sid]){
+
+            if (sessioninfos[sid]) {
               sessioninfos[sid].time = currentTime;
               sessioninfos[sid].rev = r;
             }
@@ -909,19 +900,18 @@ function _correctMarkersInPad(atext, apool) {
   while (iter.hasNext()) {
     var op = iter.next();
 
-    var hasMarker = _.find(AttributeManager.lineAttributes, function(attribute){
+    var hasMarker = _.find(AttributeManager.lineAttributes, function(attribute) {
       return Changeset.opAttributeValue(op, attribute, apool);
     }) !== undefined;
 
     if (hasMarker) {
-      for(var i=0;i<op.chars;i++) {
+      for (var i = 0; i < op.chars; i++) {
         if (offset > 0 && text.charAt(offset-1) != '\n') {
           badMarkers.push(offset);
         }
         offset++;
       }
-    }
-    else {
+    } else {
       offset += op.chars;
     }
   }
@@ -932,12 +922,15 @@ function _correctMarkersInPad(atext, apool) {
 
   // create changeset that removes these bad markers
   offset = 0;
+
   var builder = Changeset.builder(text.length);
+
   badMarkers.forEach(function(pos) {
     builder.keepText(text.substring(offset, pos));
     builder.remove(1);
     offset = pos+1;
   });
+
   return builder.toString();
 }
 
@@ -950,7 +943,7 @@ function handleSwitchToPad(client, message)
 
   async.forEach(roomClients, function(client, callback) {
     var sinfo = sessioninfos[client.id];
-    if(sinfo && sinfo.author == currentSession.author) {
+    if (sinfo && sinfo.author == currentSession.author) {
       // fix user's counter, works on page refresh or if user closes browser window and then rejoins
       sessioninfos[client.id] = {};
       client.leave(padId);
@@ -986,24 +979,23 @@ function createSessionInfo(client, message)
  */
 function handleClientReady(client, message)
 {
-  //check if all ok
-  if(!message.token)
-  {
+  // check if all ok
+  if (!message.token) {
     messageLogger.warn("Dropped message, CLIENT_READY Message has no token!");
     return;
   }
-  if(!message.padId)
-  {
+
+  if (!message.padId) {
     messageLogger.warn("Dropped message, CLIENT_READY Message has no padId!");
     return;
   }
-  if(!message.protocolVersion)
-  {
+
+  if (!message.protocolVersion) {
     messageLogger.warn("Dropped message, CLIENT_READY Message has no protocolVersion!");
     return;
   }
-  if(message.protocolVersion != 2)
-  {
+
+  if (message.protocolVersion != 2) {
     messageLogger.warn("Dropped message, CLIENT_READY Message has a unknown protocolVersion '" + message.protocolVersion + "'!");
     return;
   }
@@ -1019,97 +1011,92 @@ function handleClientReady(client, message)
   hooks.callAll("clientReady", message);
 
   async.series([
-    //Get ro/rw id:s
-    function (callback)
-    {
+    // Get ro/rw id:s
+    function(callback) {
       readOnlyManager.getIds(message.padId, function(err, value) {
-        if(ERR(err, callback)) return;
+        if (ERR(err, callback)) return;
+
         padIds = value;
         callback();
       });
     },
-    //check permissions
-    function(callback)
-    {
+
+    // check permissions
+    function(callback) {
       // Note: message.sessionID is an entierly different kind of
-      // session from the sessions we use here! Beware! FIXME: Call
-      // our "sessions" "connections".
+      // session from the sessions we use here! Beware!
+      // FIXME: Call our "sessions" "connections".
       // FIXME: Use a hook instead
       // FIXME: Allow to override readwrite access with readonly
-      securityManager.checkAccess (padIds.padId, message.sessionID, message.token, message.password, function(err, statusObject)
-      {
-        if(ERR(err, callback)) return;
+      securityManager.checkAccess(padIds.padId, message.sessionID, message.token, message.password, function(err, statusObject) {
+        if (ERR(err, callback)) return;
 
-        //access was granted
-        if(statusObject.accessStatus == "grant")
-        {
+        if (statusObject.accessStatus == "grant") {
+          // access was granted
           author = statusObject.authorID;
           callback();
-        }
-        //no access, send the client a message that tell him why
-        else
-        {
+        } else {
+          // no access, send the client a message that tells him why
           client.json.send({accessStatus: statusObject.accessStatus})
         }
       });
     },
-    //get all authordata of this new user, and load the pad-object from the database
+
+    // get all authordata of this new user, and load the pad-object from the database
     function(callback)
     {
       async.parallel([
-        //get colorId and name
-        function(callback)
-        {
-          authorManager.getAuthor(author, function(err, value)
-          {
-            if(ERR(err, callback)) return;
+        // get colorId and name
+        function(callback) {
+          authorManager.getAuthor(author, function(err, value) {
+            if (ERR(err, callback)) return;
+
             authorColorId = value.colorId;
             authorName = value.name;
             callback();
           });
         },
-        //get pad
-        function(callback)
-        {
-          padManager.getPad(padIds.padId, function(err, value)
-          {
-            if(ERR(err, callback)) return;
+
+        // get pad
+        function(callback) {
+          padManager.getPad(padIds.padId, function(err, value) {
+            if (ERR(err, callback)) return;
+
             pad = value;
             callback();
           });
         }
       ], callback);
     },
-    //these db requests all need the pad object (timestamp of latest revission, author data)
-    function(callback)
-    {
+
+    // these db requests all need the pad object (timestamp of latest revission, author data)
+    function(callback) {
       var authors = pad.getAllAuthors();
 
       async.parallel([
-        //get timestamp of latest revission needed for timeslider
-        function(callback)
-        {
-          pad.getRevisionDate(pad.getHeadRevisionNumber(), function(err, date)
-          {
-            if(ERR(err, callback)) return;
+        // get timestamp of latest revission needed for timeslider
+        function(callback) {
+          pad.getRevisionDate(pad.getHeadRevisionNumber(), function(err, date) {
+            if (ERR(err, callback)) return;
+
             currentTime = date;
             callback();
           });
         },
-        //get all author data out of the database
-        function(callback)
-        {
-          async.forEach(authors, function(authorId, callback)
-          {
-            authorManager.getAuthor(authorId, function(err, author)
-            {
-              if(!author && !err)
-              {
+
+        // get all author data out of the database
+        function(callback) {
+          async.forEach(authors, function(authorId, callback) {
+            authorManager.getAuthor(authorId, function(err, author) {
+              if (!author && !err) {
                 messageLogger.error("There is no author for authorId:", authorId);
+
                 return callback();
               }
-              if(ERR(err, callback)) return;
-              historicalAuthorData[authorId] = {name: author.name, colorId: author.colorId}; // Filter author attribs (e.g. don't send author's pads to all clients)
+
+              if (ERR(err, callback)) return;
+
+              historicalAuthorData[authorId] = { name: author.name, colorId: author.colorId }; // Filter author attribs (e.g. don't send author's pads to all clients)
               callback();
             });
           }, callback);
@@ -1117,56 +1104,57 @@ function handleClientReady(client, message)
       ], callback);
 
     },
-    //glue the clientVars together, send them and tell the other clients that a new one is there
-    function(callback)
-    {
-      //Check that the client is still here. It might have disconnected between callbacks.
-      if(sessioninfos[client.id] === undefined)
-        return callback();
 
-      //Check if this author is already on the pad, if yes, kick the other sessions!
+    // glue the clientVars together, send them and tell the other clients that a new one is there
+    function(callback) {
+      // Check that the client is still here. It might have disconnected between callbacks.
+      if(sessioninfos[client.id] === undefined) {
+        return callback();
+      }
+
+      // Check if this author is already on the pad, if yes, kick the other sessions!
       var roomClients = _getRoomClients(pad.id);
 
       async.forEach(roomClients, function(client, callback) {
         var sinfo = sessioninfos[client.id];
-        if(sinfo && sinfo.author == author) {
+
+        if (sinfo && sinfo.author == author) {
           // fix user's counter, works on page refresh or if user closes browser window and then rejoins
           sessioninfos[client.id] = {};
           client.leave(padIds.padId);
-          client.json.send({disconnect:"userdup"});
+          client.json.send({ disconnect:"userdup" });
         }
       });
 
-      //Save in sessioninfos that this session belonges to this pad
+      // Save in sessioninfos that this session belonges to this pad
       sessioninfos[client.id].padId = padIds.padId;
       sessioninfos[client.id].readOnlyPadId = padIds.readOnlyPadId;
       sessioninfos[client.id].readonly = padIds.readonly;
 
-      //Log creation/(re-)entering of a pad
+      // Log creation/(re-)entering of a pad
       var ip = remoteAddress[client.id];
 
-      //Anonymize the IP address if IP logging is disabled
-      if(settings.disableIPlogging) {
+      // Anonymize the IP address if IP logging is disabled
+      if (settings.disableIPlogging) {
         ip = 'ANONYMOUS';
       }
 
-      if(pad.head > 0) {
-        accessLogger.info('[ENTER] Pad "'+padIds.padId+'": Client '+client.id+' with IP "'+ip+'" entered the pad');
-      }
-      else if(pad.head == 0) {
-        accessLogger.info('[CREATE] Pad "'+padIds.padId+'": Client '+client.id+' with IP "'+ip+'" created the pad');
+      if (pad.head > 0) {
+        accessLogger.info('[ENTER] Pad "' + padIds.padId + '": Client ' + client.id + ' with IP "' + ip + '" entered the pad');
+      } else if (pad.head == 0) {
+        accessLogger.info('[CREATE] Pad "' + padIds.padId + '": Client ' + client.id + ' with IP "' + ip + '" created the pad');
       }
 
-      //If this is a reconnect, we don't have to send the client the ClientVars again
-      if(message.reconnect == true)
-      {
-        //Join the pad and start receiving updates
+      if (message.reconnect == true) {
+        // If this is a reconnect, we don't have to send the client the ClientVars again
+        // Join the pad and start receiving updates
         client.join(padIds.padId);
-        //Save the revision in sessioninfos, we take the revision from the info the client send to us
+
+        // Save the revision in sessioninfos, we take the revision from the info the client send to us
         sessioninfos[client.id].rev = message.client_rev;
 
-        //During the client reconnect, client might miss some revisions from other clients. By using client revision,
-        //this below code sends all the revisions missed during the client reconnect
+        // During the client reconnect, client might miss some revisions from other clients. By using client revision,
+        // this below code sends all the revisions missed during the client reconnect
         var revisionsNeeded = [];
         var changesets = {};
 
@@ -1174,68 +1162,68 @@ function handleClientReady(client, message)
         var endNum = pad.getHeadRevisionNumber() + 1;
 
         async.series([
-          //push all the revision numbers needed into revisionsNeeded array
-          function(callback)
-          {
+          // push all the revision numbers needed into revisionsNeeded array
+          function(callback) {
             var headNum = pad.getHeadRevisionNumber();
-            if (endNum > headNum+1)
-              endNum = headNum+1;
-            if (startNum < 0)
-              startNum = 0;
 
-            for(var r=startNum;r<endNum;r++)
-            {
+            if (endNum > headNum+1) {
+              endNum = headNum+1;
+            }
+
+            if (startNum < 0) {
+              startNum = 0;
+            }
+
+            for (var r = startNum; r < endNum; r++) {
               revisionsNeeded.push(r);
               changesets[r] = {};
             }
+
             callback();
           },
-          //get changesets needed for pending revisions
-          function(callback)
-          {
-            async.eachSeries(revisionsNeeded, function(revNum, callback)
-            {
-              pad.getRevisionChangeset(revNum, function(err, value)
-              {
-                if(ERR(err)) return;
+
+          // get changesets needed for pending revisions
+          function(callback) {
+            async.eachSeries(revisionsNeeded, function(revNum, callback) {
+              pad.getRevisionChangeset(revNum, function(err, value) {
+                if (ERR(err)) return;
+
                 changesets[revNum]['changeset'] = value;
                 callback();
               });
             }, callback);
           },
-          //get author for each changeset
-          function(callback)
-          {
-            async.eachSeries(revisionsNeeded, function(revNum, callback)
-            {
-              pad.getRevisionAuthor(revNum, function(err, value)
-              {
-                if(ERR(err)) return;
+
+          // get author for each changeset
+          function(callback) {
+            async.eachSeries(revisionsNeeded, function(revNum, callback) {
+              pad.getRevisionAuthor(revNum, function(err, value) {
+                if (ERR(err)) return;
+
                 changesets[revNum]['author'] = value;
                 callback();
               });
             }, callback);
           },
-          //get timestamp for each changeset
-          function(callback)
-          {
-            async.eachSeries(revisionsNeeded, function(revNum, callback)
-            {
-              pad.getRevisionDate(revNum, function(err, value)
-              {
-                if(ERR(err)) return;
+
+          // get timestamp for each changeset
+          function(callback) {
+            async.eachSeries(revisionsNeeded, function(revNum, callback) {
+              pad.getRevisionDate(revNum, function(err, value) {
+                if (ERR(err)) return;
+
                 changesets[revNum]['timestamp'] = value;
                 callback();
               });
             }, callback);
           }
         ],
-        //return error and pending changesets
-        function(err)
-        {
-          if(ERR(err, callback)) return;
-          async.eachSeries(revisionsNeeded, function(r, callback)
-          {
+
+        // return error and pending changesets
+        function(err) {
+          if (ERR(err, callback)) return;
+
+          async.eachSeries(revisionsNeeded, function(r, callback) {
             var forWire = Changeset.prepareForWire(changesets[r]['changeset'], pad.pool);
             var wireMsg = {"type":"COLLABROOM",
                            "data":{type:"CLIENT_RECONNECT",
@@ -1249,8 +1237,8 @@ function handleClientReady(client, message)
             client.json.send(wireMsg);
             callback();
           });
-          if (startNum == endNum)
-          {
+
+          if (startNum == endNum) {
             var Msg = {"type":"COLLABROOM",
                        "data":{type:"CLIENT_RECONNECT",
                                noChanges: true,
@@ -1259,19 +1247,17 @@ function handleClientReady(client, message)
             client.json.send(Msg);
           }
         });
-      }
-      //This is a normal first connect
-      else
-      {
-        //prepare all values for the wire, there'S a chance that this throws, if the pad is corrupted
+      } else {
+        // This is a normal first connect
+        // prepare all values for the wire, there's a chance that this throws, if the pad is corrupted
         try {
           var atext = Changeset.cloneAText(pad.atext);
           var attribsForWire = Changeset.prepareForWire(atext.attribs, pad.pool);
           var apool = attribsForWire.pool.toJsonable();
           atext.attribs = attribsForWire.translated;
-        }catch(e) {
+        } catch(e) {
           console.error(e.stack || e)
-          client.json.send({disconnect:"corruptPad"});// pull the breaks
+          client.json.send({ disconnect:"corruptPad" });// pull the brakes
           return callback();
         }
 
@@ -1335,35 +1321,36 @@ function handleClientReady(client, message)
           "initialChangesets": [] // FIXME: REMOVE THIS SHIT
         }
 
-        //Add a username to the clientVars if one avaiable
-        if(authorName != null)
-        {
+        // Add a username to the clientVars if one avaiable
+        if (authorName != null) {
           clientVars.userName = authorName;
         }
 
-        //call the clientVars-hook so plugins can modify them before they get sent to the client
-        hooks.aCallAll("clientVars", { clientVars: clientVars, pad: pad }, function ( err, messages ) {
-          if(ERR(err, callback)) return;
+        // call the clientVars-hook so plugins can modify them before they get sent to the client
+        hooks.aCallAll("clientVars", { clientVars: clientVars, pad: pad }, function( err, messages ) {
+          if (ERR(err, callback)) return;
 
           _.each(messages, function(newVars) {
-            //combine our old object with the new attributes from the hook
+            // combine our old object with the new attributes from the hook
             for(var attr in newVars) {
               clientVars[attr] = newVars[attr];
             }
           });
 
-          //Join the pad and start receiving updates
+          // Join the pad and start receiving updates
           client.join(padIds.padId);
-          //Send the clientVars to the Client
-          client.json.send({type: "CLIENT_VARS", data: clientVars});
-          //Save the current revision in sessioninfos, should be the same as in clientVars
+
+          // Send the clientVars to the Client
+          client.json.send({ type: "CLIENT_VARS", data: clientVars });
+
+          // Save the current revision in sessioninfos, should be the same as in clientVars
           sessioninfos[client.id].rev = pad.getHeadRevisionNumber();
         });
       }
 
       sessioninfos[client.id].author = author;
 
-      //prepare the notification for the other users on the pad, that this user joined
+      // prepare the notification for the other users on the pad, that this user joined
       var messageToTheOtherUsers = {
         "type": "COLLABROOM",
         "data": {
@@ -1377,47 +1364,47 @@ function handleClientReady(client, message)
         }
       };
 
-      //Add the authorname of this new User, if avaiable
-      if(authorName != null)
-      {
+      // Add the authorname of this new User, if avaiable
+      if (authorName != null) {
         messageToTheOtherUsers.data.userInfo.name = authorName;
       }
 
       // notify all existing users about new user
       client.broadcast.to(padIds.padId).json.send(messageToTheOtherUsers);
 
-      //Get sessions for this pad
+      // Get sessions for this pad
       var roomClients = _getRoomClients(pad.id);
 
-      async.forEach(roomClients, function(roomClient, callback)
-      {
+      async.forEach(roomClients, function(roomClient, callback) {
         var author;
 
-        //Jump over, if this session is the connection session
-        if(roomClient.id == client.id)
+        // Jump over, if this session is the connection session
+        if (roomClient.id == client.id) {
           return callback();
+        }
 
-
-        //Since sessioninfos might change while being enumerated, check if the
-        //sessionID is still assigned to a valid session
-        if(sessioninfos[roomClient.id] !== undefined)
+        // Since sessioninfos might change while being enumerated, check if the
+        // sessionID is still assigned to a valid session
+        if (sessioninfos[roomClient.id] !== undefined) {
           author = sessioninfos[roomClient.id].author;
-        else // If the client id is not valid, callback();
+        } else {
+          // If the client id is not valid, callback();
           return callback();
+        }
 
         async.waterfall([
-          //get the authorname & colorId
-          function(callback)
-          {
+          // get the authorname & colorId
+          function(callback) {
             // reuse previously created cache of author's data
-            if(historicalAuthorData[author])
+            if (historicalAuthorData[author]) {
               callback(null, historicalAuthorData[author]);
-            else
+            } else {
               authorManager.getAuthor(author, callback);
+            }
           },
-          function (authorInfo, callback)
-          {
-            //Send the new User a Notification about this other user
+
+          function(authorInfo, callback) {
+            // Send the new User a Notification about this other user
             var msg = {
               "type": "COLLABROOM",
               "data": {
@@ -1431,13 +1418,14 @@ function handleClientReady(client, message)
                 }
               }
             };
+
             client.json.send(msg);
           }
         ], callback);
       }, callback);
     }
-  ],function(err)
-  {
+  ],
+  function(err) {
     ERR(err);
   });
 }
@@ -1447,35 +1435,34 @@ function handleClientReady(client, message)
  */
 function handleChangesetRequest(client, message)
 {
-  //check if all ok
-  if(message.data == null)
-  {
+  // check if all ok
+  if (message.data == null) {
     messageLogger.warn("Dropped message, changeset request has no data!");
     return;
   }
-  if(message.padId == null)
-  {
+
+  if (message.padId == null) {
     messageLogger.warn("Dropped message, changeset request has no padId!");
     return;
   }
-  if(message.data.granularity == null)
-  {
+
+  if (message.data.granularity == null) {
     messageLogger.warn("Dropped message, changeset request has no granularity!");
     return;
   }
-  //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill
-  if(Math.floor(message.data.granularity) !== message.data.granularity)
-  {
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#Polyfill
+  if (Math.floor(message.data.granularity) !== message.data.granularity) {
     messageLogger.warn("Dropped message, changeset request granularity is not an integer!");
     return;
   }
-  if(message.data.start == null)
-  {
+
+  if (message.data.start == null) {
     messageLogger.warn("Dropped message, changeset request has no start!");
     return;
   }
-  if(message.data.requestID == null)
-  {
+
+  if (message.data.requestID == null) {
     messageLogger.warn("Dropped message, changeset request has no requestID!");
     return;
   }
@@ -1486,23 +1473,24 @@ function handleChangesetRequest(client, message)
   var padIds;
 
   async.series([
-    function (callback) {
+    function(callback) {
       readOnlyManager.getIds(message.padId, function(err, value) {
-        if(ERR(err, callback)) return;
+        if (ERR(err, callback)) return;
+
         padIds = value;
         callback();
       });
     },
-    function (callback) {
-      //build the requested rough changesets and send them back
-      getChangesetInfo(padIds.padId, start, end, granularity, function(err, changesetInfo)
-      {
-        if(err) return console.error('Error while handling a changeset request for '+padIds.padId, err, message.data);
+
+    function(callback) {
+      // build the requested rough changesets and send them back
+      getChangesetInfo(padIds.padId, start, end, granularity, function(err, changesetInfo) {
+        if (err) return console.error('Error while handling a changeset request for ' + padIds.padId, err, message.data);
 
         var data = changesetInfo;
         data.requestID = message.data.requestID;
 
-        client.json.send({type: "CHANGESET_REQ", data: data});
+        client.json.send({ type: "CHANGESET_REQ", data: data });
       });
     }
   ]);
@@ -1526,96 +1514,91 @@ function getChangesetInfo(padId, startNum, endNum, granularity, callback)
   var head_revision = 0;
 
   async.series([
-    //get the pad from the database
-    function(callback)
-    {
-      padManager.getPad(padId, function(err, _pad)
-      {
-        if(ERR(err, callback)) return;
+    // get the pad from the database
+    function(callback) {
+      padManager.getPad(padId, function(err, _pad) {
+        if (ERR(err, callback)) return;
+
         pad = _pad;
         head_revision = pad.getHeadRevisionNumber();
         callback();
       });
     },
-    function(callback)
-    {
-      //calculate the last full endnum
+
+    function(callback) {
+      // calculate the last full endnum
       var lastRev = pad.getHeadRevisionNumber();
-      if (endNum > lastRev+1) {
-        endNum = lastRev+1;
+      if (endNum > lastRev + 1) {
+        endNum = lastRev + 1;
       }
-      endNum = Math.floor(endNum / granularity)*granularity;
+
+      endNum = Math.floor(endNum / granularity) * granularity;
 
       var compositesChangesetNeeded = [];
       var revTimesNeeded = [];
 
-      //figure out which composite Changeset and revTimes we need, to load them in bulk
+      // figure out which composite Changeset and revTimes we need, to load them in bulk
       var compositeStart = startNum;
-      while (compositeStart < endNum)
-      {
+      while (compositeStart < endNum) {
         var compositeEnd = compositeStart + granularity;
 
-        //add the composite Changeset we needed
-        compositesChangesetNeeded.push({start: compositeStart, end: compositeEnd});
+        // add the composite Changeset we needed
+        compositesChangesetNeeded.push({ start: compositeStart, end: compositeEnd });
 
-        //add the t1 time we need
+        // add the t1 time we need
         revTimesNeeded.push(compositeStart == 0 ? 0 : compositeStart - 1);
-        //add the t2 time we need
+
+        // add the t2 time we need
         revTimesNeeded.push(compositeEnd - 1);
 
         compositeStart += granularity;
       }
 
-      //get all needed db values parallel
+      // get all needed db values parallel
       async.parallel([
-        function(callback)
-        {
-          //get all needed composite Changesets
-          async.forEach(compositesChangesetNeeded, function(item, callback)
-          {
-            composePadChangesets(padId, item.start, item.end, function(err, changeset)
-            {
-              if(ERR(err, callback)) return;
+        function(callback) {
+          // get all needed composite Changesets
+          async.forEach(compositesChangesetNeeded, function(item, callback) {
+            composePadChangesets(padId, item.start, item.end, function(err, changeset) {
+              if (ERR(err, callback)) return;
+
               composedChangesets[item.start + "/" + item.end] = changeset;
               callback();
             });
           }, callback);
         },
-        function(callback)
-        {
-          //get all needed revision Dates
-          async.forEach(revTimesNeeded, function(revNum, callback)
-          {
-            pad.getRevisionDate(revNum, function(err, revDate)
-            {
-              if(ERR(err, callback)) return;
+
+        function(callback) {
+          // get all needed revision Dates
+          async.forEach(revTimesNeeded, function(revNum, callback) {
+            pad.getRevisionDate(revNum, function(err, revDate) {
+              if (ERR(err, callback)) return;
+
               revisionDate[revNum] = Math.floor(revDate/1000);
               callback();
             });
           }, callback);
         },
-        //get the lines
-        function(callback)
-        {
-          getPadLines(padId, startNum-1, function(err, _lines)
-          {
-            if(ERR(err, callback)) return;
+
+        // get the lines
+        function(callback) {
+          getPadLines(padId, startNum-1, function(err, _lines) {
+            if (ERR(err, callback)) return;
+
             lines = _lines;
             callback();
           });
         }
       ], callback);
     },
-    //doesn't know what happens here excatly :/
-    function(callback)
-    {
+
+    // don't know what happens here exactly :/
+    function(callback) {
       var compositeStart = startNum;
 
-      while (compositeStart < endNum)
-      {
+      while (compositeStart < endNum) {
         var compositeEnd = compositeStart + granularity;
-        if (compositeEnd > endNum || compositeEnd > head_revision+1)
-        {
+        if (compositeEnd > endNum || compositeEnd > head_revision+1) {
           break;
         }
 
@@ -1629,12 +1612,9 @@ function getChangesetInfo(padId, startNum, endNum, granularity, callback)
         var backwards2 = Changeset.moveOpsToNewPool(backwards, pad.apool(), apool);
 
         var t1, t2;
-        if (compositeStart == 0)
-        {
+        if (compositeStart == 0) {
           t1 = revisionDate[0];
-        }
-        else
-        {
+        } else {
           t1 = revisionDate[compositeStart - 1];
         }
 
@@ -1649,9 +1629,9 @@ function getChangesetInfo(padId, startNum, endNum, granularity, callback)
 
       callback();
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
+  ],
+  function(err) {
+    if (ERR(err, callback)) return;
 
     callback(null, {forwardsChangesets: forwardsChangesets,
                     backwardsChangesets: backwardsChangesets,
@@ -1674,43 +1654,41 @@ function getPadLines(padId, revNum, callback)
   var pad;
 
   async.series([
-    //get the pad from the database
-    function(callback)
-    {
-      padManager.getPad(padId, function(err, _pad)
-      {
-        if(ERR(err, callback)) return;
+    // get the pad from the database
+    function(callback) {
+      padManager.getPad(padId, function(err, _pad) {
+        if (ERR(err, callback)) return;
+
         pad = _pad;
         callback();
       });
     },
-    //get the atext
-    function(callback)
-    {
-      if(revNum >= 0)
-      {
-        pad.getInternalRevisionAText(revNum, function(err, _atext)
-        {
-          if(ERR(err, callback)) return;
+
+    // get the atext
+    function(callback) {
+      if (revNum >= 0) {
+        pad.getInternalRevisionAText(revNum, function(err, _atext) {
+          if (ERR(err, callback)) return;
+
           atext = _atext;
           callback();
         });
-      }
-      else
-      {
+      } else {
         atext = Changeset.makeAText("\n");
         callback(null);
       }
     },
-    function(callback)
-    {
+
+    function(callback) {
       result.textlines = Changeset.splitTextLines(atext.text);
       result.alines = Changeset.splitAttributionLines(atext.attribs, atext.text);
       callback(null);
     }
-  ], function(err)
-  {
-    if(ERR(err, callback)) return;
+  ],
+
+  function(err) {
+    if (ERR(err, callback)) return;
+
     callback(null, result);
   });
 }
@@ -1726,74 +1704,77 @@ function composePadChangesets(padId, startNum, endNum, callback)
   var changeset;
 
   async.series([
-    //get the pad from the database
-    function(callback)
-    {
-      padManager.getPad(padId, function(err, _pad)
-      {
-        if(ERR(err, callback)) return;
+    // get the pad from the database
+    function(callback) {
+      padManager.getPad(padId, function(err, _pad) {
+        if (ERR(err, callback)) return;
+
         pad = _pad;
         callback();
       });
     },
-    //fetch all changesets we need
-    function(callback)
-    {
+
+    // fetch all changesets we need
+    function(callback) {
       var changesetsNeeded=[];
 
       var headNum = pad.getHeadRevisionNumber();
-      if (endNum > headNum+1)
-        endNum = headNum+1;
-      if (startNum < 0)
+      if (endNum > headNum + 1) {
+        endNum = headNum + 1;
+      }
+
+      if (startNum < 0) {
         startNum = 0;
-      //create a array for all changesets, we will
-      //replace the values with the changeset later
-      for(var r=startNum;r<endNum;r++)
-      {
+      }
+
+      // create an array for all changesets, we will
+      // replace the values with the changeset later
+      for (var r = startNum; r < endNum; r++) {
         changesetsNeeded.push(r);
       }
 
-      //get all changesets
-      async.forEach(changesetsNeeded, function(revNum,callback)
-      {
-        pad.getRevisionChangeset(revNum, function(err, value)
-        {
-          if(ERR(err, callback)) return;
+      // get all changesets
+      async.forEach(changesetsNeeded, function(revNum,callback) {
+        pad.getRevisionChangeset(revNum, function(err, value) {
+          if (ERR(err, callback)) return;
+
           changesets[revNum] = value;
           callback();
         });
       },callback);
     },
-    //compose Changesets
-    function(callback)
-    {
+
+    // compose Changesets
+    function(callback) {
       changeset = changesets[startNum];
       var pool = pad.apool();
 
       try {
-        for(var r=startNum+1;r<endNum;r++) {
+        for (var r = startNum + 1; r < endNum; r++) {
           var cs = changesets[r];
           changeset = Changeset.compose(changeset, cs, pool);
         }
-      } catch(e){
+      } catch(e) {
         // r-1 indicates the rev that was build starting with startNum, applying startNum+1, +2, +3
-        console.warn("failed to compose cs in pad:",padId," startrev:",startNum," current rev:",r);
+        console.warn("failed to compose cs in pad:", padId, " startrev:", startNum, " current rev:", r);
         return callback(e);
       }
 
       callback(null);
     }
   ],
-  //return err and changeset
-  function(err)
-  {
-    if(ERR(err, callback)) return;
+
+  // return err and changeset
+  function(err) {
+    if (ERR(err, callback)) return;
+
     callback(null, changeset);
   });
 }
 
 function _getRoomClients(padID) {
-  var roomClients = []; var room = socketio.sockets.adapter.rooms[padID];
+  var roomClients = [];
+  var room = socketio.sockets.adapter.rooms[padID];
 
   if (room) {
     for (var id in room.sockets) {
@@ -1807,7 +1788,7 @@ function _getRoomClients(padID) {
 /**
  * Get the number of users in a pad
  */
-exports.padUsersCount = function (padID, callback) {
+exports.padUsersCount = function(padID, callback) {
   callback(null, {
     padUsersCount: _getRoomClients(padID).length
   });
@@ -1816,16 +1797,16 @@ exports.padUsersCount = function (padID, callback) {
 /**
  * Get the list of users in a pad
  */
-exports.padUsers = function (padID, callback) {
+exports.padUsers = function(padID, callback) {
   var result = [];
 
   var roomClients = _getRoomClients(padID);
 
   async.forEach(roomClients, function(roomClient, callback) {
     var s = sessioninfos[roomClient.id];
-    if(s) {
+    if (s) {
       authorManager.getAuthor(s.author, function(err, author) {
-        if(ERR(err, callback)) return;
+        if (ERR(err, callback)) return;
 
         author.id = s.author;
         result.push(author);
@@ -1834,8 +1815,9 @@ exports.padUsers = function (padID, callback) {
     } else {
       callback();
     }
-  }, function(err) {
-    if(ERR(err, callback)) return;
+  },
+  function(err) {
+    if (ERR(err, callback)) return;
 
     callback(null, {padUsers: result});
   });

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -268,6 +268,12 @@ exports.handleMessage = async function(client, message)
     // FIXME: Use a hook instead
     // FIXME: Allow to override readwrite access with readonly
 
+    // the session may have been dropped during earlier processing
+    if (!sessioninfos[client.id]) {
+      messageLogger.warn("Dropping message from a connection that has gone away.")
+      return;
+    }
+
     // Simulate using the load testing tool
     if (!sessioninfos[client.id].auth) {
       console.error("Auth was never applied to a session.  If you are using the stress-test tool then restart Etherpad and the Stress test tool.")

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -38,6 +38,7 @@ var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks.js");
 var channels = require("channels");
 var stats = require('../stats');
 var remoteAddress = require("../utils/RemoteAddress").remoteAddress;
+const thenify = require("thenify").withCallback;
 
 /**
  * A associative array that saves informations about a session
@@ -1788,16 +1789,16 @@ function _getRoomClients(padID) {
 /**
  * Get the number of users in a pad
  */
-exports.padUsersCount = function(padID, callback) {
+exports.padUsersCount = thenify(function(padID, callback) {
   callback(null, {
     padUsersCount: _getRoomClients(padID).length
   });
-}
+});
 
 /**
  * Get the list of users in a pad
  */
-exports.padUsers = function(padID, callback) {
+exports.padUsers = thenify(function(padID, callback) {
   var result = [];
 
   var roomClients = _getRoomClients(padID);
@@ -1821,6 +1822,6 @@ exports.padUsers = function(padID, callback) {
 
     callback(null, {padUsers: result});
   });
-}
+});
 
 exports.sessioninfos = sessioninfos;

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -330,7 +330,7 @@ function handleSaveRevisionMessage(client, message){
  * @param msg {Object} the message we're sending
  * @param sessionID {string} the socketIO session to which we're sending this message
  */
-exports.handleCustomObjectMessage = thenify(function(msg, sessionID, cb) {
+exports.handleCustomObjectMessage = async function(msg, sessionID) {
   if (msg.data.type === "CUSTOM") {
     if (sessionID){
       // a sessionID is targeted: directly to this sessionID
@@ -340,9 +340,7 @@ exports.handleCustomObjectMessage = thenify(function(msg, sessionID, cb) {
       socketio.sockets.in(msg.data.payload.padId).json.send(msg);
     }
   }
-  cb(null, {});
-});
-
+}
 
 /**
  * Handles a custom message (sent via HTTP API request)
@@ -809,7 +807,7 @@ function handleUserChanges(data, cb)
   });
 }
 
-exports.updatePadClients = function(pad, callback)
+exports.updatePadClients = thenify(function(pad, callback)
 {
   // skip this if no-one is on this pad
   var roomClients = _getRoomClients(pad.id);
@@ -886,7 +884,7 @@ exports.updatePadClients = function(pad, callback)
       callback
     );
   },callback);
-}
+});
 
 /**
  * Copied from the Etherpad Source Code. Don't know what this method does excatly...
@@ -1503,7 +1501,7 @@ function handleChangesetRequest(client, message)
  * Tries to rebuild the getChangestInfo function of the original Etherpad
  * https://github.com/ether/pad/blob/master/etherpad/src/etherpad/control/pad/pad_changeset_control.js#L144
  */
-function getChangesetInfo(padId, startNum, endNum, granularity, callback)
+let getChangesetInfo = thenify(function getChangesetInfo(padId, startNum, endNum, granularity, callback)
 {
   var forwardsChangesets = [];
   var backwardsChangesets = [];
@@ -1643,13 +1641,13 @@ function getChangesetInfo(padId, startNum, endNum, granularity, callback)
                     start: startNum,
                     granularity: granularity });
   });
-}
+});
 
 /**
  * Tries to rebuild the getPadLines function of the original Etherpad
  * https://github.com/ether/pad/blob/master/etherpad/src/etherpad/control/pad/pad_changeset_control.js#L263
  */
-function getPadLines(padId, revNum, callback)
+let getPadLines = thenify(function getPadLines(padId, revNum, callback)
 {
   var atext;
   var result = {};
@@ -1693,13 +1691,13 @@ function getPadLines(padId, revNum, callback)
 
     callback(null, result);
   });
-}
+});
 
 /**
  * Tries to rebuild the composePadChangeset function of the original Etherpad
  * https://github.com/ether/pad/blob/master/etherpad/src/etherpad/control/pad/pad_changeset_control.js#L241
  */
-function composePadChangesets(padId, startNum, endNum, callback)
+let composePadChangesets = thenify(function(padId, startNum, endNum, callback)
 {
   var pad;
   var changesets = {};
@@ -1772,7 +1770,7 @@ function composePadChangesets(padId, startNum, endNum, callback)
 
     callback(null, changeset);
   });
-}
+});
 
 function _getRoomClients(padID) {
   var roomClients = [];
@@ -1790,39 +1788,32 @@ function _getRoomClients(padID) {
 /**
  * Get the number of users in a pad
  */
-exports.padUsersCount = thenify(function(padID, callback) {
-  callback(null, {
+exports.padUsersCount = function(padID) {
+  return {
     padUsersCount: _getRoomClients(padID).length
-  });
-});
+  }
+}
 
 /**
  * Get the list of users in a pad
  */
-exports.padUsers = thenify(function(padID, callback) {
-  var result = [];
+exports.padUsers = async function(padID) {
 
-  var roomClients = _getRoomClients(padID);
+  let padUsers = [];
+  let roomClients = _getRoomClients(padID);
 
-  async.forEach(roomClients, function(roomClient, callback) {
-    var s = sessioninfos[roomClient.id];
+  for (let i = 0, n = roomClients.length; i < n; ++i) {
+    let roomClient = roomClients[i];
+
+    let s = sessioninfos[roomClient.id];
     if (s) {
-      authorManager.getAuthor(s.author, function(err, author) {
-        if (ERR(err, callback)) return;
-
-        author.id = s.author;
-        result.push(author);
-        callback();
-      });
-    } else {
-      callback();
+      let author = await authorManager.getAuthor(s.author);
+      author.id = s.author;
+      padUsers.push(author);
     }
-  },
-  function(err) {
-    if (ERR(err, callback)) return;
+  }
 
-    callback(null, {padUsers: result});
-  });
-});
+  return { padUsers };
+}
 
 exports.sessioninfos = sessioninfos;

--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -95,7 +95,7 @@ exports.setSocketIO = function(_socket) {
           var checkAccessCallback = function(err, statusObject) {
             ERR(err);
 
-            if (statusObject.accessStatus == "grant") {
+            if (statusObject.accessStatus === "grant") {
               // access was granted, mark the client as authorized and handle the message
               clientAuthorized = true;
               handleMessage(client, message);

--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -75,7 +75,7 @@ exports.setSocketIO = function(_socket) {
     }
 
     // tell all components about this connect
-    for (var i in components) {
+    for (let i in components) {
       components[i].handleConnect(client);
     }
 
@@ -117,7 +117,7 @@ exports.setSocketIO = function(_socket) {
 
     client.on('disconnect', function() {
       // tell all components about this disconnect
-      for (var i in components) {
+      for (let i in components) {
         components[i].handleDisconnect(client);
       }
     });
@@ -142,14 +142,10 @@ function handleMessage(client, message)
 // this ensures there are no passwords in the log
 function stringifyWithoutPassword(message)
 {
-  var newMessage = {};
+  let newMessage = Object.assign({}, message);
 
-  for (var i in message) {
-    if (i == "password" && message[i] != null) {
-      newMessage["password"] = "xxx";
-    } else {
-      newMessage[i] = message[i];
-    }
+  if (newMessage.password != null) {
+    newMessage.password = "xxx";
   }
 
   return JSON.stringify(newMessage);

--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -1,5 +1,5 @@
 /**
- * This is the Socket.IO Router. It routes the Messages between the 
+ * This is the Socket.IO Router. It routes the Messages between the
  * components of the Server. The components are at the moment: pad and timeslider
  */
 
@@ -31,20 +31,20 @@ var settings = require('../utils/Settings');
  * Saves all components
  * key is the component name
  * value is the component module
- */ 
+ */
 var components = {};
 
 var socket;
- 
+
 /**
  * adds a component
  */
 exports.addComponent = function(moduleName, module)
 {
-  //save the component
+  // save the component
   components[moduleName] = module;
-  
-  //give the module the socket
+
+  // give the module the socket
   module.setSocketIO(socket);
 }
 
@@ -52,57 +52,55 @@ exports.addComponent = function(moduleName, module)
  * sets the socket.io and adds event functions for routing
  */
 exports.setSocketIO = function(_socket) {
-  //save this socket internaly
+  // save this socket internaly
   socket = _socket;
-  
+
   socket.sockets.on('connection', function(client)
   {
-
     // Broken: See http://stackoverflow.com/questions/4647348/send-message-to-specific-client-with-socket-io-and-node-js
     // Fixed by having a persistant object, ideally this would actually be in the database layer
     // TODO move to database layer
-    if(settings.trustProxy && client.handshake.headers['x-forwarded-for'] !== undefined){
+    if (settings.trustProxy && client.handshake.headers['x-forwarded-for'] !== undefined) {
       remoteAddress[client.id] = client.handshake.headers['x-forwarded-for'];
-    }
-    else{
+    } else {
       remoteAddress[client.id] = client.handshake.address;
     }
+
     var clientAuthorized = false;
-    
-    //wrap the original send function to log the messages
+
+    // wrap the original send function to log the messages
     client._send = client.send;
     client.send = function(message) {
       messageLogger.debug("to " + client.id + ": " + stringifyWithoutPassword(message));
       client._send(message);
     }
-  
-    //tell all components about this connect
-    for(var i in components) {
-      components[i].handleConnect(client);
-    } 
 
-    client.on('message', function(message)
-    {
-      if(message.protocolVersion && message.protocolVersion != 2) {
+    // tell all components about this connect
+    for (var i in components) {
+      components[i].handleConnect(client);
+    }
+
+    client.on('message', function(message) {
+      if (message.protocolVersion && message.protocolVersion != 2) {
         messageLogger.warn("Protocolversion header is not correct:" + stringifyWithoutPassword(message));
         return;
       }
 
-      //client is authorized, everything ok
-      if(clientAuthorized) {
+      if (clientAuthorized) {
+        // client is authorized, everything ok
         handleMessage(client, message);
-      } else { //try to authorize the client
-        if(message.padId !== undefined && message.sessionID !== undefined && message.token !== undefined && message.password !== undefined) {
+      } else {
+        // try to authorize the client
+        if (message.padId !== undefined && message.sessionID !== undefined && message.token !== undefined && message.password !== undefined) {
           var checkAccessCallback = function(err, statusObject) {
             ERR(err);
 
-            //access was granted, mark the client as authorized and handle the message
-            if(statusObject.accessStatus == "grant") {
+            if (statusObject.accessStatus == "grant") {
+              // access was granted, mark the client as authorized and handle the message
               clientAuthorized = true;
               handleMessage(client, message);
-            }
-            //no access, send the client a message that tell him why
-            else {
+            } else {
+              // no access, send the client a message that tells him why
               messageLogger.warn("Authentication try failed:" + stringifyWithoutPassword(message));
               client.json.send({accessStatus: statusObject.accessStatus});
             }
@@ -110,57 +108,55 @@ exports.setSocketIO = function(_socket) {
           if (message.padId.indexOf("r.") === 0) {
             readOnlyManager.getPadId(message.padId, function(err, value) {
               ERR(err);
-              securityManager.checkAccess (value, message.sessionID, message.token, message.password, checkAccessCallback);
+              securityManager.checkAccess(value, message.sessionID, message.token, message.password, checkAccessCallback);
             });
           } else {
-            //this message has everything to try an authorization
+            // this message has everything to try an authorization
             securityManager.checkAccess (message.padId, message.sessionID, message.token, message.password, checkAccessCallback);
           }
-        } else { //drop message
+        } else {
+          // drop message
           messageLogger.warn("Dropped message cause of bad permissions:" + stringifyWithoutPassword(message));
         }
       }
     });
 
-    client.on('disconnect', function()
-    {
-      //tell all components about this disconnect
-      for(var i in components)
-      {
+    client.on('disconnect', function() {
+      // tell all components about this disconnect
+      for (var i in components) {
         components[i].handleDisconnect(client);
       }
     });
   });
 }
 
-//try to handle the message of this client
+// try to handle the message of this client
 function handleMessage(client, message)
 {
-
-  if(message.component && components[message.component]) {
-    //check if component is registered in the components array
-    if(components[message.component]) {
+  if (message.component && components[message.component]) {
+    // check if component is registered in the components array
+    if (components[message.component]) {
       messageLogger.debug("from " + client.id + ": " + stringifyWithoutPassword(message));
       components[message.component].handleMessage(client, message);
     }
   } else {
     messageLogger.error("Can't route the message:" + stringifyWithoutPassword(message));
   }
-} 
+}
 
-//returns a stringified representation of a message, removes the password
-//this ensures there are no passwords in the log
+// returns a stringified representation of a message, removes the password
+// this ensures there are no passwords in the log
 function stringifyWithoutPassword(message)
 {
   var newMessage = {};
-  
-  for(var i in message)
-  {
-    if(i == "password" && message[i] != null)
+
+  for (var i in message) {
+    if (i == "password" && message[i] != null) {
       newMessage["password"] = "xxx";
-    else
-      newMessage[i]=message[i];
+    } else {
+      newMessage[i] = message[i];
+    }
   }
-  
+
   return JSON.stringify(newMessage);
 }

--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -116,7 +116,7 @@ exports.setSocketIO = function(_socket) {
           }
         } else {
           // drop message
-          messageLogger.warn("Dropped message cause of bad permissions:" + stringifyWithoutPassword(message));
+          messageLogger.warn("Dropped message because of bad permissions:" + stringifyWithoutPassword(message));
         }
       }
     });

--- a/src/node/hooks/express/adminplugins.js
+++ b/src/node/hooks/express/adminplugins.js
@@ -5,7 +5,7 @@ var plugins = require('ep_etherpad-lite/static/js/pluginfw/plugins');
 var _ = require('underscore');
 var semver = require('semver');
 
-exports.expressCreateServer = function (hook_name, args, cb) {
+exports.expressCreateServer = function(hook_name, args, cb) {
   args.app.get('/admin/plugins', function(req, res) {
     var plugins = require("ep_etherpad-lite/static/js/pluginfw/plugins");
     var render_args = {
@@ -13,74 +13,81 @@ exports.expressCreateServer = function (hook_name, args, cb) {
       search_results: {},
       errors: [],
     };
-    res.send( eejs.require("ep_etherpad-lite/templates/admin/plugins.html", render_args) );
+
+    res.send(eejs.require("ep_etherpad-lite/templates/admin/plugins.html", render_args));
   });
+
   args.app.get('/admin/plugins/info', function(req, res) {
     var gitCommit = settings.getGitCommit();
     var epVersion = settings.getEpVersion();
-    res.send( eejs.require("ep_etherpad-lite/templates/admin/plugins-info.html",
-      {
-        gitCommit: gitCommit,
-        epVersion: epVersion
-      }) 
-    );
+
+    res.send(eejs.require("ep_etherpad-lite/templates/admin/plugins-info.html", {
+      gitCommit: gitCommit,
+      epVersion: epVersion
+    }));
   });
 }
 
-exports.socketio = function (hook_name, args, cb) {
+exports.socketio = function(hook_name, args, cb) {
   var io = args.io.of("/pluginfw/installer");
-  io.on('connection', function (socket) {
-
+  io.on('connection', function(socket) {
     if (!socket.conn.request.session || !socket.conn.request.session.user || !socket.conn.request.session.user.is_admin) return;
 
-    socket.on("getInstalled", function (query) {
+    socket.on("getInstalled", function(query) {
       // send currently installed plugins
       var installed = Object.keys(plugins.plugins).map(function(plugin) {
         return plugins.plugins[plugin].package
-      })
+      });
+
       socket.emit("results:installed", {installed: installed});
     });
-    
+
     socket.on("checkUpdates", function() {
       // Check plugins for updates
-      installer.getAvailablePlugins(/*maxCacheAge:*/60*10, function(er, results) {
-        if(er) {
+      installer.getAvailablePlugins(/*maxCacheAge:*/ 60 * 10, function(er, results) {
+        if (er) {
           console.warn(er);
           socket.emit("results:updatable", {updatable: {}});
           return;
         }
+
         var updatable = _(plugins.plugins).keys().filter(function(plugin) {
-          if(!results[plugin]) return false;
-          var latestVersion = results[plugin].version
-          var currentVersion = plugins.plugins[plugin].package.version
-          return semver.gt(latestVersion, currentVersion)
+          if (!results[plugin]) return false;
+
+          var latestVersion = results[plugin].version;
+          var currentVersion = plugins.plugins[plugin].package.version;
+
+          return semver.gt(latestVersion, currentVersion);
         });
+
         socket.emit("results:updatable", {updatable: updatable});
       });
-    })
-    
-    socket.on("getAvailable", function (query) {
-        installer.getAvailablePlugins(/*maxCacheAge:*/false, function (er, results) {
-          if(er) {
-            console.error(er)
-            results = {}
+    });
+
+    socket.on("getAvailable", function(query) {
+        installer.getAvailablePlugins(/*maxCacheAge:*/ false, function(er, results) {
+          if (er) {
+            console.error(er);
+            results = {};
           }
+
           socket.emit("results:available", results);
       });
     });
 
-    socket.on("search", function (query) {
-      installer.search(query.searchTerm, /*maxCacheAge:*/60*10, function (er, results) {
-        if(er) {
-          console.error(er)
-          results = {}
+    socket.on("search", function(query) {
+      installer.search(query.searchTerm, /*maxCacheAge:*/ 60 * 10, function(er, results) {
+        if (er) {
+          console.error(er);
+          results = {};
         }
+
         var res = Object.keys(results)
           .map(function(pluginName) {
-            return results[pluginName]
+            return results[pluginName];
           })
           .filter(function(plugin) {
-            return !plugins.plugins[plugin.name]
+            return !plugins.plugins[plugin.name];
           });
         res = sortPluginList(res, query.sortBy, query.sortDir)
           .slice(query.offset, query.offset+query.limit);
@@ -88,16 +95,18 @@ exports.socketio = function (hook_name, args, cb) {
       });
     });
 
-    socket.on("install", function (plugin_name) {
-      installer.install(plugin_name, function (er) {
-        if(er) console.warn(er)
+    socket.on("install", function(plugin_name) {
+      installer.install(plugin_name, function(er) {
+        if (er) console.warn(er);
+
         socket.emit("finished:install", {plugin: plugin_name, code: er? er.code : null, error: er? er.message : null});
       });
     });
 
-    socket.on("uninstall", function (plugin_name) {
-      installer.uninstall(plugin_name, function (er) {
-        if(er) console.warn(er)
+    socket.on("uninstall", function(plugin_name) {
+      installer.uninstall(plugin_name, function(er) {
+        if (er) console.warn(er);
+
         socket.emit("finished:uninstall", {plugin: plugin_name, error: er? er.message : null});
       });
     });
@@ -106,11 +115,15 @@ exports.socketio = function (hook_name, args, cb) {
 
 function sortPluginList(plugins, property, /*ASC?*/dir) {
   return plugins.sort(function(a, b) {
-    if (a[property] < b[property])
-       return dir? -1 : 1;
-    if (a[property] > b[property])
-       return dir? 1 : -1;
+    if (a[property] < b[property]) {
+      return dir? -1 : 1;
+    }
+
+    if (a[property] > b[property]) {
+      return dir? 1 : -1;
+    }
+
     // a must be equal to b
     return 0;
-  })
+  });
 }

--- a/src/node/hooks/express/errorhandling.js
+++ b/src/node/hooks/express/errorhandling.js
@@ -21,7 +21,7 @@ exports.gracefulShutdown = function(err) {
   console.log("graceful shutdown...");
 
   // do the db shutdown
-  db.db.doShutdown(function() {
+  db.doShutdown().then(function() {
     console.log("db sucessfully closed.");
 
     process.exit(0);

--- a/src/node/hooks/express/errorhandling.js
+++ b/src/node/hooks/express/errorhandling.js
@@ -11,20 +11,23 @@ exports.gracefulShutdown = function(err) {
     console.error(err);
   }
 
-  //ensure there is only one graceful shutdown running
-  if(exports.onShutdown) return;
+  // ensure there is only one graceful shutdown running
+  if (exports.onShutdown) {
+    return;
+  }
+
   exports.onShutdown = true;
 
   console.log("graceful shutdown...");
 
-  //do the db shutdown
+  // do the db shutdown
   db.db.doShutdown(function() {
     console.log("db sucessfully closed.");
 
     process.exit(0);
   });
 
-  setTimeout(function(){
+  setTimeout(function() {
     process.exit(1);
   }, 3000);
 }
@@ -35,14 +38,14 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   exports.app = args.app;
 
   // Handle errors
-  args.app.use(function(err, req, res, next){
+  args.app.use(function(err, req, res, next) {
     // if an error occurs Connect will pass it down
     // through these "error-handling" middleware
     // allowing you to respond however you like
     res.status(500).send({ error: 'Sorry, something bad happened!' });
     console.error(err.stack? err.stack : err.toString());
     stats.meter('http500').mark()
-  })
+  });
 
   /*
    * Connect graceful shutdown with sigint and uncaught exception

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -13,7 +13,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
       return;
     }
 
-    //if abiword is disabled, and this is a format we only support with abiword, output a message
+    // if abiword is disabled, and this is a format we only support with abiword, output a message
     if (settings.exportAvailable() == "no" &&
        ["odt", "pdf", "doc"].indexOf(req.params.type) !== -1) {
       res.send("This export is not enabled at this Etherpad instance. Set the path to Abiword or SOffice in settings.json to enable this feature");
@@ -24,9 +24,8 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 
     hasPadAccess(req, res, function() {
       console.log('req.params.pad', req.params.pad);
-      padManager.doesPadExists(req.params.pad, function(err, exists)
-      {
-        if(!exists) {
+      padManager.doesPadExists(req.params.pad, function(err, exists) {
+        if (!exists) {
           return next();
         }
 
@@ -35,12 +34,11 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     });
   });
 
-  //handle import requests
+  // handle import requests
   args.app.post('/p/:pad/import', function(req, res, next) {
     hasPadAccess(req, res, function() {
-      padManager.doesPadExists(req.params.pad, function(err, exists)
-      {
-        if(!exists) {
+      padManager.doesPadExists(req.params.pad, function(err, exists) {
+        if (!exists) {
           return next();
         }
 

--- a/src/node/hooks/express/padreadonly.js
+++ b/src/node/hooks/express/padreadonly.js
@@ -5,52 +5,45 @@ var hasPadAccess = require("../../padaccess");
 var exporthtml = require("../../utils/ExportHtml");
 
 exports.expressCreateServer = function (hook_name, args, cb) {
-  //serve read only pad
-  args.app.get('/ro/:id', function(req, res)
-  {
+  // serve read only pad
+  args.app.get('/ro/:id', function(req, res) {
     var html;
     var padId;
 
     async.series([
-      //translate the read only pad to a padId
-      function(callback)
-      {
-        readOnlyManager.getPadId(req.params.id, function(err, _padId)
-        {
+      // translate the read only pad to a padId
+      function(callback) {
+        readOnlyManager.getPadId(req.params.id, function(err, _padId) {
           if(ERR(err, callback)) return;
 
           padId = _padId;
 
-          //we need that to tell hasPadAcess about the pad
+          // we need that to tell hasPadAcess about the pad
           req.params.pad = padId;
 
           callback();
         });
       },
-      //render the html document
-      function(callback)
-      {
-        //return if the there is no padId
-        if(padId == null)
-        {
+      // render the html document
+      function(callback) {
+        // return if the there is no padId
+        if(padId == null) {
           callback("notfound");
           return;
         }
 
-        hasPadAccess(req, res, function()
-        {
-          //render the html document
-          exporthtml.getPadHTMLDocument(padId, null, function(err, _html)
-          {
+        hasPadAccess(req, res, function() {
+          // render the html document
+          exporthtml.getPadHTMLDocument(padId, null, function(err, _html) {
             if(ERR(err, callback)) return;
             html = _html;
             callback();
           });
         });
       }
-    ], function(err)
-    {
-      //throw any unexpected error
+    ],
+    function(err) {
+      // throw any unexpected error
       if(err && err != "notfound")
         ERR(err);
 

--- a/src/node/hooks/express/padreadonly.js
+++ b/src/node/hooks/express/padreadonly.js
@@ -1,57 +1,26 @@
-var async = require('async');
-var ERR = require("async-stacktrace");
 var readOnlyManager = require("../../db/ReadOnlyManager");
 var hasPadAccess = require("../../padaccess");
 var exporthtml = require("../../utils/ExportHtml");
 
 exports.expressCreateServer = function (hook_name, args, cb) {
   // serve read only pad
-  args.app.get('/ro/:id', function(req, res) {
-    var html;
-    var padId;
+  args.app.get('/ro/:id', async function(req, res) {
 
-    async.series([
-      // translate the read only pad to a padId
-      function(callback) {
-        readOnlyManager.getPadId(req.params.id, function(err, _padId) {
-          if(ERR(err, callback)) return;
+    // translate the read only pad to a padId
+    let padId = await readOnlyManager.getPadId(req.params.id);
+    if (padId == null) {
+      res.status(404).send('404 - Not Found');
+      return;
+    }
 
-          padId = _padId;
+    // we need that to tell hasPadAcess about the pad
+    req.params.pad = padId;
 
-          // we need that to tell hasPadAcess about the pad
-          req.params.pad = padId;
-
-          callback();
-        });
-      },
+    if (await hasPadAccess(req, res)) {
       // render the html document
-      function(callback) {
-        // return if the there is no padId
-        if(padId == null) {
-          callback("notfound");
-          return;
-        }
-
-        hasPadAccess(req, res, function() {
-          // render the html document
-          exporthtml.getPadHTMLDocument(padId, null, function(err, _html) {
-            if(ERR(err, callback)) return;
-            html = _html;
-            callback();
-          });
-        });
-      }
-    ],
-    function(err) {
-      // throw any unexpected error
-      if(err && err != "notfound")
-        ERR(err);
-
-      if(err == "notfound")
-        res.status(404).send('404 - Not Found');
-      else
-        res.send(html);
-    });
+      html = await exporthtml.getPadHTMLDocument(padId, null);
+      res.send(html);
+    }
   });
 
 }

--- a/src/node/hooks/express/padurlsanitize.js
+++ b/src/node/hooks/express/padurlsanitize.js
@@ -2,29 +2,26 @@ var padManager = require('../../db/PadManager');
 var url = require('url');
 
 exports.expressCreateServer = function (hook_name, args, cb) {
-  //redirects browser to the pad's sanitized url if needed. otherwise, renders the html
+
+  // redirects browser to the pad's sanitized url if needed. otherwise, renders the html
   args.app.param('pad', function (req, res, next, padId) {
-    //ensure the padname is valid and the url doesn't end with a /
-    if(!padManager.isValidPadId(padId) || /\/$/.test(req.url))
-    {
+    // ensure the padname is valid and the url doesn't end with a /
+    if (!padManager.isValidPadId(padId) || /\/$/.test(req.url)) {
       res.status(404).send('Such a padname is forbidden');
       return;
     }
 
     padManager.sanitizePadId(padId, function(sanitizedPadId) {
-      //the pad id was sanitized, so we redirect to the sanitized version
-      if(sanitizedPadId != padId)
-      {
+      if (sanitizedPadId != padId) {
+        // the pad id was sanitized, so we redirect to the sanitized version
         var real_url = sanitizedPadId;
         real_url = encodeURIComponent(real_url);
         var query = url.parse(req.url).query;
         if ( query ) real_url += '?' + query;
         res.header('Location', real_url);
         res.status(302).send('You should be redirected to <a href="' + real_url + '">' + real_url + '</a>');
-      }
-      //the pad id was fine, so just render it
-      else
-      {
+      } else {
+        // the pad id was fine, so just render it
         next();
       }
     });

--- a/src/node/hooks/express/padurlsanitize.js
+++ b/src/node/hooks/express/padurlsanitize.js
@@ -12,7 +12,10 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     }
 
     padManager.sanitizePadId(padId, function(sanitizedPadId) {
-      if (sanitizedPadId != padId) {
+      if (sanitizedPadId === padId) {
+        // the pad id was fine, so just render it
+        next();
+      } else {
         // the pad id was sanitized, so we redirect to the sanitized version
         var real_url = sanitizedPadId;
         real_url = encodeURIComponent(real_url);
@@ -20,9 +23,6 @@ exports.expressCreateServer = function (hook_name, args, cb) {
         if ( query ) real_url += '?' + query;
         res.header('Location', real_url);
         res.status(302).send('You should be redirected to <a href="' + real_url + '">' + real_url + '</a>');
-      } else {
-        // the pad id was fine, so just render it
-        next();
       }
     });
   });

--- a/src/node/hooks/express/padurlsanitize.js
+++ b/src/node/hooks/express/padurlsanitize.js
@@ -4,26 +4,26 @@ var url = require('url');
 exports.expressCreateServer = function (hook_name, args, cb) {
 
   // redirects browser to the pad's sanitized url if needed. otherwise, renders the html
-  args.app.param('pad', function (req, res, next, padId) {
+  args.app.param('pad', async function (req, res, next, padId) {
     // ensure the padname is valid and the url doesn't end with a /
     if (!padManager.isValidPadId(padId) || /\/$/.test(req.url)) {
       res.status(404).send('Such a padname is forbidden');
       return;
     }
 
-    padManager.sanitizePadId(padId, function(sanitizedPadId) {
-      if (sanitizedPadId === padId) {
-        // the pad id was fine, so just render it
-        next();
-      } else {
-        // the pad id was sanitized, so we redirect to the sanitized version
-        var real_url = sanitizedPadId;
-        real_url = encodeURIComponent(real_url);
-        var query = url.parse(req.url).query;
-        if ( query ) real_url += '?' + query;
-        res.header('Location', real_url);
-        res.status(302).send('You should be redirected to <a href="' + real_url + '">' + real_url + '</a>');
-      }
-    });
+    let sanitizedPadId = await padManager.sanitizePadId(padId);
+
+    if (sanitizedPadId === padId) {
+      // the pad id was fine, so just render it
+      next();
+    } else {
+      // the pad id was sanitized, so we redirect to the sanitized version
+      var real_url = sanitizedPadId;
+      real_url = encodeURIComponent(real_url);
+      var query = url.parse(req.url).query;
+      if ( query ) real_url += '?' + query;
+      res.header('Location', real_url);
+      res.status(302).send('You should be redirected to <a href="' + real_url + '">' + real_url + '</a>');
+    }
   });
 }

--- a/src/node/hooks/express/tests.js
+++ b/src/node/hooks/express/tests.js
@@ -1,24 +1,19 @@
 var path = require("path")
   , npm = require("npm")
   , fs = require("fs")
-  , async = require("async");
+  , util = require("util");
 
 exports.expressCreateServer = function (hook_name, args, cb) {
-  args.app.get('/tests/frontend/specs_list.js', function(req, res) {
-    async.parallel({
-      coreSpecs: function(callback) {
-        exports.getCoreTests(callback);
-      },
-      pluginSpecs: function(callback) {
-        exports.getPluginTests(callback);
-      }
-    },
-    function(err, results) {
-      var files = results.coreSpecs; // push the core specs to a file object
-      files = files.concat(results.pluginSpecs); // add the plugin Specs to the core specs
-      console.debug("Sent browser the following test specs:", files.sort());
-      res.send("var specs_list = " + JSON.stringify(files.sort()) + ";\n");
-    });
+  args.app.get('/tests/frontend/specs_list.js', async function(req, res) {
+    let [coreTests, pluginTests] = await Promise.all([
+      exports.getCoreTests(),
+      exports.getPluginTests()
+    ]);
+
+    // merge the two sets of results
+    let files = [].concat(coreTests, pluginTests).sort();
+    console.debug("Sent browser the following test specs:", files);
+    res.send("var specs_list = " + JSON.stringify(files) + ";\n");
   });
 
   // path.join seems to normalize by default, but we'll just be explicit
@@ -63,30 +58,30 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   });
 }
 
-exports.getPluginTests = function(callback) {
-  var pluginSpecs = [];
-  var plugins = fs.readdirSync('node_modules');
-  plugins.forEach(function(plugin) {
-    if (fs.existsSync("node_modules/" + plugin + "/static/tests/frontend/specs")) {
-      // if plugins exists
-      var specFiles = fs.readdirSync("node_modules/" + plugin + "/static/tests/frontend/specs/");
-      async.forEach(specFiles, function(spec) {
-         // for each specFile push it to pluginSpecs
-         pluginSpecs.push("/static/plugins/" + plugin + "/static/tests/frontend/specs/" + spec);
-      },
-      function(err) {
-         // blow up if something bad happens!
-      });
-    }
-  });
-  callback(null, pluginSpecs);
+const readdir = util.promisify(fs.readdir);
+
+exports.getPluginTests = async function(callback) {
+  const moduleDir = "node_modules/";
+  const specPath = "/static/tests/frontend/specs/";
+  const staticDir = "/static/plugins/";
+
+  let pluginSpecs = [];
+
+  let plugins = await readdir(moduleDir);
+  let promises = plugins
+    .map(plugin => [ plugin, moduleDir + plugin + specPath] )
+    .filter(([plugin, specDir]) => fs.existsSync(specDir)) // check plugin exists
+    .map(([plugin, specDir]) => {
+      return readdir(specDir)
+        .then(specFiles => specFiles.map(spec => {
+          pluginSpecs.push(staticDir + plugin + specPath + spec);
+        }));
+    });
+
+  return Promise.all(promises).then(() => pluginSpecs);
 }
 
-exports.getCoreTests = function(callback) {
+exports.getCoreTests = function() {
   // get the core test specs
-  fs.readdir('tests/frontend/specs', function(err, coreSpecs) {
-    if (err) { return res.send(500); }
-
-    callback(null, coreSpecs);
-  });
+  return readdir('tests/frontend/specs');
 }

--- a/src/node/hooks/express/tests.js
+++ b/src/node/hooks/express/tests.js
@@ -4,37 +4,35 @@ var path = require("path")
   , async = require("async");
 
 exports.expressCreateServer = function (hook_name, args, cb) {
-  args.app.get('/tests/frontend/specs_list.js', function(req, res){
-
+  args.app.get('/tests/frontend/specs_list.js', function(req, res) {
     async.parallel({
-      coreSpecs: function(callback){
+      coreSpecs: function(callback) {
         exports.getCoreTests(callback);
       },
-      pluginSpecs: function(callback){
+      pluginSpecs: function(callback) {
         exports.getPluginTests(callback);
       }
     },
-    function(err, results){
+    function(err, results) {
       var files = results.coreSpecs; // push the core specs to a file object
       files = files.concat(results.pluginSpecs); // add the plugin Specs to the core specs
       console.debug("Sent browser the following test specs:", files.sort());
       res.send("var specs_list = " + JSON.stringify(files.sort()) + ";\n");
     });
-
   });
-
 
   // path.join seems to normalize by default, but we'll just be explicit
   var rootTestFolder = path.normalize(path.join(npm.root, "../tests/frontend/"));
 
-  var url2FilePath = function(url){
+  var url2FilePath = function(url) {
     var subPath = url.substr("/tests/frontend".length);
-    if (subPath == ""){
+    if (subPath == "") {
       subPath = "index.html"
     }
     subPath = subPath.split("?")[0];
 
     var filePath = path.normalize(path.join(rootTestFolder, subPath));
+
     // make sure we jail the paths to the test folder, otherwise serve index
     if (filePath.indexOf(rootTestFolder) !== 0) {
       filePath = path.join(rootTestFolder, "index.html");
@@ -46,13 +44,13 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     var specFilePath = url2FilePath(req.url);
     var specFileName = path.basename(specFilePath);
 
-    fs.readFile(specFilePath, function(err, content){
-      if(err){ return res.send(500); }
-   
+    fs.readFile(specFilePath, function(err, content) {
+      if (err) { return res.send(500); }
+
       content = "describe(" + JSON.stringify(specFileName) + ", function(){   " + content + "   });";
 
       res.send(content);
-    }); 
+    });
   });
 
   args.app.get('/tests/frontend/*', function (req, res) {
@@ -62,19 +60,21 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 
   args.app.get('/tests/frontend', function (req, res) {
     res.redirect('/tests/frontend/');
-  }); 
+  });
 }
 
-exports.getPluginTests = function(callback){
+exports.getPluginTests = function(callback) {
   var pluginSpecs = [];
   var plugins = fs.readdirSync('node_modules');
-  plugins.forEach(function(plugin){
-    if(fs.existsSync("node_modules/"+plugin+"/static/tests/frontend/specs")){ // if plugins exists
-      var specFiles = fs.readdirSync("node_modules/"+plugin+"/static/tests/frontend/specs/");
-      async.forEach(specFiles, function(spec){ // for each specFile push it to pluginSpecs
-         pluginSpecs.push("/static/plugins/"+plugin+"/static/tests/frontend/specs/" + spec);
+  plugins.forEach(function(plugin) {
+    if (fs.existsSync("node_modules/" + plugin + "/static/tests/frontend/specs")) {
+      // if plugins exists
+      var specFiles = fs.readdirSync("node_modules/" + plugin + "/static/tests/frontend/specs/");
+      async.forEach(specFiles, function(spec) {
+         // for each specFile push it to pluginSpecs
+         pluginSpecs.push("/static/plugins/" + plugin + "/static/tests/frontend/specs/" + spec);
       },
-      function(err){
+      function(err) {
          // blow up if something bad happens!
       });
     }
@@ -82,10 +82,11 @@ exports.getPluginTests = function(callback){
   callback(null, pluginSpecs);
 }
 
-exports.getCoreTests = function(callback){
-  fs.readdir('tests/frontend/specs', function(err, coreSpecs){ // get the core test specs
-    if(err){ return res.send(500); }
+exports.getCoreTests = function(callback) {
+  // get the core test specs
+  fs.readdir('tests/frontend/specs', function(err, coreSpecs) {
+    if (err) { return res.send(500); }
+
     callback(null, coreSpecs);
   });
 }
-

--- a/src/node/padaccess.js
+++ b/src/node/padaccess.js
@@ -6,7 +6,7 @@ module.exports = function (req, res, callback) {
   securityManager.checkAccess(req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password, function(err, accessObj) {
     if (ERR(err, callback)) return;
 
-    if (accessObj.accessStatus == "grant") {
+    if (accessObj.accessStatus === "grant") {
       // there is access, continue
       callback();
     } else {

--- a/src/node/padaccess.js
+++ b/src/node/padaccess.js
@@ -1,17 +1,20 @@
-var ERR = require("async-stacktrace");
 var securityManager = require('./db/SecurityManager');
 
 // checks for padAccess
-module.exports = function (req, res, callback) {
-  securityManager.checkAccess(req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password, function(err, accessObj) {
-    if (ERR(err, callback)) return;
+module.exports = async function (req, res) {
+  try {
+    let accessObj = await securityManager.checkAccess(req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password);
 
     if (accessObj.accessStatus === "grant") {
       // there is access, continue
-      callback();
+      return true;
     } else {
       // no access
       res.status(403).send("403 - Can't touch this");
+      return false;
     }
-  });
+  } catch (err) {
+    // @TODO - send internal server error here?
+    throw err;
+  }
 }

--- a/src/node/padaccess.js
+++ b/src/node/padaccess.js
@@ -1,16 +1,16 @@
 var ERR = require("async-stacktrace");
 var securityManager = require('./db/SecurityManager');
 
-//checks for padAccess
+// checks for padAccess
 module.exports = function (req, res, callback) {
   securityManager.checkAccess(req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password, function(err, accessObj) {
-    if(ERR(err, callback)) return;
+    if (ERR(err, callback)) return;
 
-    //there is access, continue
-    if(accessObj.accessStatus == "grant") {
+    if (accessObj.accessStatus == "grant") {
+      // there is access, continue
       callback();
-    //no access
     } else {
+      // no access
       res.status(403).send("403 - Can't touch this");
     }
   });

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * This module is started with bin/run.sh. It sets up a Express HTTP and a Socket.IO Server. 
- * Static file Requests are answered directly from this module, Socket.IO messages are passed 
+ * This module is started with bin/run.sh. It sets up a Express HTTP and a Socket.IO Server.
+ * Static file Requests are answered directly from this module, Socket.IO messages are passed
  * to MessageHandler and minfied requests are passed to minified.
  */
 
@@ -46,8 +46,8 @@ NodeVersion.enforceMinNodeVersion('8.9.0');
  */
 var stats = require('./stats');
 stats.gauge('memoryUsage', function() {
-  return process.memoryUsage().rss
-})
+  return process.memoryUsage().rss;
+});
 
 var settings
   , db
@@ -59,8 +59,8 @@ async.waterfall([
   // load npm
   function(callback) {
     npm.load({}, function(er) {
-      callback(er)
-    })
+      callback(er);
+    });
   },
 
   // load everything
@@ -73,14 +73,13 @@ async.waterfall([
     callback();
   },
 
-  //initalize the database
-  function (callback)
-  {
+  // initalize the database
+  function (callback) {
     db.init(callback);
   },
 
   function(callback) {
-    plugins.update(callback)
+    plugins.update(callback);
   },
 
   function (callback) {
@@ -93,9 +92,8 @@ async.waterfall([
     callback();
   },
 
-  //initalize the http server
-  function (callback)
-  {
+  // initalize the http server
+  function (callback) {
     hooks.callAll("createServer", {});
     callback(null);
   }

--- a/src/node/utils/ExportEtherpad.js
+++ b/src/node/utils/ExportEtherpad.js
@@ -18,8 +18,9 @@
 var async = require("async");
 var db = require("../db/DB").db;
 var ERR = require("async-stacktrace");
+const thenify = require("thenify").withCallback;
 
-exports.getPadRaw = function(padId, callback){
+exports.getPadRaw = thenify(function(padId, callback){
   async.waterfall([
   function(cb){
     db.get("pad:"+padId, cb);
@@ -69,4 +70,4 @@ exports.getPadRaw = function(padId, callback){
   ], function(err, data){
     callback(null, data);
   });
-}
+});

--- a/src/node/utils/ExportEtherpad.js
+++ b/src/node/utils/ExportEtherpad.js
@@ -15,59 +15,48 @@
  */
 
 
-var async = require("async");
-var db = require("../db/DB").db;
-var ERR = require("async-stacktrace");
-const thenify = require("thenify").withCallback;
+let db = require("../db/DB");
 
-exports.getPadRaw = thenify(function(padId, callback){
-  async.waterfall([
-  function(cb){
-    db.get("pad:"+padId, cb);
-  },
-  function(padcontent,cb){
-    var records = ["pad:"+padId];
-    for (var i = 0; i <= padcontent.head; i++) {
-      records.push("pad:"+padId+":revs:" + i);
-    }
+exports.getPadRaw = async function(padId) {
 
-    for (var i = 0; i <= padcontent.chatHead; i++) {
-      records.push("pad:"+padId+":chat:" + i);
-    }
+  let padKey = "pad:" + padId;
+  let padcontent = await db.get(padKey);
 
-    var data = {};
-
-    async.forEachSeries(Object.keys(records), function(key, r){
-
-      // For each piece of info about a pad.
-      db.get(records[key], function(err, entry){
-        data[records[key]] = entry;
-
-        // Get the Pad Authors
-        if(entry.pool && entry.pool.numToAttrib){
-          var authors = entry.pool.numToAttrib;
-          async.forEachSeries(Object.keys(authors), function(k, c){
-            if(authors[k][0] === "author"){
-              var authorId = authors[k][1];
-
-              // Get the author info
-              db.get("globalAuthor:"+authorId, function(e, authorEntry){
-                if(authorEntry && authorEntry.padIDs) authorEntry.padIDs = padId;
-                if(!e) data["globalAuthor:"+authorId] = authorEntry;
-              });
-
-            }
-            // console.log("authorsK", authors[k]);
-            c(null);
-          });
-        }
-        r(null); // callback;
-      });
-    }, function(err){
-      cb(err, data);
-    })
+  let records = [ padKey ];
+  for (let i = 0; i <= padcontent.head; i++) {
+    records.push(padKey + ":revs:" + i);
   }
-  ], function(err, data){
-    callback(null, data);
-  });
-});
+
+  for (let i = 0; i <= padcontent.chatHead; i++) {
+    records.push(padKey + ":chat:" + i);
+  }
+
+  let data = {};
+  for (let key of records)  {
+
+    // For each piece of info about a pad.
+    let entry = data[key] = await db.get(key);
+
+    // Get the Pad Authors
+    if (entry.pool && entry.pool.numToAttrib) {
+      let authors = entry.pool.numToAttrib;
+
+      for (let k of Object.keys(authors)) {
+        if (authors[k][0] === "author") {
+          let authorId = authors[k][1];
+
+          // Get the author info
+          let authorEntry = await db.get("globalAuthor:" + authorId);
+          if (authorEntry) {
+            data["globalAuthor:" + authorId] = authorEntry;
+            if (authorEntry.padIDs) {
+              authorEntry.padIDs = padId;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return data;
+}

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -25,6 +25,7 @@ var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
 var eejs = require('ep_etherpad-lite/node/eejs');
 var _analyzeLine = require('./ExportHelper')._analyzeLine;
 var _encodeWhitespace = require('./ExportHelper')._encodeWhitespace;
+const thenify = require("thenify").withCallback;
 
 function getPadHTML(pad, revNum, callback)
 {
@@ -67,7 +68,7 @@ function getPadHTML(pad, revNum, callback)
   });
 }
 
-exports.getPadHTML = getPadHTML;
+exports.getPadHTML = thenify(getPadHTML);
 exports.getHTMLFromAtext = getHTMLFromAtext;
 
 function getHTMLFromAtext(pad, atext, authorColors)
@@ -459,7 +460,7 @@ function getHTMLFromAtext(pad, atext, authorColors)
   return pieces.join('');
 }
 
-exports.getPadHTMLDocument = function (padId, revNum, callback)
+exports.getPadHTMLDocument = thenify(function (padId, revNum, callback)
 {
   padManager.getPad(padId, function (err, pad)
   {
@@ -484,7 +485,7 @@ exports.getPadHTMLDocument = function (padId, revNum, callback)
       });
     });
   });
-};
+});
 
 // copied from ACE
 var _REGEX_WORDCHAR = /[\u0030-\u0039\u0041-\u005A\u0061-\u007A\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\u0100-\u1FFF\u3040-\u9FFF\uF900-\uFDFF\uFE70-\uFEFE\uFF10-\uFF19\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFDC]/;

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -14,61 +14,29 @@
  * limitations under the License.
  */
 
-
-var async = require("async");
 var Changeset = require("ep_etherpad-lite/static/js/Changeset");
 var padManager = require("../db/PadManager");
-var ERR = require("async-stacktrace");
 var _ = require('underscore');
 var Security = require('ep_etherpad-lite/static/js/security');
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
 var eejs = require('ep_etherpad-lite/node/eejs');
 var _analyzeLine = require('./ExportHelper')._analyzeLine;
 var _encodeWhitespace = require('./ExportHelper')._encodeWhitespace;
-const thenify = require("thenify").withCallback;
 
-function getPadHTML(pad, revNum, callback)
+async function getPadHTML(pad, revNum)
 {
-  var atext = pad.atext;
-  var html;
-  async.waterfall([
+  let atext = pad.atext;
+
   // fetch revision atext
-  function (callback)
-  {
-    if (revNum != undefined)
-    {
-      pad.getInternalRevisionAText(revNum, function (err, revisionAtext)
-      {
-        if(ERR(err, callback)) return;
-        atext = revisionAtext;
-        callback();
-      });
-    }
-    else
-    {
-      callback(null);
-    }
-  },
+  if (revNum != undefined) {
+    atext = await pad.getInternalRevisionAText(revNum);
+  }
 
   // convert atext to html
-
-
-  function (callback)
-  {
-    html = getHTMLFromAtext(pad, atext);
-    callback(null);
-  }],
-  // run final callback
-
-
-  function (err)
-  {
-    if(ERR(err, callback)) return;
-    callback(null, html);
-  });
+  return getHTMLFromAtext(pad, atext);
 }
 
-exports.getPadHTML = thenify(getPadHTML);
+exports.getPadHTML = getPadHTML;
 exports.getHTMLFromAtext = getHTMLFromAtext;
 
 function getHTMLFromAtext(pad, atext, authorColors)
@@ -82,15 +50,16 @@ function getHTMLFromAtext(pad, atext, authorColors)
 
   // prepare tags stored as ['tag', true] to be exported
   hooks.aCallAll("exportHtmlAdditionalTags", pad, function(err, newProps){
-    newProps.forEach(function (propName, i){
+    newProps.forEach(function (propName, i) {
       tags.push(propName);
       props.push(propName);
     });
   });
+
   // prepare tags stored as ['tag', 'value'] to be exported. This will generate HTML
   // with tags like <span data-tag="value">
   hooks.aCallAll("exportHtmlAdditionalTagsWithData", pad, function(err, newProps){
-    newProps.forEach(function (propName, i){
+    newProps.forEach(function (propName, i) {
       tags.push('span data-' + propName[0] + '="' + propName[1] + '"');
       props.push(propName);
     });
@@ -454,38 +423,31 @@ function getHTMLFromAtext(pad, atext, authorColors)
 
       hooks.aCallAll("getLineHTMLForExport", context);
         pieces.push(context.lineContent, "<br>");
-      }
     }
+  }
 
   return pieces.join('');
 }
 
-exports.getPadHTMLDocument = thenify(function (padId, revNum, callback)
+exports.getPadHTMLDocument = async function (padId, revNum)
 {
-  padManager.getPad(padId, function (err, pad)
-  {
-    if(ERR(err, callback)) return;
+  let pad = await padManager.getPad(padId);
 
-    var stylesForExportCSS = "";
-    // Include some Styles into the Head for Export
-    hooks.aCallAll("stylesForExport", padId, function(err, stylesForExport){
-      stylesForExport.forEach(function(css){
-        stylesForExportCSS += css;
-      });
-
-      getPadHTML(pad, revNum, function (err, html)
-      {
-        if(ERR(err, callback)) return;
-        var exportedDoc = eejs.require("ep_etherpad-lite/templates/export_html.html", {
-          body: html,
-          padId: Security.escapeHTML(padId),
-          extraCSS: stylesForExportCSS
-        });
-        callback(null, exportedDoc);
-      });
-    });
+  // Include some Styles into the Head for Export
+  let stylesForExportCSS = "";
+  let stylesForExport = await hooks.aCallAll("stylesForExport", padId);
+  stylesForExport.forEach(function(css){
+    stylesForExportCSS += css;
   });
-});
+
+  let html = await getPadHTML(pad, revNum);
+
+  return eejs.require("ep_etherpad-lite/templates/export_html.html", {
+    body: html,
+    padId: Security.escapeHTML(padId),
+    extraCSS: stylesForExportCSS
+  });
+}
 
 // copied from ACE
 var _REGEX_WORDCHAR = /[\u0030-\u0039\u0041-\u005A\u0061-\u007A\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF\u0100-\u1FFF\u3040-\u9FFF\uF900-\uFDFF\uFE70-\uFEFE\uFF10-\uFF19\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFDC]/;

--- a/src/node/utils/ExportTxt.js
+++ b/src/node/utils/ExportTxt.js
@@ -30,40 +30,32 @@ function getPadTXT(pad, revNum, callback)
   var atext = pad.atext;
   var html;
   async.waterfall([
+
   // fetch revision atext
+  function(callback) {
+    if (revNum != undefined) {
+      pad.getInternalRevisionAText(revNum, function(err, revisionAtext) {
+        if (ERR(err, callback)) return;
 
-
-  function (callback)
-  {
-    if (revNum != undefined)
-    {
-      pad.getInternalRevisionAText(revNum, function (err, revisionAtext)
-      {
-        if(ERR(err, callback)) return;
         atext = revisionAtext;
         callback();
       });
-    }
-    else
-    {
+    } else {
       callback(null);
     }
   },
 
   // convert atext to html
-
-
-  function (callback)
-  {
-    html = getTXTFromAtext(pad, atext); // only this line is different to the HTML function
+  function(callback) {
+    // only this line is different to the HTML function
+    html = getTXTFromAtext(pad, atext);
     callback(null);
   }],
+
   // run final callback
+  function(err) {
+    if (ERR(err, callback)) return;
 
-
-  function (err)
-  {
-    if(ERR(err, callback)) return;
     callback(null, html);
   });
 }
@@ -80,17 +72,14 @@ function getTXTFromAtext(pad, atext, authorColors)
   var anumMap = {};
   var css = "";
 
-  props.forEach(function (propName, i)
-  {
+  props.forEach(function(propName, i) {
     var propTrueNum = apool.putAttrib([propName, true], true);
-    if (propTrueNum >= 0)
-    {
+    if (propTrueNum >= 0) {
       anumMap[propTrueNum] = i;
     }
   });
 
-  function getLineTXT(text, attribs)
-  {
+  function getLineTXT(text, attribs) {
     var propVals = [false, false, false];
     var ENTER = 1;
     var STAY = 2;
@@ -106,94 +95,77 @@ function getTXTFromAtext(pad, atext, authorColors)
 
     var idx = 0;
 
-    function processNextChars(numChars)
-    {
-      if (numChars <= 0)
-      {
+    function processNextChars(numChars) {
+      if (numChars <= 0) {
         return;
       }
 
       var iter = Changeset.opIterator(Changeset.subattribution(attribs, idx, idx + numChars));
       idx += numChars;
 
-      while (iter.hasNext())
-      {
+      while (iter.hasNext()) {
         var o = iter.next();
         var propChanged = false;
-        Changeset.eachAttribNumber(o.attribs, function (a)
-        {
-          if (a in anumMap)
-          {
+
+        Changeset.eachAttribNumber(o.attribs, function(a) {
+          if (a in anumMap) {
             var i = anumMap[a]; // i = 0 => bold, etc.
-            if (!propVals[i])
-            {
+
+            if (!propVals[i]) {
               propVals[i] = ENTER;
               propChanged = true;
-            }
-            else
-            {
+            } else {
               propVals[i] = STAY;
             }
           }
         });
-        for (var i = 0; i < propVals.length; i++)
-        {
-          if (propVals[i] === true)
-          {
+
+        for (var i = 0; i < propVals.length; i++) {
+          if (propVals[i] === true) {
             propVals[i] = LEAVE;
             propChanged = true;
-          }
-          else if (propVals[i] === STAY)
-          {
-            propVals[i] = true; // set it back
+          } else if (propVals[i] === STAY) {
+            // set it back
+            propVals[i] = true;
           }
         }
+
         // now each member of propVal is in {false,LEAVE,ENTER,true}
         // according to what happens at start of span
-        if (propChanged)
-        {
+        if (propChanged) {
           // leaving bold (e.g.) also leaves italics, etc.
           var left = false;
-          for (var i = 0; i < propVals.length; i++)
-          {
+
+          for (var i = 0; i < propVals.length; i++) {
             var v = propVals[i];
-            if (!left)
-            {
-              if (v === LEAVE)
-              {
+
+            if (!left) {
+              if (v === LEAVE) {
                 left = true;
               }
-            }
-            else
-            {
-              if (v === true)
-              {
-                propVals[i] = STAY; // tag will be closed and re-opened
+            } else {
+              if (v === true) {
+                // tag will be closed and re-opened
+                propVals[i] = STAY;
               }
             }
           }
 
           var tags2close = [];
 
-          for (var i = propVals.length - 1; i >= 0; i--)
-          {
-            if (propVals[i] === LEAVE)
-            {
+          for (var i = propVals.length - 1; i >= 0; i--) {
+            if (propVals[i] === LEAVE) {
               //emitCloseTag(i);
               tags2close.push(i);
               propVals[i] = false;
-            }
-            else if (propVals[i] === STAY)
-            {
+            } else if (propVals[i] === STAY) {
               //emitCloseTag(i);
               tags2close.push(i);
             }
           }
 
-          for (var i = 0; i < propVals.length; i++)
-          {
-            if (propVals[i] === ENTER || propVals[i] === STAY)
-            {
+          for (var i = 0; i < propVals.length; i++) {
+            if (propVals[i] === ENTER || propVals[i] === STAY) {
               propVals[i] = true;
             }
           }
@@ -201,9 +173,9 @@ function getTXTFromAtext(pad, atext, authorColors)
         } // end if (propChanged)
 
         var chars = o.chars;
-        if (o.lines)
-        {
-          chars--; // exclude newline at end of line, if present
+        if (o.lines) {
+          // exclude newline at end of line, if present
+          chars--;
         }
 
         var s = taker.take(chars);
@@ -220,19 +192,19 @@ function getTXTFromAtext(pad, atext, authorColors)
       } // end iteration over spans in line
 
       var tags2close = [];
-      for (var i = propVals.length - 1; i >= 0; i--)
-      {
-        if (propVals[i])
-        {
+      for (var i = propVals.length - 1; i >= 0; i--) {
+        if (propVals[i]) {
           tags2close.push(i);
           propVals[i] = false;
         }
       }
 
     } // end processNextChars
+
     processNextChars(text.length - idx);
     return(assem.toString());
   } // end getLineHTML
+
   var pieces = [css];
 
   // Need to deal with constraints imposed on HTML lists; can
@@ -242,41 +214,44 @@ function getTXTFromAtext(pad, atext, authorColors)
   // so we want to do something reasonable there.  We also
   // want to deal gracefully with blank lines.
   // => keeps track of the parents level of indentation
-  for (var i = 0; i < textLines.length; i++)
-  {
+  for (var i = 0; i < textLines.length; i++) {
     var line = _analyzeLine(textLines[i], attribLines[i], apool);
     var lineContent = getLineTXT(line.text, line.aline);
-    if(line.listTypeName == "bullet"){
+
+    if (line.listTypeName == "bullet") {
       lineContent = "* " + lineContent; // add a bullet
     }
-    if(line.listLevel > 0){
-      for (var j = line.listLevel - 1; j >= 0; j--){
+
+    if (line.listLevel > 0) {
+      for (var j = line.listLevel - 1; j >= 0; j--) {
         pieces.push('\t');
       }
-      if(line.listTypeName == "number"){
+
+      if (line.listTypeName == "number") {
         pieces.push(line.listLevel + ". ");
         // This is bad because it doesn't truly reflect what the user
         // sees because browsers do magic on nested <ol><li>s
       }
+
       pieces.push(lineContent, '\n');
-    }else{
+    } else {
       pieces.push(lineContent, '\n');
     }
   }
 
   return pieces.join('');
 }
+
 exports.getTXTFromAtext = getTXTFromAtext;
 
-exports.getPadTXTDocument = function (padId, revNum, callback)
+exports.getPadTXTDocument = function(padId, revNum, callback)
 {
-  padManager.getPad(padId, function (err, pad)
-  {
-    if(ERR(err, callback)) return;
+  padManager.getPad(padId, function(err, pad) {
+    if (ERR(err, callback)) return;
 
-    getPadTXT(pad, revNum, function (err, html)
-    {
-      if(ERR(err, callback)) return;
+    getPadTXT(pad, revNum, function(err, html) {
+      if (ERR(err, callback)) return;
+
       callback(null, html);
     });
   });

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -18,57 +18,56 @@ var log4js = require('log4js');
 var async = require("async");
 var db = require("../db/DB").db;
 
-exports.setPadRaw = function(padId, records, callback){
+exports.setPadRaw = function(padId, records, callback)
+{
   records = JSON.parse(records);
 
-  async.eachSeries(Object.keys(records), function(key, cb){
-    var value = records[key]
+  async.eachSeries(Object.keys(records), function(key, cb) {
+    var value = records[key];
 
-    if(!value){
+    if (!value) {
       return setImmediate(cb);
     }
 
-    // Author data
-    if(value.padIDs){
-      // rewrite author pad ids
+    if (value.padIDs) {
+      // Author data - rewrite author pad ids
       value.padIDs[padId] = 1;
       var newKey = key;
 
       // Does this author already exist?
-      db.get(key, function(err, author){
-        if(author){
-          // Yes, add the padID to the author..
-          if( Object.prototype.toString.call(author) === '[object Array]'){
+      db.get(key, function(err, author) {
+        if (author) {
+          // Yes, add the padID to the author
+          if (Object.prototype.toString.call(author) === '[object Array]') {
             author.padIDs.push(padId);
           }
           value = author;
-        }else{
+        } else {
           // No, create a new array with the author info in
           value.padIDs = [padId];
         }
       });
-
-    // Not author data, probably pad data
-    }else{
-      // we can split it to look to see if its pad data
+    } else {
+      // Not author data, probably pad data
+      // we can split it to look to see if it's pad data
       var oldPadId = key.split(":");
 
-      // we know its pad data..
-      if(oldPadId[0] === "pad"){
-
+      // we know it's pad data
+      if (oldPadId[0] === "pad") {
         // so set the new pad id for the author
         oldPadId[1] = padId;
-        
+
         // and create the value
         var newKey = oldPadId.join(":"); // create the new key
       }
-
     }
+
     // Write the value to the server
     db.set(newKey, value);
 
     setImmediate(cb);
-  }, function(){
+  },
+  function() {
     callback(null, true);
   });
 }

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -17,8 +17,9 @@
 var log4js = require('log4js');
 var async = require("async");
 var db = require("../db/DB").db;
+const thenify = require("thenify").withCallback;
 
-exports.setPadRaw = function(padId, records, callback)
+exports.setPadRaw = thenify(function(padId, records, callback)
 {
   records = JSON.parse(records);
 
@@ -70,4 +71,4 @@ exports.setPadRaw = function(padId, records, callback)
   function() {
     callback(null, true);
   });
-}
+});

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -15,43 +15,44 @@
  */
 
 var log4js = require('log4js');
-var async = require("async");
-var db = require("../db/DB").db;
-const thenify = require("thenify").withCallback;
+const db = require("../db/DB");
 
-exports.setPadRaw = thenify(function(padId, records, callback)
+exports.setPadRaw = function(padId, records)
 {
   records = JSON.parse(records);
 
-  async.eachSeries(Object.keys(records), function(key, cb) {
-    var value = records[key];
+  Object.keys(records).forEach(async function(key) {
+    let value = records[key];
 
     if (!value) {
-      return setImmediate(cb);
+      return;
     }
+
+    let newKey;
 
     if (value.padIDs) {
       // Author data - rewrite author pad ids
       value.padIDs[padId] = 1;
-      var newKey = key;
+      newKey = key;
 
       // Does this author already exist?
-      db.get(key, function(err, author) {
-        if (author) {
-          // Yes, add the padID to the author
-          if (Object.prototype.toString.call(author) === '[object Array]') {
-            author.padIDs.push(padId);
-          }
-          value = author;
-        } else {
-          // No, create a new array with the author info in
-          value.padIDs = [padId];
+      let author = await db.get(key);
+
+      if (author) {
+        // Yes, add the padID to the author
+        if (Object.prototype.toString.call(author) === '[object Array]') {
+          author.padIDs.push(padId);
         }
-      });
+
+        value = author;
+      } else {
+        // No, create a new array with the author info in
+        value.padIDs = [ padId ];
+      }
     } else {
       // Not author data, probably pad data
       // we can split it to look to see if it's pad data
-      var oldPadId = key.split(":");
+      let oldPadId = key.split(":");
 
       // we know it's pad data
       if (oldPadId[0] === "pad") {
@@ -59,16 +60,11 @@ exports.setPadRaw = thenify(function(padId, records, callback)
         oldPadId[1] = padId;
 
         // and create the value
-        var newKey = oldPadId.join(":"); // create the new key
+        newKey = oldPadId.join(":"); // create the new key
       }
     }
 
     // Write the value to the server
-    db.set(newKey, value);
-
-    setImmediate(cb);
-  },
-  function() {
-    callback(null, true);
+    await db.set(newKey, value);
   });
-});
+}

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -18,6 +18,7 @@ var log4js = require('log4js');
 var Changeset = require("ep_etherpad-lite/static/js/Changeset");
 var contentcollector = require("ep_etherpad-lite/static/js/contentcollector");
 var cheerio = require("cheerio");
+const thenify = require("thenify").withCallback;
 
 function setPadHTML(pad, html, callback)
 {
@@ -94,4 +95,4 @@ function setPadHTML(pad, html, callback)
   callback(null);
 }
 
-exports.setPadHTML = setPadHTML;
+exports.setPadHTML = thenify(setPadHTML);

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -36,19 +36,22 @@ function setPadHTML(pad, html, callback)
   // Convert a dom tree into a list of lines and attribute liens
   // using the content collector object
   var cc = contentcollector.makeContentCollector(true, null, pad.pool);
-  try{ // we use a try here because if the HTML is bad it will blow up
+  try {
+    // we use a try here because if the HTML is bad it will blow up
     cc.collectContent(doc);
-  }catch(e){
+  } catch(e) {
     apiLogger.warn("HTML was not properly formed", e);
-    return callback(e); // We don't process the HTML because it was bad..
+
+    // don't process the HTML because it was bad
+    return callback(e);
   }
 
   var result = cc.finish();
 
   apiLogger.debug('Lines:');
+
   var i;
-  for (i = 0; i < result.lines.length; i += 1)
-  {
+  for (i = 0; i < result.lines.length; i += 1) {
     apiLogger.debug('Line ' + (i + 1) + ' text: ' + result.lines[i]);
     apiLogger.debug('Line ' + (i + 1) + ' attributes: ' + result.lineAttribs[i]);
   }
@@ -59,18 +62,15 @@ function setPadHTML(pad, html, callback)
   apiLogger.debug(newText);
   var newAttribs = result.lineAttribs.join('|1+1') + '|1+1';
 
-  function eachAttribRun(attribs, func /*(startInNewText, endInNewText, attribs)*/ )
-  {
+  function eachAttribRun(attribs, func /*(startInNewText, endInNewText, attribs)*/ ) {
     var attribsIter = Changeset.opIterator(attribs);
     var textIndex = 0;
     var newTextStart = 0;
     var newTextEnd = newText.length;
-    while (attribsIter.hasNext())
-    {
+    while (attribsIter.hasNext()) {
       var op = attribsIter.next();
       var nextIndex = textIndex + op.chars;
-      if (!(nextIndex <= newTextStart || textIndex >= newTextEnd))
-      {
+      if (!(nextIndex <= newTextStart || textIndex >= newTextEnd)) {
         func(Math.max(newTextStart, textIndex), Math.min(newTextEnd, nextIndex), op.attribs);
       }
       textIndex = nextIndex;
@@ -81,13 +81,13 @@ function setPadHTML(pad, html, callback)
   var builder = Changeset.builder(1);
 
   // assemble each line into the builder
-  eachAttribRun(newAttribs, function(start, end, attribs)
-  {
+  eachAttribRun(newAttribs, function(start, end, attribs) {
     builder.insert(newText.substring(start, end), attribs);
   });
 
   // the changeset is ready!
   var theChangeset = builder.toString();
+
   apiLogger.debug('The changeset: ' + theChangeset);
   pad.setText("\n");
   pad.appendRevision(theChangeset);

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -18,9 +18,8 @@ var log4js = require('log4js');
 var Changeset = require("ep_etherpad-lite/static/js/Changeset");
 var contentcollector = require("ep_etherpad-lite/static/js/contentcollector");
 var cheerio = require("cheerio");
-const thenify = require("thenify").withCallback;
 
-function setPadHTML(pad, html, callback)
+exports.setPadHTML = function(pad, html)
 {
   var apiLogger = log4js.getLogger("ImportHtml");
 
@@ -44,7 +43,7 @@ function setPadHTML(pad, html, callback)
     apiLogger.warn("HTML was not properly formed", e);
 
     // don't process the HTML because it was bad
-    return callback(e);
+    throw e;
   }
 
   var result = cc.finish();
@@ -52,7 +51,7 @@ function setPadHTML(pad, html, callback)
   apiLogger.debug('Lines:');
 
   var i;
-  for (i = 0; i < result.lines.length; i += 1) {
+  for (i = 0; i < result.lines.length; i++) {
     apiLogger.debug('Line ' + (i + 1) + ' text: ' + result.lines[i]);
     apiLogger.debug('Line ' + (i + 1) + ' attributes: ' + result.lineAttribs[i]);
   }
@@ -92,7 +91,4 @@ function setPadHTML(pad, html, callback)
   apiLogger.debug('The changeset: ' + theChangeset);
   pad.setText("\n");
   pad.appendRevision(theChangeset);
-  callback(null);
 }
-
-exports.setPadHTML = thenify(setPadHTML);

--- a/src/node/utils/TidyHtml.js
+++ b/src/node/utils/TidyHtml.js
@@ -5,38 +5,39 @@
 var log4js = require('log4js');
 var settings = require('./Settings');
 var spawn = require('child_process').spawn;
-const thenify = require("thenify").withCallback;
 
-exports.tidy = thenify(function(srcFile, callback) {
+exports.tidy = function(srcFile) {
   var logger = log4js.getLogger('TidyHtml');
 
-  // Don't do anything if Tidy hasn't been enabled
-  if (!settings.tidyHtml) {
-    logger.debug('tidyHtml has not been configured yet, ignoring tidy request');
-    return callback(null);
-  }
+  return new Promise((resolve, reject) => {
 
-  var errMessage = '';
-
-  // Spawn a new tidy instance that cleans up the file inline
-  logger.debug('Tidying ' + srcFile);
-  var tidy = spawn(settings.tidyHtml, ['-modify', srcFile]);
-
-  // Keep track of any error messages
-  tidy.stderr.on('data', function (data) {
-    errMessage += data.toString();
-  });
-
-  // Wait until Tidy is done
-  tidy.on('close', function(code) {
-    // Tidy returns a 0 when no errors occur and a 1 exit code when
-    // the file could be tidied but a few warnings were generated
-    if (code === 0 || code === 1) {
-      logger.debug('Tidied ' + srcFile + ' successfully');
-      return callback(null);
-    } else {
-      logger.error('Failed to tidy ' + srcFile + '\n' + errMessage);
-      return callback('Tidy died with exit code ' + code);
+    // Don't do anything if Tidy hasn't been enabled
+    if (!settings.tidyHtml) {
+      logger.debug('tidyHtml has not been configured yet, ignoring tidy request');
+      return resolve(null);
     }
+
+    var errMessage = '';
+
+    // Spawn a new tidy instance that cleans up the file inline
+    logger.debug('Tidying ' + srcFile);
+    var tidy = spawn(settings.tidyHtml, ['-modify', srcFile]);
+
+    // Keep track of any error messages
+    tidy.stderr.on('data', function (data) {
+      errMessage += data.toString();
+    });
+
+    tidy.on('close', function(code) {
+      // Tidy returns a 0 when no errors occur and a 1 exit code when
+      // the file could be tidied but a few warnings were generated
+      if (code === 0 || code === 1) {
+        logger.debug('Tidied ' + srcFile + ' successfully');
+        resolve(null);
+      } else {
+        logger.error('Failed to tidy ' + srcFile + '\n' + errMessage);
+        reject('Tidy died with exit code ' + code);
+      }
+    });
   });
-});
+}

--- a/src/node/utils/TidyHtml.js
+++ b/src/node/utils/TidyHtml.js
@@ -5,8 +5,9 @@
 var log4js = require('log4js');
 var settings = require('./Settings');
 var spawn = require('child_process').spawn;
+const thenify = require("thenify").withCallback;
 
-exports.tidy = function(srcFile, callback) {
+exports.tidy = thenify(function(srcFile, callback) {
   var logger = log4js.getLogger('TidyHtml');
 
   // Don't do anything if Tidy hasn't been enabled
@@ -38,4 +39,4 @@ exports.tidy = function(srcFile, callback) {
       return callback('Tidy died with exit code ' + code);
     }
   });
-};
+});

--- a/src/node/utils/padDiff.js
+++ b/src/node/utils/padDiff.js
@@ -1,6 +1,7 @@
 var Changeset = require("../../static/js/Changeset");
 var async = require("async");
 var exportHtml = require('./ExportHtml');
+const thenify = require("thenify").withCallback;
 
 function PadDiff (pad, fromRev, toRev) {
   // check parameters
@@ -78,7 +79,7 @@ PadDiff.prototype._isClearAuthorship = function(changeset) {
   return true;
 };
 
-PadDiff.prototype._createClearAuthorship = function(rev, callback) {
+PadDiff.prototype._createClearAuthorship = thenify(function(rev, callback) {
   var self = this;
   this._pad.getInternalRevisionAText(rev, function(err, atext) {
     if (err) {
@@ -92,9 +93,9 @@ PadDiff.prototype._createClearAuthorship = function(rev, callback) {
 
    callback(null, changeset);
   });
-};
+});
 
-PadDiff.prototype._createClearStartAtext = function(rev, callback) {
+PadDiff.prototype._createClearStartAtext = thenify(function(rev, callback) {
   var self = this;
 
   // get the atext of this revision
@@ -119,9 +120,9 @@ PadDiff.prototype._createClearStartAtext = function(rev, callback) {
       callback(null, newAText);
     });
   });
-};
+});
 
-PadDiff.prototype._getChangesetsInBulk = function(startRev, count, callback) {
+PadDiff.prototype._getChangesetsInBulk = thenify(function(startRev, count, callback) {
   var self = this;
 
   // find out which revisions we need
@@ -150,7 +151,7 @@ PadDiff.prototype._getChangesetsInBulk = function(startRev, count, callback) {
   function(err) {
     callback(err, changesets, authors);
   });
-};
+});
 
 PadDiff.prototype._addAuthors = function(authors) {
   var self = this;
@@ -163,7 +164,7 @@ PadDiff.prototype._addAuthors = function(authors) {
   });
 };
 
-PadDiff.prototype._createDiffAtext = function(callback) {
+PadDiff.prototype._createDiffAtext = thenify(function(callback) {
   var self = this;
   var bulkSize = 100;
 
@@ -237,9 +238,9 @@ PadDiff.prototype._createDiffAtext = function(callback) {
       }
     );
   });
-};
+});
 
-PadDiff.prototype.getHtml = function(callback) {
+PadDiff.prototype.getHtml = thenify(function(callback) {
   // cache the html
   if (this._html != null) {
     return callback(null, this._html);
@@ -283,9 +284,9 @@ PadDiff.prototype.getHtml = function(callback) {
   function(err) {
     callback(err, html);
   });
-};
+});
 
-PadDiff.prototype.getAuthors = function(callback) {
+PadDiff.prototype.getAuthors = thenify(function(callback) {
   var self = this;
 
   // check if html was already produced, if not produce it, this generates the author array at the same time
@@ -300,7 +301,7 @@ PadDiff.prototype.getAuthors = function(callback) {
   } else {
     callback(null, self._authors);
   }
-};
+});
 
 PadDiff.prototype._extendChangesetWithAuthor = function(changeset, author, apool) {
   // unpack

--- a/src/node/utils/padDiff.js
+++ b/src/node/utils/padDiff.js
@@ -1,336 +1,348 @@
 var Changeset = require("../../static/js/Changeset");
 var async = require("async");
 var exportHtml = require('./ExportHtml');
- 
-function PadDiff (pad, fromRev, toRev){      
-  //check parameters
-  if(!pad || !pad.id || !pad.atext || !pad.pool)
-  {
+
+function PadDiff (pad, fromRev, toRev) {
+  // check parameters
+  if (!pad || !pad.id || !pad.atext || !pad.pool) {
     throw new Error('Invalid pad');
   }
- 
+
   var range = pad.getValidRevisionRange(fromRev, toRev);
-  if(!range) { throw new Error('Invalid revision range.' + 
+  if (!range) {
+    throw new Error('Invalid revision range.' +
       ' startRev: ' + fromRev +
-      ' endRev: ' + toRev); }
-  
+      ' endRev: ' + toRev);
+  }
+
   this._pad = pad;
   this._fromRev = range.startRev;
   this._toRev = range.endRev;
   this._html = null;
   this._authors = [];
 }
- 
-PadDiff.prototype._isClearAuthorship = function(changeset){
-  //unpack
+
+PadDiff.prototype._isClearAuthorship = function(changeset) {
+  // unpack
   var unpacked = Changeset.unpack(changeset);
-  
-  //check if there is nothing in the charBank
-  if(unpacked.charBank !== "")
+
+  // check if there is nothing in the charBank
+  if (unpacked.charBank !== "") {
     return false;
-  
-  //check if oldLength == newLength
-  if(unpacked.oldLen !== unpacked.newLen)
+  }
+
+  // check if oldLength == newLength
+  if (unpacked.oldLen !== unpacked.newLen) {
     return false;
- 
-  //lets iterator over the operators
+  }
+
+  // lets iterator over the operators
   var iterator = Changeset.opIterator(unpacked.ops);
-  
-  //get the first operator, this should be a clear operator
+
+  // get the first operator, this should be a clear operator
   var clearOperator = iterator.next();
-  
-  //check if there is only one operator
-  if(iterator.hasNext() === true)
+
+  // check if there is only one operator
+  if (iterator.hasNext() === true) {
     return false;
-    
-  //check if this operator doesn't change text
-  if(clearOperator.opcode !== "=")
+  }
+
+  // check if this operator doesn't change text
+  if (clearOperator.opcode !== "=") {
     return false;
-    
-  //check that this operator applys to the complete text
-  //if the text ends with a new line, its exactly one character less, else it has the same length
-  if(clearOperator.chars !== unpacked.oldLen-1 && clearOperator.chars !== unpacked.oldLen)
+  }
+
+  // check that this operator applys to the complete text
+  // if the text ends with a new line, its exactly one character less, else it has the same length
+  if (clearOperator.chars !== unpacked.oldLen-1 && clearOperator.chars !== unpacked.oldLen) {
     return false;
-  
+  }
+
   var attributes = [];
-  Changeset.eachAttribNumber(changeset, function(attrNum){
+  Changeset.eachAttribNumber(changeset, function(attrNum) {
     attributes.push(attrNum);
   });
-    
-  //check that this changeset uses only one attribute
-  if(attributes.length !== 1)
+
+  // check that this changeset uses only one attribute
+  if (attributes.length !== 1) {
     return false;
-    
+  }
+
   var appliedAttribute = this._pad.pool.getAttrib(attributes[0]);
-  
-  //check if the applied attribute is an anonymous author attribute
-  if(appliedAttribute[0] !== "author" || appliedAttribute[1] !== "")
+
+  // check if the applied attribute is an anonymous author attribute
+  if (appliedAttribute[0] !== "author" || appliedAttribute[1] !== "") {
     return false;
-    
+  }
+
   return true;
 };
- 
-PadDiff.prototype._createClearAuthorship = function(rev, callback){
+
+PadDiff.prototype._createClearAuthorship = function(rev, callback) {
   var self = this;
-  this._pad.getInternalRevisionAText(rev, function(err, atext){
-   if(err){
-     return callback(err);
-   }
-   
-   //build clearAuthorship changeset
+  this._pad.getInternalRevisionAText(rev, function(err, atext) {
+    if (err) {
+      return callback(err);
+    }
+
+   // build clearAuthorship changeset
    var builder = Changeset.builder(atext.text.length);
    builder.keepText(atext.text, [['author','']], self._pad.pool);
    var changeset = builder.toString();
-   
+
    callback(null, changeset);
   });
 };
- 
-PadDiff.prototype._createClearStartAtext = function(rev, callback){
+
+PadDiff.prototype._createClearStartAtext = function(rev, callback) {
   var self = this;
-  
-  //get the atext of this revision
-  this._pad.getInternalRevisionAText(rev, function(err, atext){
-   if(err){
-     return callback(err);
-   }
-   
-   //create the clearAuthorship changeset
-   self._createClearAuthorship(rev, function(err, changeset){
-     if(err){
-       return callback(err);
-     }
-   
-     try {
-     //apply the clearAuthorship changeset
-     var newAText = Changeset.applyToAText(changeset, atext, self._pad.pool);
-     } catch(err) {
-      return callback(err)
-     }
-     
-     callback(null, newAText);
-   });
-  });
-};
- 
-PadDiff.prototype._getChangesetsInBulk = function(startRev, count, callback) {
-  var self = this;
-  
-  //find out which revisions we need
-  var revisions = [];
-  for(var i=startRev;i<(startRev+count) && i<=this._pad.head;i++){
-    revisions.push(i);
-  }
-  
-  var changesets = [], authors = [];
-  
-  //get all needed revisions
-  async.forEach(revisions, function(rev, callback){
-    self._pad.getRevision(rev, function(err, revision){
-      if(err){
+
+  // get the atext of this revision
+  this._pad.getInternalRevisionAText(rev, function(err, atext) {
+    if (err) {
+      return callback(err);
+    }
+
+    // create the clearAuthorship changeset
+    self._createClearAuthorship(rev, function(err, changeset) {
+      if (err) {
         return callback(err);
       }
-      
+
+      try {
+        // apply the clearAuthorship changeset
+        var newAText = Changeset.applyToAText(changeset, atext, self._pad.pool);
+      } catch(err) {
+        return callback(err)
+      }
+
+      callback(null, newAText);
+    });
+  });
+};
+
+PadDiff.prototype._getChangesetsInBulk = function(startRev, count, callback) {
+  var self = this;
+
+  // find out which revisions we need
+  var revisions = [];
+  for (var i = startRev; i < (startRev + count) && i <= this._pad.head; i++) {
+    revisions.push(i);
+  }
+
+  var changesets = [], authors = [];
+
+  // get all needed revisions
+  async.forEach(revisions, function(rev, callback) {
+    self._pad.getRevision(rev, function(err, revision) {
+      if (err) {
+        return callback(err);
+      }
+
       var arrayNum = rev-startRev;
-      
+
       changesets[arrayNum] = revision.changeset;
       authors[arrayNum] = revision.meta.author;
-  
+
       callback();
     });
-  }, function(err){
+  },
+  function(err) {
     callback(err, changesets, authors);
   });
 };
- 
+
 PadDiff.prototype._addAuthors = function(authors) {
   var self = this;
-  //add to array if not in the array
-  authors.forEach(function(author){
-    if(self._authors.indexOf(author) == -1){
+
+  // add to array if not in the array
+  authors.forEach(function(author) {
+    if (self._authors.indexOf(author) == -1) {
       self._authors.push(author);
     }
   });
 };
- 
+
 PadDiff.prototype._createDiffAtext = function(callback) {
   var self = this;
   var bulkSize = 100;
-  
-  //get the cleaned startAText
-  self._createClearStartAtext(self._fromRev, function(err, atext){
-    if(err) { return callback(err); }
-    
+
+  // get the cleaned startAText
+  self._createClearStartAtext(self._fromRev, function(err, atext) {
+    if (err) { return callback(err); }
+
     var superChangeset = null;
-    
+
     var rev = self._fromRev + 1;
- 
-    //async while loop
+
+    // async while loop
     async.whilst(
-      //loop condition
+      // loop condition
       function () { return rev <= self._toRev; },
-      
-      //loop body
+
+      // loop body
       function (callback) {
-        //get the bulk
-        self._getChangesetsInBulk(rev,bulkSize,function(err, changesets, authors){
+        // get the bulk
+        self._getChangesetsInBulk(rev,bulkSize,function(err, changesets, authors) {
           var addedAuthors = [];
-          
-          //run trough all changesets
-          for(var i=0;i<changesets.length && (rev+i)<=self._toRev;i++){
+
+          // run trough all changesets
+          for (var i = 0; i < changesets.length && (rev + i) <= self._toRev; i++) {
             var changeset = changesets[i];
-            
-            //skip clearAuthorship Changesets
-            if(self._isClearAuthorship(changeset)){
+
+            // skip clearAuthorship Changesets
+            if (self._isClearAuthorship(changeset)) {
               continue;
             }
-            
+
             changeset = self._extendChangesetWithAuthor(changeset, authors[i], self._pad.pool);
-            
-            //add this author to the authorarray
+
+            // add this author to the authorarray
             addedAuthors.push(authors[i]);
-            
-            //compose it with the superChangset            
-            if(superChangeset === null){
+
+            // compose it with the superChangset
+            if (superChangeset === null) {
               superChangeset = changeset;
-            } else {           
+            } else {
               superChangeset = Changeset.composeWithDeletions(superChangeset, changeset, self._pad.pool);
             }
           }
-          
-          //add the authors to the PadDiff authorArray
+
+          // add the authors to the PadDiff authorArray
           self._addAuthors(addedAuthors);
-        
-          //lets continue with the next bulk 
+
+          // lets continue with the next bulk
           rev += bulkSize;
           callback();
         });
       },
-      
-      //after the loop has ended
+
+      // after the loop has ended
       function (err) {
-        //if there are only clearAuthorship changesets, we don't get a superChangeset, so we can skip this step
-        if(superChangeset){
+        // if there are only clearAuthorship changesets, we don't get a superChangeset, so we can skip this step
+        if (superChangeset) {
           var deletionChangeset = self._createDeletionChangeset(superChangeset,atext,self._pad.pool);
-        
+
           try {
-            //apply the superChangeset, which includes all addings
-            atext = Changeset.applyToAText(superChangeset,atext,self._pad.pool);
-            //apply the deletionChangeset, which adds a deletions
-            atext = Changeset.applyToAText(deletionChangeset,atext,self._pad.pool);
+            // apply the superChangeset, which includes all addings
+            atext = Changeset.applyToAText(superChangeset, atext, self._pad.pool);
+            // apply the deletionChangeset, which adds a deletions
+            atext = Changeset.applyToAText(deletionChangeset, atext, self._pad.pool);
           } catch(err) {
            return callback(err)
           }
-        }      
- 
+        }
+
         callback(err, atext);
       }
     );
   });
 };
- 
-PadDiff.prototype.getHtml = function(callback){
-  //cache the html
-  if(this._html != null){
+
+PadDiff.prototype.getHtml = function(callback) {
+  // cache the html
+  if (this._html != null) {
     return callback(null, this._html);
   }
-  
+
   var self = this;
   var atext, html, authorColors;
-  
+
   async.series([
-    //get the diff atext
-    function(callback){
-      self._createDiffAtext(function(err, _atext){
-        if(err){
+    // get the diff atext
+    function(callback) {
+      self._createDiffAtext(function(err, _atext) {
+        if (err) {
           return callback(err);
         }
-        
+
         atext = _atext;
         callback();
       });
     },
-    //get the authorColor table
-    function(callback){
-      self._pad.getAllAuthorColors(function(err, _authorColors){
-        if(err){
+
+    // get the authorColor table
+    function(callback) {
+      self._pad.getAllAuthorColors(function(err, _authorColors) {
+        if (err) {
           return callback(err);
         }
-        
+
         authorColors = _authorColors;
         callback();
       });
     },
-    //convert the atext to html
-    function(callback){
+
+    // convert the atext to html
+    function(callback) {
       html = exportHtml.getHTMLFromAtext(self._pad, atext, authorColors);
       self._html = html;
       callback();
     }
-  ], function(err){
+  ],
+  function(err) {
     callback(err, html);
   });
 };
- 
-PadDiff.prototype.getAuthors = function(callback){
+
+PadDiff.prototype.getAuthors = function(callback) {
   var self = this;
-  
-  //check if html was already produced, if not produce it, this generates the author array at the same time
-  if(self._html == null){
-    self.getHtml(function(err){
-      if(err){
+
+  // check if html was already produced, if not produce it, this generates the author array at the same time
+  if (self._html == null) {
+    self.getHtml(function(err) {
+      if (err) {
         return callback(err);
       }
-      
+
       callback(null, self._authors);
     });
   } else {
     callback(null, self._authors);
   }
 };
- 
-PadDiff.prototype._extendChangesetWithAuthor = function(changeset, author, apool) {  
-  //unpack
-  var unpacked = Changeset.unpack(changeset);  
-  
+
+PadDiff.prototype._extendChangesetWithAuthor = function(changeset, author, apool) {
+  // unpack
+  var unpacked = Changeset.unpack(changeset);
+
   var iterator = Changeset.opIterator(unpacked.ops);
   var assem = Changeset.opAssembler();
-  
-  //create deleted attribs
+
+  // create deleted attribs
   var authorAttrib = apool.putAttrib(["author", author || ""]);
   var deletedAttrib = apool.putAttrib(["removed", true]);
   var attribs = "*" + Changeset.numToString(authorAttrib) + "*" + Changeset.numToString(deletedAttrib);
-  
-  //iteratore over the operators of the changeset
-  while(iterator.hasNext()){
+
+  // iteratore over the operators of the changeset
+  while(iterator.hasNext()) {
     var operator = iterator.next();
-    
-    //this is a delete operator, extend it with the author
-    if(operator.opcode === "-"){
+
+    if (operator.opcode === "-") {
+      // this is a delete operator, extend it with the author
       operator.attribs = attribs;
-    } 
-    //this is operator changes only attributes, let's mark which author did that
-    else if(operator.opcode === "=" && operator.attribs){
+    } else if (operator.opcode === "=" && operator.attribs) {
+      // this is operator changes only attributes, let's mark which author did that
       operator.attribs+="*"+Changeset.numToString(authorAttrib);
     }
-    
-    //append the new operator to our assembler
+
+    // append the new operator to our assembler
     assem.append(operator);
   }
-  
-  //return the modified changeset
+
+  // return the modified changeset
   return Changeset.pack(unpacked.oldLen, unpacked.newLen, assem.toString(), unpacked.charBank);
 };
- 
-//this method is 80% like Changeset.inverse. I just changed so instead of reverting, it adds deletions and attribute changes to to the atext.
+
+// this method is 80% like Changeset.inverse. I just changed so instead of reverting, it adds deletions and attribute changes to to the atext.
 PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
   var lines = Changeset.splitTextLines(startAText.text);
   var alines = Changeset.splitAttributionLines(startAText.attribs, startAText.text);
-  
+
   // lines and alines are what the exports is meant to apply to.
   // They may be arrays or objects with .get(i) and .length methods.
   // They include final newlines on lines.
- 
+
   function lines_get(idx) {
     if (lines.get) {
       return lines.get(idx);
@@ -338,7 +350,7 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
       return lines[idx];
     }
   }
- 
+
   function alines_get(idx) {
     if (alines.get) {
       return alines.get(idx);
@@ -346,19 +358,19 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
       return alines[idx];
     }
   }
- 
+
   var curLine = 0;
   var curChar = 0;
   var curLineOpIter = null;
   var curLineOpIterLine;
   var curLineNextOp = Changeset.newOp('+');
- 
+
   var unpacked = Changeset.unpack(cs);
   var csIter = Changeset.opIterator(unpacked.ops);
   var builder = Changeset.builder(unpacked.newLen);
- 
+
   function consumeAttribRuns(numChars, func /*(len, attribs, endsLine)*/ ) {
- 
+
     if ((!curLineOpIter) || (curLineOpIterLine != curLine)) {
       // create curLineOpIter and advance it to curChar
       curLineOpIter = Changeset.opIterator(alines_get(curLine));
@@ -375,7 +387,7 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
         }
       }
     }
- 
+
     while (numChars > 0) {
       if ((!curLineNextOp.chars) && (!curLineOpIter.hasNext())) {
         curLine++;
@@ -384,22 +396,25 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
         curLineNextOp.chars = 0;
         curLineOpIter = Changeset.opIterator(alines_get(curLine));
       }
+
       if (!curLineNextOp.chars) {
         curLineOpIter.next(curLineNextOp);
       }
+
       var charsToUse = Math.min(numChars, curLineNextOp.chars);
+
       func(charsToUse, curLineNextOp.attribs, charsToUse == curLineNextOp.chars && curLineNextOp.lines > 0);
       numChars -= charsToUse;
       curLineNextOp.chars -= charsToUse;
       curChar += charsToUse;
     }
- 
+
     if ((!curLineNextOp.chars) && (!curLineOpIter.hasNext())) {
       curLine++;
       curChar = 0;
     }
   }
- 
+
   function skip(N, L) {
     if (L) {
       curLine += L;
@@ -412,27 +427,29 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
       }
     }
   }
- 
+
   function nextText(numChars) {
     var len = 0;
     var assem = Changeset.stringAssembler();
     var firstString = lines_get(curLine).substring(curChar);
     len += firstString.length;
     assem.append(firstString);
- 
+
     var lineNum = curLine + 1;
+
     while (len < numChars) {
       var nextString = lines_get(lineNum);
       len += nextString.length;
       assem.append(nextString);
       lineNum++;
     }
- 
+
     return assem.toString().substring(0, numChars);
   }
- 
+
   function cachedStrFunc(func) {
     var cache = {};
+
     return function (s) {
       if (!cache[s]) {
         cache[s] = func(s);
@@ -440,57 +457,59 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
       return cache[s];
     };
   }
- 
+
   var attribKeys = [];
   var attribValues = [];
- 
-  //iterate over all operators of this changeset
+
+  // iterate over all operators of this changeset
   while (csIter.hasNext()) {
     var csOp = csIter.next();
- 
-    if (csOp.opcode == '=') {      
+
+    if (csOp.opcode == '=') {
       var textBank = nextText(csOp.chars);
- 
+
       // decide if this equal operator is an attribution change or not. We can see this by checkinf if attribs is set.
       // If the text this operator applies to is only a star, than this is a false positive and should be ignored
       if (csOp.attribs && textBank != "*") {
         var deletedAttrib = apool.putAttrib(["removed", true]);
         var authorAttrib = apool.putAttrib(["author", ""]);
- 
+
         attribKeys.length = 0;
         attribValues.length = 0;
         Changeset.eachAttribNumber(csOp.attribs, function (n) {
           attribKeys.push(apool.getAttribKey(n));
           attribValues.push(apool.getAttribValue(n));
- 
-          if(apool.getAttribKey(n) === "author"){
+
+          if (apool.getAttribKey(n) === "author") {
             authorAttrib = n;
           }
         });
- 
+
         var undoBackToAttribs = cachedStrFunc(function (attribs) {
           var backAttribs = [];
           for (var i = 0; i < attribKeys.length; i++) {
             var appliedKey = attribKeys[i];
             var appliedValue = attribValues[i];
             var oldValue = Changeset.attribsAttributeValue(attribs, appliedKey, apool);
+
             if (appliedValue != oldValue) {
               backAttribs.push([appliedKey, oldValue]);
             }
           }
+
           return Changeset.makeAttribsString('=', backAttribs, apool);
         });
- 
+
         var oldAttribsAddition = "*" + Changeset.numToString(deletedAttrib) + "*" + Changeset.numToString(authorAttrib);
- 
+
         var textLeftToProcess = textBank;
- 
-        while(textLeftToProcess.length > 0){
-          //process till the next line break or process only one line break
+
+        while(textLeftToProcess.length > 0) {
+          // process till the next line break or process only one line break
           var lengthToProcess = textLeftToProcess.indexOf("\n");
           var lineBreak = false;
-          switch(lengthToProcess){
-            case -1: 
+          switch(lengthToProcess) {
+            case -1:
               lengthToProcess=textLeftToProcess.length;
               break;
             case 0:
@@ -498,27 +517,28 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
               lengthToProcess=1;
               break;
           }
- 
-          //get the text we want to procceed in this step
+
+          // get the text we want to procceed in this step
           var processText = textLeftToProcess.substr(0, lengthToProcess);
+
           textLeftToProcess = textLeftToProcess.substr(lengthToProcess);
- 
-          if(lineBreak){
-            builder.keep(1, 1); //just skip linebreaks, don't do a insert + keep for a linebreak
- 
-            //consume the attributes of this linebreak
-            consumeAttribRuns(1, function(){});
+
+          if (lineBreak) {
+            builder.keep(1, 1); // just skip linebreaks, don't do a insert + keep for a linebreak
+
+            // consume the attributes of this linebreak
+            consumeAttribRuns(1, function() {});
           } else {
-            //add the old text via an insert, but add a deletion attribute + the author attribute of the author who deleted it
+            // add the old text via an insert, but add a deletion attribute + the author attribute of the author who deleted it
             var textBankIndex = 0;
             consumeAttribRuns(lengthToProcess, function (len, attribs, endsLine) {
-              //get the old attributes back
+              // get the old attributes back
               var attribs = (undoBackToAttribs(attribs) || "") + oldAttribsAddition;
- 
+
               builder.insert(processText.substr(textBankIndex, len), attribs);
               textBankIndex += len;
             });
- 
+
             builder.keep(lengthToProcess, 0);
           }
         }
@@ -531,16 +551,16 @@ PadDiff.prototype._createDeletionChangeset = function(cs, startAText, apool) {
     } else if (csOp.opcode == '-') {
       var textBank = nextText(csOp.chars);
       var textBankIndex = 0;
-      
+
       consumeAttribRuns(csOp.chars, function (len, attribs, endsLine) {
         builder.insert(textBank.substr(textBankIndex, len), attribs + csOp.attribs);
         textBankIndex += len;
       });
     }
   }
- 
+
   return Changeset.checkRep(builder.toString());
 };
- 
-//export the constructor
+
+// export the constructor
 module.exports = PadDiff;

--- a/src/package.json
+++ b/src/package.json
@@ -48,6 +48,7 @@
     "languages4translatewiki": "0.1.3",
     "log4js": "0.6.35",
     "measured-core": "1.11.2",
+    "nodeify": "^1.0.1",
     "npm": "6.4.1",
     "object.values": "^1.0.4",
     "request": "2.88.0",
@@ -87,4 +88,3 @@
   "version": "1.7.5",
   "license": "Apache-2.0"
 }
-

--- a/src/package.json
+++ b/src/package.json
@@ -58,7 +58,6 @@
     "slide": "1.1.6",
     "socket.io": "2.1.1",
     "swagger-node-express": "2.1.3",
-    "thenify": "^3.3.0",
     "tinycon": "0.0.1",
     "ueberdb2": "0.4.0",
     "uglify-js": "2.6.2",

--- a/src/package.json
+++ b/src/package.json
@@ -57,6 +57,7 @@
     "slide": "1.1.6",
     "socket.io": "2.1.1",
     "swagger-node-express": "2.1.3",
+    "thenify": "^3.3.0",
     "tinycon": "0.0.1",
     "ueberdb2": "0.4.0",
     "uglify-js": "2.6.2",

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -78,7 +78,7 @@ exports.callAll = function (hook_name, args) {
   }
 }
 
-exports.aCallAll = function (hook_name, args, cb) {
+function aCallAll(hook_name, args, cb) {
   if (!args) args = {};
   if (!cb) cb = function () {};
   if (exports.plugins.hooks[hook_name] === undefined) return cb(null, []);
@@ -93,6 +93,19 @@ exports.aCallAll = function (hook_name, args, cb) {
   );
 }
 
+/* return a Promise if cb is not supplied */
+exports.aCallAll = function (hook_name, args, cb) {
+  if (cb === undefined) {
+    return new Promise(function(resolve, reject) {
+      aCallAll(hook_name, args, function(err, res) {
+	return err ? reject(err) : resolve(res);
+      });
+    });
+  } else {
+    return aCallAll(hook_name, args, cb);
+  }
+}
+
 exports.callFirst = function (hook_name, args) {
   if (!args) args = {};
   if (exports.plugins.hooks[hook_name] === undefined) return [];
@@ -101,7 +114,7 @@ exports.callFirst = function (hook_name, args) {
   });
 }
 
-exports.aCallFirst = function (hook_name, args, cb) {
+function aCallFirst(hook_name, args, cb) {
   if (!args) args = {};
   if (!cb) cb = function () {};
   if (exports.plugins.hooks[hook_name] === undefined) return cb(null, []);
@@ -112,6 +125,19 @@ exports.aCallFirst = function (hook_name, args, cb) {
     },
     cb
   );
+}
+
+/* return a Promise if cb is not supplied */
+exports.aCallFirst = function (hook_name, args, cb) {
+  if (cb === undefined) {
+    return new Promise(function(resolve, reject) {
+      aCallFirst(hook_name, args, function(err, res) {
+	return err ? reject(err) : resolve(res);
+      });
+    });
+  } else {
+    return aCallFirst(hook_name, args, cb);
+  }
 }
 
 exports.callAllStr = function(hook_name, args, sep, pre, post) {

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -4,12 +4,14 @@ var npm = require("npm");
 var request = require("request");
 
 var npmIsLoaded = false;
-var withNpm = function (npmfn) {
-  if(npmIsLoaded) return npmfn();
-  npm.load({}, function (er) {
+var withNpm = function(npmfn) {
+  if (npmIsLoaded) return npmfn();
+
+  npm.load({}, function(er) {
     if (er) return npmfn(er);
+
     npmIsLoaded = true;
-    npm.on("log", function (message) {
+    npm.on("log", function(message) {
       console.log('npm: ',message)
     });
     npmfn();
@@ -17,26 +19,33 @@ var withNpm = function (npmfn) {
 }
 
 var tasks = 0
+
 function wrapTaskCb(cb) {
-  tasks++
+  tasks++;
+
   return function() {
     cb && cb.apply(this, arguments);
     tasks--;
-    if(tasks == 0) onAllTasksFinished();
+    if (tasks == 0) onAllTasksFinished();
   }
 }
+
 function onAllTasksFinished() {
-  hooks.aCallAll("restartServer", {}, function () {});
+  hooks.aCallAll("restartServer", {}, function() {});
 }
 
 exports.uninstall = function(plugin_name, cb) {
   cb = wrapTaskCb(cb);
-  withNpm(function (er) {
+
+  withNpm(function(er) {
     if (er) return cb && cb(er);
-    npm.commands.uninstall([plugin_name], function (er) {
+
+    npm.commands.uninstall([plugin_name], function(er) {
       if (er) return cb && cb(er);
-      hooks.aCallAll("pluginUninstall", {plugin_name: plugin_name}, function (er, data) {
+
+      hooks.aCallAll("pluginUninstall", {plugin_name: plugin_name}, function(er, data) {
         if (er) return cb(er);
+
         plugins.update(cb);
       });
     });
@@ -44,13 +53,17 @@ exports.uninstall = function(plugin_name, cb) {
 };
 
 exports.install = function(plugin_name, cb) {
-  cb = wrapTaskCb(cb)
-  withNpm(function (er) {
+  cb = wrapTaskCb(cb);
+
+  withNpm(function(er) {
     if (er) return cb && cb(er);
-    npm.commands.install([plugin_name], function (er) {
+
+    npm.commands.install([plugin_name], function(er) {
       if (er) return cb && cb(er);
-      hooks.aCallAll("pluginInstall", {plugin_name: plugin_name}, function (er, data) {
+
+      hooks.aCallAll("pluginInstall", {plugin_name: plugin_name}, function(er, data) {
         if (er) return cb(er);
+
         plugins.update(cb);
       });
     });
@@ -63,41 +76,53 @@ var cacheTimestamp = 0;
 exports.getAvailablePlugins = function(maxCacheAge, cb) {
   request("https://static.etherpad.org/plugins.json", function(er, response, plugins){
     if (er) return cb && cb(er);
-    if(exports.availablePlugins && maxCacheAge && Math.round(+new Date/1000)-cacheTimestamp <= maxCacheAge) {
-      return cb && cb(null, exports.availablePlugins)
+
+    if (exports.availablePlugins && maxCacheAge && Math.round(+ new Date / 1000) - cacheTimestamp <= maxCacheAge) {
+      return cb && cb(null, exports.availablePlugins);
     }
+
     try {
       plugins = JSON.parse(plugins);
     } catch (err) {
       console.error('error parsing plugins.json:', err);
       plugins = [];
     }
+
     exports.availablePlugins = plugins;
-    cacheTimestamp = Math.round(+new Date/1000);
-    cb && cb(null, plugins)
+    cacheTimestamp = Math.round(+ new Date / 1000);
+
+    cb && cb(null, plugins);
   });
 };
 
 
 exports.search = function(searchTerm, maxCacheAge, cb) {
   exports.getAvailablePlugins(maxCacheAge, function(er, results) {
-    if(er) return cb && cb(er);
+    if (er) return cb && cb(er);
+
     var res = {};
-    if (searchTerm)
+
+    if (searchTerm) {
       searchTerm = searchTerm.toLowerCase();
-    for (var pluginName in results) { // for every available plugin
+    }
+
+    for (var pluginName in results) {
+      // for every available plugin
       if (pluginName.indexOf(plugins.prefix) != 0) continue; // TODO: Also search in keywords here!
 
-      if(searchTerm && !~results[pluginName].name.toLowerCase().indexOf(searchTerm)
+      if (searchTerm && !~results[pluginName].name.toLowerCase().indexOf(searchTerm)
          && (typeof results[pluginName].description != "undefined" && !~results[pluginName].description.toLowerCase().indexOf(searchTerm) )
-           ){
-           if(typeof results[pluginName].description === "undefined"){
+           ) {
+           if (typeof results[pluginName].description === "undefined") {
              console.debug('plugin without Description: %s', results[pluginName].name);
            }
+
            continue;
       }
+
       res[pluginName] = results[pluginName];
     }
-    cb && cb(null, res)
-  })
+
+    cb && cb(null, res);
+  });
 };

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -77,33 +77,35 @@ exports.install = function(plugin_name, cb) {
 exports.availablePlugins = null;
 var cacheTimestamp = 0;
 
-exports.getAvailablePlugins = function(maxCacheAge, cb) {
-  request("https://static.etherpad.org/plugins.json", function(er, response, plugins){
-    if (er) return cb && cb(er);
+exports.getAvailablePlugins = function(maxCacheAge) {
+  var nowTimestamp = Math.round(Date.now() / 1000);
 
-    if (exports.availablePlugins && maxCacheAge && Math.round(+ new Date / 1000) - cacheTimestamp <= maxCacheAge) {
-      return cb && cb(null, exports.availablePlugins);
+  return new Promise(function(resolve, reject) {
+    // check cache age before making any request
+    if (exports.availablePlugins && maxCacheAge && (nowTimestamp - cacheTimestamp) <= maxCacheAge) {
+      return resolve(exports.availablePlugins);
     }
 
-    try {
-      plugins = JSON.parse(plugins);
-    } catch (err) {
-      console.error('error parsing plugins.json:', err);
-      plugins = [];
-    }
+    request("https://static.etherpad.org/plugins.json", function(er, response, plugins) {
+      if (er) return reject(er);
 
-    exports.availablePlugins = plugins;
-    cacheTimestamp = Math.round(+ new Date / 1000);
+      try {
+        plugins = JSON.parse(plugins);
+      } catch (err) {
+        console.error('error parsing plugins.json:', err);
+        plugins = [];
+      }
 
-    cb && cb(null, plugins);
+      exports.availablePlugins = plugins;
+      cacheTimestamp = nowTimestamp;
+      resolve(plugins);
+    });
   });
 };
 
 
-exports.search = function(searchTerm, maxCacheAge, cb) {
-  exports.getAvailablePlugins(maxCacheAge, function(er, results) {
-    if (er) return cb && cb(er);
-
+exports.search = function(searchTerm, maxCacheAge) {
+  return exports.getAvailablePlugins(maxCacheAge).then(function(results) {
     var res = {};
 
     if (searchTerm) {
@@ -127,6 +129,6 @@ exports.search = function(searchTerm, maxCacheAge, cb) {
       res[pluginName] = results[pluginName];
     }
 
-    cb && cb(null, res);
+    return res;
   });
 };

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -34,6 +34,10 @@ function onAllTasksFinished() {
   hooks.aCallAll("restartServer", {}, function() {});
 }
 
+/*
+ * We cannot use arrow functions in this file, because code in /src/static
+ * can end up being loaded in browsers, and we still support IE11.
+ */
 exports.uninstall = function(plugin_name, cb) {
   cb = wrapTaskCb(cb);
 
@@ -42,16 +46,18 @@ exports.uninstall = function(plugin_name, cb) {
 
     npm.commands.uninstall([plugin_name], function(er) {
       if (er) return cb && cb(er);
-
-      hooks.aCallAll("pluginUninstall", {plugin_name: plugin_name}, function(er, data) {
-        if (er) return cb(er);
-
-        plugins.update(cb);
-      });
+      hooks.aCallAll("pluginUninstall", {plugin_name: plugin_name})
+        .then(plugins.update)
+        .then(function() { cb(null) })
+        .catch(function(er) { cb(er) });
     });
   });
 };
 
+/*
+ * We cannot use arrow functions in this file, because code in /src/static
+ * can end up being loaded in browsers, and we still support IE11.
+ */
 exports.install = function(plugin_name, cb) {
   cb = wrapTaskCb(cb);
 
@@ -60,12 +66,10 @@ exports.install = function(plugin_name, cb) {
 
     npm.commands.install([plugin_name], function(er) {
       if (er) return cb && cb(er);
-
-      hooks.aCallAll("pluginInstall", {plugin_name: plugin_name}, function(er, data) {
-        if (er) return cb(er);
-
-        plugins.update(cb);
-      });
+      hooks.aCallAll("pluginInstall", {plugin_name: plugin_name})
+        .then(plugins.update)
+        .then(function() { cb(null) })
+        .catch(function(er) { cb(er) });
     });
   });
 };

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -55,6 +55,7 @@ exports.formatHooks = function (hook_set_name) {
 
 exports.callInit = function (cb) {
   var hooks = require("./hooks");
+
   async.map(
     Object.keys(exports.plugins),
     function (plugin_name, cb) {
@@ -83,6 +84,7 @@ exports.update = function (cb) {
   exports.getPackages(function (er, packages) {
     var parts = [];
     var plugins = {};
+
     // Load plugin metadata ep.json
     async.forEach(
       Object.keys(packages),
@@ -106,6 +108,7 @@ exports.getPackages = function (cb) {
   var dir = path.resolve(npm.dir, '..');
   readInstalled(dir, function (er, data) {
     if (er) cb(er, null);
+
     var packages = {};
     function flatten(deps) {
       _.chain(deps).keys().each(function (name) {
@@ -116,12 +119,12 @@ exports.getPackages = function (cb) {
           delete packages[name].dependencies;
           delete packages[name].parent;
         }
-      
+
         // I don't think we need recursion
         //if (deps[name].dependencies !== undefined) flatten(deps[name].dependencies);
       });
     }
-  
+
     var tmp = {};
     tmp[data.name] = data;
     flatten(tmp[data.name].dependencies);

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -1,7 +1,6 @@
 var npm = require("npm/lib/npm.js");
 var readInstalled = require("./read-installed.js");
 var path = require("path");
-var async = require("async");
 var fs = require("fs");
 var tsort = require("./tsort");
 var util = require("util");
@@ -15,6 +14,7 @@ exports.plugins = {};
 exports.parts = [];
 exports.hooks = {};
 
+// @TODO RPB this appears to be unused
 exports.ensure = function (cb) {
   if (!exports.loaded)
     exports.update(cb);
@@ -53,109 +53,94 @@ exports.formatHooks = function (hook_set_name) {
   return "<dl>" + res.join("\n") + "</dl>";
 };
 
-exports.callInit = function (cb) {
+exports.callInit = function () {
+  const fsp_stat = util.promisify(fs.stat);
+  const fsp_writeFile = util.promisify(fs.writeFile);
+
   var hooks = require("./hooks");
 
-  async.map(
-    Object.keys(exports.plugins),
-    function (plugin_name, cb) {
-      var plugin = exports.plugins[plugin_name];
-      fs.stat(path.normalize(path.join(plugin.package.path, ".ep_initialized")), function (err, stats) {
-        if (err) {
-          async.waterfall([
-            function (cb) { fs.writeFile(path.normalize(path.join(plugin.package.path, ".ep_initialized")), 'done', cb); },
-            function (cb) { hooks.aCallAll("init_" + plugin_name, {}, cb); },
-            cb,
-          ]);
-        } else {
-          cb();
-        }
-      });
-    },
-    function () { cb(); }
-  );
+  let p = Object.keys(exports.plugins).map(function (plugin_name) {
+    let plugin = exports.plugins[plugin_name];
+    let ep_init = path.normalize(path.join(plugin.package.path, ".ep_initialized"));
+    return fsp_stat(ep_init).catch(async function() {
+      await fsp_writeFile(ep_init, "done");
+      await hooks.aCallAll("init_" + plugin_name, {});
+    });
+  });
+
+  return Promise.all(p);
 }
 
 exports.pathNormalization = function (part, hook_fn_name) {
   return path.normalize(path.join(path.dirname(exports.plugins[part.plugin].package.path), hook_fn_name));
 }
 
-exports.update = function (cb) {
-  exports.getPackages(function (er, packages) {
-    var parts = [];
-    var plugins = {};
+exports.update = async function () {
+  let packages = await exports.getPackages();
+  var parts = [];
+  var plugins = {};
 
-    // Load plugin metadata ep.json
-    async.forEach(
-      Object.keys(packages),
-      function (plugin_name, cb) {
-        loadPlugin(packages, plugin_name, plugins, parts, cb);
-      },
-      function (err) {
-        if (err) cb(err);
-        exports.plugins = plugins;
-        exports.parts = sortParts(parts);
-        exports.hooks = pluginUtils.extractHooks(exports.parts, "hooks", exports.pathNormalization);
-        exports.loaded = true;
-        exports.callInit(cb);
-      }
-    );
+  // Load plugin metadata ep.json
+  let p = Object.keys(packages).map(function (plugin_name) {
+    return loadPlugin(packages, plugin_name, plugins, parts);
   });
-  };
 
-exports.getPackages = function (cb) {
+  return Promise.all(p).then(function() {
+    exports.plugins = plugins;
+    exports.parts = sortParts(parts);
+    exports.hooks = pluginUtils.extractHooks(exports.parts, "hooks", exports.pathNormalization);
+    exports.loaded = true;
+  }).then(exports.callInit);
+}
+
+exports.getPackages = async function () {
   // Load list of installed NPM packages, flatten it to a list, and filter out only packages with names that
   var dir = path.resolve(npm.dir, '..');
-  readInstalled(dir, function (er, data) {
-    if (er) cb(er, null);
+  let data = await util.promisify(readInstalled)(dir);
 
-    var packages = {};
-    function flatten(deps) {
-      _.chain(deps).keys().each(function (name) {
-        if (name.indexOf(exports.prefix) === 0) {
-          packages[name] = _.clone(deps[name]);
-          // Delete anything that creates loops so that the plugin
-          // list can be sent as JSON to the web client
-          delete packages[name].dependencies;
-          delete packages[name].parent;
-        }
+  var packages = {};
+  function flatten(deps) {
+    _.chain(deps).keys().each(function (name) {
+      if (name.indexOf(exports.prefix) === 0) {
+        packages[name] = _.clone(deps[name]);
+        // Delete anything that creates loops so that the plugin
+        // list can be sent as JSON to the web client
+        delete packages[name].dependencies;
+        delete packages[name].parent;
+      }
 
-        // I don't think we need recursion
-        //if (deps[name].dependencies !== undefined) flatten(deps[name].dependencies);
-      });
-    }
+      // I don't think we need recursion
+      //if (deps[name].dependencies !== undefined) flatten(deps[name].dependencies);
+    });
+  }
 
-    var tmp = {};
-    tmp[data.name] = data;
-    flatten(tmp[data.name].dependencies);
-    cb(null, packages);
-  });
+  var tmp = {};
+  tmp[data.name] = data;
+  flatten(tmp[data.name].dependencies);
+  return packages;
 };
 
-function loadPlugin(packages, plugin_name, plugins, parts, cb) {
+async function loadPlugin(packages, plugin_name, plugins, parts) {
+  let fsp_readFile = util.promisify(fs.readFile);
+
   var plugin_path = path.resolve(packages[plugin_name].path, "ep.json");
-  fs.readFile(
-    plugin_path,
-    function (er, data) {
-      if (er) {
-        console.error("Unable to load plugin definition file " + plugin_path);
-        return cb();
-      }
-      try {
-        var plugin = JSON.parse(data);
-        plugin['package'] = packages[plugin_name];
-        plugins[plugin_name] = plugin;
-        _.each(plugin.parts, function (part) {
-          part.plugin = plugin_name;
-          part.full_name = plugin_name + "/" + part.name;
-          parts[part.full_name] = part;
-        });
-      } catch (ex) {
-        console.error("Unable to parse plugin definition file " + plugin_path + ": " + ex.toString());
-      }
-      cb();
+  try {
+    let data = await fsp_readFile(plugin_path);
+    try {
+      var plugin = JSON.parse(data);
+      plugin['package'] = packages[plugin_name];
+      plugins[plugin_name] = plugin;
+      _.each(plugin.parts, function (part) {
+        part.plugin = plugin_name;
+        part.full_name = plugin_name + "/" + part.name;
+        parts[part.full_name] = part;
+      });
+    } catch (ex) {
+      console.error("Unable to parse plugin definition file " + plugin_path + ": " + ex.toString());
     }
-  );
+  } catch (er) {
+    console.error("Unable to load plugin definition file " + plugin_path);
+  }
 }
 
 function partsToParentChildList(parts) {

--- a/tests/backend/specs/api/tidy.js
+++ b/tests/backend/specs/api/tidy.js
@@ -1,10 +1,12 @@
 var assert = require('assert')
+        os = require('os'),
         fs = require('fs'),
       path = require('path'),
   TidyHtml = null,
   Settings = null;
 
 var npm = require("../../../../src/node_modules/npm/lib/npm.js");
+var nodeify = require('../../../../src/node_modules/nodeify');
 
 describe('tidyHtml', function() {
   before(function(done) {
@@ -15,6 +17,10 @@ describe('tidyHtml', function() {
       return done()
     });
   });
+
+  function tidy(file, callback) {
+    return nodeify(TidyHtml.tidy(file), callback);
+  }
 
   it('Tidies HTML', function(done) {
     // If the user hasn't configured Tidy, we skip this tests as it's required for this test
@@ -27,7 +33,7 @@ describe('tidyHtml', function() {
 
     var tmpFile = path.join(tmpDir, 'tmp_' + (Math.floor(Math.random() * 1000000)) + '.html')
     fs.writeFileSync(tmpFile, '<html><body><p>a paragraph</p><li>List without outer UL</li>trailing closing p</p></body></html>');
-    TidyHtml.tidy(tmpFile, function(err){
+    tidy(tmpFile, function(err){
       assert.ok(!err);
 
       // Read the file again
@@ -56,7 +62,7 @@ describe('tidyHtml', function() {
       this.skip();
     }
 
-    TidyHtml.tidy('/some/none/existing/file.html', function(err) {
+    tidy('/some/none/existing/file.html', function(err) {
       assert.ok(err);
       return done();
     });


### PR DESCRIPTION
This PR represents the line of work that refactors Etherpad to use `async`/`await` calls instead of callbacks, vastly simplifying the code, as per #3540.

This represents a vast change, and by its nature requires a lot of testing, hence its WIP status. It is currently deployed on https://beta.etherpad.org. It will be merged as soon as deemed sufficiently stable.

**It has the priority over other work**: present and future PRs, in case of conflicting changes, will need to rebase themselves over this work.

The development is by contributor @raybellis.
The branch will be periodically force-pushed if needed, please update often.
