### PR TITLE
Timeout logic - Ready for review

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -173,8 +173,20 @@ function sendClientReady(isReconnect, messageType)
   //this is a reconnect, lets tell the server our revisionnumber
   if(isReconnect == true)
   {
+    // Hammer approach for now.  This is obviously wrong and needs a proper fix
+    // TODO: See https://github.com/ether/etherpad-lite/issues/3830
+    document.location=document.location;
+
+    // Switching to pad should work but doesn't...
+    // return pad.switchToPad(padId); // hacky but whatever.
+    // It might be related to Auth because failure logs...
+    //   [ERROR] console - Auth was never applied to a session.
+    //   If you are using the stress-test tool then restart Etherpad
+    //   and the Stress test tool.
+
     msg.client_rev=pad.collabClient.getCurrentRevisionNumber();
     msg.reconnect=true;
+
   }
 
   socket.json.send(msg);

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -210,6 +210,7 @@ function handshake()
   });
 
   socket.on('reconnecting', function() {
+    padeditor.disable();
     pad.collabClient.setStateIdle();
     pad.collabClient.setIsPendingRevision(true);
     pad.collabClient.setChannelState("RECONNECTING");


### PR DESCRIPTION
Solution for https://github.com/ether/etherpad-lite/issues/3830

- [x] Doesn't allow edit when in a disconnected state (dunno how that happened).
- [ ] Doesn't make for badchangeset upon reconnection
OR
- [x] Temp fix in place which is not as great a UX but works fine.