### PR TITLE
Support plugin installation when building docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,14 @@ LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 # If not given, build the latest development version.
 ARG ETHERPAD_VERSION=develop
 
+# plugins to install while building the container. By default no plugins are
+# installed.
+# If given a value, it has to be a space-separated, quoted list of plugin names.
+#
+# EXAMPLE:
+#   ETHERPAD_PLUGINS="ep_codepad ep_author_neat"
+ARG ETHERPAD_PLUGINS=
+
 # Set the following to production to avoid installing devDeps
 # this can be done with build args (and is mandatory to build ARM version)
 ARG NODE_ENV=development
@@ -37,6 +45,12 @@ WORKDIR /opt/etherpad-lite
 
 # install node dependencies for Etherpad
 RUN bin/installDeps.sh
+
+# Install the plugins, if ETHERPAD_PLUGINS is not empty.
+#
+# Bash trick: in the for loop ${ETHERPAD_PLUGINS} is NOT quoted, in order to be
+# able to split at spaces.
+RUN for PLUGIN_NAME in ${ETHERPAD_PLUGINS}; do npm install "${PLUGIN_NAME}"; done
 
 # Copy the custom configuration file, if present. The configuration file has to
 # be manually put inside the same directory containing the Dockerfile (we cannot

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,8 +33,10 @@ RUN echo "Getting version: ${ETHERPAD_VERSION}" && \
 		--strip-components=1 && \
 	rm /opt/etherpad-lite.tar.gz
 
+WORKDIR /opt/etherpad-lite
+
 # install node dependencies for Etherpad
-RUN /opt/etherpad-lite/bin/installDeps.sh
+RUN bin/installDeps.sh
 
 # Copy the custom configuration file, if present. The configuration file has to
 # be manually put inside the same directory containing the Dockerfile (we cannot
@@ -45,5 +47,4 @@ RUN /opt/etherpad-lite/bin/installDeps.sh
 COPY nop setting[s].json /opt/etherpad-lite/
 
 EXPOSE 9001
-WORKDIR /opt/etherpad-lite
 CMD ["node", "node_modules/ep_etherpad-lite/node/server.js"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,11 +2,22 @@
 
 This directory contains the files that are used to build the official Docker image on https://hub.docker.com/r/etherpad/etherpad.
 
-# Rebuilding with custom settings
-In order to use a personalized settings file, **you will have to rebuild your image**.
+# Downloading from Docker Hub
+If you are ok downloading a [prebuilt image from Docker Hub](https://hub.docker.com/r/etherpad/etherpad), these are the commands:
+```bash
+# gets the latest published version
+docker pull etherpad/etherpad
 
-All of these instructions are as a member of the `docker` group.
+# gets a specific version
+docker pull etherpad/etherpad:1.7.5
+```
 
+# Build a personalized container
+
+If you want to use a personalized settings file, **you will have to rebuild your image**.
+All of the following instructions are as a member of the `docker` group.
+
+## Rebuilding with custom settings
 Prepare your custom `settings.json` file:
 ```bash
 cd <BASEDIR>/docker
@@ -16,29 +27,26 @@ cp ../settings.json.template settings.json
 
 **Each configuration parameter can also be set via an environment variable**, using the syntax `"${ENV_VAR}"` or `"${ENV_VAR:default_value}"`. For details, refer to `settings.json.template`.
 
-Build the version you prefer:
+## Examples
+
+Build the latest development version:
 ```bash
-# builds latest development version
 docker build --tag <YOUR_USERNAME>/etherpad .
-
-# builds latest stable version
-docker build --build-arg ETHERPAD_VERSION=master --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
-
-# builds a specific version
-docker build --build-arg ETHERPAD_VERSION=1.7.5 --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
-
-# builds a specific git hash
-docker build --build-arg ETHERPAD_VERSION=4c45ac3cb1ae --tag <YOUR_USERNAME>/etherpad .
 ```
 
-# Downloading from Docker Hub
-If you are ok downloading a [prebuilt image from Docker Hub](https://hub.docker.com/r/etherpad/etherpad), these are the commands:
+Build the latest stable version:
 ```bash
-# gets the latest published version
-docker pull etherpad/etherpad
+docker build --build-arg ETHERPAD_VERSION=master --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
+```
 
-# gets a specific version
-docker pull etherpad/etherpad:1.7.5
+Build a specific tagged version:
+```bash
+docker build --build-arg ETHERPAD_VERSION=1.7.5 --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
+```
+
+Build a specific git hash:
+```bash
+docker build --build-arg ETHERPAD_VERSION=4c45ac3cb1ae --tag <YOUR_USERNAME>/etherpad .
 ```
 
 # Running your instance:

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,6 +27,12 @@ cp ../settings.json.template settings.json
 
 **Each configuration parameter can also be set via an environment variable**, using the syntax `"${ENV_VAR}"` or `"${ENV_VAR:default_value}"`. For details, refer to `settings.json.template`.
 
+## Rebuilding including some plugins
+If you want to install some plugins in your container, it is sufficient to list them in the ETHERPAD_PLUGINS build variable.
+The variable value has to be a space separated, double quoted list of plugin names (see examples).
+
+Some plugins will need personalized settings in the `settings.json` file. Just refer to the previous section, and include them in your custom `settings.json`.
+
 ## Examples
 
 Build the latest development version:
@@ -47,6 +53,11 @@ docker build --build-arg ETHERPAD_VERSION=1.7.5 --build-arg NODE_ENV=production 
 Build a specific git hash:
 ```bash
 docker build --build-arg ETHERPAD_VERSION=4c45ac3cb1ae --tag <YOUR_USERNAME>/etherpad .
+```
+
+Include two plugins in the container:
+```bash
+docker build --build-arg ETHERPAD_PLUGINS="ep_codepad ep_author_neat" --tag <YOUR_USERNAME>/etherpad .
 ```
 
 # Running your instance:


### PR DESCRIPTION
This PR implements #3618, introducing support for a new build argument, `ETHERPAD_PLUGINS`, which can contain a space-separated (and double quoted) list of plugins to be installed while building the container.

Example:
```bash
docker build --build-arg ETHERPAD_PLUGINS="ep_codepad ep_author_neat" --tag <YOUR_USERNAME>/etherpad .
```
