### PR TITLE
Add env var for defaultPadText

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -69,6 +69,7 @@ Available options:
 * `DB_PASS`: the password for the database username
 * `DB_CHARSET`: the character set for the tables (only required for MySQL)
 * `DB_FILENAME`: in case `DB_TYPE` is `DirtyDB`, the database filename. Default: `var/dirty.db`
+* `DEFAULT_PAD_TEXT`: The default text of a pad
 * `ADMIN_PASSWORD`: the password for the `admin` user (leave unspecified if you do not want to create it)
 * `USER_PASSWORD`: the password for the first user `user` (leave unspecified if you do not want to create it)
 * `TRUST_PROXY`: set to `true` if you are using a reverse proxy in front of Etherpad (for example: Traefik for SSL termination via Let's Encrypt). This will affect security and correctness of the logs if not done

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -65,6 +65,10 @@
  *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
  *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
  *
+ * 3) if you want to use newlines in the default value of a string parameter,
+ *    use "\n" as usual.
+ *
+ *    "defaultPadText" : "${DEFAULT_PAD_TEXT}Line 1\nLine 2"
  */
 {
   /*
@@ -159,7 +163,7 @@
   /*
    * The default text of a pad
    */
-  "defaultPadText" : "Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at http:\/\/etherpad.org\n",
+  "defaultPadText" : "${DEFAULT_PAD_TEXT:Welcome to Etherpad!\n\nThis pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents!\n\nGet involved with Etherpad at http:\/\/etherpad.org\n}",
 
   /*
    * Default Pad behavior.

--- a/settings.json.template
+++ b/settings.json.template
@@ -56,6 +56,10 @@
  *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
  *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
  *
+ * 3) if you want to use newlines in the default value of a string parameter,
+ *    use "\n" as usual.
+ *
+ *    "defaultPadText" : "${DEFAULT_PAD_TEXT}Line 1\nLine 2"
  */
 {
   /*

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -474,7 +474,7 @@ function lookupEnvironmentVariables(obj) {
      * "${ENV_VAR}" or "${ENV_VAR:default_value}")
      */
     // MUXATOR 2019-03-21: we could use named capture groups here once we migrate to nodejs v10
-    const match = value.match(/^\$\{([^:]*)(:(.*))?\}$/);
+    const match = value.match(/^\$\{([^:]*)(:((.|\n)*))?\}$/);
 
     if (match === null) {
       // no match: use the value literally, without any substitution


### PR DESCRIPTION
I had to escape the line breaks otherwise the default string will be converted by `JSON.parse()` into multiple strings over multiple lines so that the the `lookupEnvironmentVariables` logic will not work for this value.