### PR TITLE
Docker: Fix etherpad user home dir for `npm install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY ./settings.json.docker /opt/etherpad-lite/settings.json
 # Running as non-root enables running this image in platforms like OpenShift
 # that do not allow images running as root.
 RUN \
-    echo 'etherpad:x:65534:65534:etherpad:/:' > /etc/passwd && \
+    echo 'etherpad:x:65534:65534:etherpad:/opt/etherpad-lite/:' > /etc/passwd && \
     echo 'etherpad:x:65534:' > /etc/group && \
     chown -R etherpad:etherpad ./
 


### PR DESCRIPTION
I tried using sqlite with etherpad-lite, but `npm install sqlite3` can't run because npm can't create its .npm directory as it's trying `mkdir $HOME/.npm` which currently evaluates to `/.npm`

```
etherpad@f717076dc742:/opt/etherpad-lite$ npm install sqlite3
npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR! 
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR! 
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 65534:65534 "/.npm"
```

This small change properly configures the home directory to `/opt/etherpad-lite`.