### PR TITLE
Fix missing 'require()' dependency in previous security fix

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -360,7 +360,11 @@
         <% e.end_block(); %>
 
         <% e.begin_block("scripts"); %>
+        
+        <script type="text/javascript" src="../static/js/require-kernel.js"></script>
+          
         <script type="text/javascript">
+            var padutils = require('../static/js/pad_utils').padutils;
             // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             (function() {
               // Display errors on page load to the user
@@ -370,7 +374,7 @@
                 var box   = document.getElementById('editorloadingbox');
                 box.innerHTML = '<p><b>An error occurred while loading the pad</b></p>'
                               + '<p><b>'+msg+'</b> '
-                              + '<small>in '+ url +' (line '+ line +')</small></p>';
+                              + '<small>in '+ padutils.escapeHTML(url) +' (line '+ line +')</small></p>';
                 // call original error handler
                 if(typeof(originalHandler) == 'function') originalHandler.call(null, arguments);
               };
@@ -378,7 +382,6 @@
             // @license-end
         </script>
 
-        <script type="text/javascript" src="../static/js/require-kernel.js"></script>
         <script type="text/javascript" src="../socket.io/socket.io.js"></script>
 
         <!-- Include base packages manually (this help with debugging) -->

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -364,6 +364,16 @@
         <script type="text/javascript" src="../static/js/require-kernel.js"></script>
           
         <script type="text/javascript">
+          
+            var pathComponents = location.pathname.split('/');
+
+            // Strip 'p' and the padname from the pathname and set as baseURL
+            var baseURL = pathComponents.slice(0,pathComponents.length-2).join('/') + '/';
+
+            require.setRootURI(baseURL + "javascripts/src");
+            require.setLibraryURI(baseURL + "javascripts/lib");
+            require.setGlobalKeyPath("require");
+          
             var padutils = require('../static/js/pad_utils').padutils;
             // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             (function() {
@@ -397,15 +407,7 @@
             // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             var clientVars = {};
             (function () {
-              var pathComponents = location.pathname.split('/');
-
-              // Strip 'p' and the padname from the pathname and set as baseURL
-              var baseURL = pathComponents.slice(0,pathComponents.length-2).join('/') + '/';
-
-              require.setRootURI(baseURL + "javascripts/src");
-              require.setLibraryURI(baseURL + "javascripts/lib");
-              require.setGlobalKeyPath("require");
-
+          
               $ = jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery; // Expose jQuery #HACK
               browser = require('ep_etherpad-lite/static/js/browser');
 


### PR DESCRIPTION
Original: https://github.com/ether/etherpad-lite/commit/5879037ddca4ab9a4002adf90fc7ce6c9f82f01b



