### PR TITLE
windows: bump the node version included in the prebuilt package

### DIFF
--- a/bin/buildForWindows.sh
+++ b/bin/buildForWindows.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-NODE_VERSION="10.18.0"
+NODE_VERSION="10.20.1"
 
 #Move to the folder where ep-lite is installed
 cd $(dirname $0)


### PR DESCRIPTION
Bump node windows runtime: **10.18.0** -> **10.20.1**.

This is the latest version as of today.

**n.b.**: I just realized we are shippign the 32 bit version if nodejs. Probably it is time to switch to 64 bits by **1.8.4**.