### PR TITLE
timeslider: important fix pad content was cropped 

### DIFF
--- a/src/static/css/timeslider.css
+++ b/src/static/css/timeslider.css
@@ -2,9 +2,6 @@
   padding: 10px;
   display: block;
 }
-#innerdocbody {
-  margin: 0 auto;
-}
 
 .timeslider-bar {
   display: flex;
@@ -128,7 +125,8 @@
   white-space: normal;
   word-break: break-word;
   width: 100%;
-  height: 100%;
+  margin: 0 auto;
+  height: auto;
 }
 
 @media (max-width: 800px) {


### PR DESCRIPTION
If the pad is bigger than height of screen, is was cropped (impossible to access the bottom). Fixed now