### PR TITLE
Testing: Add and test padPrefs for helper.newPad

### DIFF
--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -52,11 +52,26 @@ var helper = {};
     return win.$;
   }
 
-  helper.clearCookies = function(){
+  helper.clearSessionCookies = function(){
     // Expire cookies, so author and language are changed after reloading the pad.
     // See https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie#Example_4_Reset_the_previous_cookie
     window.document.cookie = 'token=;expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     window.document.cookie = 'language=;expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+  }
+
+  // Can only happen when the iframe exists, so we're doing it separately from other cookies
+  helper.clearPadPrefCookie = function(){
+    helper.padChrome$.document.cookie = 'prefsHttp=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  }
+
+  // Overwrite all prefs in pad cookie. Assumes http, not https.
+  //
+  // `helper.padChrome$.document.cookie` (the iframe) and `window.document.cookie`
+  // seem to have independent cookies, UNLESS we put path=/ here (which we don't).
+  // I don't fully understand it, but this function seems to properly simulate
+  // padCookie.setPref in the client code
+  helper.setPadPrefCookie = function(prefs){
+    helper.padChrome$.document.cookie = ("prefsHttp=" + escape(JSON.stringify(prefs)) + ";expires=Thu, 01 Jan 3000 00:00:00 GMT");
   }
 
   // Functionality for knowing what key event type is required for tests
@@ -86,7 +101,7 @@ var helper = {};
 
     //clear cookies
     if(opts.clearCookies){
-      helper.clearCookies();
+      helper.clearSessionCookies();
     }
 
     if(!padName)
@@ -100,10 +115,16 @@ var helper = {};
     $iframeContainer.find("iframe").purgeFrame().done(function(){
       $iframeContainer.append($iframe);
       $iframe.one('load', function(){
+        helper.padChrome$ = getFrameJQuery(                $('#iframe-container iframe'));
+        if (opts.clearCookies) {
+          helper.clearPadPrefCookie();
+        }
+        if (opts.padPrefs) {
+          helper.setPadPrefCookie(opts.padPrefs);
+        }
         helper.waitFor(function(){
           return !$iframe.contents().find("#editorloadingbox").is(":visible");
         }, 50000).done(function(){
-          helper.padChrome$ = getFrameJQuery(                $('#iframe-container iframe'));
           helper.padOuter$  = getFrameJQuery(helper.padChrome$('iframe[name="ace_outer"]'));
           helper.padInner$  = getFrameJQuery( helper.padOuter$('iframe[name="ace_inner"]'));
 

--- a/tests/frontend/specs/embed_value.js
+++ b/tests/frontend/specs/embed_value.js
@@ -19,8 +19,8 @@ describe("embed links", function(){
     var width = $embediFrame.attr("width");
     var height = $embediFrame.attr("height");
     var name = $embediFrame.attr("name");
-    expect(width).to.be('600');
-    expect(height).to.be('400');
+    expect(width).to.be('100%');
+    expect(height).to.be('600');
     expect(name).to.be(readonly ? "embed_readonly" : "embed_readwrite");
 
     //parse the url

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -50,15 +50,16 @@ describe("the test helper", function(){
       // set cookies far into the future to make sure they're not expired yet
       window.document.cookie = 'token=foo;expires=Thu, 01 Jan 3030 00:00:00 GMT; path=/';
       window.document.cookie = 'language=bar;expires=Thu, 01 Jan 3030 00:00:00 GMT; path=/';
-      const testCookie = 'token=foo; language=bar'
 
-      expect(window.document.cookie).to.be(testCookie)
+      expect(window.document.cookie).to.contain('token=foo');
+      expect(window.document.cookie).to.contain('language=bar');
 
       helper.newPad(function(){
         // helper function seems to have cleared cookies
         // NOTE: this doesn't yet mean it's proven to have taken effect by this point in execution
         var firstCookie = window.document.cookie
-        expect(firstCookie).to.not.be(testCookie)
+        expect(firstCookie).to.not.contain('token=foo');
+        expect(firstCookie).to.not.contain('language=bar');
 
         var chrome$ = helper.padChrome$;
 
@@ -73,7 +74,16 @@ describe("the test helper", function(){
         $usernameInput.blur();
 
         // Before refreshing, make sure the name is there
-        expect($usernameInput.val()).to.be('John McLear')
+        expect($usernameInput.val()).to.be('John McLear');
+
+        // Now that we have a chrome, we can set a pad cookie, so we can confirm it gets wiped as well
+        chrome$.document.cookie = 'prefsHtml=baz;expires=Thu, 01 Jan 3030 00:00:00 GMT';
+        expect(chrome$.document.cookie).to.contain('prefsHtml=baz');
+
+        // Cookies are weird. Because it's attached to chrome$ (as helper.setPadCookies does), AND we
+        // didn't put path=/, we shouldn't expect it to be visible on window.document.cookie. Let's just
+        // be sure.
+        expect(window.document.cookie).to.not.contain('prefsHtml=baz');
 
         setTimeout(function(){ //give it a second to save the username on the server side
           helper.newPad(function(){ // get a new pad, let it clear the cookies
@@ -82,8 +92,12 @@ describe("the test helper", function(){
             // helper function seems to have cleared cookies
             // NOTE: this doesn't yet mean cookies were cleared effectively.
             // We still need to test below that we're in a new session
-            expect(window.document.cookie).to.not.be(testCookie)
-            expect(window.document.cookie).to.not.be(firstCookie)
+            expect(window.document.cookie).to.not.contain('token=foo');
+            expect(window.document.cookie).to.not.contain('language=bar');
+            expect(chrome$.document.cookie).to.contain('prefsHtml=baz');
+            expect(window.document.cookie).to.not.contain('prefsHtml=baz');
+
+            expect(window.document.cookie).to.not.be(firstCookie);
 
             // click on the settings button to make settings visible
             var $userButton = chrome$(".buttonicon-showusers");
@@ -91,12 +105,26 @@ describe("the test helper", function(){
 
             // confirm that the session was actually cleared
             var $usernameInput = chrome$("#myusernameedit");
-            expect($usernameInput.val()).to.be('')
+            expect($usernameInput.val()).to.be('Enter your name');
 
             done();
           });
         }, 1000);
-      })
+      });
+    });
+
+    it("sets pad prefs cookie", function(done) {
+      this.timeout(60000);
+
+      helper.newPad({
+        padPrefs: {foo:"bar"},
+        cb: function(){
+          var chrome$ = helper.padChrome$;
+          expect(chrome$.document.cookie).to.contain('prefsHttp=%7B%22');
+          expect(chrome$.document.cookie).to.contain('foo%22%3A%22bar');
+          done();
+        }
+      });
     });
   });
 


### PR DESCRIPTION
This allows for setting "prefs" in tests, which is going to be very useful if not vital for testing ep_webrtc. (I use it here: https://github.com/ether/ep_webrtc/pull/56).

Also, I fixed a couple unrelated front end tests that were failing locally. All pass now on Firefox and Chromium!