### PR TITLE
tests: Fix backend testing which were always partially broken due to cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
   include:
     - name: "Run the Backend tests"
       install:
+        - "bin/installDeps.sh"
         - "cd src && npm install && cd -"
       script:
         - "tests/frontend/travis/runnerBackend.sh"

--- a/tests/frontend/travis/runnerBackend.sh
+++ b/tests/frontend/travis/runnerBackend.sh
@@ -29,7 +29,7 @@ echo "Now I will try for 15 seconds to connect to Etherpad on http://localhost:9
 echo "Successfully connected to Etherpad on http://localhost:9001"
 
 # Build the minified files?
-curl http://localhost:9001/p/minifyme -f -s
+curl http://localhost:9001/p/minifyme -f -s > /dev/null
 
 # just in case, let's wait for another 10 seconds before going on
 sleep 10


### PR DESCRIPTION
Backend tests were dependent on cache which is a terrible idea.

1. Builds clean.
2. Doesn't spam log with curl request.