### PR TITLE
Support for default values in envvars lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If cloning to a subdirectory within another project, you may need to do the foll
 You can modify the settings in `settings.json`.
 If you need to handle multiple settings files, you can pass the path to a settings file to `bin/run.sh` using the `-s|--settings` option: this allows you to run multiple Etherpad instances from the same installation.
 Similarly, `--credentials` can be used to give a settings override file, `--apikey` to give a different APIKEY.txt file and `--sessionkey` to give a non-default SESSIONKEY.txt.
+**Each configuration parameter can also be set via an environment variable**, using the syntax `"${ENV_VAR}"` or `"${ENV_VAR:default_value}"`. For details, refer to `settings.json.template`.
 Once you have access to your /admin section settings can be modified through the web browser.
 
 You should use a dedicated database such as "mysql", if you are planning on using etherpad-in a production environment, since the "dirtyDB" database driver is only for testing and/or development purposes.

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ cp ../settings.json.template settings.json
 [ further edit your settings.json as needed]
 ```
 
-**Each configuration parameter can also be set via an environment variable**, using the syntax `"${ENV_VAR_NAME}"`. For details, refer to `settings.json.template`.
+**Each configuration parameter can also be set via an environment variable**, using the syntax `"${ENV_VAR}"` or `"${ENV_VAR:default_value}"`. For details, refer to `settings.json.template`.
 
 Build the version you prefer:
 ```bash

--- a/settings.json.template
+++ b/settings.json.template
@@ -11,7 +11,7 @@
  * =================================
  *
  * All the configuration values can be read from environment variables using the
- * syntax "${ENV_VAR_NAME}".
+ * syntax "${ENV_VAR}".
  * This is useful, for example, when running in a Docker container.
  *
  * EXAMPLE:
@@ -23,21 +23,23 @@
  * variables PORT, MINIFY and SKIN_NAME.
  *
  * REMARKS:
- * Please note that a variable substitution always needs to be quoted.
- *    "port":   9001,          <-- Literal values. When not using substitution,
- *    "minify": false              only strings must be quoted: booleans and
- *    "skin":   "colibris"         numbers must not.
+ * Please note that variable substitution always needs to be quoted.
  *
- *    "port":   ${PORT}        <-- ERROR: this is not valid json
- *    "minify": ${MINIFY}
- *    "skin":   ${SKIN_NAME}
+ *    "port":     9001,          <-- Literal values. When not using
+ *    "minify":   false              substitution, only strings must be quoted.
+ *    "skinName": "colibris"         Booleans and numbers must not.
  *
- *    "port":   "${PORT}"      <-- CORRECT: if you want to use a variable
- *    "minify": "${MINIFY}"        substitution, put quotes around its name,
- *    "skin":   "${SKIN_NAME}"     even if the required value is a number or a
- *                                 boolean.
- *                                 Etherpad will take care of rewriting it to
- *                                 the proper type if necessary.
+ *    "port":     "${PORT}"      <-- CORRECT: if you want to use a variable
+ *    "minify":   "${MINIFY}"        substitution, put quotes around its name,
+ *    "skinName": "${SKIN_NAME}"     even if the required value is a number or a
+ *                                   boolean.
+ *                                   Etherpad will take care of rewriting it to
+ *                                   the proper type if necessary.
+ *
+ *    "port":     ${PORT}        <-- ERROR: this is not valid json. Quotes
+ *    "minify":   ${MINIFY}          around variable names are missing.
+ *    "skinName": ${SKIN_NAME}
+ *
  */
 {
   /*

--- a/settings.json.template
+++ b/settings.json.template
@@ -11,33 +11,38 @@
  * =================================
  *
  * All the configuration values can be read from environment variables using the
- * syntax "${ENV_VAR}".
+ * syntax "${ENV_VAR}" or "${ENV_VAR:default_value}".
+ *
  * This is useful, for example, when running in a Docker container.
  *
  * EXAMPLE:
- *    "port":     "${PORT}"
+ *    "port":     "${PORT:9001}"
  *    "minify":   "${MINIFY}"
- *    "skinName": "${SKIN_NAME}"
+ *    "skinName": "${SKIN_NAME:colibris}"
  *
  * Would read the configuration values for those items from the environment
  * variables PORT, MINIFY and SKIN_NAME.
+ * If PORT and SKIN_NAME variables were not defined, the default values 9001 and
+ * "colibris" would be used. The configuration value "minify", on the other
+ * hand, does not have a default indicated. Thus, if the environment variable
+ * MINIFY were undefined, "minify" would be null (do not do this).
  *
  * REMARKS:
  * Please note that variable substitution always needs to be quoted.
  *
- *    "port":     9001,          <-- Literal values. When not using
- *    "minify":   false              substitution, only strings must be quoted.
- *    "skinName": "colibris"         Booleans and numbers must not.
+ *    "port":     9001,            <-- Literal values. When not using
+ *    "minify":   false                substitution, only strings must be
+ *    "skinName": "colibris"           quoted. Booleans and numbers must not.
  *
- *    "port":     "${PORT}"      <-- CORRECT: if you want to use a variable
- *    "minify":   "${MINIFY}"        substitution, put quotes around its name,
- *    "skinName": "${SKIN_NAME}"     even if the required value is a number or a
- *                                   boolean.
- *                                   Etherpad will take care of rewriting it to
- *                                   the proper type if necessary.
+ *    "port":     "${PORT:9001}"   <-- CORRECT: if you want to use a variable
+ *    "minify":   "${MINIFY:true}"     substitution, put quotes around its name,
+ *    "skinName": "${SKIN_NAME}"       even if the required value is a number or
+ *                                     a boolean.
+ *                                     Etherpad will take care of rewriting it
+ *                                     to the proper type if necessary.
  *
- *    "port":     ${PORT}        <-- ERROR: this is not valid json. Quotes
- *    "minify":   ${MINIFY}          around variable names are missing.
+ *    "port":     ${PORT:9001}     <-- ERROR: this is not valid json. Quotes
+ *    "minify":   ${MINIFY}            around variable names are missing.
  *    "skinName": ${SKIN_NAME}
  *
  */

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -372,13 +372,13 @@ function storeSettings(settingsObj) {
 
 /**
  * Takes a javascript object containing Etherpad's configuration, and returns
- * another object, in which all the string properties whose name is of the form
- * "${ENV_VAR}", got their value replaced with the value of the given
+ * another object, in which all the string properties whose value is of the form
+ * "${ENV_VAR}" got their value replaced with the contents of the given
  * environment variable.
  *
- * An environment variable's value is always a string. However, the code base
- * makes use of the various json types. To maintain compatiblity, some
- * heuristics is applied:
+ * By definition, an environment variable's value is always a string. However,
+ * the code base makes use of the various json types. To maintain compatiblity,
+ * some heuristics is applied:
  *
  * - if ENV_VAR does not exist in the environment, null is returned;
  * - if ENV_VAR's value is "true" or "false", it is converted to the js boolean
@@ -386,10 +386,21 @@ function storeSettings(settingsObj) {
  * - if ENV_VAR's value looks like a number, it is converted to a js number
  *   (details in the code).
  *
- * Variable substitution is performed doing a round trip conversion to/from
- * json, using a custom replacer parameter in JSON.stringify(), and parsing the
- * JSON back again. This ensures that environment variable replacement is
- * performed even on nested objects.
+ * The following is a scheme of the behaviour of this function:
+ *
+ * +---------------------------+---------------+------------------+
+ * | Configuration string in   | Value of      | Resulting confi- |
+ * | settings.json             | ENV_VAR       | guration value   |
+ * |---------------------------|---------------|------------------|
+ * | "${ENV_VAR}"              | "some_string" | "some_string"    |
+ * | "${ENV_VAR}"              | "9001"        | 9001             |
+ * | "${ENV_VAR}"              | undefined     | null             |
+ * +---------------------------+---------------+------------------+
+ *
+ * IMPLEMENTATION NOTE: variable substitution is performed doing a round trip
+ *     conversion to/from json, using a custom replacer parameter in
+ *     JSON.stringify(), and parsing the JSON back again. This ensures that
+ *     environment variable replacement is performed even on nested objects.
  *
  * see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter
  */

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -370,6 +370,33 @@ function storeSettings(settingsObj) {
   }
 }
 
+/*
+ * If stringValue is a numeric string, or its value is "true" or "false", coerce
+ * them to appropriate JS types. Otherwise return stringValue as-is.
+ */
+function coerceValue(stringValue) {
+    // cooked from https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
+    const isNumeric = !isNaN(stringValue) && !isNaN(parseFloat(stringValue) && isFinite(stringValue));
+
+    if (isNumeric) {
+      // detected numeric string. Coerce to a number
+
+      return +stringValue;
+    }
+
+    // the boolean literal case is easy.
+    if (stringValue === "true" ) {
+      return true;
+    }
+
+    if (stringValue === "false") {
+      return false;
+    }
+
+    // otherwise, return this value as-is
+    return stringValue;
+}
+
 /**
  * Takes a javascript object containing Etherpad's configuration, and returns
  * another object, in which all the string properties whose value is of the form
@@ -458,30 +485,9 @@ function lookupEnvironmentVariables(obj) {
      * For numeric and boolean strings let's convert it to proper types before
      * returning it, in order to maintain backward compatibility.
      */
+    console.debug(`Configuration key "${key}" will be read from environment variable "${envVarName}"`);
 
-    // cooked from https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
-    const isNumeric = !isNaN(envVarValue) && !isNaN(parseFloat(envVarValue) && isFinite(envVarValue));
-
-    if (isNumeric) {
-      console.debug(`Configuration key "${key}" will be read from environment variable ${envVarName}. Detected numeric string, that will be coerced to a number`);
-
-      return +envVarValue;
-    }
-
-    // the boolean literal case is easy.
-    if (envVarValue === "true" || envVarValue === "false") {
-      console.debug(`Configuration key "${key}" will be read from environment variable ${envVarName}. Detected boolean string, that will be coerced to a boolean`);
-
-      return (envVarValue === "true");
-    }
-
-    /*
-     * The only remaining case is that envVarValue is a string with no special
-     * meaning, and we just return it as-is.
-     */
-    console.debug(`Configuration key "${key}" will be read from environment variable ${envVarName}`);
-
-    return envVarValue;
+    return coerceValue(envVarValue);
   });
 
   const newSettings = JSON.parse(stringifiedAndReplaced);

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -443,7 +443,7 @@ function lookupEnvironmentVariables(obj) {
     const envVarValue = process.env[envVarName];
 
     if (envVarValue === undefined) {
-      console.warn(`Configuration key ${key} tried to read its value from environment variable ${envVarName}, but no value was found. Returning null. Please check your configuration and environment settings.`);
+      console.warn(`Environment variable "${envVarName}" does not contain any value for configuration key "${key}". Returning null. Please check your configuration and environment settings.`);
 
       /*
        * We have to return null, because if we just returned undefined, the


### PR DESCRIPTION
This patch series prepares the code for supporting using the `${ENV_VAR:default_value}` syntax in the configuration file, as specified in #3578.
The final commit implements the functionality.

| Configuration string in settings.json | Value of ENV_VAR | Resulting configuration value |
| ---- | ---- | ---- |
| `"${ENV_VAR}"` | `"some_string"` | `"some_string"` |
| `"${ENV_VAR}"` | `"9001"` | `9001` |
| `"${ENV_VAR}"` | `undefined` | `null` |
| `"${ENV_VAR:some_default}"` | `"some_string"` | `"some_string"` |
| `"${ENV_VAR:some_default}"` | `undefined` | `"some_default"` |

