### PR TITLE
append .token when you don't want to disonnect a user if theyare on a pad & timeslider

### DIFF
--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -117,7 +117,7 @@ function sendSocketMsg(type, data)
               "type": type,
               "data": data,
               "padId": padId,
-              "token": token,
+              "token": token + ".timeslider",
               "sessionID": sessionID,
               "password": password,
               "protocolVersion": 2};


### PR DESCRIPTION
For https://github.com/ether/etherpad-lite/issues/753

Still to do:
- [ ] Test to see if it breaks security
- [ ] Test to see if it was this that made timeslider hang in chrome w/ lots of activity / after time.  It might have been the other bug fixed in #3934