### PR TITLE
support configuration via environment variables

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,6 +14,8 @@ cp ../settings.json.template settings.json
 [ further edit your settings.json as needed]
 ```
 
+**Each configuration parameter can also be set via an environment variable**, using the syntax `"${ENV_VAR_NAME}"`. For details, refer to `settings.json.template`.
+
 Build the version you prefer:
 ```bash
 # builds latest development version

--- a/settings.json.template
+++ b/settings.json.template
@@ -5,6 +5,39 @@
  *
  * Please note that starting from Etherpad 1.6.0 you can store DB credentials in
  * a separate file (credentials.json).
+ *
+ *
+ * ENVIRONMENT VARIABLE SUBSTITUTION
+ * =================================
+ *
+ * All the configuration values can be read from environment variables using the
+ * syntax "${ENV_VAR_NAME}".
+ * This is useful, for example, when running in a Docker container.
+ *
+ * EXAMPLE:
+ *    "port":     "${PORT}"
+ *    "minify":   "${MINIFY}"
+ *    "skinName": "${SKIN_NAME}"
+ *
+ * Would read the configuration values for those items from the environment
+ * variables PORT, MINIFY and SKIN_NAME.
+ *
+ * REMARKS:
+ * Please note that a variable substitution always needs to be quoted.
+ *    "port":   9001,          <-- Literal values. When not using substitution,
+ *    "minify": false              only strings must be quoted: booleans and
+ *    "skin":   "colibris"         numbers must not.
+ *
+ *    "port":   ${PORT}        <-- ERROR: this is not valid json
+ *    "minify": ${MINIFY}
+ *    "skin":   ${SKIN_NAME}
+ *
+ *    "port":   "${PORT}"      <-- CORRECT: if you want to use a variable
+ *    "minify": "${MINIFY}"        substitution, put quotes around its name,
+ *    "skin":   "${SKIN_NAME}"     even if the required value is a number or a
+ *                                 boolean.
+ *                                 Etherpad will take care of rewriting it to
+ *                                 the proper type if necessary.
  */
 {
   /*

--- a/settings.json.template
+++ b/settings.json.template
@@ -3,8 +3,8 @@
  *
  * Please edit settings.json, not settings.json.template
  *
- * Please note that since Etherpad 1.6.0 you can store DB credentials in a
- * separate file (credentials.json).
+ * Please note that starting from Etherpad 1.6.0 you can store DB credentials in
+ * a separate file (credentials.json).
  */
 {
   /*

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -379,9 +379,14 @@ exports.reloadSettings = function reloadSettings() {
     process.exit(1);
   }
 
-  if (credentialsStr) {
-    credentialsStr = jsonminify(credentialsStr).replace(",]","]").replace(",}","}");
-    credentials = JSON.parse(credentialsStr);
+  try {
+    if (credentialsStr) {
+      credentialsStr = jsonminify(credentialsStr).replace(",]","]").replace(",}","}");
+      credentials = JSON.parse(credentialsStr);
+    }
+  } catch(e) {
+    console.error(`There was an error processing your credentials file from ${credentialsFilename}:` + e.message);
+    process.exit(1);
   }
 
   //loop trough the settings

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -287,29 +287,26 @@ exports.scrollWhenFocusLineIsOutOfViewport = {
 //checks if abiword is avaiable
 exports.abiwordAvailable = function()
 {
-  if(exports.abiword != null)
-  {
+  if (exports.abiword != null) {
     return os.type().indexOf("Windows") != -1 ? "withoutPDF" : "yes";
-  }
-  else
-  {
+  } else {
     return "no";
   }
 };
 
-exports.sofficeAvailable = function () {
-  if(exports.soffice != null) {
+exports.sofficeAvailable = function() {
+  if (exports.soffice != null) {
     return os.type().indexOf("Windows") != -1 ? "withoutPDF": "yes";
   } else {
     return "no";
   }
 };
 
-exports.exportAvailable = function () {
+exports.exportAvailable = function() {
   var abiword = exports.abiwordAvailable();
   var soffice = exports.sofficeAvailable();
 
-  if(abiword == "no" && soffice == "no") {
+  if (abiword == "no" && soffice == "no") {
     return "no";
   } else if ((abiword == "withoutPDF" && soffice == "no") || (abiword == "no" && soffice == "withoutPDF")) {
     return "withoutPDF";
@@ -321,8 +318,7 @@ exports.exportAvailable = function () {
 // Provide git version if available
 exports.getGitCommit = function() {
   var version = "";
-  try
-  {
+  try {
     var rootPath = path.resolve(npm.dir, '..');
     if (fs.lstatSync(rootPath + '/.git').isFile()) {
       rootPath = fs.readFileSync(rootPath + '/.git', "utf8");
@@ -334,9 +330,7 @@ exports.getGitCommit = function() {
     var refPath = rootPath + "/" + ref.substring(5, ref.indexOf("\n"));
     version = fs.readFileSync(refPath, "utf-8");
     version = version.substring(0, 7);
-  }
-  catch(e)
-  {
+  } catch(e) {
     console.warn("Can't get git version for server header\n" + e.message)
   }
   return version;
@@ -350,24 +344,24 @@ exports.getEpVersion = function() {
 exports.reloadSettings = function reloadSettings() {
   // Discover where the settings file lives
   var settingsFilename = absolutePaths.makeAbsolute(argv.settings || "settings.json");
-  
+
   // Discover if a credential file exists
   var credentialsFilename = absolutePaths.makeAbsolute(argv.credentials || "credentials.json");
 
   var settingsStr, credentialsStr;
-  try{
+  try {
     //read the settings sync
     settingsStr = fs.readFileSync(settingsFilename).toString();
     console.info(`Settings loaded from: ${settingsFilename}`);
-  } catch(e){
+  } catch(e) {
     console.warn(`No settings file found in ${settingsFilename}. Continuing using defaults!`);
   }
 
-  try{
+  try {
     //read the credentials sync
     credentialsStr = fs.readFileSync(credentialsFilename).toString();
     console.info(`Credentials file read from: ${credentialsFilename}`);
-  } catch(e){
+  } catch(e) {
     // Doesn't matter if no credentials file found..
     console.info(`No credentials file found in ${credentialsFilename}. Ignoring.`);
   }
@@ -376,68 +370,58 @@ exports.reloadSettings = function reloadSettings() {
   var settings;
   var credentials;
   try {
-    if(settingsStr) {
+    if (settingsStr) {
       settingsStr = jsonminify(settingsStr).replace(",]","]").replace(",}","}");
       settings = JSON.parse(settingsStr);
     }
-  }catch(e){
+  } catch(e) {
     console.error(`There was an error processing your settings file from ${settingsFilename}:` + e.message);
     process.exit(1);
   }
 
-  if(credentialsStr) {
+  if (credentialsStr) {
     credentialsStr = jsonminify(credentialsStr).replace(",]","]").replace(",}","}");
     credentials = JSON.parse(credentialsStr);
   }
 
   //loop trough the settings
-  for(var i in settings)
-  {
+  for (var i in settings) {
     //test if the setting start with a lowercase character
-    if(i.charAt(0).search("[a-z]") !== 0)
-    {
+    if (i.charAt(0).search("[a-z]") !== 0) {
       console.warn(`Settings should start with a lowercase character: '${i}'`);
     }
 
     //we know this setting, so we overwrite it
     //or it's a settings hash, specific to a plugin
-    if(exports[i] !== undefined || i.indexOf('ep_')==0)
-    {
+    if (exports[i] !== undefined || i.indexOf('ep_') == 0) {
       if (_.isObject(settings[i]) && !_.isArray(settings[i])) {
         exports[i] = _.defaults(settings[i], exports[i]);
       } else {
         exports[i] = settings[i];
       }
-    }
-    //this setting is unkown, output a warning and throw it away
-    else
-    {
+    } else {
+      // this setting is unknown, output a warning and throw it away
       console.warn(`Unknown Setting: '${i}'. This setting doesn't exist or it was removed`);
     }
   }
 
   //loop trough the settings
-  for(var i in credentials)
-  {
+  for (var i in credentials) {
     //test if the setting start with a lowercase character
-    if(i.charAt(0).search("[a-z]") !== 0)
-    {
+    if (i.charAt(0).search("[a-z]") !== 0) {
       console.warn(`Settings should start with a lowercase character: '${i}'`);
     }
 
     //we know this setting, so we overwrite it
     //or it's a settings hash, specific to a plugin
-    if(exports[i] !== undefined || i.indexOf('ep_')==0)
-    {
+    if (exports[i] !== undefined || i.indexOf('ep_') == 0) {
       if (_.isObject(credentials[i]) && !_.isArray(credentials[i])) {
         exports[i] = _.defaults(credentials[i], exports[i]);
       } else {
         exports[i] = credentials[i];
       }
-    }
-    //this setting is unkown, output a warning and throw it away
-    else
-    {
+    } else {
+      // this setting is unknown, output a warning and throw it away
       console.warn(`Unknown Setting: '${i}'. This setting doesn't exist or it was removed`);
     }
   }
@@ -483,14 +467,13 @@ exports.reloadSettings = function reloadSettings() {
     console.info(`Using skin "${exports.skinName}" in dir: ${skinPath}`);
   }
 
-  if(exports.abiword){
+  if (exports.abiword) {
     // Check abiword actually exists
-    if(exports.abiword != null)
-    {
+    if (exports.abiword != null) {
       fs.exists(exports.abiword, function(exists) {
         if (!exists) {
           var abiwordError = "Abiword does not exist at this path, check your settings file";
-          if(!exports.suppressErrorsInPadText){
+          if (!exports.suppressErrorsInPadText) {
             exports.defaultPadText = exports.defaultPadText + "\nError: " + abiwordError + suppressDisableMsg;
           }
           console.error(abiwordError);
@@ -500,12 +483,12 @@ exports.reloadSettings = function reloadSettings() {
     }
   }
 
-  if(exports.soffice) {
-    fs.exists(exports.soffice, function (exists) {
-      if(!exists) {
+  if (exports.soffice) {
+    fs.exists(exports.soffice, function(exists) {
+      if (!exists) {
         var sofficeError = "SOffice does not exist at this path, check your settings file";
 
-        if(!exports.suppressErrorsInPadText) {
+        if (!exports.suppressErrorsInPadText) {
           exports.defaultPadText = exports.defaultPadText + "\nError: " + sofficeError + suppressDisableMsg;
         }
         console.error(sofficeError);
@@ -528,9 +511,9 @@ exports.reloadSettings = function reloadSettings() {
     console.warn("Declaring the sessionKey in the settings.json is deprecated. This value is auto-generated now. Please remove the setting from the file.");
   }
 
-  if(exports.dbType === "dirty"){
+  if (exports.dbType === "dirty") {
     var dirtyWarning = "DirtyDB is used. This is fine for testing but not recommended for production.";
-    if(!exports.suppressErrorsInPadText){
+    if (!exports.suppressErrorsInPadText) {
       exports.defaultPadText = exports.defaultPadText + "\nWarning: " + dirtyWarning + suppressDisableMsg;
     }
 

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -472,11 +472,11 @@ exports.reloadSettings = function reloadSettings() {
     if (exports.abiword != null) {
       fs.exists(exports.abiword, function(exists) {
         if (!exists) {
-          var abiwordError = "Abiword does not exist at this path, check your settings file";
+          var abiwordError = "Abiword does not exist at this path, check your settings file.";
           if (!exports.suppressErrorsInPadText) {
             exports.defaultPadText = exports.defaultPadText + "\nError: " + abiwordError + suppressDisableMsg;
           }
-          console.error(abiwordError);
+          console.error(abiwordError + ` File location: ${exports.abiword}`);
           exports.abiword = null;
         }
       });
@@ -486,12 +486,12 @@ exports.reloadSettings = function reloadSettings() {
   if (exports.soffice) {
     fs.exists(exports.soffice, function(exists) {
       if (!exists) {
-        var sofficeError = "SOffice does not exist at this path, check your settings file";
+        var sofficeError = "soffice (libreoffice) does not exist at this path, check your settings file.";
 
         if (!exports.suppressErrorsInPadText) {
           exports.defaultPadText = exports.defaultPadText + "\nError: " + sofficeError + suppressDisableMsg;
         }
-        console.error(sofficeError);
+        console.error(sofficeError + ` File location: ${exports.soffice}`);
         exports.soffice = null;
       }
     });


### PR DESCRIPTION
This patch series prepares the `Settings.js` module, getting rid of duplicate code, and then implements support for configuring Etherpad via environment variables, as per proposal in #3543 (which, in turn, steals from [Elastic Search's configuration syntax](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/settings.html#_environment_variable_substitution), albeit with a small difference).

All the configuration values can be read from environment variables using the syntax `"${ENV_VAR_NAME}"`.
This is useful, for example, when running in a Docker container.

# EXAMPLE:
```
   "port":     "${PORT}"
   "minify":   "${MINIFY}"
   "skinName": "${SKIN_NAME}"
```

Would read the configuration values for those items from the environment
variables `PORT`, `MINIFY` and `SKIN_NAME`.

# REMARKS:
Please note that **a variable substitution always needs to be quoted**, even if it is substituing a variable that normally would not need to be quoted in json.

```
   "port":   9001,          <-- Literal values. When not using substitution,
   "minify": false              only strings must be quoted: booleans and
   "skin":   "colibris"         numbers must not.

   "port":   ${PORT}        <-- ERROR: this is not valid json
   "minify": ${MINIFY}
   "skin":   ${SKIN_NAME}

   "port":   "${PORT}"      <-- CORRECT: if you want to use a variable
   "minify": "${MINIFY}"        substitution, put quotes around its name,
   "skin":   "${SKIN_NAME}"     even if the required value is a number or a
                                boolean.
                                Etherpad will take care of rewriting it to
                                the proper type if necessary.
```
