### PR TITLE
Await padManager.getPad in getPadLines

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1363,7 +1363,7 @@ async function getChangesetInfo(padId, startNum, endNum, granularity)
  */
 async function getPadLines(padId, revNum)
 {
-  let pad = padManager.getPad(padId);
+  let pad = await padManager.getPad(padId);
 
   // get the atext
   let atext;


### PR DESCRIPTION
`padManager.getPad` is an `async` function, therefore it needs to be `await`ed. Otherwise the timeslider cannot load old revisions.