### PR TITLE
NODE_ENV controls run-time behaviour, thus needs to be set by ENV

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ ARG ETHERPAD_PLUGINS=
 
 # Set the following to production to avoid installing devDeps
 # this can be done with build args (and is mandatory to build ARM version)
-ARG NODE_ENV=development
+ENV NODE_ENV=development
 
 # grab the ETHERPAD_VERSION tarball from github (no need to clone the whole
 # repository)


### PR DESCRIPTION
Setting the NODE_ENV to production does not change the run-time behaviour of etherpad-lite:

> [2019-08-07 10:29:49.914] [WARN] console - Etherpad is running in Development mode.  This mode is slower for users and less secure than production mode.  You should set the NODE_ENV environment variable to production by using: export NODE_ENV=production

Using the ENV command in the Dockerfile resolves this. 