### PR TITLE
ueberdb: update 0.4.5 -> 0.4.9 to fix a performance regression

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -413,9 +413,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "13.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
+      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
     },
     "@types/request": {
       "version": "2.48.4",
@@ -7334,9 +7334,9 @@
       }
     },
     "ueberdb2": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/ueberdb2/-/ueberdb2-0.4.5.tgz",
-      "integrity": "sha512-D8TogZ6Dc4Ot909b0D0QQRSanVB3W4EtqA8smKEZS7H5eIbAWFOyBF74XADIB9f+NASSjdu8DU3EJeKe9Xdzjg==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/ueberdb2/-/ueberdb2-0.4.9.tgz",
+      "integrity": "sha512-ZP7jhNtc7N3qogp9EYqBffC55KaxGZH3AgupzMh01DUr/E8QV2BU4THBpUVVJUGgoSBU8XxTkTMY9GOakJUTyA==",
       "requires": {
         "async": "^3.2.0",
         "cassandra-driver": "^4.5.0",

--- a/src/package.json
+++ b/src/package.json
@@ -61,7 +61,7 @@
     "slide": "1.1.6",
     "socket.io": "2.1.1",
     "tinycon": "0.0.1",
-    "ueberdb2": "0.4.5",
+    "ueberdb2": "0.4.9",
     "uglify-js": "3.8.1",
     "underscore": "1.8.3",
     "unorm": "1.4.1"


### PR DESCRIPTION
This PR resolves a performance regression on MySQL introduced in ueberDb **0.4.5** (which was released as part of Etherpad **1.8.3**), bumping ueberDb to **0.4.9**.

This PR replaces #3952, in order to also include https://github.com/ether/ueberDB/issues/127 (backport of the performance fix on `bulkDelete()`). It also resolves merge conflicts on `package-lock.json`.

For a discussion on the performance fix, please see https://github.com/ether/ueberDB/commit/7762f0096458bcb1ada3ad634d1a43f99a1354f0 and the issue that came out of it: https://github.com/ether/ueberDB/issues/125.
