### PR TITLE
Fix allowUnknownFileEnds in 1.8.0 when importing files with unknown extension

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -101,7 +101,7 @@ async function doImport(req, res, padId)
       let oldSrcFile = srcFile;
 
       srcFile = path.join(path.dirname(srcFile), path.basename(srcFile, fileEnding) + ".txt");
-      await fs.rename(oldSrcFile, srcFile);
+      await fsp_rename(oldSrcFile, srcFile);
     } else {
       console.warn("Not allowing unknown file type to be imported", fileEnding);
       throw "uploadFailed";


### PR DESCRIPTION
`fs.rename()` is callback based, we need `fsp_rename()` which is declared above and is promised based, in order to catch the `unhandled promised rejection ...` warning

PS: I haven't tested this at all. I was looking at what kind of issues are open for this project and this one seems the obvious fix. Also, sorry if this PR is useless, feel free to close it, especially if it causes more work for integrating it than it helps.