### PR TITLE
Chat bubble: by default hide in CSS

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -643,6 +643,7 @@ table#otheruserstable {
   border-top-right-radius: 5px;
   background-color: #fff;
   cursor: pointer;
+  display: none;
 }
 #chaticon a {
   text-decoration: none

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -74,7 +74,7 @@ function randomString()
 var getParameters = [
   { name: "noColors",         checkVal: "true",  callback: function(val) { settings.noColors = true; $('#clearAuthorship').hide(); } },
   { name: "showControls",     checkVal: "false", callback: function(val) { $('#editbar').addClass('hideControlsEditbar'); $('#editorcontainer').addClass('hideControlsEditor'); } },
-  { name: "showChat",         checkVal: "false", callback: function(val) { $('#chaticon').hide(); } },
+  { name: "showChat",         checkVal: "true", callback: function(val) { $('#chaticon').show(); } },
   { name: "showLineNumbers",  checkVal: "false", callback: function(val) { settings.LineNumbersDisabled = true; } },
   { name: "useMonospaceFont", checkVal: "true",  callback: function(val) { settings.useMonospaceFontGlobal = true; } },
   // If the username is set as a parameter we should set a global value that we can call once we have initiated the pad.


### PR DESCRIPTION
The current behaviour is to show the chat bubble and hide if chat is
disabled.

Because of this, the bubble appears wrongfully for a short time.

With this PR, by default it is hidden and displayed only if chat is
enabled.

Fixes: #3088