### PR TITLE
docker: Enable env var settings by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-settings.json
+/settings.json
 !settings.json.template
 APIKEY.txt
 SESSIONKEY.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN for PLUGIN_NAME in ${ETHERPAD_PLUGINS}; do npm install "${PLUGIN_NAME}"; don
 #
 # For the conditional COPY trick, see:
 #   https://stackoverflow.com/questions/31528384/conditional-copy-add-in-dockerfile#46801962
-COPY nop setting[s].json /opt/etherpad-lite/
+COPY ./settings.json /opt/etherpad-lite/
 
 EXPOSE 9001
 CMD ["node", "node_modules/ep_etherpad-lite/node/server.js"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -68,3 +68,53 @@ docker run --detach --publish <DESIDERED_PORT>:9001 <YOUR_USERNAME>/etherpad
 ```
 
 And point your browser to `http://<YOUR_IP>:<DESIDERED_PORT>`
+
+# Options available by default
+
+The `settings.json` available by default enables some configuration to be set from the environment.
+
+Available options:
+* `TITLE`: The name of the instance
+* `FAVICON`: favicon default name, or a fully specified URL to your own favicon
+* `SKIN_NAME`: either `no-skin`, `colibris` or an existing directory under `src/static/skins`.
+* `IP`: IP which etherpad should bind at. Change to `::` for IPv6
+* `PORT`: port which etherpad should bind at
+* `SHOW_SETTINGS_IN_ADMIN_PAGE`: hide/show the settings.json in admin page
+* `DB_TYPE`: a database supported by https://www.npmjs.com/package/ueberdb2
+* `DB_HOST`: the host of the database
+* `DB_PORT`: the port of the database
+* `DB_NAME`: the database name
+* `DB_USER`: a database user with sufficient permissions to create tables
+* `DB_PASS`: the password for the database username
+* `DB_CHARSET`: the character set for the tables (only required for MySQL)
+* `DB_FILENAME`: in case `DB_TYPE` is `DirtyDB`, the database filename. Default: `var/dirty.db`
+* `ADMIN_PASSWORD`: the password for the `admin` user (leave unspecified if you do not want to create it)
+* `USER_PASSWORD`: the password for the first user `user` (leave unspecified if you do not want to create it)
+* `LOGLEVEL`: valid values are `DEBUG`, `INFO`, `WARN` and `ERROR`
+
+## Examples
+
+Use a Postgres database, no admin user enabled:
+
+```shell
+docker run -d \
+	--name etherpad         \
+	-p 9001:9001            \
+	-e 'DB_TYPE=postgres'   \
+	-e 'DB_HOST=db.local'   \
+	-e 'DB_PORT=4321'       \
+	-e 'DB_NAME=etherpad'   \
+	-e 'DB_USER=dbusername' \
+	-e 'DB_PASS=mypassword' \
+	etherpad/etherpad
+```
+
+Run enabling the administrative user `admin`:
+
+```shell
+docker run -d \
+	--name etherpad \
+	-p 9001:9001 \
+	-e 'ADMIN_PASSWORD=supersecret' \
+	etherpad/etherpad
+```

--- a/docker/nop
+++ b/docker/nop
@@ -1,4 +1,0 @@
-THIS IS A DUMMY FILE
-
-It is used to trick Docker in doing a conditional COPY
-see: https://stackoverflow.com/questions/31528384/conditional-copy-add-in-dockerfile#46801962

--- a/docker/settings.json
+++ b/docker/settings.json
@@ -1,0 +1,475 @@
+/*
+ * This file must be valid JSON. But comments are allowed
+ *
+ * Please edit settings.json, not settings.json.template
+ *
+ * Please note that starting from Etherpad 1.6.0 you can store DB credentials in
+ * a separate file (credentials.json).
+ *
+ *
+ * ENVIRONMENT VARIABLE SUBSTITUTION
+ * =================================
+ *
+ * All the configuration values can be read from environment variables using the
+ * syntax "${ENV_VAR}" or "${ENV_VAR:default_value}".
+ *
+ * This is useful, for example, when running in a Docker container.
+ *
+ * EXAMPLE:
+ *    "port":     "${PORT:9001}"
+ *    "minify":   "${MINIFY}"
+ *    "skinName": "${SKIN_NAME:colibris}"
+ *
+ * Would read the configuration values for those items from the environment
+ * variables PORT, MINIFY and SKIN_NAME.
+ *
+ * If PORT and SKIN_NAME variables were not defined, the default values 9001 and
+ * "colibris" would be used.
+ * The configuration value "minify", on the other hand, does not have a
+ * designated default value. Thus, if the environment variable MINIFY were
+ * undefined, "minify" would be null.
+ *
+ * REMARKS:
+ * 1) please note that variable substitution always needs to be quoted.
+ *
+ *    "port":     9001,            <-- Literal values. When not using
+ *    "minify":   false                substitution, only strings must be
+ *    "skinName": "colibris"           quoted. Booleans and numbers must not.
+ *
+ *    "port":     "${PORT:9001}"   <-- CORRECT: if you want to use a variable
+ *    "minify":   "${MINIFY:true}"     substitution, put quotes around its name,
+ *    "skinName": "${SKIN_NAME}"       even if the required value is a number or
+ *                                     a boolean.
+ *                                     Etherpad will take care of rewriting it
+ *                                     to the proper type if necessary.
+ *
+ *    "port":     ${PORT:9001}     <-- ERROR: this is not valid json. Quotes
+ *    "minify":   ${MINIFY}            around variable names are missing.
+ *    "skinName": ${SKIN_NAME}
+ *
+ * 2) Beware of undefined variables and default values: nulls and empty strings
+ *    are different!
+ *
+ *    This is particularly important for user's passwords (see the relevant
+ *    section):
+ *
+ *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
+ *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
+ *
+ */
+{
+  /*
+   * Name your instance!
+   */
+  "title": "${TITLE:Etherpad}",
+
+  /*
+   * favicon default name
+   * alternatively, set up a fully specified Url to your own favicon
+   */
+  "favicon": "${FAVICON:favicon.ico}",
+
+  /*
+   * Skin name.
+   *
+   * Its value has to be an existing directory under src/static/skins.
+   * You can write your own, or use one of the included ones:
+   *
+   * - "no-skin":  an empty skin (default). This yields the unmodified,
+   *               traditional Etherpad theme.
+   * - "colibris": the new experimental skin (since Etherpad 1.8), candidate to
+   *               become the default in Etherpad 2.0
+   */
+  "skinName": "${SKIN_NAME:colibris}",
+
+  /*
+   * IP and port which etherpad should bind at
+   */
+  "ip": "${IP:0.0.0.0}",
+  "port": "${PORT:9001}",
+
+  /*
+   * Option to hide/show the settings.json in admin page.
+   *
+   * Default option is set to true
+   */
+  "showSettingsInAdminPage": "${SHOW_SETTINGS_IN_ADMIN_PAGE:true}",
+
+  /*
+   * Node native SSL support
+   *
+   * This is disabled by default.
+   * Make sure to have the minimum and correct file access permissions set so
+   * that the Etherpad server can access them
+   */
+
+  /*
+  "ssl" : {
+            "key"  : "/path-to-your/epl-server.key",
+            "cert" : "/path-to-your/epl-server.crt",
+            "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
+          },
+  */
+
+  /*
+   * The type of the database.
+   *
+   * You can choose between many DB drivers, for example: dirty, postgres,
+   * sqlite, mysql.
+   *
+   * You shouldn't use "dirty" for for anything else than testing or
+   * development.
+   *
+   *
+   * Database specific settings are dependent on dbType, and go in dbSettings.
+   * Remember that since Etherpad 1.6.0 you can also store these informations in
+   * credentials.json.
+   *
+   * For a complete list of the supported drivers, please refer to:
+   * https://www.npmjs.com/package/ueberdb2
+   */
+
+  "dbType": "${DB_TYPE:dirty}",
+  "dbSettings": {
+    "host":     "${DB_HOST}",
+    "port":     "${DB_PORT}",
+    "database": "${DB_NAME}",
+    "user":     "${DB_USER}",
+    "password": "${DB_PASS}",
+    "charset":  "${DB_CHARSET}",
+    "filename": "${DB_FILENAME:var/dirty.db}"
+  },
+
+  /*
+   * The default text of a pad
+   */
+  "defaultPadText" : "Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at http:\/\/etherpad.org\n",
+
+  /*
+   * Default Pad behavior.
+   *
+   * Change them if you want to override.
+   */
+  "padOptions": {
+    "noColors":         false,
+    "showControls":     true,
+    "showChat":         true,
+    "showLineNumbers":  true,
+    "useMonospaceFont": false,
+    "userName":         false,
+    "userColor":        false,
+    "rtl":              false,
+    "alwaysShowChat":   false,
+    "chatAndUsers":     false,
+    "lang":             "en-gb"
+  },
+
+  /*
+   * Pad Shortcut Keys
+   */
+  "padShortcutEnabled" : {
+    "altF9":     true, /* focus on the File Menu and/or editbar */
+    "altC":      true, /* focus on the Chat window */
+    "cmdShift2": true, /* shows a gritter popup showing a line author */
+    "delete":    true,
+    "return":    true,
+    "esc":       true, /* in mozilla versions 14-19 avoid reconnecting pad */
+    "cmdS":      true, /* save a revision */
+    "tab":       true, /* indent */
+    "cmdZ":      true, /* undo/redo */
+    "cmdY":      true, /* redo */
+    "cmdI":      true, /* italic */
+    "cmdB":      true, /* bold */
+    "cmdU":      true, /* underline */
+    "cmd5":      true, /* strike through */
+    "cmdShiftL": true, /* unordered list */
+    "cmdShiftN": true, /* ordered list */
+    "cmdShift1": true, /* ordered list */
+    "cmdShiftC": true, /* clear authorship */
+    "cmdH":      true, /* backspace */
+    "ctrlHome":  true, /* scroll to top of pad */
+    "pageUp":    true,
+    "pageDown":  true
+  },
+
+  /*
+   * Should we suppress errors from being visible in the default Pad Text?
+   */
+  "suppressErrorsInPadText": false,
+
+  /*
+   * If this option is enabled, a user must have a session to access pads.
+   * This effectively allows only group pads to be accessed.
+   */
+  "requireSession": false,
+
+  /*
+   * Users may edit pads but not create new ones.
+   *
+   * Pad creation is only via the API.
+   * This applies both to group pads and regular pads.
+   */
+  "editOnly": false,
+
+  /*
+   * If set to true, those users who have a valid session will automatically be
+   * granted access to password protected pads.
+   */
+  "sessionNoPassword": false,
+
+  /*
+   * If true, all css & js will be minified before sending to the client.
+   *
+   * This will improve the loading performance massively, but makes it difficult
+   * to debug the javascript/css
+   */
+  "minify": true,
+
+  /*
+   * How long may clients use served javascript code (in seconds)?
+   *
+   * Not setting this may cause problems during deployment.
+   * Set to 0 to disable caching.
+   */
+  "maxAge": 21600, // 60 * 60 * 6 = 6 hours
+
+  /*
+   * Absolute path to the Abiword executable.
+   *
+   * Abiword is needed to get advanced import/export features of pads. Setting
+   * it to null disables Abiword and will only allow plain text and HTML
+   * import/exports.
+   */
+  "abiword": null,
+
+  /*
+   * This is the absolute path to the soffice executable.
+   *
+   * LibreOffice can be used in lieu of Abiword to export pads.
+   * Setting it to null disables LibreOffice exporting.
+   */
+  "soffice": null,
+
+  /*
+   * Path to the Tidy executable.
+   *
+   * Tidy is used to improve the quality of exported pads.
+   * Setting it to null disables Tidy.
+   */
+  "tidyHtml": null,
+
+  /*
+   * Allow import of file types other than the supported ones:
+   * txt, doc, docx, rtf, odt, html & htm
+   */
+  "allowUnknownFileEnds": true,
+
+  /*
+   * This setting is used if you require authentication of all users.
+   *
+   * Note: "/admin" always requires authentication.
+   */
+  "requireAuthentication": false,
+
+  /*
+   * Require authorization by a module, or a user with is_admin set, see below.
+   */
+  "requireAuthorization": false,
+
+  /*
+   * When you use NGINX or another proxy/load-balancer set this to true.
+   */
+  "trustProxy": false,
+
+  /*
+   * Privacy: disable IP logging
+   */
+  "disableIPlogging": false,
+
+  /*
+   * Time (in seconds) to automatically reconnect pad when a "Force reconnect"
+   * message is shown to user.
+   *
+   * Set to 0 to disable automatic reconnection.
+   */
+  "automaticReconnectionTimeout": 0,
+
+  /*
+   * By default, when caret is moved out of viewport, it scrolls the minimum
+   * height needed to make this line visible.
+   */
+  "scrollWhenFocusLineIsOutOfViewport": {
+
+    /*
+     * Percentage of viewport height to be additionally scrolled.
+     *
+     * E.g.: use "percentage.editionAboveViewport": 0.5, to place caret line in
+     *       the middle of viewport, when user edits a line above of the
+     *       viewport
+     *
+     * Set to 0 to disable extra scrolling
+     */
+    "percentage": {
+      "editionAboveViewport": 0,
+      "editionBelowViewport": 0
+    },
+
+    /*
+     * Time (in milliseconds) used to animate the scroll transition.
+     * Set to 0 to disable animation
+     */
+    "duration": 0,
+
+    /*
+     * Flag to control if it should scroll when user places the caret in the
+     * last line of the viewport
+     */
+    "scrollWhenCaretIsInTheLastLineOfViewport": false,
+
+    /*
+     * Percentage of viewport height to be additionally scrolled when user
+     * presses arrow up in the line of the top of the viewport.
+     *
+     * Set to 0 to let the scroll to be handled as default by Etherpad
+     */
+    "percentageToScrollWhenUserPressesArrowUp": 0
+  },
+
+  /*
+   * Users for basic authentication.
+   *
+   * is_admin = true gives access to /admin.
+   * If you do not uncomment this, /admin will not be available!
+   *
+   * WARNING: passwords should not be stored in plaintext in this file.
+   *          If you want to mitigate this, please install ep_hash_auth and
+   *          follow the section "secure your installation" in README.md
+   */
+
+  "users": {
+    "admin": {
+      // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+      // 2) please note that if password is null, the user will not be created
+      "password": "${ADMIN_PASSWORD}",
+      "is_admin": true
+    },
+    "user": {
+      // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+      // 2) please note that if password is null, the user will not be created
+      "password": "${USER_PASSWORD}",
+      "is_admin": false
+    }
+  },
+
+  /*
+   * Restrict socket.io transport methods
+   */
+  "socketTransportProtocols" : ["xhr-polling", "jsonp-polling", "htmlfile"],
+
+  /*
+   * Allow Load Testing tools to hit the Etherpad Instance.
+   *
+   * WARNING: this will disable security on the instance.
+   */
+  "loadTest": false,
+
+  /*
+   * Disable indentation on new line when previous line ends with some special
+   * chars (':', '[', '(', '{')
+   */
+
+  /*
+  "indentationOnNewLine": false,
+  */
+
+  /*
+   * Toolbar buttons configuration.
+   *
+   * Uncomment to customize.
+   */
+
+  /*
+  "toolbar": {
+    "left": [
+      ["bold", "italic", "underline", "strikethrough"],
+      ["orderedlist", "unorderedlist", "indent", "outdent"],
+      ["undo", "redo"],
+      ["clearauthorship"]
+    ],
+    "right": [
+      ["importexport", "timeslider", "savedrevision"],
+      ["settings", "embed"],
+      ["showusers"]
+    ],
+    "timeslider": [
+      ["timeslider_export", "timeslider_returnToPad"]
+    ]
+  },
+  */
+
+  /*
+   * Expose Etherpad version in the web interface and in the Server http header.
+   *
+   * Do not enable on production machines.
+   */
+  "exposeVersion": false,
+
+  /*
+   * The log level we are using.
+   *
+   * Valid values: DEBUG, INFO, WARN, ERROR
+   */
+  "loglevel": "${LOGLEVEL:INFO}",
+
+  /*
+   * Logging configuration. See log4js documentation for further information:
+   * https://github.com/nomiddlename/log4js-node
+   *
+   * You can add as many appenders as you want here.
+   */
+  "logconfig" :
+    { "appenders": [
+        { "type": "console"
+        //, "category": "access"// only logs pad access
+        }
+
+      /*
+      , { "type": "file"
+      , "filename": "your-log-file-here.log"
+      , "maxLogSize": 1024
+      , "backups": 3 // how many log files there're gonna be at max
+      //, "category": "test" // only log a specific category
+        }
+      */
+
+      /*
+      , { "type": "logLevelFilter"
+        , "level": "warn" // filters out all log messages that have a lower level than "error"
+        , "appender":
+          {  Use whatever appender you want here  }
+        }
+      */
+
+      /*
+      , { "type": "logLevelFilter"
+        , "level": "error" // filters out all log messages that have a lower level than "error"
+        , "appender":
+          { "type": "smtp"
+          , "subject": "An error occurred in your EPL instance!"
+          , "recipients": "bar@blurdybloop.com, baz@blurdybloop.com"
+          , "sendInterval": 300 // 60 * 5 = 5 minutes -- will buffer log messages; set to 0 to send a mail for every message
+          , "transport": "SMTP", "SMTP": { // see https://github.com/andris9/Nodemailer#possible-transport-methods
+              "host": "smtp.example.com", "port": 465,
+              "secureConnection": true,
+              "auth": {
+                  "user": "foo@example.com",
+                  "pass": "bar_foo"
+              }
+            }
+          }
+        }
+      */
+
+      ]
+    } // logconfig
+}


### PR DESCRIPTION
By leveraging the templating mechanism in `settings.json`, this change
allows a Docker client to run a prebuilt image and change some basic
configuration settings, like the instance name or, more importantly, the
database coordinates.

Also addresses https://github.com/ether/etherpad-lite/issues/3623