### PR TITLE
Better ux for no cookies

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,7 +24,7 @@
   "pad.colorpicker.cancel": "Cancel",
 
   "pad.loading": "Loading...",
-  "pad.noCookie": "Cookie could not be found. Please allow cookies in your browser!",
+  "pad.noCookie": "Cookie could not be found. Please allow cookies in your browser!  Your session and settings will not be saved between visits.  This may be due to Etherpad being included in an iFrame in some Browsers.  Please ensure Etherpad is on the same subdomain/domain as the parent iFrame",
   "pad.passwordRequired": "You need a password to access this pad",
   "pad.permissionDenied": "You do not have permission to access this pad",
   "pad.wrongPassword": "Your password was wrong",

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -47,25 +47,35 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   io.use(function(socket, accept) {
     var data = socket.request;
     // Use a setting if we want to allow load Testing
-    if(!data.headers.cookie && settings.loadTest){
+
+    // Sometimes browsers might not have cookies at all, for example Safari in iFrames Cross domain
+    // https://github.com/ether/etherpad-lite/issues/4031
+    // if requireSession is false we can allow them to still get on the pad.
+    // Note that this does make security less tight because any socketIO connection can be established without
+    // any logic on the client to do any handshaking..  I am not concerned about this though, the real solution
+    // here is to implement rateLimiting on SocketIO ACCEPT_COMMIT messages.
+
+    if(!data.headers.cookie && (settings.loadTest || !settings.requireSession)){
       accept(null, true);
     }else{
       if (!data.headers.cookie) return accept('No session cookie transmitted.', false);
     }
-    cookieParserFn(data, {}, function(err){
-      if(err) {
-        console.error(err);
-        accept("Couldn't parse request cookies. ", false);
-        return;
-      }
+    if(data.headers.cookie){
+      cookieParserFn(data, {}, function(err){
+        if(err) {
+          console.error(err);
+          accept("Couldn't parse request cookies. ", false);
+          return;
+        }
 
-      data.sessionID = data.signedCookies.express_sid;
-      args.app.sessionStore.get(data.sessionID, function (err, session) {
-        if (err || !session) return accept('Bad session / session has expired', false);
-        data.session = new sessionModule.Session(data, session);
-        accept(null, true);
+        data.sessionID = data.signedCookies.express_sid;
+        args.app.sessionStore.get(data.sessionID, function (err, session) {
+          if (err || !session) return accept('Bad session / session has expired', false);
+          data.session = new sessionModule.Session(data, session);
+          accept(null, true);
+        });
       });
-    });
+    }
   });
 
   // var socketIOLogger = log4js.getLogger("socket.io");

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -465,11 +465,6 @@ var pad = {
       // This will check if the prefs-cookie is set.
       // Otherwise it shows up a message to the user.
       padcookie.init();
-      if (!padcookie.isCookiesEnabled())
-      {
-        $('#loading').hide();
-        $('#noCookie').show();
-      }
     });
   },
   _afterHandshake: function()

--- a/src/static/js/pad_cookie.js
+++ b/src/static/js/pad_cookie.js
@@ -78,7 +78,12 @@ var padcookie = (function()
 
     if ((!getRawCookie()) && (!alreadyWarnedAboutNoCookies))
     {
-      alert("Warning: it appears that your browser does not have cookies enabled." + " EtherPad uses cookies to keep track of unique users for the purpose" + " of putting a quota on the number of active users.  Using EtherPad without " + " cookies may fill up your server's user quota faster than expected.");
+      $.gritter.add({
+        title: "Error",
+        text: html10n.get("pad.noCookie"),
+        sticky: true,
+        class_name: "error"
+      });
       alreadyWarnedAboutNoCookies = true;
     }
   }

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -103,9 +103,6 @@
         <div id="wrongPassword">
           <p data-l10n-id="pad.wrongPassword">Your password was wrong</p>
         </div>
-        <div id="noCookie">
-          <p data-l10n-id="pad.noCookie">Cookie could not be found. Please allow cookies in your browser!</p>
-        </div>
         <% e.begin_block("loading"); %>
         <p data-l10n-id="pad.loading" id="loading">Loading...</p>
         <% e.end_block(); %>


### PR DESCRIPTION
Here is a PR with a much better UX.  This is a proposed fix.

Safari / Brave users CAN use a pad in an iframe BUT if they refresh/rejoin Etherpad is not aware of who they are.

For #4031

- [ ] Needs testing against different security setups / sessions etc. @muxator 
- [ ] ?i18n the warning? and make the gritter a warning and persist? @seballot 
- [ ] Style the Cookie error @ seballot

![image](https://user-images.githubusercontent.com/220864/82306871-8523c400-99b7-11ea-82a4-63e8a331e345.png)