### PR TITLE
DOCS: Basic styles for tables - https://github.com/ether/etherpad-lite/issues/3563

### DIFF
--- a/doc/assets/style.css
+++ b/doc/assets/style.css
@@ -45,3 +45,18 @@ a:hover {
   overflow: auto;
   padding: 5px;
 }
+
+table, th, td {
+  text-align: left;
+  border: 1px solid gray;
+  border-collapse: collapse;
+}
+
+th {
+  padding: 0.5em;
+  background: #EEE;
+}
+
+td {
+  padding: 0.5em;
+}


### PR DESCRIPTION
**Details**

Basic styles for tables in documentation to improve readability.

![image](https://user-images.githubusercontent.com/7405383/80390607-51bcb080-88b5-11ea-8314-5be8bc5a6fb5.png)

Related to:

* https://github.com/ether/etherpad-lite/issues/3563