### PR TITLE
change referrer policy. Stop sending referers as much as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.8
+* SECURITY: change referrer policy so that Etherpad addresses aren't leaked when links are clicked (discussion: https://github.com/ether/etherpad-lite/pull/3636)
+
 # 1.8-beta.1
 * FEATURE: code was migrated to `async`/`await`, getting rid of a lot of callbacks (see https://github.com/ether/etherpad-lite/issues/3540)
 * FEATURE: support configuration via environment variables

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -76,6 +76,15 @@ exports.restartServer = function () {
     // https://github.com/ether/etherpad-lite/issues/2547
     res.header("X-UA-Compatible", "IE=Edge,chrome=1");
 
+    // Enable a strong referrer policy. Same-origin won't drop Referers when
+    // loading local resources, but it will drop them when loading foreign resources.
+    // It's still a last bastion of referrer security. External URLs should be
+    // already marked with rel="noreferer" and user-generated content pages are already
+    // marked with <meta name="referrer" content="no-referrer">
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+    // https://github.com/ether/etherpad-lite/pull/3636
+    res.header("Referrer-Policy", "same-origin");
+
     // send git version in the Server response header if exposeVersion is true.
     if (settings.exposeVersion) {
       res.header("Server", serverName);

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -285,7 +285,10 @@ function getHTMLFromAtext(pad, atext, authorColors)
         var url = urlData[1];
         var urlLength = url.length;
         processNextChars(startIndex - idx);
-        assem.append('<a href="' + Security.escapeHTMLAttribute(url) + '">');
+        // Using rel="noreferrer" stops leaking the URL/location of the exported HTML when clicking links in the document.
+        // Not all browsers understand this attribute, but it's part of the HTML5 standard.
+        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
+        assem.append('<a href="' + Security.escapeHTMLAttribute(url) + '" rel="noreferrer">');
         processNextChars(urlLength);
         assem.append('</a>');
       });

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -287,8 +287,12 @@ function getHTMLFromAtext(pad, atext, authorColors)
         processNextChars(startIndex - idx);
         // Using rel="noreferrer" stops leaking the URL/location of the exported HTML when clicking links in the document.
         // Not all browsers understand this attribute, but it's part of the HTML5 standard.
-        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
-        assem.append('<a href="' + Security.escapeHTMLAttribute(url) + '" rel="noreferrer">');
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
+        // Additionally, we do rel="noopener" to ensure a higher level of referrer security.
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
+        // https://mathiasbynens.github.io/rel-noopener/
+        // https://github.com/ether/etherpad-lite/pull/3636
+        assem.append('<a href="' + Security.escapeHTMLAttribute(url) + '" rel="noreferrer noopener">');
         processNextChars(urlLength);
         assem.append('</a>');
       });

--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -198,7 +198,10 @@ domline.createDomLine = function(nonEmpty, doesWrap, optBrowser, optDocument)
         {
           href = "http://"+href;
         }
-        extraOpenTags = extraOpenTags + '<a href="' + Security.escapeHTMLAttribute(href) + '">';
+        // Using rel="noreferrer" stops leaking the URL/location of the pad when clicking links in the document.
+        // Not all browsers understand this attribute, but it's part of the HTML5 standard.
+        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
+        extraOpenTags = extraOpenTags + '<a href="' + Security.escapeHTMLAttribute(href) + '" rel="noreferrer">';
         extraCloseTags = '</a>' + extraCloseTags;
       }
       if (simpleTags)

--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -200,8 +200,12 @@ domline.createDomLine = function(nonEmpty, doesWrap, optBrowser, optDocument)
         }
         // Using rel="noreferrer" stops leaking the URL/location of the pad when clicking links in the document.
         // Not all browsers understand this attribute, but it's part of the HTML5 standard.
-        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
-        extraOpenTags = extraOpenTags + '<a href="' + Security.escapeHTMLAttribute(href) + '" rel="noreferrer">';
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
+        // Additionally, we do rel="noopener" to ensure a higher level of referrer security.
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
+        // https://mathiasbynens.github.io/rel-noopener/
+        // https://github.com/ether/etherpad-lite/pull/3636
+        extraOpenTags = extraOpenTags + '<a href="' + Security.escapeHTMLAttribute(href) + '" rel="noreferrer noopener">';
         extraCloseTags = '</a>' + extraCloseTags;
       }
       if (simpleTags)

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -225,8 +225,12 @@ var padutils = {
         advanceTo(startIndex);
         // Using rel="noreferrer" stops leaking the URL/location of the pad when clicking links in the document.
         // Not all browsers understand this attribute, but it's part of the HTML5 standard.
-        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
-        pieces.push('<a ', (target ? 'target="' + Security.escapeHTMLAttribute(target) + '" ' : ''), 'href="', Security.escapeHTMLAttribute(href), '" rel="noreferrer">');
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer
+        // Additionally, we do rel="noopener" to ensure a higher level of referrer security.
+        // https://html.spec.whatwg.org/multipage/links.html#link-type-noopener
+        // https://mathiasbynens.github.io/rel-noopener/
+        // https://github.com/ether/etherpad-lite/pull/3636
+        pieces.push('<a ', (target ? 'target="' + Security.escapeHTMLAttribute(target) + '" ' : ''), 'href="', Security.escapeHTMLAttribute(href), '" rel="noreferrer noopener">');
         advanceTo(startIndex + href.length);
         pieces.push('</a>');
       }

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -223,7 +223,10 @@ var padutils = {
         var startIndex = urls[j][0];
         var href = urls[j][1];
         advanceTo(startIndex);
-        pieces.push('<a ', (target ? 'target="' + Security.escapeHTMLAttribute(target) + '" ' : ''), 'href="', Security.escapeHTMLAttribute(href), '">');
+        // Using rel="noreferrer" stops leaking the URL/location of the pad when clicking links in the document.
+        // Not all browsers understand this attribute, but it's part of the HTML5 standard.
+        // http://www.w3.org/TR/html5/links.html#link-type-noreferrer
+        pieces.push('<a ', (target ? 'target="' + Security.escapeHTMLAttribute(target) + '" ' : ''), 'href="', Security.escapeHTMLAttribute(href), '" rel="noreferrer">');
         advanceTo(startIndex + href.length);
         pieces.push('</a>');
       }


### PR DESCRIPTION
Before this patch I managed to send a bunch of referrers to third party websites with Firefox. Unfortunately, meta name="referrer" isn't enough.
I added "noopener" because that's also what Nextcloud does. One may want to check another pull request from 2015 which may be more complete, but it was denied with a plugin proposal: #2498
References to earlier issues: #1603, #3043