### PR TITLE
PadMessageHandler: fix for scoping error hiding original error

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1429,11 +1429,12 @@ async function composePadChangesets (padId, startNum, endNum)
   }));
 
   // compose Changesets
+  let r;
   try {
     let changeset = changesets[startNum];
     let pool = pad.apool();
 
-    for (let r = startNum + 1; r < endNum; r++) {
+    for (r = startNum + 1; r < endNum; r++) {
       let cs = changesets[r];
       changeset = Changeset.compose(changeset, cs, pool);
     }


### PR DESCRIPTION
`r` is undefined outside of the for loop, but used in the catch block of the try
statement

This fix is a quickfix.

This PR is based on devlop