### PR TITLE
docker: make settings fully configurable via env vars

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -58,11 +58,11 @@ The `settings.json.docker` available by default enables some configuration to be
 
 | Variable           | Description                                                                                | Default                                                                                                                                                                                                                             |
 | ------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TITLE`            | The name of the instance                                                                   |                                                                                                                                                                                                                                     |
-| `FAVICON`          | favicon default name, or a fully specified URL to your own favicon                         |                                                                                                                                                                                                                                     |
-| `DEFAULT_PAD_TEXT` | The default text of a pad                                                                  |                                                                                                                                                                                                                                     |
-| `IP`               | IP which etherpad should bind at. Change to `::` for IPv6                                  |                                                                                                                                                                                                                                     |
-| `PORT`             | port which etherpad should bind at                                                         |                                                                                                                                                                                                                                     |
+| `TITLE`            | The name of the instance                                                                   | `Etherpad`                                                                                                                                                                                                                          |
+| `FAVICON`          | favicon default name, or a fully specified URL to your own favicon                         | `favicon.ico`                                                                                                                                                                                                                       |
+| `DEFAULT_PAD_TEXT` | The default text of a pad                                                                  | `Welcome to Etherpad! This pad text is synchronized as you type, so that everyone viewing this page sees the same text. This allows you to collaborate seamlessly on documents! Get involved with Etherpad at https://etherpad.org` |
+| `IP`               | IP which etherpad should bind at. Change to `::` for IPv6                                  | `0.0.0.0`                                                                                                                                                                                                                           |
+| `PORT`             | port which etherpad should bind at                                                         | `9001`                                                                                                                                                                                                                              |
 | `ADMIN_PASSWORD`   | the password for the `admin` user (leave unspecified if you do not want to create it)      |                                                                                                                                                                                                                                     |
 | `USER_PASSWORD`    | the password for the first user `user` (leave unspecified if you do not want to create it) |                                                                                                                                                                                                                                     |
 
@@ -71,14 +71,14 @@ The `settings.json.docker` available by default enables some configuration to be
 
 | Variable      | Description                                                    | Default                                                               |
 | ------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `DB_TYPE`     | a database supported by https://www.npmjs.com/package/ueberdb2 |                                                                       |
+| `DB_TYPE`     | a database supported by https://www.npmjs.com/package/ueberdb2 | not set, thus will fall back to `DirtyDB` (please choose one instead) |
 | `DB_HOST`     | the host of the database                                       |                                                                       |
 | `DB_PORT`     | the port of the database                                       |                                                                       |
 | `DB_NAME`     | the database name                                              |                                                                       |
 | `DB_USER`     | a database user with sufficient permissions to create tables   |                                                                       |
 | `DB_PASS`     | the password for the database username                         |                                                                       |
 | `DB_CHARSET`  | the character set for the tables (only required for MySQL)     |                                                                       |
-| `DB_FILENAME` | in case `DB_TYPE` is `DirtyDB`, the database filename.         |                                                                       |
+| `DB_FILENAME` | in case `DB_TYPE` is `DirtyDB`, the database filename.         | `var/dirty.db`                                                        |
 
 If your database needs additional settings, you will have to use a personalized `settings.json.docker` and rebuild the container (or otherwise put the updated `settings.json` inside your image).
 
@@ -87,25 +87,25 @@ If your database needs additional settings, you will have to use a personalized 
 
 | Variable        | Description                                                                    | Default                                                   |
 | --------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| `SKIN_NAME`     | either `no-skin`, `colibris` or an existing directory under `src/static/skins` |                                                           |
+| `SKIN_NAME`     | either `no-skin`, `colibris` or an existing directory under `src/static/skins` | `colibris`                                                |
 
 
 ### Logging
 
 | Variable             | Description                                          | Default |
 | -------------------- | ---------------------------------------------------- | ------- |
-| `LOGLEVEL`           | valid values are `DEBUG`, `INFO`, `WARN` and `ERROR` |         |
+| `LOGLEVEL`           | valid values are `DEBUG`, `INFO`, `WARN` and `ERROR` | `INFO`  |
 
 
 ### Advanced
 
 | Variable                          | Description                                                                                                                                                                                            | Default            |
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `SHOW_SETTINGS_IN_ADMIN_PAGE`     | hide/show the settings.json in admin page                                                                                                                                                              |                    |
-| `TRUST_PROXY`                     | set to `true` if you are using a reverse proxy in front of Etherpad (for example: Traefik for SSL termination via Let's Encrypt). This will affect security and correctness of the logs if not done    |                    |
-| `IMPORT_MAX_FILE_SIZE`            | maximum allowed file size when importing a pad, in bytes.                                                                                                                                              |                    |
-| `IMPORT_EXPORT_MAX_REQ_PER_IP`    | maximum number of import/export calls per IP.                                                                                                                                                          |                    |
-| `IMPORT_EXPORT_RATE_LIMIT_WINDOW` | the call rate for import/export requests will be estimated in this time window (in milliseconds)                                                                                                       |                    |
+| `SHOW_SETTINGS_IN_ADMIN_PAGE`     | hide/show the settings.json in admin page                                                                                                                                                              | `true`             |
+| `TRUST_PROXY`                     | set to `true` if you are using a reverse proxy in front of Etherpad (for example: Traefik for SSL termination via Let's Encrypt). This will affect security and correctness of the logs if not done    | `false`            |
+| `IMPORT_MAX_FILE_SIZE`            | maximum allowed file size when importing a pad, in bytes.                                                                                                                                              | `52428800` (50 MB) |
+| `IMPORT_EXPORT_MAX_REQ_PER_IP`    | maximum number of import/export calls per IP.                                                                                                                                                          | `10`               |
+| `IMPORT_EXPORT_RATE_LIMIT_WINDOW` | the call rate for import/export requests will be estimated in this time window (in milliseconds)                                                                                                       | `90000`            |
 
 
 ### Examples

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -76,6 +76,8 @@ The `settings.json.docker` available by default enables some configuration to be
 * `DB_CHARSET`: the character set for the tables (only required for MySQL)
 * `DB_FILENAME`: in case `DB_TYPE` is `DirtyDB`, the database filename. Default: `var/dirty.db`
 
+If your database needs additional settings, you will have to use a personalized `settings.json.docker` and rebuild the container (or otherwise put the updated `settings.json` inside your image).
+
 
 ### Skins
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -56,46 +56,56 @@ The `settings.json.docker` available by default enables some configuration to be
 
 ### General
 
-* `TITLE`: The name of the instance
-* `FAVICON`: favicon default name, or a fully specified URL to your own favicon
-* `DEFAULT_PAD_TEXT`: The default text of a pad
-* `IP`: IP which etherpad should bind at. Change to `::` for IPv6
-* `PORT`: port which etherpad should bind at
-* `ADMIN_PASSWORD`: the password for the `admin` user (leave unspecified if you do not want to create it)
-* `USER_PASSWORD`: the password for the first user `user` (leave unspecified if you do not want to create it)
+| Variable           | Description                                                                                | Default                                                                                                                                                                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TITLE`            | The name of the instance                                                                   |                                                                                                                                                                                                                                     |
+| `FAVICON`          | favicon default name, or a fully specified URL to your own favicon                         |                                                                                                                                                                                                                                     |
+| `DEFAULT_PAD_TEXT` | The default text of a pad                                                                  |                                                                                                                                                                                                                                     |
+| `IP`               | IP which etherpad should bind at. Change to `::` for IPv6                                  |                                                                                                                                                                                                                                     |
+| `PORT`             | port which etherpad should bind at                                                         |                                                                                                                                                                                                                                     |
+| `ADMIN_PASSWORD`   | the password for the `admin` user (leave unspecified if you do not want to create it)      |                                                                                                                                                                                                                                     |
+| `USER_PASSWORD`    | the password for the first user `user` (leave unspecified if you do not want to create it) |                                                                                                                                                                                                                                     |
 
 
 ### Database
 
-* `DB_TYPE`: a database supported by https://www.npmjs.com/package/ueberdb2
-* `DB_HOST`: the host of the database
-* `DB_PORT`: the port of the database
-* `DB_NAME`: the database name
-* `DB_USER`: a database user with sufficient permissions to create tables
-* `DB_PASS`: the password for the database username
-* `DB_CHARSET`: the character set for the tables (only required for MySQL)
-* `DB_FILENAME`: in case `DB_TYPE` is `DirtyDB`, the database filename. Default: `var/dirty.db`
+| Variable      | Description                                                    | Default                                                               |
+| ------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `DB_TYPE`     | a database supported by https://www.npmjs.com/package/ueberdb2 |                                                                       |
+| `DB_HOST`     | the host of the database                                       |                                                                       |
+| `DB_PORT`     | the port of the database                                       |                                                                       |
+| `DB_NAME`     | the database name                                              |                                                                       |
+| `DB_USER`     | a database user with sufficient permissions to create tables   |                                                                       |
+| `DB_PASS`     | the password for the database username                         |                                                                       |
+| `DB_CHARSET`  | the character set for the tables (only required for MySQL)     |                                                                       |
+| `DB_FILENAME` | in case `DB_TYPE` is `DirtyDB`, the database filename.         |                                                                       |
 
 If your database needs additional settings, you will have to use a personalized `settings.json.docker` and rebuild the container (or otherwise put the updated `settings.json` inside your image).
 
 
 ### Skins
 
-* `SKIN_NAME`: either `no-skin`, `colibris` or an existing directory under `src/static/skins`.
+| Variable        | Description                                                                    | Default                                                   |
+| --------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `SKIN_NAME`     | either `no-skin`, `colibris` or an existing directory under `src/static/skins` |                                                           |
 
 
 ### Logging
 
-* `LOGLEVEL`: valid values are `DEBUG`, `INFO`, `WARN` and `ERROR`
+| Variable             | Description                                          | Default |
+| -------------------- | ---------------------------------------------------- | ------- |
+| `LOGLEVEL`           | valid values are `DEBUG`, `INFO`, `WARN` and `ERROR` |         |
 
 
 ### Advanced
 
-* `SHOW_SETTINGS_IN_ADMIN_PAGE`: hide/show the settings.json in admin page
-* `TRUST_PROXY`: set to `true` if you are using a reverse proxy in front of Etherpad (for example: Traefik for SSL termination via Let's Encrypt). This will affect security and correctness of the logs if not done
-* `IMPORT_MAX_FILE_SIZE`: maximum allowed file size when importing a pad, in bytes. Default: 52428800 (50 MB)
-* `IMPORT_EXPORT_MAX_REQ_PER_IP`: maximum number of import/export calls per IP. Default: 10
-* `IMPORT_EXPORT_RATE_LIMIT_WINDOW`: the call rate for import/export requests will be estimated in this time window (in milliseconds). Default: 90000 ms
+| Variable                          | Description                                                                                                                                                                                            | Default            |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------ |
+| `SHOW_SETTINGS_IN_ADMIN_PAGE`     | hide/show the settings.json in admin page                                                                                                                                                              |                    |
+| `TRUST_PROXY`                     | set to `true` if you are using a reverse proxy in front of Etherpad (for example: Traefik for SSL termination via Let's Encrypt). This will affect security and correctness of the logs if not done    |                    |
+| `IMPORT_MAX_FILE_SIZE`            | maximum allowed file size when importing a pad, in bytes.                                                                                                                                              |                    |
+| `IMPORT_EXPORT_MAX_REQ_PER_IP`    | maximum number of import/export calls per IP.                                                                                                                                                          |                    |
+| `IMPORT_EXPORT_RATE_LIMIT_WINDOW` | the call rate for import/export requests will be estimated in this time window (in milliseconds)                                                                                                       |                    |
 
 
 ### Examples

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -52,7 +52,7 @@ And point your browser to `http://<YOUR_IP>:<DESIRED_PORT>`
 
 ## Options available by default
 
-The `settings.json.docker` available by default enables some configuration to be set from the environment.
+The `settings.json.docker` available by default allows to control almost every setting via environment variables.
 
 ### General
 
@@ -83,11 +83,72 @@ The `settings.json.docker` available by default enables some configuration to be
 If your database needs additional settings, you will have to use a personalized `settings.json.docker` and rebuild the container (or otherwise put the updated `settings.json` inside your image).
 
 
+### Pad Options
+
+| Variable                         | Description | Default |
+| -------------------------------- | ----------- | ------- |
+| `PAD_OPTIONS_NO_COLORS`          |             | `false` |
+| `PAD_OPTIONS_SHOW_CONTROLS`      |             | `true`  |
+| `PAD_OPTIONS_SHOW_CHAT`          |             | `true`  |
+| `PAD_OPTIONS_SHOW_LINE_NUMBERS`  |             | `true`  |
+| `PAD_OPTIONS_USE_MONOSPACE_FONT` |             | `false` |
+| `PAD_OPTIONS_USER_NAME`          |             | `false` |
+| `PAD_OPTIONS_USER_COLOR`         |             | `false` |
+| `PAD_OPTIONS_RTL`                |             | `false` |
+| `PAD_OPTIONS_ALWAYS_SHOW_CHAT`   |             | `false` |
+| `PAD_OPTIONS_CHAT_AND_USERS`     |             | `false` |
+| `PAD_OPTIONS_LANG`               |             | `en-gb` |
+
+
+### Shortcuts
+
+| Variable                            | Description                                      | Default |
+| ----------------------------------- | ------------------------------------------------ | ------- |
+| `PAD_SHORTCUTS_ENABLED_ALT_F9`      | focus on the File Menu and/or editbar            | `true`  |
+| `PAD_SHORTCUTS_ENABLED_ALT_C`       | focus on the Chat window                         | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_S`       | save a revision                                  | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_Z`       | undo/redo                                        | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_Y`       | redo                                             | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_I`       | italic                                           | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_B`       | bold                                             | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_U`       | underline                                        | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_H`       | backspace                                        | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_5`       | strike through                                   | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_SHIFT_1` | ordered list                                     | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_SHIFT_2` | shows a gritter popup showing a line author      | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_SHIFT_L` | unordered list                                   | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_SHIFT_N` | ordered list                                     | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CMD_SHIFT_C` | clear authorship                                 | `true`  |
+| `PAD_SHORTCUTS_ENABLED_DELETE`      |                                                  | `true`  |
+| `PAD_SHORTCUTS_ENABLED_RETURN`      |                                                  | `true`  |
+| `PAD_SHORTCUTS_ENABLED_ESC`         | in mozilla versions 14-19 avoid reconnecting pad | `true`  |
+| `PAD_SHORTCUTS_ENABLED_TAB`         | indent                                           | `true`  |
+| `PAD_SHORTCUTS_ENABLED_CTRL_HOME`   | scroll to top of pad                             | `true`  |
+| `PAD_SHORTCUTS_ENABLED_PAGE_UP`     |                                                  | `true`  |
+| `PAD_SHORTCUTS_ENABLED_PAGE_DOWN`   |                                                  | `true`  |
+
+
 ### Skins
+
+You can use the UI skin variants builder at `/p/test#skinvariantsbuilder`
+
+For the colibris skin only, you can choose how to render the three main containers:
+  * toolbar (top menu with icons)
+  * editor (containing the text of the pad)
+  * background (area outside of editor, mostly visible when using page style)
+
+For each of the 3 containers you can choose 4 color combinations:
+   * super-light
+   * light
+   * dark
+   * super-dark
+
+For the editor container, you can also make it full width by adding `full-width-editor` variant (by default editor is rendered as a page, with a max-width of 900px).
 
 | Variable        | Description                                                                    | Default                                                   |
 | --------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------- |
 | `SKIN_NAME`     | either `no-skin`, `colibris` or an existing directory under `src/static/skins` | `colibris`                                                |
+| `SKIN_VARIANTS` | multiple skin variants separated by spaces                                     | `super-light-toolbar super-light-editor light-background` |
 
 
 ### Logging
@@ -95,6 +156,7 @@ If your database needs additional settings, you will have to use a personalized 
 | Variable             | Description                                          | Default |
 | -------------------- | ---------------------------------------------------- | ------- |
 | `LOGLEVEL`           | valid values are `DEBUG`, `INFO`, `WARN` and `ERROR` | `INFO`  |
+| `DISABLE_IP_LOGGING` | Privacy: disable IP logging                          | `false` |
 
 
 ### Advanced
@@ -106,6 +168,26 @@ If your database needs additional settings, you will have to use a personalized 
 | `IMPORT_MAX_FILE_SIZE`            | maximum allowed file size when importing a pad, in bytes.                                                                                                                                              | `52428800` (50 MB) |
 | `IMPORT_EXPORT_MAX_REQ_PER_IP`    | maximum number of import/export calls per IP.                                                                                                                                                          | `10`               |
 | `IMPORT_EXPORT_RATE_LIMIT_WINDOW` | the call rate for import/export requests will be estimated in this time window (in milliseconds)                                                                                                       | `90000`            |
+| `SUPPRESS_ERRORS_IN_PAD_TEXT`     | Should we suppress errors from being visible in the default Pad Text?                                                                                                                                  | `false`            |
+| `REQUIRE_SESSION`                 | If this option is enabled, a user must have a session to access pads. This effectively allows only group pads to be accessed.                                                                          | `false`            |
+| `EDIT_ONLY`                       | Users may edit pads but not create new ones. Pad creation is only via the API. This applies both to group pads and regular pads.                                                                       | `false`            |
+| `SESSION_NO_PASSWORD`             | If set to true, those users who have a valid session will automatically be granted access to password protected pads.                                                                                  | `false`            |
+| `MINIFY`                          | If true, all css & js will be minified before sending to the client. This will improve the loading performance massively, but makes it difficult to debug the javascript/css                           | `true`             |
+| `MAX_AGE`                         | How long may clients use served javascript code (in seconds)? Not setting this may cause problems during deployment. Set to 0 to disable caching.                                                      | `21600` (6 hours)  |
+| `ABIWORD`                         | Absolute path to the Abiword executable. Abiword is needed to get advanced import/export features of pads. Setting it to null disables Abiword and will only allow plain text and HTML import/exports. | `null`             |
+| `SOFFICE`                         | This is the absolute path to the soffice executable. LibreOffice can be used in lieu of Abiword to export pads. Setting it to null disables LibreOffice exporting.                                     | `null`             |
+| `TIDY_HTML`                       | Path to the Tidy executable. Tidy is used to improve the quality of exported pads. Setting it to null disables Tidy.                                                                                   | `null`             |
+| `ALLOW_UNKNOWN_FILE_ENDS`         | Allow import of file types other than the supported ones: txt, doc, docx, rtf, odt, html & htm                                                                                                         | `true`             |
+| `REQUIRE_AUTHENTICATION`          | This setting is used if you require authentication of all users. Note: "/admin" always requires authentication.                                                                                        | `false`            |
+| `REQUIRE_AUTHORIZATION`           | Require authorization by a module, or a user with is_admin set, see below.                                                                                                                             | `false`            |
+| `AUTOMATIC_RECONNECTION_TIMEOUT`  | Time (in seconds) to automatically reconnect pad when a "Force reconnect" message is shown to user. Set to 0 to disable automatic reconnection.                                                        | `0`                |
+| `FOCUS_LINE_PERCENTAGE_ABOVE`     | Percentage of viewport height to be additionally scrolled. e.g. 0.5, to place caret line in the middle of viewport, when user edits a line above of the viewport. Set to 0 to disable extra scrolling  | `0`                |
+| `FOCUS_LINE_PERCENTAGE_BELOW`     | Percentage of viewport height to be additionally scrolled. e.g. 0.5, to place caret line in the middle of viewport, when user edits a line below of the viewport. Set to 0 to disable extra scrolling  | `0`                |
+| `FOCUS_LINE_PERCENTAGE_ARROW_UP`  | Percentage of viewport height to be additionally scrolled when user presses arrow up in the line of the top of the viewport. Set to 0 to let the scroll to be handled as default by Etherpad           | `0`                |
+| `FOCUS_LINE_DURATION`             | Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation                                                                                                            | `0`                |
+| `FOCUS_LINE_CARET_SCROLL`         | Flag to control if it should scroll when user places the caret in the last line of the viewport                                                                                                        | `false`            |
+| `LOAD_TEST`                       | Allow Load Testing tools to hit the Etherpad Instance. WARNING: this will disable security on the instance.                                                                                            | `false`            |
+| `EXPOSE_VERSION`                  | Expose Etherpad version in the web interface and in the Server http header. Do not enable on production machines.                                                                                      | `false`            |
 
 
 ### Examples

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -54,14 +54,19 @@ And point your browser to `http://<YOUR_IP>:<DESIRED_PORT>`
 
 The `settings.json.docker` available by default enables some configuration to be set from the environment.
 
-Available options:
+### General
 
 * `TITLE`: The name of the instance
 * `FAVICON`: favicon default name, or a fully specified URL to your own favicon
-* `SKIN_NAME`: either `no-skin`, `colibris` or an existing directory under `src/static/skins`.
+* `DEFAULT_PAD_TEXT`: The default text of a pad
 * `IP`: IP which etherpad should bind at. Change to `::` for IPv6
 * `PORT`: port which etherpad should bind at
-* `SHOW_SETTINGS_IN_ADMIN_PAGE`: hide/show the settings.json in admin page
+* `ADMIN_PASSWORD`: the password for the `admin` user (leave unspecified if you do not want to create it)
+* `USER_PASSWORD`: the password for the first user `user` (leave unspecified if you do not want to create it)
+
+
+### Database
+
 * `DB_TYPE`: a database supported by https://www.npmjs.com/package/ueberdb2
 * `DB_HOST`: the host of the database
 * `DB_PORT`: the port of the database
@@ -70,14 +75,26 @@ Available options:
 * `DB_PASS`: the password for the database username
 * `DB_CHARSET`: the character set for the tables (only required for MySQL)
 * `DB_FILENAME`: in case `DB_TYPE` is `DirtyDB`, the database filename. Default: `var/dirty.db`
-* `DEFAULT_PAD_TEXT`: The default text of a pad
-* `ADMIN_PASSWORD`: the password for the `admin` user (leave unspecified if you do not want to create it)
-* `USER_PASSWORD`: the password for the first user `user` (leave unspecified if you do not want to create it)
+
+
+### Skins
+
+* `SKIN_NAME`: either `no-skin`, `colibris` or an existing directory under `src/static/skins`.
+
+
+### Logging
+
+* `LOGLEVEL`: valid values are `DEBUG`, `INFO`, `WARN` and `ERROR`
+
+
+### Advanced
+
+* `SHOW_SETTINGS_IN_ADMIN_PAGE`: hide/show the settings.json in admin page
 * `TRUST_PROXY`: set to `true` if you are using a reverse proxy in front of Etherpad (for example: Traefik for SSL termination via Let's Encrypt). This will affect security and correctness of the logs if not done
 * `IMPORT_MAX_FILE_SIZE`: maximum allowed file size when importing a pad, in bytes. Default: 52428800 (50 MB)
 * `IMPORT_EXPORT_MAX_REQ_PER_IP`: maximum number of import/export calls per IP. Default: 10
 * `IMPORT_EXPORT_RATE_LIMIT_WINDOW`: the call rate for import/export requests will be estimated in this time window (in milliseconds). Default: 90000 ms
-* `LOGLEVEL`: valid values are `DEBUG`, `INFO`, `WARN` and `ERROR`
+
 
 ### Examples
 

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -65,6 +65,9 @@
  *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
  *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
  *
+ *    If you want to use an empty value (null) as default value for a variable,
+ *    simply do not set it, without putting any colons: "${ABIWORD}".
+ *
  * 3) if you want to use newlines in the default value of a string parameter,
  *    use "\n" as usual.
  *

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -122,7 +122,7 @@
    * "full-width-editor" variant (by default editor is rendered as a page, with
    * a max-width of 900px).
    */
-  "skinVariants": "super-light-toolbar super-light-editor light-background",
+  "skinVariants": "${SKIN_VARIANTS:super-light-toolbar super-light-editor light-background}",
 
   /*
    * IP and port which Etherpad should bind at.
@@ -200,57 +200,57 @@
    * Change them if you want to override.
    */
   "padOptions": {
-    "noColors":         false,
-    "showControls":     true,
-    "showChat":         true,
-    "showLineNumbers":  true,
-    "useMonospaceFont": false,
-    "userName":         false,
-    "userColor":        false,
-    "rtl":              false,
-    "alwaysShowChat":   false,
-    "chatAndUsers":     false,
-    "lang":             "en-gb"
+    "noColors":         "${PAD_OPTIONS_NO_COLORS:false}",
+    "showControls":     "${PAD_OPTIONS_SHOW_CONTROLS:true}",
+    "showChat":         "${PAD_OPTIONS_SHOW_CHAT:true}",
+    "showLineNumbers":  "${PAD_OPTIONS_SHOW_LINE_NUMBERS:true}",
+    "useMonospaceFont": "${PAD_OPTIONS_USE_MONOSPACE_FONT:false}",
+    "userName":         "${PAD_OPTIONS_USER_NAME:false}",
+    "userColor":        "${PAD_OPTIONS_USER_COLOR:false}",
+    "rtl":              "${PAD_OPTIONS_RTL:false}",
+    "alwaysShowChat":   "${PAD_OPTIONS_ALWAYS_SHOW_CHAT:false}",
+    "chatAndUsers":     "${PAD_OPTIONS_CHAT_AND_USERS:false}",
+    "lang":             "${PAD_OPTIONS_LANG:en-gb}"
   },
 
   /*
    * Pad Shortcut Keys
    */
   "padShortcutEnabled" : {
-    "altF9":     true, /* focus on the File Menu and/or editbar */
-    "altC":      true, /* focus on the Chat window */
-    "cmdShift2": true, /* shows a gritter popup showing a line author */
-    "delete":    true,
-    "return":    true,
-    "esc":       true, /* in mozilla versions 14-19 avoid reconnecting pad */
-    "cmdS":      true, /* save a revision */
-    "tab":       true, /* indent */
-    "cmdZ":      true, /* undo/redo */
-    "cmdY":      true, /* redo */
-    "cmdI":      true, /* italic */
-    "cmdB":      true, /* bold */
-    "cmdU":      true, /* underline */
-    "cmd5":      true, /* strike through */
-    "cmdShiftL": true, /* unordered list */
-    "cmdShiftN": true, /* ordered list */
-    "cmdShift1": true, /* ordered list */
-    "cmdShiftC": true, /* clear authorship */
-    "cmdH":      true, /* backspace */
-    "ctrlHome":  true, /* scroll to top of pad */
-    "pageUp":    true,
-    "pageDown":  true
+    "altF9":     "${PAD_SHORTCUTS_ENABLED_ALT_F9:true}",      /* focus on the File Menu and/or editbar */
+    "altC":      "${PAD_SHORTCUTS_ENABLED_ALT_C:true}",       /* focus on the Chat window */
+    "cmdShift2": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_2:true}", /* shows a gritter popup showing a line author */
+    "delete":    "${PAD_SHORTCUTS_ENABLED_DELETE:true}",
+    "return":    "${PAD_SHORTCUTS_ENABLED_RETURN:true}",
+    "esc":       "${PAD_SHORTCUTS_ENABLED_ESC:true}",         /* in mozilla versions 14-19 avoid reconnecting pad */
+    "cmdS":      "${PAD_SHORTCUTS_ENABLED_CMD_S:true}",       /* save a revision */
+    "tab":       "${PAD_SHORTCUTS_ENABLED_TAB:true}",         /* indent */
+    "cmdZ":      "${PAD_SHORTCUTS_ENABLED_CMD_Z:true}",       /* undo/redo */
+    "cmdY":      "${PAD_SHORTCUTS_ENABLED_CMD_Y:true}",       /* redo */
+    "cmdI":      "${PAD_SHORTCUTS_ENABLED_CMD_I:true}",       /* italic */
+    "cmdB":      "${PAD_SHORTCUTS_ENABLED_CMD_B:true}",       /* bold */
+    "cmdU":      "${PAD_SHORTCUTS_ENABLED_CMD_U:true}",       /* underline */
+    "cmd5":      "${PAD_SHORTCUTS_ENABLED_CMD_5:true}",       /* strike through */
+    "cmdShiftL": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_L:true}", /* unordered list */
+    "cmdShiftN": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_N:true}", /* ordered list */
+    "cmdShift1": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_1:true}", /* ordered list */
+    "cmdShiftC": "${PAD_SHORTCUTS_ENABLED_CMD_SHIFT_C:true}", /* clear authorship */
+    "cmdH":      "${PAD_SHORTCUTS_ENABLED_CMD_H:true}",       /* backspace */
+    "ctrlHome":  "${PAD_SHORTCUTS_ENABLED_CTRL_HOME:true}",   /* scroll to top of pad */
+    "pageUp":    "${PAD_SHORTCUTS_ENABLED_PAGE_UP:true}",
+    "pageDown":  "${PAD_SHORTCUTS_ENABLED_PAGE_DOWN:true}"
   },
 
   /*
    * Should we suppress errors from being visible in the default Pad Text?
    */
-  "suppressErrorsInPadText": false,
+  "suppressErrorsInPadText": "${SUPPRESS_ERRORS_IN_PAD_TEXT:false}",
 
   /*
    * If this option is enabled, a user must have a session to access pads.
    * This effectively allows only group pads to be accessed.
    */
-  "requireSession": false,
+  "requireSession": "${REQUIRE_SESSION:false}",
 
   /*
    * Users may edit pads but not create new ones.
@@ -258,13 +258,13 @@
    * Pad creation is only via the API.
    * This applies both to group pads and regular pads.
    */
-  "editOnly": false,
+  "editOnly": "${EDIT_ONLY:false}",
 
   /*
    * If set to true, those users who have a valid session will automatically be
    * granted access to password protected pads.
    */
-  "sessionNoPassword": false,
+  "sessionNoPassword": "${SESSION_NO_PASSWORD:false}",
 
   /*
    * If true, all css & js will be minified before sending to the client.
@@ -272,7 +272,7 @@
    * This will improve the loading performance massively, but makes it difficult
    * to debug the javascript/css
    */
-  "minify": true,
+  "minify": "${MINIFY:true}",
 
   /*
    * How long may clients use served javascript code (in seconds)?
@@ -280,7 +280,7 @@
    * Not setting this may cause problems during deployment.
    * Set to 0 to disable caching.
    */
-  "maxAge": 21600, // 60 * 60 * 6 = 6 hours
+  "maxAge": "${MAX_AGE:21600}", // 60 * 60 * 6 = 6 hours
 
   /*
    * Absolute path to the Abiword executable.
@@ -289,7 +289,7 @@
    * it to null disables Abiword and will only allow plain text and HTML
    * import/exports.
    */
-  "abiword": null,
+  "abiword": "${ABIWORD}",
 
   /*
    * This is the absolute path to the soffice executable.
@@ -297,7 +297,7 @@
    * LibreOffice can be used in lieu of Abiword to export pads.
    * Setting it to null disables LibreOffice exporting.
    */
-  "soffice": null,
+  "soffice": "${SOFFICE}",
 
   /*
    * Path to the Tidy executable.
@@ -305,25 +305,25 @@
    * Tidy is used to improve the quality of exported pads.
    * Setting it to null disables Tidy.
    */
-  "tidyHtml": null,
+  "tidyHtml": "${TIDY_HTML}",
 
   /*
    * Allow import of file types other than the supported ones:
    * txt, doc, docx, rtf, odt, html & htm
    */
-  "allowUnknownFileEnds": true,
+  "allowUnknownFileEnds": "${ALLOW_UNKNOWN_FILE_ENDS:true}",
 
   /*
    * This setting is used if you require authentication of all users.
    *
    * Note: "/admin" always requires authentication.
    */
-  "requireAuthentication": false,
+  "requireAuthentication": "${REQUIRE_AUTHENTICATION:false}",
 
   /*
    * Require authorization by a module, or a user with is_admin set, see below.
    */
-  "requireAuthorization": false,
+  "requireAuthorization": "${REQUIRE_AUTHORIZATION:false}",
 
   /*
    * When you use NGINX or another proxy/load-balancer set this to true.
@@ -339,7 +339,7 @@
   /*
    * Privacy: disable IP logging
    */
-  "disableIPlogging": false,
+  "disableIPlogging": "${DISABLE_IP_LOGGING:false}",
 
   /*
    * Time (in seconds) to automatically reconnect pad when a "Force reconnect"
@@ -347,7 +347,7 @@
    *
    * Set to 0 to disable automatic reconnection.
    */
-  "automaticReconnectionTimeout": 0,
+  "automaticReconnectionTimeout": "${AUTOMATIC_RECONNECTION_TIMEOUT:0}",
 
   /*
    * By default, when caret is moved out of viewport, it scrolls the minimum
@@ -365,21 +365,21 @@
      * Set to 0 to disable extra scrolling
      */
     "percentage": {
-      "editionAboveViewport": 0,
-      "editionBelowViewport": 0
+      "editionAboveViewport": "${FOCUS_LINE_PERCENTAGE_ABOVE:0}",
+      "editionBelowViewport": "${FOCUS_LINE_PERCENTAGE_BELOW:0}"
     },
 
     /*
      * Time (in milliseconds) used to animate the scroll transition.
      * Set to 0 to disable animation
      */
-    "duration": 0,
+    "duration": "${FOCUS_LINE_DURATION:0}",
 
     /*
      * Flag to control if it should scroll when user places the caret in the
      * last line of the viewport
      */
-    "scrollWhenCaretIsInTheLastLineOfViewport": false,
+    "scrollWhenCaretIsInTheLastLineOfViewport": "${FOCUS_LINE_CARET_SCROLL:false}",
 
     /*
      * Percentage of viewport height to be additionally scrolled when user
@@ -387,7 +387,7 @@
      *
      * Set to 0 to let the scroll to be handled as default by Etherpad
      */
-    "percentageToScrollWhenUserPressesArrowUp": 0
+    "percentageToScrollWhenUserPressesArrowUp": "${FOCUS_LINE_PERCENTAGE_ARROW_UP:0}"
   },
 
   /*
@@ -426,7 +426,7 @@
    *
    * WARNING: this will disable security on the instance.
    */
-  "loadTest": false,
+  "loadTest": "${LOAD_TEST:false}",
 
   /*
    * Disable indentation on new line when previous line ends with some special
@@ -492,7 +492,7 @@
    *
    * Do not enable on production machines.
    */
-  "exposeVersion": false,
+  "exposeVersion": "${EXPOSE_VERSION:false}",
 
   /*
    * The log level we are using.

--- a/settings.json.template
+++ b/settings.json.template
@@ -56,6 +56,9 @@
  *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
  *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
  *
+ *    If you want to use an empty value (null) as default value for a variable,
+ *    simply do not set it, without putting any colons: "${ABIWORD}".
+ *
  * 3) if you want to use newlines in the default value of a string parameter,
  *    use "\n" as usual.
  *

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -421,6 +421,14 @@ function storeSettings(settingsObj) {
 /*
  * If stringValue is a numeric string, or its value is "true" or "false", coerce
  * them to appropriate JS types. Otherwise return stringValue as-is.
+ *
+ * Please note that this function is used for converting types for default
+ * values in the settings file (for example: "${PORT:9001}"), and that there is
+ * no coercition for "null" values.
+ *
+ * If the user wants a variable to be null by default, he'll have to use the
+ * short syntax "${ABIWORD}", and not "${ABIWORD:null}": the latter would result
+ * in the literal string "null", instead.
  */
 function coerceValue(stringValue) {
     // cooked from https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
@@ -525,7 +533,7 @@ function lookupEnvironmentVariables(obj) {
     const defaultValue = match[3];
 
     if ((envVarValue === undefined) && (defaultValue === undefined)) {
-      console.warn(`Environment variable "${envVarName}" does not contain any value for configuration key "${key}", and no default was given. Returning null. Please check your configuration and environment settings.`);
+      console.warn(`Environment variable "${envVarName}" does not contain any value for configuration key "${key}", and no default was given. Returning null.`);
 
       /*
        * We have to return null, because if we just returned undefined, the


### PR DESCRIPTION
* Refactored docs for env vars using tables
* Added new env vars for nearly all configuration options
* Added possibility to set env setting to `null` using env vars

Please note: I was not able to test everything. Theoretically everything should work.