### PR TITLE
Docker: Add args for customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,25 @@ ENV NODE_ENV=production
 #
 # Running as non-root enables running this image in platforms like OpenShift
 # that do not allow images running as root.
-RUN useradd --uid 5001 --create-home etherpad
+#
+# If any of the following args are set to the empty string, default
+# values will be chosen.
+ARG EP_HOME=
+ARG EP_UID=5001
+ARG EP_GID=0
+ARG EP_SHELL=
+RUN groupadd --system ${EP_GID:+--gid "${EP_GID}" --non-unique} etherpad && \
+    useradd --system ${EP_UID:+--uid "${EP_UID}" --non-unique} --gid etherpad \
+        ${EP_HOME:+--home-dir "${EP_HOME}"} --create-home \
+        ${EP_SHELL:+--shell "${EP_SHELL}"} etherpad
 
-RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
+RUN mkdir /opt/etherpad-lite && chown etherpad:etherpad /opt/etherpad-lite
 
 USER etherpad
 
 WORKDIR /opt/etherpad-lite
 
-COPY --chown=etherpad:0 ./ ./
+COPY --chown=etherpad:etherpad ./ ./
 
 # install node dependencies for Etherpad
 RUN bin/installDeps.sh && \
@@ -45,9 +55,9 @@ RUN bin/installDeps.sh && \
 RUN for PLUGIN_NAME in ${ETHERPAD_PLUGINS}; do npm install "${PLUGIN_NAME}" || exit 1; done
 
 # Copy the configuration file.
-COPY --chown=etherpad:0 ./settings.json.docker /opt/etherpad-lite/settings.json
+COPY --chown=etherpad:etherpad ./settings.json.docker /opt/etherpad-lite/settings.json
 
-# Fix permissions for root group
+# Fix group permissions
 RUN chmod -R g=u .
 
 EXPOSE 9001

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,12 @@ RUN groupadd --system ${EP_GID:+--gid "${EP_GID}" --non-unique} etherpad && \
         ${EP_HOME:+--home-dir "${EP_HOME}"} --create-home \
         ${EP_SHELL:+--shell "${EP_SHELL}"} etherpad
 
-RUN mkdir /opt/etherpad-lite && chown etherpad:etherpad /opt/etherpad-lite
+ARG EP_DIR=/srv/etherpad/etherpad-lite
+RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 
 USER etherpad
 
-WORKDIR /opt/etherpad-lite
+WORKDIR "${EP_DIR}"
 
 COPY --chown=etherpad:etherpad ./ ./
 
@@ -55,7 +56,7 @@ RUN bin/installDeps.sh && \
 RUN for PLUGIN_NAME in ${ETHERPAD_PLUGINS}; do npm install "${PLUGIN_NAME}" || exit 1; done
 
 # Copy the configuration file.
-COPY --chown=etherpad:etherpad ./settings.json.docker /opt/etherpad-lite/settings.json
+COPY --chown=etherpad:etherpad ./settings.json.docker "${EP_DIR}"/settings.json
 
 # Fix group permissions
 RUN chmod -R g=u .


### PR DESCRIPTION
  * Add build args so that the user can choose the home directory, UID, GID, and shell for the `etherpad` user.
  * Add a build arg so that the user can set the Etherpad directory
  * Don't copy Docker files or backup files into the Docker image