### PR TITLE
startup: use "npm ci" instead of "npm install" in startup scripts

### DIFF
--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -100,7 +100,7 @@ echo "Ensure that all dependencies are up to date...  If this is the first time 
   cd node_modules
   [ -e ep_etherpad-lite ] || ln -s ../src ep_etherpad-lite
   cd ep_etherpad-lite
-  npm install --save --loglevel warn
+  npm ci
 ) || {
   rm -rf src/node_modules
   exit 1

--- a/bin/installOnWindows.bat
+++ b/bin/installOnWindows.bat
@@ -14,7 +14,7 @@ cd /D node_modules
 mklink /D "ep_etherpad-lite" "..\src"
 
 cd /D "ep_etherpad-lite"
-cmd /C npm install --loglevel warn || exit /B 1
+cmd /C npm ci || exit /B 1
 
 cd /D "%~dp0\.."
 


### PR DESCRIPTION
Advantages:
- reproducible install: every user will have the same, exact install, instead of
  a slightly different one
- speed: installation of dependencies is measurably faster
- explicit: if a user setup is broken, from now on he'll have a clear error
  message

Closes #3778


**TODO**:
Check impact on plugins (both via npm install and the admin interface)