### PR TITLE
Some fixes caught by the Typescript compiler

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -260,7 +260,7 @@ exports.getHTML = async function(padID, rev)
   }
 
   // get the html of this revision
-  html = await exportHtml.getPadHTML(pad, rev);
+  let html = await exportHtml.getPadHTML(pad, rev);
 
   // wrap the HTML
   html = "<!DOCTYPE HTML><html><body>" + html + "</body></html>";

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -525,7 +525,7 @@ exports.restoreRevision = async function(padID, rev)
 {
   // check if rev is a number
   if (rev === undefined) {
-    throw new customeError("rev is not defined", "apierror");
+    throw new customError("rev is not defined", "apierror");
   }
   rev = checkValidRev(rev);
 

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -399,7 +399,7 @@ Pad.prototype.copy = async function copy(destinationID, force) {
 
     // exists and forcing
     let pad = await padManager.getPad(destinationID);
-    await pad.remove(callback);
+    await pad.remove();
   }
 
   // copy the 'pad' entry

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -393,8 +393,6 @@ Pad.prototype.copy = async function copy(destinationID, force) {
     if (!force) {
       console.error("erroring out without force");
       throw new customError("destinationID already exists", "apierror");
-
-      return;
     }
 
     // exists and forcing

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -287,7 +287,7 @@ exports.handleMessage = async function(client, message)
 
     if (padId.indexOf("r.") === 0) {
       // Pad is readOnly, first get the real Pad ID
-      padId = await readOnlyManager.getPadId(padID);
+      padId = await readOnlyManager.getPadId(padId);
     }
 
     let { accessStatus } = await securityManager.checkAccess(padId, auth.sessionID, auth.token, auth.password);

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -257,9 +257,9 @@ exports.handleMessage = async function(client, message)
 
     // check permissions
 
-    // client tried to auth for the first time (first msg from the client)
     if (message.type == "CLIENT_READY") {
-        createSessionInfo(client, message);
+      // client tried to auth for the first time (first msg from the client)
+      createSessionInfo(client, message);
     }
 
     // Note: message.sessionID is an entirely different kind of
@@ -285,15 +285,15 @@ exports.handleMessage = async function(client, message)
     // check if pad is requested via readOnly
     let padId = auth.padID;
 
-    // Pad is readOnly, first get the real Pad ID
     if (padId.indexOf("r.") === 0) {
+      // Pad is readOnly, first get the real Pad ID
       padId = await readOnlyManager.getPadId(padID);
     }
 
     let { accessStatus } = await securityManager.checkAccess(padId, auth.sessionID, auth.token, auth.password);
 
-    // no access, send the client a message that tells him why
     if (accessStatus !== "grant") {
+      // no access, send the client a message that tells him why
       client.json.send({ accessStatus });
       return;
     }

--- a/src/node/hooks/express/padreadonly.js
+++ b/src/node/hooks/express/padreadonly.js
@@ -18,7 +18,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 
     if (await hasPadAccess(req, res)) {
       // render the html document
-      html = await exporthtml.getPadHTMLDocument(padId, null);
+      let html = await exporthtml.getPadHTMLDocument(padId, null);
       res.send(html);
     }
   });

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -70,7 +70,7 @@ for (var key in tar) {
 
 // What follows is a terrible hack to avoid loop-back within the server.
 // TODO: Serve files from another service, or directly from the file system.
-function requestURI(url, method, headers, callback, redirectCount) {
+function requestURI(url, method, headers, callback) {
   var parsedURL = urlutil.parse(url);
 
   var status = 500, headers = {}, content = [];

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -137,7 +137,7 @@ function requestURIs(locations, method, headers, callback) {
  * @param req the Express request
  * @param res the Express response
  */
-function minify(req, res, next)
+function minify(req, res)
 {
   var filename = req.params['filename'];
 

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -240,7 +240,7 @@ function minify(req, res)
         res.end();
       }
     }
-  });
+  }, 3);
 }
 
 // find all includes in ace.js and embed them.
@@ -287,6 +287,10 @@ function getAceFile(callback) {
 
 // Check for the existance of the file and get the last modification date.
 function statFile(filename, callback, dirStatLimit) {
+  /*
+   * The only external call to this function provides an explicit value for
+   * dirStatLimit: this check could be removed.
+   */
   if (typeof dirStatLimit === 'undefined') {
     dirStatLimit = 3;
   }


### PR DESCRIPTION
These are assorted fixes found while during an experimental conversion to Typescript.

The most notable fixes are:

- `PadMessageHandler.handleMessage()` got the wrong `padId` for read only pads. This would lead to a crash.
- a redundant `callback` parameter to `pad.remove()` in `Pad.prototype.copy()` could cause a crash at runtime.
- in case of error, `restoreRevision()` would crash instead of writing a log message
