### PR TITLE
Csp nonce - Security! - Ready for Review/Merge

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -286,6 +286,6 @@ exports.doImport = function (req, res, padId)
     }
   }).then(() => {
     // close the connection
-    res.send("<script>document.addEventListener('DOMContentLoaded', function(){ var impexp = window.parent.padimpexp.handleFrameCall('" + req.directDatabaseAccess +"', '" + status + "'); })</script>");
+    res.send("<script nonce='"+settings.nonce.importFrame || ''+"'>document.addEventListener('DOMContentLoaded', function(){ var impexp = window.parent.padimpexp.handleFrameCall('" + req.directDatabaseAccess +"', '" + status + "'); })</script>");
   });
 }

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -35,7 +35,7 @@ var _ = require('./underscore');
 
 function scriptTag(source) {
   return (
-    '<script type="text/javascript">\n'
+    '<script type="text/javascript" nonce="aceTemporaryNonce">\n'
     + source.replace(/<\//g, '<\\/') +
     '</script>'
   )

--- a/src/static/js/admin/jquery.autosize.js
+++ b/src/static/js/admin/jquery.autosize.js
@@ -1,20 +1,21 @@
-// Autosize 1.13 - jQuery plugin for textareas
-// (c) 2012 Jack Moore - jacklmoore.com
-// license: www.opensource.org/licenses/mit-license.php
-
+/*!
+	Autosize 1.18.18
+	license: MIT
+	http://www.jacklmoore.com/autosize
+*/
 (function ($) {
 	var
 	defaults = {
 		className: 'autosizejs',
-		append: "",
-		callback: false
+		id: 'autosizejs',
+		append: '\n',
+		callback: false,
+		resizeDelay: 10,
+		placeholder: true
 	},
-	hidden = 'hidden',
-	borderBox = 'border-box',
-	lineHeight = 'lineHeight',
-	copy = '<textarea tabindex="-1" style="position:absolute; top:-9999px; left:-9999px; right:auto; bottom:auto; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden;"/>',
-	// line-height is omitted because IE7/IE8 doesn't return the correct value.
-	copyStyle = [
+
+	// line-height is conditionally included because IE7/IE8/old Opera do not return the correct value.
+	typographyStyles = [
 		'fontFamily',
 		'fontSize',
 		'fontWeight',
@@ -22,159 +23,251 @@
 		'letterSpacing',
 		'textTransform',
 		'wordSpacing',
-		'textIndent'
+		'textIndent',
+		'whiteSpace'
 	],
-	oninput = 'oninput',
-	onpropertychange = 'onpropertychange',
-	test = $(copy)[0];
 
-	// For testing support in old FireFox
-	test.setAttribute(oninput, "return");
+	// to keep track which textarea is being mirrored when adjust() is called.
+	mirrored,
 
-	if ($.isFunction(test[oninput]) || onpropertychange in test) {
+	// the mirror element, which is used to calculate what size the mirrored element should be.
+	mirror = $('<textarea tabindex="-1"/>').data('autosize', true)[0];
 
-		// test that line-height can be accurately copied to avoid
-		// incorrect value reporting in old IE and old Opera
-		$(test).css(lineHeight, '99px');
-		if ($(test).css(lineHeight) === '99px') {
-			copyStyle.push(lineHeight);
+	// border:0 is unnecessary, but avoids a bug in Firefox on OSX
+	mirror.style.cssText = "position:absolute; top:-999px; left:0; right:auto; bottom:auto; border:0; padding: 0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden; transition:none; -webkit-transition:none; -moz-transition:none;";
+
+	// test that line-height can be accurately copied.
+	mirror.style.lineHeight = '99px';
+	if ($(mirror).css('lineHeight') === '99px') {
+		typographyStyles.push('lineHeight');
+	}
+	mirror.style.lineHeight = '';
+
+	$.fn.autosize = function (options) {
+		if (!this.length) {
+			return this;
 		}
 
-		$.fn.autosize = function (options) {
-			options = $.extend({}, defaults, options || {});
+		options = $.extend({}, defaults, options || {});
 
-			return this.each(function () {
-				var
-				ta = this,
-				$ta = $(ta),
-				mirror,
-				minHeight = $ta.height(),
-				maxHeight = parseInt($ta.css('maxHeight'), 10),
-				active,
-				i = copyStyle.length,
-				resize,
-				boxOffset = 0,
-				value = ta.value,
-				callback = $.isFunction(options.callback);
+		if (mirror.parentNode !== document.body) {
+			$(document.body).append(mirror);
+		}
 
-				if ($ta.css('box-sizing') === borderBox || $ta.css('-moz-box-sizing') === borderBox || $ta.css('-webkit-box-sizing') === borderBox){
-					boxOffset = $ta.outerHeight() - $ta.height();
-				}
+		return this.each(function () {
+			var
+			ta = this,
+			$ta = $(ta),
+			maxHeight,
+			minHeight,
+			boxOffset = 0,
+			callback = $.isFunction(options.callback),
+			originalStyles = {
+				height: ta.style.height,
+				overflow: ta.style.overflow,
+				overflowY: ta.style.overflowY,
+				wordWrap: ta.style.wordWrap,
+				resize: ta.style.resize
+			},
+			timeout,
+			width = $ta.width(),
+			taResize = $ta.css('resize');
 
-				if ($ta.data('mirror') || $ta.data('ismirror')) {
-					// if autosize has already been applied, exit.
-					// if autosize is being applied to a mirror element, exit.
-					return;
-				} else {
-					mirror = $(copy).data('ismirror', true).addClass(options.className)[0];
+			if ($ta.data('autosize')) {
+				// exit if autosize has already been applied, or if the textarea is the mirror element.
+				return;
+			}
+			$ta.data('autosize', true);
 
-					resize = $ta.css('resize') === 'none' ? 'none' : 'horizontal';
+			if ($ta.css('box-sizing') === 'border-box' || $ta.css('-moz-box-sizing') === 'border-box' || $ta.css('-webkit-box-sizing') === 'border-box'){
+				boxOffset = $ta.outerHeight() - $ta.height();
+			}
 
-					$ta.data('mirror', $(mirror)).css({
-						overflow: hidden,
-						overflowY: hidden,
-						wordWrap: 'break-word',
-						resize: resize
-					});
-				}
+			// IE8 and lower return 'auto', which parses to NaN, if no min-height is set.
+			minHeight = Math.max(parseFloat($ta.css('minHeight')) - boxOffset || 0, $ta.height());
 
-				// Opera returns '-1px' when max-height is set to 'none'.
-				maxHeight = maxHeight && maxHeight > 0 ? maxHeight : 9e4;
+			$ta.css({
+				overflow: 'hidden',
+				overflowY: 'hidden',
+				wordWrap: 'break-word' // horizontal overflow is hidden, so break-word is necessary for handling words longer than the textarea width
+			});
 
-				// Using mainly bare JS in this function because it is going
-				// to fire very often while typing, and needs to very efficient.
-				function adjust() {
-					var height, overflow, original;
+			if (taResize === 'vertical') {
+				$ta.css('resize','none');
+			} else if (taResize === 'both') {
+				$ta.css('resize', 'horizontal');
+			}
 
-					// the active flag keeps IE from tripping all over itself.  Otherwise
-					// actions in the adjust function will cause IE to call adjust again.
-					if (!active) {
-						active = true;
-						mirror.value = ta.value + options.append;
-						mirror.style.overflowY = ta.style.overflowY;
-						original = parseInt(ta.style.height,10);
+			// getComputedStyle is preferred here because it preserves sub-pixel values, while jQuery's .width() rounds to an integer.
+			function setWidth() {
+				var width;
+				var style = window.getComputedStyle ? window.getComputedStyle(ta, null) : null;
 
-						// Update the width in case the original textarea width has changed
-						mirror.style.width = $ta.css('width');
-
-						// Needed for IE to reliably return the correct scrollHeight
-						mirror.scrollTop = 0;
-
-						// Set a very high value for scrollTop to be sure the
-						// mirror is scrolled all the way to the bottom.
-						mirror.scrollTop = 9e4;
-
-						height = mirror.scrollTop;
-						overflow = hidden;
-						if (height > maxHeight) {
-							height = maxHeight;
-							overflow = 'scroll';
-						} else if (height < minHeight) {
-							height = minHeight;
-						}
-						height += boxOffset;
-						ta.style.overflowY = overflow;
-
-						if (original !== height) {
-							ta.style.height = height + 'px';
-							if (callback) {
-								options.callback.call(ta);
-							}
-						}
-						
-						// This small timeout gives IE a chance to draw it's scrollbar
-						// before adjust can be run again (prevents an infinite loop).
-						setTimeout(function () {
-							active = false;
-						}, 1);
+				if (style) {
+					width = parseFloat(style.width);
+					if (style.boxSizing === 'border-box' || style.webkitBoxSizing === 'border-box' || style.mozBoxSizing === 'border-box') {
+						$.each(['paddingLeft', 'paddingRight', 'borderLeftWidth', 'borderRightWidth'], function(i,val){
+							width -= parseFloat(style[val]);
+						});
 					}
+				} else {
+					width = $ta.width();
 				}
+
+				mirror.style.width = Math.max(width,0) + 'px';
+			}
+
+			function initMirror() {
+				var styles = {};
+
+				mirrored = ta;
+				mirror.className = options.className;
+				mirror.id = options.id;
+				maxHeight = parseFloat($ta.css('maxHeight'));
 
 				// mirror is a duplicate textarea located off-screen that
 				// is automatically updated to contain the same text as the
 				// original textarea.  mirror always has a height of 0.
 				// This gives a cross-browser supported way getting the actual
 				// height of the text, through the scrollTop property.
-				while (i--) {
-					mirror.style[copyStyle[i]] = $ta.css(copyStyle[i]);
+				$.each(typographyStyles, function(i,val){
+					styles[val] = $ta.css(val);
+				});
+
+				$(mirror).css(styles).attr('wrap', $ta.attr('wrap'));
+
+				setWidth();
+
+				// Chrome-specific fix:
+				// When the textarea y-overflow is hidden, Chrome doesn't reflow the text to account for the space
+				// made available by removing the scrollbar. This workaround triggers the reflow for Chrome.
+				if (window.chrome) {
+					var width = ta.style.width;
+					ta.style.width = '0px';
+					var ignore = ta.offsetWidth;
+					ta.style.width = width;
 				}
+			}
 
-				$('body').append(mirror);
+			// Using mainly bare JS in this function because it is going
+			// to fire very often while typing, and needs to very efficient.
+			function adjust() {
+				var height, originalHeight;
 
-				if (onpropertychange in ta) {
-					if (oninput in ta) {
-						// Detects IE9.  IE9 does not fire onpropertychange or oninput for deletions,
-						// so binding to onkeyup to catch most of those occassions.  There is no way that I
-						// know of to detect something like 'cut' in IE9.
-						ta[oninput] = ta.onkeyup = adjust;
-					} else {
-						// IE7 / IE8
-						ta[onpropertychange] = adjust;
-					}
+				if (mirrored !== ta) {
+					initMirror();
 				} else {
-					// Modern Browsers
-					ta[oninput] = adjust;
-
-					// The textarea overflow is now hidden.  But Chrome doesn't reflow the text after the scrollbars are removed.
-					// This is a hack to get Chrome to reflow it's text.
-					ta.value = '';
-					ta.value = value;
+					setWidth();
 				}
 
-				$(window).resize(adjust);
+				if (!ta.value && options.placeholder) {
+					// If the textarea is empty, copy the placeholder text into
+					// the mirror control and use that for sizing so that we
+					// don't end up with placeholder getting trimmed.
+					mirror.value = ($ta.attr("placeholder") || '');
+				} else {
+					mirror.value = ta.value;
+				}
 
-				// Allow for manual triggering if needed.
-				$ta.bind('autosize', adjust);
+				mirror.value += options.append || '';
+				mirror.style.overflowY = ta.style.overflowY;
+				originalHeight = parseFloat(ta.style.height) || 0;
 
-				// Call adjust in case the textarea already contains text.
+				// Setting scrollTop to zero is needed in IE8 and lower for the next step to be accurately applied
+				mirror.scrollTop = 0;
+
+				mirror.scrollTop = 9e4;
+
+				// Using scrollTop rather than scrollHeight because scrollHeight is non-standard and includes padding.
+				height = mirror.scrollTop;
+
+				if (maxHeight && height > maxHeight) {
+					ta.style.overflowY = 'scroll';
+					height = maxHeight;
+				} else {
+					ta.style.overflowY = 'hidden';
+					if (height < minHeight) {
+						height = minHeight;
+					}
+				}
+
+				height += boxOffset;
+
+				if (Math.abs(originalHeight - height) > 1/100) {
+					ta.style.height = height + 'px';
+
+					// Trigger a repaint for IE8 for when ta is nested 2 or more levels inside an inline-block
+					mirror.className = mirror.className;
+
+					if (callback) {
+						options.callback.call(ta,ta);
+					}
+					$ta.trigger('autosize.resized');
+				}
+			}
+
+			function resize () {
+				clearTimeout(timeout);
+				timeout = setTimeout(function(){
+					var newWidth = $ta.width();
+
+					if (newWidth !== width) {
+						width = newWidth;
+						adjust();
+					}
+				}, parseInt(options.resizeDelay,10));
+			}
+
+			if ('onpropertychange' in ta) {
+				if ('oninput' in ta) {
+					// Detects IE9.  IE9 does not fire onpropertychange or oninput for deletions,
+					// so binding to onkeyup to catch most of those occasions.  There is no way that I
+					// know of to detect something like 'cut' in IE9.
+					$ta.on('input.autosize keyup.autosize', adjust);
+				} else {
+					// IE7 / IE8
+					$ta.on('propertychange.autosize', function(){
+						if(event.propertyName === 'value'){
+							adjust();
+						}
+					});
+				}
+			} else {
+				// Modern Browsers
+				$ta.on('input.autosize', adjust);
+			}
+
+			// Set options.resizeDelay to false if using fixed-width textarea elements.
+			// Uses a timeout and width check to reduce the amount of times adjust needs to be called after window resize.
+
+			if (options.resizeDelay !== false) {
+				$(window).on('resize.autosize', resize);
+			}
+
+			// Event for manual triggering if needed.
+			// Should only be needed when the value of the textarea is changed through JavaScript rather than user input.
+			$ta.on('autosize.resize', adjust);
+
+			// Event for manual triggering that also forces the styles to update as well.
+			// Should only be needed if one of typography styles of the textarea change, and the textarea is already the target of the adjust method.
+			$ta.on('autosize.resizeIncludeStyle', function() {
+				mirrored = null;
 				adjust();
 			});
-		};
-	} else {
-		// Makes no changes for older browsers (FireFox3- and Safari4-)
-		$.fn.autosize = function (callback) {
-			return this;
-		};
-	}
 
-}(jQuery));
+			$ta.on('autosize.destroy', function(){
+				mirrored = null;
+				clearTimeout(timeout);
+				$(window).off('resize', resize);
+				$ta
+					.off('autosize')
+					.off('.autosize')
+					.css(originalStyles)
+					.removeData('autosize');
+			});
+
+			// Call adjust in case the textarea already contains text.
+			adjust();
+		});
+	};
+}(jQuery || $)); // jQuery or jQuery-like library, such as Zepto

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -5,7 +5,7 @@
 <html>
 
         <title><%=settings.title%></title>
-    <script>
+    <script nonce="<%=settings.nonce && settings.nonce.padLicense || ''%>">
       /*
       |@licstart  The following is the entire license notice for the
       JavaScript code in this page.|
@@ -167,10 +167,10 @@
                     <% if (settings.editOnly) { %>
                         <label id="label" for="padname" data-l10n-id="index.openPad"></label>
                     <% } else {%>
-                        <button id="button" onclick="go2Random()" data-l10n-id="index.newPad"></button>
+                        <button id="button" data-l10n-id="index.newPad"></button>
                         <label id="label" for="padname" data-l10n-id="index.createOpenPad"></label>
                     <% } %>
-                    <form action="#" onsubmit="go2Name();return false;">
+                        <form id="form" action="#">
                         <input type="text" id="padname" maxlength="50" autofocus x-webkit-speech>
                         <button type="submit">OK</button>
                     </form>
@@ -182,7 +182,18 @@
         <% e.begin_block("indexCustomScripts"); %>
         <script src="static/skins/<%=encodeURI(settings.skinName)%>/index.js?v=<%=settings.randomVersionString%>"></script>
         <% e.end_block(); %>
-        <script>
+        <script nonce="<%=settings.nonce && settings.nonce.index || ''%>">
+
+            var button = document.getElementById("button");
+            button.onclick = function(){
+              go2Random();
+            }
+
+            var form = document.getElementById("form");
+            form.onsubmit = function(){
+              go2Name();return false;
+            }
+
             // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             <% e.begin_block("indexCustomInlineScripts"); %>
             function go2Name()

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -11,7 +11,7 @@
 <% e.end_block(); %>
 
   <title><%=settings.title%></title>
-  <script>
+  <script nonce="<%=settings.nonce && settings.nonce.padLicense || ''%>">
     /*
     |@licstart  The following is the entire license notice for the
     JavaScript code in this page.|
@@ -443,7 +443,7 @@
   <!-- Include pad_utils manually -->
   <script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/pad_utils.js?callback=require.define&v=<%=settings.randomVersionString%>"></script>
 
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="<%=settings.nonce && settings.nonce.padErrorHandler || ''%>">
       // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
       (function() {
         // Display errors on page load to the user
@@ -472,7 +472,7 @@
   <% e.end_block(); %>
 
   <!-- Bootstrap page -->
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="<%=settings.nonce && settings.nonce.padBootstrap || ''%>">
       // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
       var clientVars = {};
       (function () {

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -5,7 +5,7 @@
 <!doctype html>
 <html class="<%=settings.skinVariants%>">
 <title data-l10n-id="timeslider.pageTitle" data-l10n-args='{ "appTitle": "<%=settings.title%>" }'><%=settings.title%> Timeslider</title>
-<script>
+<script nonce="<%=settings.nonce && settings.nonce.timesliderLicense || ''%>">
   /*
   |@licstart  The following is the entire license notice for the
   JavaScript code in this page.|
@@ -258,7 +258,7 @@
 <script type="text/javascript" src="../../static/skins/<%=encodeURI(settings.skinName)%>/timeslider.js?v=<%=settings.randomVersionString%>"></script>
 
 <!-- Bootstrap -->
-<script type="text/javascript" >
+<script type="text/javascript" nonce="<%=settings.nonce && settings.nonce.timesliderBootstrap || ''%>">
   // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
   var clientVars = {};
   var BroadcastSlider;


### PR DESCRIPTION
This provides CSP functionality inside of Etherpad

Etherpad has a lot of inline JS, instead of removing it (which would be nice but not required) CSP provides the functionality to generate a nonce (generated using the ep_helmet plugin) and providing that to the page.

Pages tested and fixed:
- [x] Index
- [x] Pad
- [x] Timeslider
- [x] Pad Import
- [x] Admin pages
- [x] Test pages (known broken but WIP on another branch so don't want to work on it)
- [x] A bunch of plugins.
- [ ] Ace has a placeholder Nonce in for when it renders the outerHTML to the page.  I can't find a good way for this but I'm not actually convinced it's exploitable...

Required for https://github.com/ether/etherpad-lite/issues/3094