### PR TITLE
Absolute paths: initial work to allow Etherpad to be run independently on CWD

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -367,7 +367,7 @@ exports.exportAvailable = function() {
 exports.getGitCommit = function() {
   var version = "";
   try {
-    var rootPath = path.resolve(npm.dir, '..');
+    var rootPath = exports.root;
     if (fs.lstatSync(rootPath + '/.git').isFile()) {
       rootPath = fs.readFileSync(rootPath + '/.git', "utf8");
       rootPath = rootPath.split(' ').pop().trim();

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -5,6 +5,7 @@ var fs = require("fs");
 var tsort = require("./tsort");
 var util = require("util");
 var _ = require("underscore");
+var settings = require('../../../node/utils/Settings');
 
 var pluginUtils = require('./shared');
 
@@ -95,7 +96,7 @@ exports.update = async function () {
 
 exports.getPackages = async function () {
   // Load list of installed NPM packages, flatten it to a list, and filter out only packages with names that
-  var dir = path.resolve(npm.dir, '..');
+  var dir = settings.root;
   let data = await util.promisify(readInstalled)(dir);
 
   var packages = {};


### PR DESCRIPTION
At the moment, Etherpad needs to be run from a specific directory, otherwise it stops without any hints of what's happening. In general, having the bahaviour of a program being dependent on CWD is surprising at best, and insecure at worst.

Some of this work already started with the module `AbsolutePaths`, released in **1.7.5**.

This PR moves on in that direction: it is no longer necessary to "cd" to the Etherpad base directory to start it: Etherpad runs from everywhere.

Known issues:
- unless the program is started as before (CWD == base directory) it is still not possible to install & uninstall plugins via the web interface

For this reason, the PR does not change the startup scripts yet.
