### PR TITLE
scroll: replace absolute import with relative one

### DIFF
--- a/src/static/js/scroll.js
+++ b/src/static/js/scroll.js
@@ -5,7 +5,7 @@
   Browser Line = each vertical line. A <div> can be break into more than one
   browser line.
 */
-var caretPosition = require('/caretPosition');
+var caretPosition = require('./caretPosition');
 
 function Scroll(outerWin) {
   // scroll settings


### PR DESCRIPTION
This was introduced by f1fcd16894e5 ("Add settings to scroll on edition out of viewport") in 2018-01-03.

@joassouza: was there a specific reason to use `require('/caretPosition')` instead of `require('./caretPosition')`, or was it just an oversight?