### PR TITLE
Add etherpad update check

### DIFF
--- a/src/node/hooks/express/adminplugins.js
+++ b/src/node/hooks/express/adminplugins.js
@@ -4,6 +4,7 @@ var installer = require('ep_etherpad-lite/static/js/pluginfw/installer');
 var plugins = require('ep_etherpad-lite/static/js/pluginfw/plugins');
 var _ = require('underscore');
 var semver = require('semver');
+const UpdateCheck = require('ep_etherpad-lite/node/utils/UpdateCheck');
 
 exports.expressCreateServer = function(hook_name, args, cb) {
   args.app.get('/admin/plugins', function(req, res) {
@@ -23,7 +24,8 @@ exports.expressCreateServer = function(hook_name, args, cb) {
 
     res.send(eejs.require("ep_etherpad-lite/templates/admin/plugins-info.html", {
       gitCommit: gitCommit,
-      epVersion: epVersion
+      epVersion: epVersion,
+      latestVersion: UpdateCheck.getLatestVersion()
     }));
   });
 }

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -21,8 +21,9 @@
  * limitations under the License.
  */
 
-var log4js = require('log4js')
+const log4js = require('log4js')
   , NodeVersion = require('./utils/NodeVersion')
+  , UpdateCheck = require('./utils/UpdateCheck')
   ;
 
 log4js.replaceConsole();
@@ -37,6 +38,9 @@ NodeVersion.enforceMinNodeVersion('10.13.0');
  * Etherpad 1.8.3 will require at least nodejs 10.13.0.
  */
 NodeVersion.checkDeprecationStatus('10.13.0', '1.8.3');
+
+// Check if Etherpad version is up-to-date
+UpdateCheck.check();
 
 /*
  * start up stats counting system

--- a/src/node/utils/UpdateCheck.js
+++ b/src/node/utils/UpdateCheck.js
@@ -1,0 +1,44 @@
+const semver = require('semver');
+const settings = require('./Settings');
+const request = require('request');
+
+let infos;
+
+function loadEtherpadInformations() {
+  return new Promise(function(resolve, reject) {
+    request('https://static.etherpad.org/info.json', function (er, response, body) {
+      if (er) return reject(er);
+
+      try {
+        infos = JSON.parse(body);
+        return resolve(infos);
+      } catch (err) {
+        return reject(err);
+      }
+    });
+  })
+}
+
+exports.getLatestVersion = function() {
+  exports.needsUpdate();
+  return infos.latestVersion;
+}
+
+exports.needsUpdate = function(cb) {
+  loadEtherpadInformations().then(function(info) {
+    if (semver.gt(info.latestVersion, settings.getEpVersion())) {
+      if (cb) return cb(true);
+    }
+  }).catch(function (err) {
+    console.error('Can not perform Etherpad update check: ' + err)
+    if (cb) return cb(false);
+  })
+}
+
+exports.check = function() {
+  exports.needsUpdate(function (needsUpdate) {
+    if (needsUpdate) {
+      console.warn('Update available: Download the actual version ' + infos.latestVersion)
+    }
+  })
+}

--- a/src/templates/admin/plugins-info.html
+++ b/src/templates/admin/plugins-info.html
@@ -24,6 +24,7 @@
       <div class="innerwrapper">
         <h2>Etherpad version</h2>
         <p>Version number: <%= epVersion %></p>
+        <p>Latest available version: <%= latestVersion %></p>
         <p>Git sha: <a href='https://github.com/ether/etherpad-lite/commit/<%= gitCommit %>'><%= gitCommit %></a></p>
 
         <h2>Installed plugins</h2>


### PR DESCRIPTION
This PR checks on static.etherpad.org for the latest etherpad version and will show a hint in the console at runtime and on the troubleshooting page in the admin area.

closes #3937
