### PR TITLE
Switches cacheKey from base64 of path to sha256 of path; fixes #3502

### DIFF
--- a/src/node/utils/caching_middleware.js
+++ b/src/node/utils/caching_middleware.js
@@ -22,6 +22,7 @@ var zlib = require('zlib');
 var settings = require('./Settings');
 var semver = require('semver');
 var existsSync = require('./path_exists');
+var crypto = require('crypto');
 
 var CACHE_DIR = path.normalize(path.join(settings.root, 'var/'));
 CACHE_DIR = existsSync(CACHE_DIR) ? CACHE_DIR : undefined;
@@ -49,7 +50,7 @@ CachingMiddleware.prototype = new function () {
         (req.get('Accept-Encoding') || '').indexOf('gzip') != -1;
 
     var path = require('url').parse(req.url).path;
-    var cacheKey = Buffer.from(path).toString('base64').replace(/[/+=]/g, '');
+    var cacheKey = crypto.createHash('sha256').update(path).digest('hex');
 
     fs.stat(CACHE_DIR + 'minified_' + cacheKey, function (error, stats) {
       var modifiedSince = (req.headers['if-modified-since']


### PR DESCRIPTION
This is a fix for #3502 where the cacheKey being a base64 encoding of the path can cause `ENAMETOOLONG` errors to be thrown. 