### PR TITLE
close all gritters on escape key

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3855,6 +3855,9 @@ function Ace2Inner(){
           fastIncorp(4);
           evt.preventDefault();
           specialHandled = true;
+
+          // close all gritters when the user hits escape key
+          parent.parent.$.gritter.removeAll();
         }
         if ((!specialHandled) && isTypeForCmdKey && String.fromCharCode(which).toLowerCase() == "s" && (evt.metaKey || evt.ctrlKey) && !evt.altKey && padShortcutEnabled.cmdS) /* Do a saved revision on ctrl S */
         {


### PR DESCRIPTION
This PR closes gritter pop ups when your focus is in the editor.  It closes ALL gritter notifications.  

This solves the problem of gritters taking too much focus from the editor, it is an accessibility requirement.