### PR TITLE
tests: future proof travis/runner.sh and make it more robust

### DIFF
--- a/tests/frontend/travis/runner.sh
+++ b/tests/frontend/travis/runner.sh
@@ -1,13 +1,46 @@
-#!/bin/sh
+#!/bin/bash
 
-#Move to the base folder
-cd `dirname $0`
+# do not continue if there is an error
+set -eu
 
-#start Etherpad
-../../../bin/run.sh > /dev/null &
-sleep 10
+# source: https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself#246128
+MY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-#start remote runner
+# reliably move to the etherpad base folder before running it
+cd "${MY_DIR}/../../../"
+
+# start Etherpad, assuming all dependencies are already installed.
+#
+# This is possible because the "install" section of .travis.yml already contains
+# a call to bin/installDeps.sh
+echo "Running Etherpad directly, assuming bin/installDeps.sh has already been run"
+node node_modules/ep_etherpad-lite/node/server.js "${@}" > /dev/null &
+
+echo "Now I will try for 15 seconds to connect to Etherpad on http://localhost:9001"
+
+# wait for at most 15 seconds until Etherpad starts accepting connections
+#
+# modified from:
+# https://unix.stackexchange.com/questions/5277/how-do-i-tell-a-script-to-wait-for-a-process-to-start-accepting-requests-on-a-po#349138
+#
+(timeout 15 bash -c 'until echo > /dev/tcp/localhost/9001; do sleep 0.5; done') || \
+    (echo "Could not connect to Etherpad on http://localhost:9001" ; exit 1)
+
+echo "Successfully connected to Etherpad on http://localhost:9001"
+
+# just in case, let's wait for another second before going on
+sleep 1
+
+# On the Travis VM, remote_runner.js is found at
+# /home/travis/build/ether/[secure]/tests/frontend/travis/remote_runner.js
+# which is the same directory that contains this script.
+# Let's move back there.
+#
+# Probably remote_runner.js is injected by Saucelabs.
+cd "${MY_DIR}"
+
+# start the remote runner
+echo "Now starting the remote runner"
 node remote_runner.js
 exit_code=$?
 


### PR DESCRIPTION
This change only slightly modifies the bahaviour of travis/runner.sh, but:

1. **speeds up the tests**, because it does not install dependencies before running them.
   Dependencies are already installed by .travis.yml in its "install" section;
2. if for some reason Etherpad does not start, there is a sudden failure, instead of launching the front end tests anyway, and then **having to wait 10 minutes for them to time out**;
3. it is **compatible with a different way of installing Etherpad dependencies** ("npm ci" instead of "npm install"), whereas the previous one broke.
   This will probably be introduced in a while, so this change future-proofs for it (see #3778).
4. it is **more robust**, because it detects more reliably the paths, and changes between them correctly;

Please note that the script now requires bash instead of a generic posix shell. This may break on platforms which default to a different shell (FreeBSD, MacOS?)
