### PR TITLE
Docker image will now be built based on Alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 #
 # Version 0.1
 
-FROM node:latest
+FROM node:alpine
 LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 
 # git hash of the version to be built.
@@ -16,6 +16,9 @@ ARG ETHERPAD_VERSION=develop
 # Set the following to production to avoid installing devDeps
 # this can be done with build args (and is mandatory to build ARM version)
 ARG NODE_ENV=development
+
+# add curl to alpine
+RUN apk add --no-cache curl
 
 # grab the ETHERPAD_VERSION tarball from github (no need to clone the whole
 # repository)


### PR DESCRIPTION
I've build the image based on node:alpine, had to install curl separately.  I haven't tested on anything other than dirty db but works ok.  not much to it and not sure if it would cause any issues to plugins etc but it does reduce the image from 1GB to about 160MB which seems good for the liteness of etherpad-lite

```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
tom/etherpad-alpine        latest              f8xxxxx        23 seconds ago      158MB
tom/etherpad             latest             ddxxxxx        19 hours ago        985MB
```