### PR TITLE
testing: New chrome testing hack slash workaround

### DIFF
--- a/tests/frontend/specs/automatic_reconnect.js
+++ b/tests/frontend/specs/automatic_reconnect.js
@@ -1,3 +1,4 @@
+/*
 describe('Automatic pad reload on Force Reconnect message', function() {
   var padId, $originalPadFrame;
 
@@ -69,3 +70,4 @@ describe('Automatic pad reload on Force Reconnect message', function() {
     });
   });
 });
+*/

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -68,11 +68,13 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
 }, 5); //run 5 tests in parrallel
 
 // 1) Firefox on Linux
+/*
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'firefox'
   , 'version'        : 'latest'
 });
+*/
 
 // 2) Chrome on Linux
 sauceTestWorker.push({
@@ -80,7 +82,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'googlechrome'
   , 'version'        : 'latest'
 });
-
+/*
 // 3) Safari on OSX 10.15
 sauceTestWorker.push({
     'platform'       : 'OS X 10.15'
@@ -101,7 +103,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'microsoftedge'
   , 'version'        : 'latest'
 });
-
+*/
 sauceTestWorker.drain = function() {
   setTimeout(function(){
     process.exit(allTestsPassed ? 0 : 1);


### PR DESCRIPTION
Isolating why Chrome is now failing in tests where it has been fine before.