### PR TITLE
Fix Unicode bug in HTML export

### DIFF
--- a/src/node/utils/ExportHelper.js
+++ b/src/node/utils/ExportHelper.js
@@ -77,7 +77,7 @@ exports._analyzeLine = function(text, aline, apool){
 
 
 exports._encodeWhitespace = function(s){
-  return s.replace(/[^\x21-\x7E\s\t\n\r]/g, function(c){
-    return "&#" +c.charCodeAt(0) + ";";
+  return s.replace(/[^\x21-\x7E\s\t\n\r]/gu, function(c){
+    return "&#" +c.codePointAt(0) + ";";
   });
 };


### PR DESCRIPTION
Currently there is a bug in the HTML exporter.

Steps to reproduce:
- Create a new pad
- Add any character with a Unicode value above 0x10000, for example `👍`.
- Export the pad to HTML

The character will not be encoded correctly for HTML. It will be represented by two character references, which refer to surrogate code units. Therefore a browser cannot display the character correctly.

After applying this commit, the character is exported as just one character reference and gets displayed properly.