### PR TITLE
simplify relative font paths

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -1287,13 +1287,13 @@ input[type=checkbox] {
 /* Montserrat Font */
 @font-face {
   font-family: "Montserrat";
-  src: url("../../static/font/Montserrat-Light.otf") format("opentype");
+  src: url("../font/Montserrat-Light.otf") format("opentype");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
     font-family: "Montserrat";
-    src: url("../../static/font/Montserrat-Regular.otf") format("opentype");
+    src: url("../font/Montserrat-Regular.otf") format("opentype");
     font-weight: bold;
     font-style: normal;
 }
@@ -1301,19 +1301,19 @@ input[type=checkbox] {
 
 @font-face {
   font-family: opendyslexic;
-  src: url("../../static/font/opendyslexic.otf") format("opentype");
+  src: url("../font/opendyslexic.otf") format("opentype");
 }
 
 /* Roboto Mono */
 @font-face {
     font-family: "RobotoMono";
-    src: url("../../static/font/RobotoMono-Regular.ttf") format("truetype");
+    src: url("../font/RobotoMono-Regular.ttf") format("truetype");
     font-weight: normal;
     font-style: normal;
 }
 @font-face {
     font-family: "RobotoMono";
-    src: url("../../static/font/RobotoMono-Bold.ttf") format("truetype");
+    src: url("../font/RobotoMono-Bold.ttf") format("truetype");
     font-weight: bold;
     font-style: normal;
 }

--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -1321,11 +1321,11 @@ input[type=checkbox] {
 
 @font-face {
   font-family: "fontawesome-etherpad";
-  src:url("../../static/font/fontawesome-etherpad.eot");
-  src:url("../../static/font/fontawesome-etherpad.eot?#iefix") format("embedded-opentype"),
-    url("../../static/font/fontawesome-etherpad.woff") format("woff"),
-    url("../../static/font/fontawesome-etherpad.ttf") format("truetype"),
-    url("../../static/font/fontawesome-etherpad.svg#fontawesome-etherpad") format("svg");
+  src:url("../font/fontawesome-etherpad.eot");
+  src:url("../font/fontawesome-etherpad.eot?#iefix") format("embedded-opentype"),
+    url("../font/fontawesome-etherpad.woff") format("woff"),
+    url("../font/fontawesome-etherpad.ttf") format("truetype"),
+    url("../font/fontawesome-etherpad.svg#fontawesome-etherpad") format("svg");
   font-weight: normal;
   font-style: normal;
 


### PR DESCRIPTION
This PR should be trivial, but I am having problems with the font paths when the CSS are minimized.

@seballot, could you help me? TL;DR is commit 10e76cae40e89b53a6f7583fd704d19d68e5460c works, while ce885962ec002320df99fcb72cd4f6f2b74fe28f (which is equivalent) causes an **HTTP/404**.

## Why
While working on resolving #3616, I noticed there are some redundant relative paths in `pad.css`. I tried to get rid of them, and probably hit a bug.

## Data
- the problem only happens using the files from this PR and when `minify: true` in `settings.json`.
- the CSS lives in `<BASE>/static/css/pad.css`
- the fonts live in `<BASE>/static/fonts/<FONTFILE>`.
- to load the fonts, `pad.css` used `../../static/font/<FONTFILE>`.
- [URLs in `src` are relative to the stylesheet path](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src)

## What I wanted to do
- there should be no need to go up two levels up until <BASE> and then go back to `<BASE>/static/fonts`

## What I have done
- I have done two commits that replace `../../static/font` with `../font` in pad.css
- the first one (10e76cae40e89b53a6f7583fd704d19d68e5460c) only modified font-awesome, and works well even when everything is minimized
- the second one (ce885962ec002320df99fcb72cd4f6f2b74fe28f) does exactly the same thing for the pad fonts (Montserrat, Open Dyslexic, etc)

## What is not working
While Font Awesome is correctly downloaded from the right location, the pad fonts do not: **when I try to change the font of a pad** (for example `opendyslexic`), the browser tries to load them from `<BASE>/fonts/<FONTFILE>` instead of `<BASE>/static/fonts/<FONTFILE>`, hitting an **HTTP/404**.


## The final CSS
This happens only when the css is minimized.

For your convenience's sake, this is the relevant snippet of the minimized `pad.css`, beautified back. Everything seems normal:

```css
/* beautified snippet form a minified http://localhost:9001/static/css/pad.css */

@font-face {
	font-family: opendyslexic;

        /* the browser calls "http://localhost:9001/font/opendyslexic.otf", WRONG!! */
	src: url(../font/opendyslexic.otf) format("opentype")
}

@font-face {
	font-family: fontawesome-etherpad;
	src: url(../font/fontawesome-etherpad.eot);
	src:
                /* the browser calls http://localhost:9001/static/font/fontawesome-etherpad.woff", CORRECT */
		url(../font/fontawesome-etherpad.woff) format("woff")
		/* other formats */
}
```

Where can be the problem? Why does it work when there is no minimization?
