### PR TITLE
Fix/fonts behind reverse proxy when minify = true

### DIFF
--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1076,6 +1076,7 @@ async function handleClientReady(client, message)
     var clientVars = {
       "skinName": settings.skinName,
       "skinVariants": settings.skinVariants,
+      "randomVersionString": settings.randomVersionString,
       "accountPrivs": {
           "maxRevisions": 100
       },

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -426,17 +426,17 @@ function compressCSS(filename, content, callback)
     /*
      * Changes done to migrate CleanCSS 3.x -> 4.x:
      *
-     * 1. Disabling rebase is necessary because otherwise the URLs for the web
-     *    fonts become wrong.
+     * 1. Rework the rebase logic, because the API was simplified (but we have
+     *    less control now). See:
+     *    https://github.com/jakubpawlowicz/clean-css/blob/08f3a74925524d30bbe7ac450979de0a8a9e54b2/README.md#important-40-breaking-changes
      *
-     *    EXAMPLE 1:
-     *        /static/css/src/static/font/fontawesome-etherpad.woff
-     *      instead of
-     *        /static/font/fontawesome-etherpad.woff
-     *    EXAMPLE 2 (this is more surprising):
-     *        /p/src/static/font/opendyslexic.otf
-     *      instead of
-     *        /static/font/opendyslexic.otf
+     *    EXAMPLE:
+     *        The URLs contained in a CSS file (including all the stylesheets
+     *        imported by it) residing on disk at:
+     *            /home/muxator/etherpad/src/static/css/pad.css
+     *
+     *        Will be rewritten rebasing them to:
+     *            /home/muxator/etherpad/src/static/css
      *
      * 2. CleanCSS.minify() can either receive a string containing the CSS, or
      *    an array of strings. In that case each array element is interpreted as
@@ -447,7 +447,13 @@ function compressCSS(filename, content, callback)
      *    "content" argument, but we have to wrap the absolute path to the CSS
      *    in an array and ask the library to read it by itself.
      */
-    new CleanCSS({rebase: false}).minify([absPath], function (errors, minified) {
+
+    const basePath = path.dirname(absPath);
+
+    new CleanCSS({
+      rebase: true,
+      rebaseTo: basePath,
+    }).minify([absPath], function (errors, minified) {
       if (errors) {
         // on error, just yield the un-minified original, but write a log message
         console.error(`CleanCSS.minify() returned an error on ${filename} (${absPath}): ${errors}`);

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -237,7 +237,7 @@ function Ace2Editor()
 
       // disableCustomScriptsAndStyles can be used to disable loading of custom scripts
       if(!clientVars.disableCustomScriptsAndStyles){
-        $$INCLUDE_CSS("../static/css/pad.css");
+        $$INCLUDE_CSS("../static/css/pad.css?v=" + clientVars.randomVersionString);
       }
 
       var additionalCSS = _(hooks.callAll("aceEditorCSS")).map(function(path){
@@ -247,7 +247,7 @@ function Ace2Editor()
         return '../static/plugins/' + path;
       });
       includedCSS = includedCSS.concat(additionalCSS);
-      $$INCLUDE_CSS("../static/skins/" + clientVars.skinName + "/pad.css");
+      $$INCLUDE_CSS("../static/skins/" + clientVars.skinName + "/pad.css?v=" + clientVars.randomVersionString);
 
       pushStyleTagsFor(iframeHTML, includedCSS);
 
@@ -321,7 +321,7 @@ window.onload = function () {\n\
       var includedCSS = [];
       var $$INCLUDE_CSS = function(filename) {includedCSS.push(filename)};
       $$INCLUDE_CSS("../static/css/iframe_editor.css");
-      $$INCLUDE_CSS("../static/css/pad.css");
+      $$INCLUDE_CSS("../static/css/pad.css?v=" + clientVars.randomVersionString);
 
 
       var additionalCSS = _(hooks.callAll("aceEditorCSS")).map(function(path){
@@ -331,7 +331,7 @@ window.onload = function () {\n\
         return '../static/plugins/' + path }
       );
       includedCSS = includedCSS.concat(additionalCSS);
-      $$INCLUDE_CSS("../static/skins/" + clientVars.skinName + "/pad.css");
+      $$INCLUDE_CSS("../static/skins/" + clientVars.skinName + "/pad.css?v=" + clientVars.randomVersionString);
 
       pushStyleTagsFor(outerHTML, includedCSS);
 


### PR DESCRIPTION
This is a proposal to fix #3956.

There is:

1. a problem of cache busting in ace.js left open by 95fd5ce2a45e;
2. 4177b3f9434 moved the font-face declarations from `src/static/css/pad.css` to two
imported files in a different directory, and this requires a rebase on clean-css.

Tested the following 4 combinations with **Firefox 75** on linux:

- minify: **true**|**false**
- directly invoking http://localhost:9001/p/somepad and http://localhost/pad/foo/p/somepad using the following nginx configuration:

  ```nginx
  server {
          listen       80;
          server_name  pad.example.com;

          access_log  /var/log/nginx/eplite.access.log;
          error_log   /var/log/nginx/eplite.error.log;

      location /pad/foo {
          rewrite                /pad/foo/(.*) /$1 break;
          rewrite                ^/pad/foo$ /pad/foo permanent;
          proxy_pass             http://localhost:9001/;
          proxy_pass_header Server;
          proxy_redirect         / /pad/foo;
          proxy_set_header       Host $host;
          proxy_buffering off;
      }

      location /pad/foo/socket.io {
          rewrite /pad/foo/socket.io/(.*) /socket.io/$1 break;
          proxy_pass http://localhost:9001/;
          proxy_redirect         / /pad/foo/;
          proxy_set_header Host $host;
          proxy_buffering off;
          proxy_set_header Host $host;  # pass the host header
          proxy_http_version 1.1;  # recommended with keepalive connections
          # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
          proxy_set_header Upgrade $http_upgrade;
          proxy_set_header Connection $connection_upgrade;
      }
  }
  ```
