### PR TITLE
tests: Gateway timeout during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
 services:
   - docker
 
+cache:
+  npm: false
+
 install:
   - "bin/installDeps.sh"
   - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
@@ -48,3 +51,4 @@ notifications:
   irc:
     channels:
       - "irc.freenode.org#etherpad-lite-dev"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
 # Frontend is focus
     - name: "Test the Frontend"
       install:
+        - "ls -lsh node_modules"
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,3 @@ notifications:
   irc:
     channels:
       - "irc.freenode.org#etherpad-lite-dev"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ services:
 install:
   - "bin/installDeps.sh"
   - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
-  - "npm install ep_test_line_attrib"
 
 before_script:
   - "tests/frontend/travis/sauce_tunnel.sh"
@@ -33,7 +32,6 @@ jobs:
       install:
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
-        - "npm install ep_test_line_attrib"
       script:
         - "tests/frontend/travis/runner.sh"
     - name: "Test the Dockerfile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ jobs:
 # Frontend is focus
     - name: "Test the Frontend"
       install:
-        - "ls -lsh node_modules"
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ jobs:
         - "cd src && npm install && cd -"
       script:
         - "tests/frontend/travis/runnerBackend.sh"
-# Frontend is focus
     - name: "Test the Frontend"
       install:
         - "bin/installDeps.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
         - "cd src && npm install && cd -"
       script:
         - "tests/frontend/travis/runnerBackend.sh"
+# Frontend is focus
     - name: "Test the Frontend"
       install:
         - "bin/installDeps.sh"

--- a/src/package.json
+++ b/src/package.json
@@ -70,6 +70,7 @@
     "etherpad-lite": "./node/server.js"
   },
   "devDependencies": {
+    "cypress": "^4.7.0",
     "mocha": "7.1.2",
     "nyc": "15.0.1",
     "supertest": "4.0.2",
@@ -87,6 +88,6 @@
     "test": "nyc mocha --timeout 5000 ../tests/backend/specs/api",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
-  "version": "1.8.5",
+  "version": "1.8.6",
   "license": "Apache-2.0"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -87,6 +87,6 @@
     "test": "nyc mocha --timeout 5000 ../tests/backend/specs/api",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "Apache-2.0"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -87,6 +87,6 @@
     "test": "nyc mocha --timeout 5000 ../tests/backend/specs/api",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
-  "version": "1.8.6",
+  "version": "1.8.4",
   "license": "Apache-2.0"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -70,7 +70,6 @@
     "etherpad-lite": "./node/server.js"
   },
   "devDependencies": {
-    "cypress": "^4.7.0",
     "mocha": "7.1.2",
     "nyc": "15.0.1",
     "supertest": "4.0.2",

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -78,14 +78,12 @@ sauceTestWorker.push({
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
-/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'googlechrome'
   , 'version'        : 'latest'
 });
-*/
 // 3) Safari on OSX 10.15
 sauceTestWorker.push({
     'platform'       : 'OS X 10.15'

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -18,6 +18,8 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
   testSettings["public"] = true;
   testSettings["build"] = process.env.GIT_HASH;
 
+  setTimeout(function(){
+
   browser.init(testSettings).get("http://localhost:9001/tests/frontend/", function(){
     var url = "https://saucelabs.com/jobs/" + browser.sessionID;
     console.log("Remote sauce test '" + name + "' started! " + url);
@@ -65,6 +67,8 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
       });
     }, 5000);
   });
+  , 10000);
+
 }, 5); //run 5 tests in parrallel
 
 // 1) Firefox on Linux
@@ -73,7 +77,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
-
+/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
@@ -101,6 +105,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'microsoftedge'
   , 'version'        : 'latest'
 });
+*/
 
 sauceTestWorker.drain = function() {
   setTimeout(function(){

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -18,55 +18,55 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
   testSettings["public"] = true;
   testSettings["build"] = process.env.GIT_HASH;
 
+  // we wait 10 seconds here with the hope it was enough time for the minified files to be built etc.
   setTimeout(function(){
+    browser.init(testSettings).get("http://localhost:9001/tests/frontend/", function(){
+      var url = "https://saucelabs.com/jobs/" + browser.sessionID;
+      console.log("Remote sauce test '" + name + "' started! " + url);
 
-  browser.init(testSettings).get("http://localhost:9001/tests/frontend/", function(){
-    var url = "https://saucelabs.com/jobs/" + browser.sessionID;
-    console.log("Remote sauce test '" + name + "' started! " + url);
+      //tear down the test excecution
+      var stopSauce = function(success){
+        getStatusInterval && clearInterval(getStatusInterval);
+        clearTimeout(timeout);
 
-    //tear down the test excecution
-    var stopSauce = function(success){
-      getStatusInterval && clearInterval(getStatusInterval);
-      clearTimeout(timeout);
+        browser.quit();
 
-      browser.quit();
+        if(!success){
+          allTestsPassed = false;
+        }
 
-      if(!success){
-        allTestsPassed = false;
+        var testResult = knownConsoleText.replace(/\[red\]/g,'\x1B[31m').replace(/\[yellow\]/g,'\x1B[33m')
+                         .replace(/\[green\]/g,'\x1B[32m').replace(/\[clear\]/g, '\x1B[39m');
+        testResult = testResult.split("\\n").map(function(line){
+          return "[" + testSettings.browserName + (testSettings.version === "" ? '' : (" " + testSettings.version)) + "] " + line;
+        }).join("\n");
+
+        console.log(testResult);
+        console.log("Remote sauce test '" + name + "' finished! " + url);
+
+        callback();
       }
 
-      var testResult = knownConsoleText.replace(/\[red\]/g,'\x1B[31m').replace(/\[yellow\]/g,'\x1B[33m')
-                       .replace(/\[green\]/g,'\x1B[32m').replace(/\[clear\]/g, '\x1B[39m');
-      testResult = testResult.split("\\n").map(function(line){
-        return "[" + testSettings.browserName + (testSettings.version === "" ? '' : (" " + testSettings.version)) + "] " + line;
-      }).join("\n");
+      //timeout for the case the test hangs
+      var timeout = setTimeout(function(){
+        stopSauce(false);
+      }, 60000 * 10);
 
-      console.log(testResult);
-      console.log("Remote sauce test '" + name + "' finished! " + url);
+      var knownConsoleText = "";
+      var getStatusInterval = setInterval(function(){
+        browser.eval("$('#console').text()", function(err, consoleText){
+          if(!consoleText || err){
+            return;
+          }
+          knownConsoleText = consoleText;
 
-      callback();
-    }
-
-    //timeout for the case the test hangs
-    var timeout = setTimeout(function(){
-      stopSauce(false);
-    }, 60000 * 10);
-
-    var knownConsoleText = "";
-    var getStatusInterval = setInterval(function(){
-      browser.eval("$('#console').text()", function(err, consoleText){
-        if(!consoleText || err){
-          return;
-        }
-        knownConsoleText = consoleText;
-
-        if(knownConsoleText.indexOf("FINISHED") > 0){
-          var success = knownConsoleText.indexOf("FAILED") === -1;
-          stopSauce(success);
-        }
-      });
-    }, 5000);
-  });
+          if(knownConsoleText.indexOf("FINISHED") > 0){
+            var success = knownConsoleText.indexOf("FAILED") === -1;
+            stopSauce(success);
+          }
+        });
+      }, 5000);
+    });
 
   }, 10000);
 

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -78,12 +78,14 @@ sauceTestWorker.push({
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
+/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'googlechrome'
   , 'version'        : 'latest'
 });
+*/
 // 3) Safari on OSX 10.15
 sauceTestWorker.push({
     'platform'       : 'OS X 10.15'

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -73,19 +73,20 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
 }, 5); //run 5 tests in parrallel
 
 // 1) Firefox on Linux
+/*
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
-/*
+*/
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'googlechrome'
   , 'version'        : 'latest'
 });
-
+/*
 // 3) Safari on OSX 10.15
 sauceTestWorker.push({
     'platform'       : 'OS X 10.15'

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -67,7 +67,8 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
       });
     }, 5000);
   });
-  , 10000);
+
+  }, 10000);
 
 }, 5); //run 5 tests in parrallel
 

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -78,7 +78,6 @@ sauceTestWorker.push({
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
-/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
@@ -91,21 +90,18 @@ sauceTestWorker.push({
   , 'browserName'    : 'safari'
   , 'version'        : 'latest'
 });
-
 // 4) IE 10 on Win 8
 sauceTestWorker.push({
     'platform'       : 'Windows 8'
   , 'browserName'    : 'iexplore'
   , 'version'        : '10.0'
 });
-
 // 5) Edge on Win 10
 sauceTestWorker.push({
     'platform'       : 'Windows 10'
   , 'browserName'    : 'microsoftedge'
   , 'version'        : 'latest'
 });
-*/
 
 sauceTestWorker.drain = function() {
   setTimeout(function(){

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -73,20 +73,18 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
 }, 5); //run 5 tests in parrallel
 
 // 1) Firefox on Linux
-/*
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
-*/
+/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'googlechrome'
   , 'version'        : 'latest'
 });
-/*
 // 3) Safari on OSX 10.15
 sauceTestWorker.push({
     'platform'       : 'OS X 10.15'

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -78,7 +78,6 @@ sauceTestWorker.push({
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
-/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
@@ -103,7 +102,6 @@ sauceTestWorker.push({
   , 'browserName'    : 'microsoftedge'
   , 'version'        : 'latest'
 });
-*/
 
 sauceTestWorker.drain = function() {
   setTimeout(function(){

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -78,6 +78,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
+/*
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
@@ -102,6 +103,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'microsoftedge'
   , 'version'        : 'latest'
 });
+*/
 
 sauceTestWorker.drain = function() {
   setTimeout(function(){

--- a/tests/frontend/travis/runnerBackend.sh
+++ b/tests/frontend/travis/runnerBackend.sh
@@ -28,8 +28,11 @@ echo "Now I will try for 15 seconds to connect to Etherpad on http://localhost:9
 
 echo "Successfully connected to Etherpad on http://localhost:9001"
 
-# just in case, let's wait for another second before going on
-sleep 1
+# Build the minified files?
+curl http://localhost:9001/p/minifyme -f -s
+
+# just in case, let's wait for another 10 seconds before going on
+sleep 10
 
 # a copy of settings.json is necessary for the backend tests to work
 cp settings.json.template settings.json


### PR DESCRIPTION
These changes have to be done on ether/etherpad-lite repo because if not they don't fire a travis build..

1. Remove npm cache from Travis, this was causing a world of pain.
2. Remove the broken line attribute tests.
3. Do a HTTP get against Etherpad to begin minification.
4. Wait 10 seconds after minification before running tests.

Still to do:

* [x] Firefox all pass
* [ ] Chrome(all pass in local browser) = fails on bold
* [x] Safari all pass
* [  ] Edge(all pass in local browser) = authorship_of_editions.js, select_formatting_buttons.js (bold & strikethrough)

I'm inclined to suggest these are saucelabs / selenium bugs.