### PR TITLE
docker: add support for arbitrary user ids (OpenShift compatibility)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ ENV NODE_ENV=development
 # that do not allow images running as root.
 RUN useradd --uid 5001 --create-home etherpad
 
-RUN mkdir /opt/etherpad-lite && chown etherpad:etherpad /opt/etherpad-lite
+RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
 
-USER etherpad:etherpad
+USER etherpad
 
 WORKDIR /opt/etherpad-lite
 
-COPY --chown=etherpad:etherpad ./ ./
+COPY --chown=etherpad:0 ./ ./
 
 # install node dependencies for Etherpad
 RUN bin/installDeps.sh && \
@@ -44,7 +44,10 @@ RUN bin/installDeps.sh && \
 RUN for PLUGIN_NAME in ${ETHERPAD_PLUGINS}; do npm install "${PLUGIN_NAME}"; done
 
 # Copy the configuration file.
-COPY --chown=etherpad:etherpad ./settings.json.docker /opt/etherpad-lite/settings.json
+COPY --chown=etherpad:0 ./settings.json.docker /opt/etherpad-lite/settings.json
+
+# Fix permissions for root group
+RUN chmod -R g=u .
 
 EXPOSE 9001
 CMD ["node", "node_modules/ep_etherpad-lite/node/server.js"]


### PR DESCRIPTION
I'm using OpenShift and this is running the containers by arbitrary user ids for security reasons but the users are always a member of the root group. So the `USER` definition of the `Dockerfile` will be ignored and the container crashes because the user has no permissions. This PR will just adjust the permissions a bit.

More information you can find here:
https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#use-uid