### PR TITLE
Fix minify cache ms

### DIFF
--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -201,6 +201,7 @@ function minify(req, res)
   statFile(filename, function (error, date, exists) {
     if (date) {
       date = new Date(date);
+      date.setMilliseconds(0);
       res.setHeader('last-modified', date.toUTCString());
       res.setHeader('date', (new Date()).toUTCString());
       if (settings.maxAge !== undefined) {


### PR DESCRIPTION
`if-modified-since` header does not include milliseconds, so https://github.com/ether/etherpad-lite/blob/develop/src/node/utils/Minify.js#L219 will always be `false`