### PR TITLE
.git is not needed in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git
+.gitignore
 .hg
 settings.json
 src/node_modules


### PR DESCRIPTION
The current docker images containing the complete .git-Repo.

Therefore I fixed content of .dockerignore