### PR TITLE
smaller docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,8 @@ RUN echo "Getting version: ${ETHERPAD_VERSION}" && \
 WORKDIR /opt/etherpad-lite
 
 # install node dependencies for Etherpad
-RUN bin/installDeps.sh
+RUN bin/installDeps.sh && \
+	rm -rf ~/.npm/_cacache
 
 # Install the plugins, if ETHERPAD_PLUGINS is not empty.
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 #
 # Version 0.1
 
-FROM node:latest
+FROM node:buster-slim
 LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 
 # git hash of the version to be built.


### PR DESCRIPTION
downsized the docker image using buster slim and a removing the npm cache.  

see: https://hub.docker.com/r/foosinn/etherpad/tags