### PR TITLE
Support for clean & safe error handling on IE 11

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -401,7 +401,6 @@
 
               var plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
               var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
-              var padutils = require('../static/js/pad_utils');
 
               plugins.baseURL = baseURL;
               plugins.update(function () {


### PR DESCRIPTION
Added pad_utils sanitization for clean and safe error handling on browsers that do not encode the path of the URL.