### PR TITLE
remove devdeps from prod builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,10 @@ LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 # If not given, build the latest development version.
 ARG ETHERPAD_VERSION=develop
 
+# Set the following to production to avoid installing devDeps
+# this can be one with build args (and is mandatory to build ARM version
+ARG NODE_ENV=development
+
 # grab the ETHERPAD_VERSION tarball from github (no need to clone the whole
 # repository)
 RUN echo "Getting version: ${ETHERPAD_VERSION}" && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,10 +22,10 @@ Build the version you prefer:
 docker build --tag <YOUR_USERNAME>/etherpad .
 
 # builds latest stable version
-docker build --build-arg ETHERPAD_VERSION=master --tag <YOUR_USERNAME>/etherpad .
+docker build --build-arg ETHERPAD_VERSION=master --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
 
 # builds a specific version
-docker build --build-arg ETHERPAD_VERSION=1.7.5 --tag <YOUR_USERNAME>/etherpad .
+docker build --build-arg ETHERPAD_VERSION=1.7.5 --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
 
 # builds a specific git hash
 docker build --build-arg ETHERPAD_VERSION=4c45ac3cb1ae --tag <YOUR_USERNAME>/etherpad .


### PR DESCRIPTION
While trying to build Etherpad for ARM , it fails due to devdeps , so I removed them from prod docker builds.
This also generates smaller builds. (mine is around 50Mb)
My docker images are at https://gitlab.com/alm-docker/etherpad/container_registry 
I enabled multiarch builds