### PR TITLE
ui: hide create/open pad buttons on index page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "index.newPad": "New Pad",
   "index.createOpenPad": "or create/open a Pad with the name:",
+  "index.openPad": "open an existing Pad with the name:",
 
   "pad.toolbar.bold.title": "Bold (Ctrl+B)",
   "pad.toolbar.italic.title": "Italic (Ctrl+I)",

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -161,12 +161,18 @@
         <div id="wrapper">
         <% e.begin_block("indexWrapper"); %>
             <div id="inner">
-                <button id="button" onclick="go2Random()" data-l10n-id="index.newPad"></button>
-                <label id="label" for="padname" data-l10n-id="index.createOpenPad"></label>
-                <form action="#" onsubmit="go2Name();return false;">
-                    <input type="text" id="padname" maxlength="50" autofocus x-webkit-speech>
-                    <button type="submit">OK</button>
-                </form>
+                <% if (!settings.requireSession) { %>
+                    <% if (settings.editOnly) { %>
+                        <label id="label" for="padname" data-l10n-id="index.openPad"></label>
+                    <% } else {%>
+                        <button id="button" onclick="go2Random()" data-l10n-id="index.newPad"></button>
+                        <label id="label" for="padname" data-l10n-id="index.createOpenPad"></label>
+                    <% } %>
+                    <form action="#" onsubmit="go2Name();return false;">
+                        <input type="text" id="padname" maxlength="50" autofocus x-webkit-speech>
+                        <button type="submit">OK</button>
+                    </form>
+                <% } %>
             </div>
         <% e.end_block(); %>
         </div>


### PR DESCRIPTION
Hide create/open pad buttons on index page since when requireSession or editOnly is set these buttons always fail

fixes #3970

This hides the buttons solely based on the settings and not depending on wether there is a session or not but i didn't know how to check that.

I also added a new translation key but only in en.json

Tests seem to be unaffected but it's hard to tell since running them multiple times results in different failures.
