### PR TITLE
PadManager: use a Set instead of an array in padList

### DIFF
--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -59,7 +59,7 @@ let padList = {
       this.initiated = true;
 
       for (let val of dbData) {
-        this.addPad(val.replace(/pad:/,""), false);
+        this.addPad(val.replace(/^pad:/,""), false);
       }
     }
 

--- a/src/node/db/PadManager.js
+++ b/src/node/db/PadManager.js
@@ -49,8 +49,8 @@ var globalPads = {
  * Updated without db access as new pads are created/old ones removed.
  */
 let padList = {
-  list: [],
-  sorted : false,
+  list: new Set(),
+  cachedList: undefined,
   initiated: false,
   init: async function() {
     let dbData = await db.findKeys("pad:*", "*:*:*");
@@ -78,29 +78,26 @@ let padList = {
   getPads: async function() {
     await this.load();
 
-    if (!this.sorted) {
-      this.list.sort();
-      this.sorted = true;
+    if (!this.cachedList) {
+      this.cachedList = Array.from(this.list).sort();
     }
 
-    return this.list;
+    return this.cachedList;
   },
   addPad: function(name) {
     if (!this.initiated) return;
 
-    if (this.list.indexOf(name) == -1) {
-      this.list.push(name);
-      this.sorted = false;
+    if (!this.list.has(name)) {
+      this.list.add(name);
+      this.cachedList = undefined;
     }
   },
   removePad: function(name) {
     if (!this.initiated) return;
 
-    var index = this.list.indexOf(name);
-
-    if (index > -1) {
-      this.list.splice(index, 1);
-      this.sorted = false;
+    if (this.list.has(name)) {
+      this.list.delete(name);
+      this.cachedList = undefined;
     }
   }
 };

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -173,6 +173,19 @@ describe('getHTML', function(){
   });
 })
 
+describe('listAllPads', function () {
+  it('list all pads', function (done) {
+    api.get(endPoint('listAllPads'))
+      .expect(function (res) {
+        if (res.body.data.padIDs.includes(testPadId) !== true) {
+          throw new Error('Unable to find pad in pad list')
+        }
+      })
+      .expect('Content-Type', /json/)
+      .expect(200, done)
+  })
+})
+
 describe('deletePad', function(){
   it('deletes a Pad', function(done) {
     api.get(endPoint('deletePad')+"&padID="+testPadId)
@@ -182,6 +195,19 @@ describe('deletePad', function(){
     .expect('Content-Type', /json/)
     .expect(200, done)
   });
+})
+
+describe('listAllPads', function () {
+  it('list all pads', function (done) {
+    api.get(endPoint('listAllPads'))
+      .expect(function (res) {
+        if (res.body.data.padIDs.includes(testPadId) !== false) {
+          throw new Error('Test pad should not be in pads list')
+        }
+      })
+      .expect('Content-Type', /json/)
+      .expect(200, done)
+  })
 })
 
 describe('getHTML', function(){
@@ -402,11 +428,8 @@ describe('createPad', function(){
 
 describe('setText', function(){
   it('Sets text on a pad Id', function(done) {
-    api.post(endPoint('setText'))
-    .send({
-      "padID": testPadId,
-      "text":  text,
-    })
+    api.post(endPoint('setText')+"&padID="+testPadId)
+    .field({text: text})
     .expect(function(res){
       if(res.body.code !== 0) throw new Error("Pad Set Text failed")
     })
@@ -430,7 +453,7 @@ describe('getText', function(){
 describe('setText', function(){
   it('Sets text on a pad Id including an explicit newline', function(done) {
     api.post(endPoint('setText')+"&padID="+testPadId)
-    .send({text: text+'\n'})
+    .field({text: text+'\n'})
     .expect(function(res){
       if(res.body.code !== 0) throw new Error("Pad Set Text failed")
     })


### PR DESCRIPTION
Before this change, an array containing the ID of all the pads was scanned each time a new pad was created or deleted.

This change uses a Set, which improves the performances when there are many pads.
It also slightly optimizes a regex, anchoring it to the start of the DB key.

This PR is the same as #3752 by @Chocobozzz, only the order of the commits was modified to introduce the tests before everything else. It was resubmitted here to sidestep merge conflicts.
