### PR TITLE
Fix inconsistencies when deleting content while timeslider is open

### DIFF
--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1529,7 +1529,17 @@ exports.moveOpsToNewPool = function (cs, oldPool, newPool) {
   return upToDollar.replace(/\*([0-9a-z]+)/g, function (_, a) {
     var oldNum = exports.parseNum(a);
     var pair = oldPool.getAttrib(oldNum);
-    if(!pair) exports.error('Can\'t copy unknown attrib (reference attrib string to non-existant pool entry). Inconsistent attrib state!');
+
+    /*
+     * Setting an empty pair. Required for when delete pad contents / attributes
+     * while another user has the timeslider open.
+     *
+     * Fixes https://github.com/ether/etherpad-lite/issues/3932
+     */
+    if (!pair) {
+      pair = [];
+    }
+
     var newNum = newPool.putAttrib(pair);
     return '*' + exports.numToString(newNum);
   }) + fromDollar;


### PR DESCRIPTION
It's a simple fix but it had to be nuanced enough to solve it properly.

Bug Ref: #3932
