### PR TITLE
docker: Build from the local working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
 # Etherpad Lite Dockerfile
 #
-# https://github.com/ether/etherpad-docker
+# https://github.com/ether/etherpad-lite
 #
 # Author: muxator
-#
-# Version 0.1
 
 FROM node:10-buster-slim
 LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
-
-# git hash of the version to be built.
-# If not given, build the latest development version.
-ARG ETHERPAD_VERSION=develop
 
 # plugins to install while building the container. By default no plugins are
 # installed.
@@ -25,23 +19,9 @@ ARG ETHERPAD_PLUGINS=
 # this can be done with build args (and is mandatory to build ARM version)
 ENV NODE_ENV=development
 
-# grab the ETHERPAD_VERSION tarball from github (no need to clone the whole
-# repository)
-RUN echo "Getting version: ${ETHERPAD_VERSION}" && \
-	curl \
-		--location \
-		--fail \
-		--silent \
-		--show-error \
-		--output /opt/etherpad-lite.tar.gz \
-		https://github.com/ether/etherpad-lite/archive/"${ETHERPAD_VERSION}".tar.gz && \
-	mkdir /opt/etherpad-lite && \
-	tar xf /opt/etherpad-lite.tar.gz \
-		--directory /opt/etherpad-lite \
-		--strip-components=1 && \
-	rm /opt/etherpad-lite.tar.gz
-
 WORKDIR /opt/etherpad-lite
+
+COPY ./ ./
 
 # install node dependencies for Etherpad
 RUN bin/installDeps.sh && \
@@ -54,7 +34,7 @@ RUN bin/installDeps.sh && \
 RUN for PLUGIN_NAME in ${ETHERPAD_PLUGINS}; do npm install "${PLUGIN_NAME}"; done
 
 # Copy the configuration file.
-COPY ./settings.json /opt/etherpad-lite/
+COPY ./docker/settings.json /opt/etherpad-lite/settings.json
 
 # Follow the principle of least privilege: run as unprivileged user.
 #

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ If cloning to a subdirectory within another project, you may need to do the foll
 2. Edit the db `filename` in `settings.json` to the relative directory with the file (e.g. `application/lib/etherpad-lite/var/dirty.db`)
 3. Add auto-generated files to the main project `.gitignore`
 
+## Docker container
+
+Find [here](doc/docker.md) information on running Etherpad in a container.
+
 # Next Steps
 
 ## Tweak the settings

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,6 +1,6 @@
 # Docker image
 
-This directory contains the files that are used to build the official Docker image on https://hub.docker.com/r/etherpad/etherpad.
+The official Docker image is available on https://hub.docker.com/r/etherpad/etherpad
 
 # Downloading from Docker Hub
 If you are ok downloading a [prebuilt image from Docker Hub](https://hub.docker.com/r/etherpad/etherpad), these are the commands:
@@ -35,24 +35,9 @@ Some plugins will need personalized settings in the `settings.json` file. Just r
 
 ## Examples
 
-Build the latest development version:
+Build a Docker image from the currently checked-out code:
 ```bash
 docker build --tag <YOUR_USERNAME>/etherpad .
-```
-
-Build the latest stable version:
-```bash
-docker build --build-arg ETHERPAD_VERSION=master --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
-```
-
-Build a specific tagged version:
-```bash
-docker build --build-arg ETHERPAD_VERSION=1.7.5 --build-arg NODE_ENV=production --tag <YOUR_USERNAME>/etherpad .
-```
-
-Build a specific git hash:
-```bash
-docker build --build-arg ETHERPAD_VERSION=4c45ac3cb1ae --tag <YOUR_USERNAME>/etherpad .
 ```
 
 Include two plugins in the container:

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,7 @@
 @include documentation
 @include stats
 @include localization
+@include docker
 @include skins
 @include api/api
 @include plugins


### PR DESCRIPTION
With this change, the Dockerfile builds the Docker image from the code
checked out in the local filesystem, instead of downloading a revision
from Git.

Implements #3657