### PR TITLE
Fix clear cookies tests

### DIFF
--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -53,7 +53,10 @@ var helper = {};
   }
 
   helper.clearCookies = function(){
-    window.document.cookie = "";
+    // Expire cookies, so author and language are changed after reloading the pad.
+    // See https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Example_4_Reset_the_previous_cookie
+    window.document.cookie = 'token=;expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    window.document.cookie = 'language=;expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   }
 
   // Functionality for knowing what key event type is required for tests

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -36,6 +36,68 @@ describe("the test helper", function(){
         done();
       });
     });
+
+    // Make sure the cookies are cleared, and make sure that the cookie
+    // clearing has taken effect at this point in the code. It has been
+    // observed that the former can happen without the latter if there
+    // isn't a timeout (within `newPad`) after clearing the cookies.
+    // However this doesn't seem to always be easily replicated, so this
+    // timeout may or may end up in the code. None the less, we test here
+    // to catch it if the bug comes up again.
+    it("clears cookies", function(done) {
+      this.timeout(60000);
+
+      // set cookies far into the future to make sure they're not expired yet
+      window.document.cookie = 'token=foo;expires=Thu, 01 Jan 3030 00:00:00 GMT; path=/';
+      window.document.cookie = 'language=bar;expires=Thu, 01 Jan 3030 00:00:00 GMT; path=/';
+      const testCookie = 'token=foo; language=bar'
+
+      expect(window.document.cookie).to.be(testCookie)
+
+      helper.newPad(function(){
+        // helper function seems to have cleared cookies
+        // NOTE: this doesn't yet mean it's proven to have taken effect by this point in execution
+        var firstCookie = window.document.cookie
+        expect(firstCookie).to.not.be(testCookie)
+
+        var chrome$ = helper.padChrome$;
+
+        // click on the settings button to make settings visible
+        var $userButton = chrome$(".buttonicon-showusers");
+        $userButton.click();
+
+        var $usernameInput = chrome$("#myusernameedit");
+        $usernameInput.click();
+
+        $usernameInput.val('John McLear');
+        $usernameInput.blur();
+
+        // Before refreshing, make sure the name is there
+        expect($usernameInput.val()).to.be('John McLear')
+
+        setTimeout(function(){ //give it a second to save the username on the server side
+          helper.newPad(function(){ // get a new pad, let it clear the cookies
+            var chrome$ = helper.padChrome$;
+
+            // helper function seems to have cleared cookies
+            // NOTE: this doesn't yet mean cookies were cleared effectively.
+            // We still need to test below that we're in a new session
+            expect(window.document.cookie).to.not.be(testCookie)
+            expect(window.document.cookie).to.not.be(firstCookie)
+
+            // click on the settings button to make settings visible
+            var $userButton = chrome$(".buttonicon-showusers");
+            $userButton.click();
+
+            // confirm that the session was actually cleared
+            var $usernameInput = chrome$("#myusernameedit");
+            expect($usernameInput.val()).to.be('')
+
+            done();
+          });
+        }, 1000);
+      })
+    });
   });
 
   describe("the waitFor method", function(){


### PR DESCRIPTION
I mentioned in #3730 that I thought that there needed to be a delay between resetting the cookies and returning from `newPad`, because the change wasn't taking effect otherwise. However, this test proves that incorrect, at least _almost all of the time_. Seemingly on rare occasion, it fails, which means either:

a) occasionally it does indeed need the delay
b) something else entirely is going on

When I have a bit more time, I can try to test it with and without the delay enough times to prove that the delay actually fixes it. But it's quite a rare occurrence so I'm not sure how to be sure about it. Alternately: it's so rare that it's fine, given that this is a test suite; this question is up to the reviewers.