### PR TITLE
ImportHandler: instead of failing when a non Ascii code is uploaded do a roundtrip conversion - Is this mergeable on 03/04/2020? Seems buggy

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -171,18 +171,6 @@ async function doImport(req, res, padId)
     }
   }
 
-  if (!useConvertor && !req.directDatabaseAccess) {
-    // Read the file with no encoding for raw buffer access.
-    let buf = await fsp_readFile(destFile);
-
-    // Check if there are only ascii chars in the uploaded file
-    let isAscii = ! Array.prototype.some.call(buf, c => (c > 240));
-
-    if (!isAscii) {
-      throw "uploadFailed";
-    }
-  }
-
   // get the pad object
   let pad = await padManager.getPad(padId);
 
@@ -191,6 +179,9 @@ async function doImport(req, res, padId)
 
   if (!req.directDatabaseAccess) {
     text = await fsp_readFile(destFile, "utf8");
+
+    let bytelike = unescape(encodeURIComponent(text));
+    text = decodeURIComponent(escape(bytelike));
 
     /*
      * The <title> tag needs to be stripped out, otherwise it is appended to the


### PR DESCRIPTION
This PR includes a change by @JohnMcLear that was originally part of #3737 (about utf8 tests).

I merged all the other changes there, and left out this one because I would like more testing.
If testing is successful (and import/export with LibreOffice works well) this change can be integrated.
