### PR TITLE
docker: build & run the container in production mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 #   ETHERPAD_PLUGINS="ep_codepad ep_author_neat"
 ARG ETHERPAD_PLUGINS=
 
-# Set the following to production to avoid installing devDeps
-# this can be done with build args (and is mandatory to build ARM version)
-ENV NODE_ENV=development
+# By default, Etherpad container is built and run in "production" mode. This is
+# leaner (development dependencies are not installed) and runs faster (among
+# other things, assets are minified & compressed).
+ENV NODE_ENV=production
 
 # Follow the principle of least privilege: run as unprivileged user.
 #

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -16,6 +16,7 @@ docker pull etherpad/etherpad:1.8.0
 
 If you want to use a personalized settings file, **you will have to rebuild your image**.
 All of the following instructions are as a member of the `docker` group.
+By default, the Etherpad Docker image is built and run in `production` mode: no development dependencies are installed, and asset bundling speeds up page load time.
 
 ### Rebuilding with custom settings
 Edit `<BASEDIR>/settings.json.docker` at your will. When rebuilding the image, this file will be copied inside your image and renamed to `setting.json`.


### PR DESCRIPTION
This is leaner (no development dependencies are included in the container) and
faster (among other things, assets are minified & compressed).
