### PR TITLE
travis: Add test for DB with docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+
+########################################
+# Etherpad docker-compose configuration
+########################################
+
+ETHERPAD_DB_NAME=etherpad
+ETHERPAD_DB_USER=etherpad
+ETHERPAD_DB_PASSWORD=etherpad_password

--- a/.env
+++ b/.env
@@ -6,3 +6,6 @@
 ETHERPAD_DB_NAME=etherpad
 ETHERPAD_DB_USER=etherpad
 ETHERPAD_DB_PASSWORD=etherpad_password
+
+# For production, download prebuilt image
+IMAGE_NAME=etherpad/etherpad:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
 
 env:
   global:
+    - IMAGE_NAME=etherpad:test
     - secure: "WMGxFkOeTTlhWB+ChMucRtIqVmMbwzYdNHuHQjKCcj8HBEPdZLfCuK/kf4rG\nVLcLQiIsyllqzNhBGVHG1nyqWr0/LTm8JRqSCDDVIhpyzp9KpCJQQJG2Uwjk\n6/HIJJh/wbxsEdLNV2crYU/EiVO3A4Bq0YTHUlbhUqG3mSCr5Ec="
     - secure: "gejXUAHYscbR6Bodw35XexpToqWkv2ifeECsbeEmjaLkYzXmUUNWJGknKSu7\nEUsSfQV8w+hxApr1Z+jNqk9aX3K1I4btL3cwk2trnNI8XRAvu1c1Iv60eerI\nkE82Rsd5lwUaMEh+/HoL8ztFCZamVndoNgX7HWp5J/NRZZMmh4g="
 
@@ -40,8 +41,22 @@ jobs:
       install:
         - "cd src && npm install && cd -"
       script:
-        - "docker build -t etherpad:test ."
-        - "docker run -d -p 9001:9001 etherpad:test && sleep 3"
+        - "docker build -t "${IMAGE_NAME}" ."
+        - "docker run -d -p 9001:9001 "${IMAGE_NAME}" && sleep 3"
+        - "cd src && npm run test-container"
+    - name: "Test a docker-compose with MySQL"
+      install:
+        - "cd src && npm install && cd -"
+      script:
+        - "docker-compose -f docker-compose_mysql.yml build"
+        - "docker-compose -f docker-compose_mysql.yml up -d && sleep 60"
+        - "cd src && npm run test-container"
+    - name: "Test a docker-compose with PostgreSQL"
+      install:
+        - "cd src && npm install && cd -"
+      script:
+        - "docker-compose -f docker-compose_postgresql.yml build"
+        - "docker-compose -f docker-compose_postgresql.yml up -d && sleep 30"
         - "cd src && npm run test-container"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ jobs:
       install:
         - "cd src && npm install && cd -"
       script:
-        - "docker build -t "${IMAGE_NAME}" ."
-        - "docker run -d -p 9001:9001 "${IMAGE_NAME}" && sleep 3"
+        - "docker build -t ${IMAGE_NAME} ."
+        - "docker run -d -p 9001:9001 ${IMAGE_NAME} && sleep 3"
         - "cd src && npm run test-container"
     - name: "Test a docker-compose with MySQL"
       install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV NODE_ENV=development
 # that do not allow images running as root.
 RUN useradd --uid 5001 --create-home etherpad
 
-RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
+RUN apt-get install -y --no-install-recommends netcat && \
+	mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
 
 USER etherpad
 
@@ -50,4 +51,5 @@ COPY --chown=etherpad:0 ./settings.json.docker /opt/etherpad-lite/settings.json
 RUN chmod -R g=u .
 
 EXPOSE 9001
+ENTRYPOINT ["/opt/etherpad-lite/entrypoint.sh"]
 CMD ["node", "node_modules/ep_etherpad-lite/node/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV NODE_ENV=development
 # that do not allow images running as root.
 RUN useradd --uid 5001 --create-home etherpad
 
-RUN apt-get install -y --no-install-recommends netcat && \
+RUN apt-get update -q && \
+	apt-get install -y --no-install-recommends netcat && \
 	mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
 
 USER etherpad

--- a/docker-compose_mysql.yml
+++ b/docker-compose_mysql.yml
@@ -1,0 +1,76 @@
+version: "2"
+
+services:
+  # https://docs.docker.com/docker-hub/builds/automated-testing/
+  #sut:
+  #  build:
+  #    context: ./test
+  #    dockerfile: Dockerfile
+  #  depends_on:
+  #    - etherpad_mariadb
+  #    - etherpad
+  #  volumes_from:
+  #    - etherpad
+  #  volumes:
+  #    - /etc/localtime:/etc/localtime:ro
+  #    - /etc/timezone:/etc/timezone:ro
+
+  etherpad:
+    # For development or CI, tag build from local Dockerfile
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      #args:
+      #  - ETHERPAD_PLUGINS=
+      #  - TAG=${TAG}
+      #  - VCS_REF=${VCS_REF}
+      #  - BUILD_DATE=${BUILD_DATE}
+    # For production, download prebuilt image
+    image: ${IMAGE_NAME}
+    container_name: etherpad
+    #restart: always
+    #command: /wait-for-service.sh node node_modules/ep_etherpad-lite/node/server.js
+    depends_on:
+      - etherpad_mariadb
+    links:
+      - etherpad_mariadb
+    volumes:
+      # Persist settings.conf
+      #- /srv/etherpad/data:/opt/etherpad-lite/var
+      # If you wish to provide your own API key
+      #- ./APIKEY.txt:/opt/etherpad-lite/APIKEY.txt
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    environment:
+      # Set the following to production to avoid installing devDeps
+      # this can be done with build args (and is mandatory to build ARM version)
+      - NODE_ENV=development
+      # Etherpad configuration
+      - TITLE=Test Etherpad
+      # Database configuration
+      - DB_TYPE=mysql
+      - DB_HOST=etherpad_mariadb # same as mariadb container name
+      - DB_PORT=3306
+      - DB_NAME=${ETHERPAD_DB_NAME}
+      - DB_USER=${ETHERPAD_DB_USER}
+      - DB_PASS=${ETHERPAD_DB_PASSWORD}
+      - DB_CHARSET=utf8mb4
+      # Custom wait script env var
+      - WAIT_FOR_SERVICES=etherpad_mariadb:3306
+
+  etherpad_mariadb:
+    image: mariadb:latest
+    container_name: etherpad_mariadb
+    restart: always
+    command: --character_set_client=utf8 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --character-set-client-handshake=FALSE
+    #ports:
+    #  - 3306:3306
+    volumes:
+      - /srv/etherpad/mysql:/var/lib/mysql
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    environment:
+      - MYSQL_ROOT_PASSWORD=mysqlrootpassword
+      - MYSQL_DATABASE=${ETHERPAD_DB_NAME}
+      - MYSQL_USER=${ETHERPAD_DB_USER}
+      - MYSQL_PASSWORD=${ETHERPAD_DB_PASSWORD}

--- a/docker-compose_mysql.yml
+++ b/docker-compose_mysql.yml
@@ -30,6 +30,8 @@ services:
     container_name: etherpad
     #restart: always
     #command: /wait-for-service.sh node node_modules/ep_etherpad-lite/node/server.js
+    ports:
+      - "9001:9001"
     depends_on:
       - etherpad_mariadb
     links:

--- a/docker-compose_mysql.yml
+++ b/docker-compose_mysql.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.3"
 
 services:
   # https://docs.docker.com/docker-hub/builds/automated-testing/
@@ -29,11 +29,11 @@ services:
     image: ${IMAGE_NAME}
     container_name: etherpad
     #restart: always
-    #command: /wait-for-service.sh node node_modules/ep_etherpad-lite/node/server.js
     ports:
       - "9001:9001"
     depends_on:
-      - etherpad_mariadb
+      etherpad_mariadb:
+        condition: service_healthy
     links:
       - etherpad_mariadb
     volumes:
@@ -65,8 +65,14 @@ services:
     container_name: etherpad_mariadb
     restart: always
     command: --character_set_client=utf8 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --character-set-client-handshake=FALSE
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 10s
+      retries: 5
     #ports:
-    #  - 3306:3306
+    #  - "3306:3306"
+    expose:
+      - '3306'
     volumes:
       - /srv/etherpad/mysql:/var/lib/mysql
       - /etc/localtime:/etc/localtime:ro

--- a/docker-compose_postgresql.yml
+++ b/docker-compose_postgresql.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.3"
 
 services:
   # https://docs.docker.com/docker-hub/builds/automated-testing/
@@ -29,11 +29,11 @@ services:
     image: ${IMAGE_NAME}
     container_name: etherpad
     #restart: always
-    #command: /wait-for-service.sh node node_modules/ep_etherpad-lite/node/server.js
     ports:
       - "9001:9001"
     depends_on:
-      - etherpad_postgres
+      etherpad_postgres:
+        condition: service_healthy
     links:
       - etherpad_postgres
     volumes:
@@ -63,8 +63,12 @@ services:
     image: postgres:latest
     container_name: etherpad_postgres
     restart: always
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${ETHERPAD_DB_USER}"]
     #ports:
-    #  - 5432:5432
+    #  - "5432:5432"
+    expose:
+      - '5432'
     volumes:
       - /srv/etherpad/postgres:/var/lib/postgresql/data
       - /etc/localtime:/etc/localtime:ro

--- a/docker-compose_postgresql.yml
+++ b/docker-compose_postgresql.yml
@@ -30,6 +30,8 @@ services:
     container_name: etherpad
     #restart: always
     #command: /wait-for-service.sh node node_modules/ep_etherpad-lite/node/server.js
+    ports:
+      - "9001:9001"
     depends_on:
       - etherpad_postgres
     links:

--- a/docker-compose_postgresql.yml
+++ b/docker-compose_postgresql.yml
@@ -1,0 +1,73 @@
+version: "2"
+
+services:
+  # https://docs.docker.com/docker-hub/builds/automated-testing/
+  #sut:
+  #  build:
+  #    context: ./test
+  #    dockerfile: Dockerfile
+  #  depends_on:
+  #    - etherpad_postgres
+  #    - etherpad
+  #  volumes_from:
+  #    - etherpad
+  #  volumes:
+  #    - /etc/localtime:/etc/localtime:ro
+  #    - /etc/timezone:/etc/timezone:ro
+
+  etherpad:
+    # For development or CI, tag build from local Dockerfile
+    build:
+      context: ./
+      dockerfile: Dockerfile
+      #args:
+      #  - ETHERPAD_PLUGINS=
+      #  - TAG=${TAG}
+      #  - VCS_REF=${VCS_REF}
+      #  - BUILD_DATE=${BUILD_DATE}
+    # For production, download prebuilt image
+    image: ${IMAGE_NAME}
+    container_name: etherpad
+    #restart: always
+    #command: /wait-for-service.sh node node_modules/ep_etherpad-lite/node/server.js
+    depends_on:
+      - etherpad_postgres
+    links:
+      - etherpad_postgres
+    volumes:
+      # Persist settings.conf
+      #- /srv/etherpad/data:/opt/etherpad-lite/var
+      # If you wish to provide your own API key
+      #- ./APIKEY.txt:/opt/etherpad-lite/APIKEY.txt
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    environment:
+      # Set the following to production to avoid installing devDeps
+      # this can be done with build args (and is mandatory to build ARM version)
+      - NODE_ENV=development
+      # Etherpad configuration
+      - TITLE=Test Etherpad
+      # Database configuration
+      - DB_TYPE=postgres
+      - DB_HOST=etherpad_postgres # same as pgsql container name
+      - DB_PORT=5432
+      - DB_NAME=${ETHERPAD_DB_NAME}
+      - DB_USER=${ETHERPAD_DB_USER}
+      - DB_PASS=${ETHERPAD_DB_PASSWORD}
+      # Custom wait script env var
+      - WAIT_FOR_SERVICES=etherpad_postgres:5432
+
+  etherpad_postgres:
+    image: postgres:latest
+    container_name: etherpad_postgres
+    restart: always
+    #ports:
+    #  - 5432:5432
+    volumes:
+      - /srv/etherpad/postgres:/var/lib/postgresql/data
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/timezone:/etc/timezone:ro
+    environment:
+      - POSTGRES_DB=${ETHERPAD_DB_NAME}
+      - POSTGRES_USER=${ETHERPAD_DB_USER}
+      - POSTGRES_PASSWORD=${ETHERPAD_DB_PASSWORD}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+# -------------------------------------------------------------------
+# Functions
+
+log() {
+  echo "[$0] [$(date +%Y-%m-%dT%H:%M:%S%:z)] $@"
+}
+
+# wait for service to be reachable
+wait_for_service() {
+    WAIT_FOR_ADDR=${1}
+    if [ -z "${WAIT_FOR_ADDR}" ]; then
+        log "Missing service's address to wait for!"
+        exit 1
+    fi
+
+    WAIT_FOR_PORT=${2}
+    if [ -z "${WAIT_FOR_PORT}" ]; then
+        log "Missing service's port to wait for!"
+        exit 1
+    fi
+
+    WAIT_TIME=0
+    WAIT_STEP=${3:-10}
+    WAIT_TIMEOUT=${4:--1}
+
+    while ! nc -z "${WAIT_FOR_ADDR}" "${WAIT_FOR_PORT}" ; do
+        if [ "${WAIT_TIMEOUT}" -gt 0 ] && [ "${WAIT_TIME}" -gt "${WAIT_TIMEOUT}" ]; then
+            log "Service '${WAIT_FOR_ADDR}:${WAIT_FOR_PORT}' was not available on time!"
+            exit 1
+        fi
+
+        log "Waiting service '${WAIT_FOR_ADDR}:${WAIT_FOR_PORT}'..."
+        sleep "${WAIT_STEP}"
+        WAIT_TIME=$(( WAIT_TIME + WAIT_STEP ))
+    done
+    log "Service '${WAIT_FOR_ADDR}:${WAIT_FOR_PORT}' available."
+}
+
+# -------------------------------------------------------------------
+# Runtime
+
+# Wait for external databases
+if [ -n "${DB_HOST}" ] && [ -n "${DB_PORT}" ]; then
+    wait_for_service "${DB_HOST}" "${DB_PORT}"
+fi
+
+log "Starting..."
+exec "$@"
+

--- a/src/static/js/scroll.js
+++ b/src/static/js/scroll.js
@@ -5,7 +5,7 @@
   Browser Line = each vertical line. A <div> can be break into more than one
   browser line.
 */
-var caretPosition = require('/caretPosition');
+var caretPosition = require('./caretPosition');
 
 function Scroll(outerWin) {
   // scroll settings


### PR DESCRIPTION
travis: Add test for DB with docker-compose to fix #3806

I made this based on how we handled database support in our fork [Monogramm/docker-etherpad](https://github.com/Monogramm/docker-etherpad) but it might not be the best here.
@pierreprinetti let me know if you have any advice