### PR TITLE
Setting for allowing import - Ready for Review / Merge

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -467,6 +467,19 @@
    */
   "importMaxFileSize": 52428800, // 50 * 1024 * 1024
 
+
+  /*
+   * From Etherpad 1.8.3 onwards import was restricted to authors who had
+   * content within the pad.
+   *
+   * This setting will override that restriction and allow any user to import
+   * without the requirement to add content to a pad.
+   *
+   * This setting is useful for when you use a plugin for authentication so you
+   * can already trust each user.
+   */
+  "allowAnyoneToImport": false, 
+
   /*
    * Toolbar buttons configuration.
    *

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1131,6 +1131,7 @@ async function handleClientReady(client, message)
       },
       "initialChangesets": [], // FIXME: REMOVE THIS SHIT
       "thisUserHasEditedThisPad": thisUserHasEditedThisPad,
+      "allowAnyoneToImport": settings.allowAnyoneToImport
     }
 
     // Add a username to the clientVars if one avaiable

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -83,20 +83,20 @@ exports.expressCreateServer = function (hook_name, args, cb) {
 
       let author = await authorManager.getAuthor4Token(req.cookies.token);
       // author is of the form: "a.g2droBYw1prY7HW9"
-      if (!author) {
+      if (!author && !settings.allowAnyoneToImport) {
         console.warn(`Unable to import file into "${req.params.pad}". No Author found for token ${req.cookies.token}`);
 
         return next();
       }
 
       let authorsPads = await authorManager.listPadsOfAuthor(author);
-      if (!authorsPads) {
+      if (!authorsPads && !settings.allowAnyoneToImport) {
         console.warn(`Unable to import file into "${req.params.pad}". Author "${author}" exists but he never contributed to any pad`);
         return next();
       }
 
       let authorsPadIDs = authorsPads.padIDs;
-      if (authorsPadIDs.indexOf(req.params.pad) === -1) {
+      if ( (authorsPadIDs.indexOf(req.params.pad) === -1) && !settings.allowAnyoneToImport) {
         console.warn(`Unable to import file into "${req.params.pad}". Author "${author}" exists but he never contributed to this pad`);
         return next();
       }

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -346,6 +346,20 @@ exports.importExportRateLimiting = {
  */
 exports.importMaxFileSize = 50 * 1024 * 1024;
 
+
+/*
+ * From Etherpad 1.8.3 onwards import was restricted to authors who had
+ * content within the pad.
+ *
+ * This setting will override that restriction and allow any user to import
+ * without the requirement to add content to a pad.
+ *
+ * This setting is useful for when you use a plugin for authentication so you
+ * can already trust each user.
+ */
+exports.allowAnyoneToImport = false,
+
+
 // checks if abiword is avaiable
 exports.abiwordAvailable = function()
 {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -408,7 +408,7 @@ var padeditbar = (function()
     toolbar.registerCommand("import_export", function () {
       toolbar.toggleDropDown("import_export", function(){
 
-        if (clientVars.thisUserHasEditedThisPad) {
+        if (clientVars.thisUserHasEditedThisPad || clientVars.allowAnyoneToImport) {
           // the user has edited this pad historically or in this session
           $('#importform').show();
           $('#importmessagepermission').hide();


### PR DESCRIPTION
https://github.com/ether/etherpad-lite/issues/3964

Reasoning:  If you have already authed a user you can assume they are "trusted".  So a setting to override this is fine for instances which use an authentication plugin.