### PR TITLE
POC: remove dependency on require-kernel

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -100,7 +100,7 @@ echo "Ensure that all dependencies are up to date...  If this is the first time 
   cd node_modules
   [ -e ep_etherpad-lite ] || ln -s ../src ep_etherpad-lite
   cd ep_etherpad-lite
-  npm install --no-save --loglevel warn
+  npm install --save --loglevel warn
 ) || {
   rm -rf src/node_modules
   exit 1

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -28,7 +28,6 @@ var CleanCSS = require('clean-css');
 var uglifyJS = require("uglify-js");
 var path = require('path');
 var plugins = require("ep_etherpad-lite/static/js/pluginfw/plugins");
-var RequireKernel = require('etherpad-require-kernel');
 var urlutil = require('url');
 
 var ROOT_DIR = path.normalize(__dirname + "/../../static/");
@@ -253,8 +252,6 @@ function getAceFile(callback) {
     if (!settings.minify) {
       founds = [];
     }
-    // Always include the require kernel.
-    founds.push('$$INCLUDE_JS("../static/js/require-kernel.js")');
 
     data += ';\n';
     data += 'Ace2Editor.EMBEDED = Ace2Editor.EMBEDED || {};\n';

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -300,8 +300,6 @@ function statFile(filename, callback, dirStatLimit) {
     lastModifiedDateOfEverything(function (error, date) {
       callback(error, date, !error);
     });
-  } else if (filename == 'js/require-kernel.js') {
-    callback(null, requireLastModified(), true);
   } else {
     fs.stat(ROOT_DIR + filename, function (error, stats) {
       if (error) {
@@ -361,16 +359,6 @@ function lastModifiedDateOfEverything(callback) {
   });
 }
 
-// This should be provided by the module, but until then, just use startup
-// time.
-var _requireLastModified = new Date();
-function requireLastModified() {
-  return _requireLastModified.toUTCString();
-}
-function requireDefinition() {
-  return 'var require = ' + RequireKernel.kernelSource + ';\n';
-}
-
 function getFileCompressed(filename, contentType, callback) {
   getFile(filename, function (error, content) {
     if (error || !content || !settings.minify) {
@@ -393,8 +381,6 @@ function getFileCompressed(filename, contentType, callback) {
 function getFile(filename, callback) {
   if (filename == 'js/ace.js') {
     getAceFile(callback);
-  } else if (filename == 'js/require-kernel.js') {
-    callback(undefined, requireDefinition());
   } else {
     fs.readFile(ROOT_DIR + filename, callback);
   }

--- a/src/package.json
+++ b/src/package.json
@@ -32,12 +32,12 @@
   "dependencies": {
     "async": "0.9.0",
     "async-stacktrace": "0.0.2",
+    "browserify": "16.2.3",
     "channels": "0.0.4",
     "cheerio": "0.20.0",
     "clean-css": "3.4.19",
     "cookie-parser": "1.4.4",
     "ejs": "2.6.1",
-    "etherpad-require-kernel": "1.0.9",
     "etherpad-yajsml": "0.0.2",
     "express": "4.16.4",
     "express-session": "1.16.1",

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -24,8 +24,6 @@
 // requires: plugins
 // requires: undefined
 
-var KERNEL_SOURCE = '../static/js/require-kernel.js';
-
 Ace2Editor.registry = {
   nextId: 1
 };
@@ -243,14 +241,9 @@ function Ace2Editor()
 
       pushStyleTagsFor(iframeHTML, includedCSS);
 
-      if (!Ace2Editor.EMBEDED && Ace2Editor.EMBEDED[KERNEL_SOURCE]) {
-        // Remotely src'd script tag will not work in IE; it must be embedded, so
-        // throw an error if it is not.
-        throw new Error("Require kernel could not be found.");
-      }
-
       iframeHTML.push(scriptTag(
-Ace2Editor.EMBEDED[KERNEL_SOURCE] + '\n\
+'var muxator = "muxator";\n\
+/* TODO: trovare un modo di caricare il bundle.js */\n\
 require.setRootURI("../javascripts/src");\n\
 require.setLibraryURI("../javascripts/lib");\n\
 require.setGlobalKeyPath("require");\n\

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -241,12 +241,17 @@ function Ace2Editor()
 
       pushStyleTagsFor(iframeHTML, includedCSS);
 
+      iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');
+
+      hooks.callAll("aceInitInnerdocbodyHead", {
+        iframeHTML: iframeHTML
+      });
+
+      iframeHTML.push('</head><body id="innerdocbody" class="innerdocbody" role="application" class="syntax" spellcheck="false">&nbsp;');
+
+      iframeHTML.push('<script type="text/javascript" src="../static/js/bundle.js"></script>');
       iframeHTML.push(scriptTag(
 'var muxator = "muxator";\n\
-/* TODO: trovare un modo di caricare il bundle.js */\n\
-require.setRootURI("../javascripts/src");\n\
-require.setLibraryURI("../javascripts/lib");\n\
-require.setGlobalKeyPath("require");\n\
 \n\
 var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");\n\
 var plugins = require("ep_etherpad-lite/static/js/pluginfw/client_plugins");\n\
@@ -260,14 +265,7 @@ plugins.ensure(function () {\n\
   Ace2Inner.init();\n\
 });\n\
 '));
-
-      iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');
-
-      hooks.callAll("aceInitInnerdocbodyHead", {
-        iframeHTML: iframeHTML
-      });
-
-      iframeHTML.push('</head><body id="innerdocbody" class="innerdocbody" role="application" class="syntax" spellcheck="false">&nbsp;</body></html>');
+      iframeHTML.push('</body></html>');
 
       // Expose myself to global for my child frame.
       var thisFunctionsName = "ChildAccessibleAce2Editor";

--- a/src/static/js/create-bundle.sh
+++ b/src/static/js/create-bundle.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+npx --no-install browserify \
+  ace2_common.js \
+  ace.js \
+  AttributeManager.js \
+  AttributePool.js \
+  broadcast.js \
+  excanvas.js \
+  pad_editor.js \
+  pad.js \
+  security.js \
+  skiplist.js \
+  timeslider.js \
+  underscore.js \
+  undomodule.js \
+  --entry=entrypoint.js \
+  --outfile=bundle.js

--- a/src/static/js/create-bundle.sh
+++ b/src/static/js/create-bundle.sh
@@ -3,6 +3,15 @@
 set -eu
 
 npx --no-install browserify \
+  -r ./ace2_inner.js:ep_etherpad-lite/static/js/ace2_inner \
+  -r ./browser.js:ep_etherpad-lite/static/js/browser \
+  -r ./chat.js:ep_etherpad-lite/static/js/chat \
+  -r ./pad_editbar.js:ep_etherpad-lite/static/js/pad_editbar \
+  -r ./pad_impexp.js:ep_etherpad-lite/static/js/pad_impexp \
+  -r ./pad.js:ep_etherpad-lite/static/js/pad \
+  -r ./pluginfw/client_plugins.js:ep_etherpad-lite/static/js/pluginfw/client_plugins \
+  -r ./pluginfw/hooks.js:ep_etherpad-lite/static/js/pluginfw/hooks \
+  -r ./rjquery.js:ep_etherpad-lite/static/js/rjquery \
   ace2_common.js \
   ace.js \
   AttributeManager.js \
@@ -10,11 +19,9 @@ npx --no-install browserify \
   broadcast.js \
   excanvas.js \
   pad_editor.js \
-  pad.js \
   security.js \
   skiplist.js \
   timeslider.js \
   underscore.js \
   undomodule.js \
-  --entry=entrypoint.js \
   --outfile=bundle.js

--- a/src/static/js/entrypoint.js
+++ b/src/static/js/entrypoint.js
@@ -1,0 +1,37 @@
+var clientVars = {};
+(function () {
+  var pathComponents = location.pathname.split('/');
+
+  // Strip 'p' and the padname from the pathname and set as baseURL
+  var baseURL = pathComponents.slice(0,pathComponents.length-2).join('/') + '/';
+
+  require.setRootURI(baseURL + "javascripts/src");
+  require.setLibraryURI(baseURL + "javascripts/lib");
+  require.setGlobalKeyPath("require");
+
+  $ = jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery; // Expose jQuery #HACK
+  browser = require('ep_etherpad-lite/static/js/browser');
+
+  var plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
+  var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+
+  plugins.baseURL = baseURL;
+  plugins.update(function () {
+    hooks.plugins = plugins;
+
+    // Call documentReady hook
+    $(function() {
+      hooks.aCallAll('documentReady');
+    });
+
+    var pad = require('ep_etherpad-lite/static/js/pad');
+    pad.baseURL = baseURL;
+    pad.init();
+  });
+
+  /* TODO: These globals shouldn't exist. */
+  pad = require('ep_etherpad-lite/static/js/pad').pad;
+  chat = require('ep_etherpad-lite/static/js/chat').chat;
+  padeditbar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
+  padimpexp = require('ep_etherpad-lite/static/js/pad_impexp').padimpexp;
+}());

--- a/src/static/js/entrypoint.js
+++ b/src/static/js/entrypoint.js
@@ -5,10 +5,6 @@ var clientVars = {};
   // Strip 'p' and the padname from the pathname and set as baseURL
   var baseURL = pathComponents.slice(0,pathComponents.length-2).join('/') + '/';
 
-  require.setRootURI(baseURL + "javascripts/src");
-  require.setLibraryURI(baseURL + "javascripts/lib");
-  require.setGlobalKeyPath("require");
-
   $ = jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery; // Expose jQuery #HACK
   browser = require('ep_etherpad-lite/static/js/browser');
 

--- a/src/static/js/scroll.js
+++ b/src/static/js/scroll.js
@@ -5,7 +5,7 @@
   Browser Line = each vertical line. A <div> can be break into more than one
   browser line.
 */
-var caretPosition = require('/caretPosition');
+var caretPosition = require('./caretPosition');
 
 function Scroll(outerWin) {
   // scroll settings

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -389,48 +389,7 @@
         <script type="text/javascript" src="../static/skins/<%=encodeURI(settings.skinName)%>/pad.js"></script>
         <% e.end_block(); %>
 
-        <!-- Bootstrap page -->
-        <script type="text/javascript">
-            // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
-            var clientVars = {};
-            (function () {
-              var pathComponents = location.pathname.split('/');
-
-              // Strip 'p' and the padname from the pathname and set as baseURL
-              var baseURL = pathComponents.slice(0,pathComponents.length-2).join('/') + '/';
-
-              require.setRootURI(baseURL + "javascripts/src");
-              require.setLibraryURI(baseURL + "javascripts/lib");
-              require.setGlobalKeyPath("require");
-
-              $ = jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery; // Expose jQuery #HACK
-              browser = require('ep_etherpad-lite/static/js/browser');
-
-              var plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
-              var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
-
-              plugins.baseURL = baseURL;
-              plugins.update(function () {
-                hooks.plugins = plugins;
-
-                // Call documentReady hook
-                $(function() {
-                  hooks.aCallAll('documentReady');
-                });
-
-                var pad = require('ep_etherpad-lite/static/js/pad');
-                pad.baseURL = baseURL;
-                pad.init();
-              });
-
-              /* TODO: These globals shouldn't exist. */
-              pad = require('ep_etherpad-lite/static/js/pad').pad;
-              chat = require('ep_etherpad-lite/static/js/chat').chat;
-              padeditbar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
-              padimpexp = require('ep_etherpad-lite/static/js/pad_impexp').padimpexp;
-            }());
-            // @license-end
-        </script>
+        <!-- Page is bootstrapped by bundle.js -->
         <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
         <% e.end_block(); %>
 </html>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -378,13 +378,6 @@
             // @license-end
         </script>
 
-        <script type="text/javascript" src="../static/js/require-kernel.js"></script>
-        <script type="text/javascript" src="../socket.io/socket.io.js"></script>
-
-        <!-- Include base packages manually (this help with debugging) -->
-        <script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define"></script>
-        <script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define"></script>
-
         <% e.begin_block("customScripts"); %>
         <script type="text/javascript" src="../static/skins/<%=encodeURI(settings.skinName)%>/pad.js"></script>
         <% e.end_block(); %>
@@ -392,4 +385,6 @@
         <!-- Page is bootstrapped by bundle.js -->
         <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
         <% e.end_block(); %>
+        <script type="text/javascript" src="../static/js/bundle.js"></script>
+        <script type="text/javascript" src="../socket.io/socket.io.js"></script>
 </html>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -387,4 +387,5 @@
         <% e.end_block(); %>
         <script type="text/javascript" src="../static/js/bundle.js"></script>
         <script type="text/javascript" src="../socket.io/socket.io.js"></script>
+        <script type="text/javascript" src="../static/js/entrypoint.js"></script>
 </html>

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -221,17 +221,12 @@
 </div>
 </div>
 
-<script type="text/javascript" src="../../static/js/require-kernel.js"></script>
-<script type="text/javascript" src="../../socket.io/socket.io.js"></script>
-
-<!-- Include base packages manually (this help with debugging) -->
-<script type="text/javascript" src="../../javascripts/lib/ep_etherpad-lite/static/js/timeslider.js?callback=require.define"></script>
-<script type="text/javascript" src="../../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define"></script>
 
 <script type="text/javascript" src="../../static/skins/<%=encodeURI(settings.skinName)%>/timeslider.js"></script>
 
 <!-- Bootstrap -->
 <script type="text/javascript" >
+  // TODO: create an entrypoint for this
   // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
   var clientVars = {};
   var BroadcastSlider;
@@ -273,5 +268,7 @@
 </script>
 <% e.end_block(); %>
 <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
+<script type="text/javascript" src="../../static/js/bundle.js"></script>
+<script type="text/javascript" src="../../socket.io/socket.io.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This is a proof-of-concept for getting rid of `ep-require-kernel`, which is unsupported and makes browsers cry, because:

> Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user’s experience.

It uses **browserify** to bundle the static js modules, which also results in a slightly lower load time and less round trips to the server (from 39 to 30 requests in a plain Etherpad installation with no skin).

This branch is currently ~deployed on https://beta.etherpad.org~.

What's working:
- pad editing
- chat
- the skin system

What's still not working:
- plugins (they do not load because there is no CommonJS loader in the browser now)
- the timeslider (easy to solve)
- the js bundle must be generated maually running `cd src/static/js ; ./create-bundle.sh`


A definitive solution would be probably use different technologies, but this work demonstrates that it is achievable.
It would be interesting to see if some results can be incorporated in https://github.com/storytouch/ep_webpack/, or if something from that plugin can be upstreamed.
