### PR TITLE
Fix(UX): Add prefers-reduced-motion query for Colibris skin #4136

### DIFF
--- a/src/static/skins/colibris/src/components/chat.css
+++ b/src/static/skins/colibris/src/components/chat.css
@@ -76,10 +76,10 @@
 }
 
 @media (prefers-reduced-motion) {
-    .chat-content {
-        transform: scale(1);
-        transition: none;
-    }
+  .chat-content {
+    transform: scale(1);
+    transition: none;
+  }
 }
 
 @media (max-width: 800px) {

--- a/src/static/skins/colibris/src/components/chat.css
+++ b/src/static/skins/colibris/src/components/chat.css
@@ -75,6 +75,13 @@
   background-color: var(--bg-color);
 }
 
+@media (prefers-reduced-motion) {
+    .chat-content {
+        transform: scale(1);
+        transition: none;
+    }
+}
+
 @media (max-width: 800px) {
   #chaticon {
     right: 0;

--- a/src/static/skins/colibris/src/components/gritter.css
+++ b/src/static/skins/colibris/src/components/gritter.css
@@ -60,8 +60,20 @@
 }
 
 .gritter-item.popup.popup-show > .popup-content {
-  transform: scale(1) translateY(0) !important;
-  transition: all 0.4s cubic-bezier(0.74, -0.05, 0.27, 1.75) !important;
+  transform: scale(1) translateY(0);
+  transition: all 0.4s cubic-bezier(0.74, -0.05, 0.27, 1.75);
+}
+@media (prefers-reduced-motion) {
+  #gritter-container.top .gritter-item.popup > .popup-content {
+    transform: scale(1) translateY(0px);
+  }
+  #gritter-container.bottom .gritter-item.popup > .popup-content {
+    transform: scale(1) translateY(0px);
+  }
+  .gritter-item.popup.popup-show > .popup-content {
+    transform: scale(1) translateY(0px);
+    transition: none;
+  }
 }
 
 /* for ep_deleted_after_delay */

--- a/src/static/skins/colibris/src/components/gritter.css
+++ b/src/static/skins/colibris/src/components/gritter.css
@@ -60,18 +60,18 @@
 }
 
 .gritter-item.popup.popup-show > .popup-content {
-  transform: scale(1) translateY(0);
-  transition: all 0.4s cubic-bezier(0.74, -0.05, 0.27, 1.75);
+  transform: scale(1) translateY(0) !important;
+  transition: all 0.4s cubic-bezier(0.74, -0.05, 0.27, 1.75) !important;
 }
 @media (prefers-reduced-motion) {
   #gritter-container.top .gritter-item.popup > .popup-content {
-    transform: scale(1) translateY(0px);
+    transform: scale(1) translateY(0px) !important;
   }
   #gritter-container.bottom .gritter-item.popup > .popup-content {
-    transform: scale(1) translateY(0px);
+    transform: scale(1) translateY(0px) !important;
   }
   .gritter-item.popup.popup-show > .popup-content {
-    transform: scale(1) translateY(0px);
+    transform: scale(1) translateY(0px) !important;
     transition: none;
   }
 }

--- a/src/static/skins/colibris/src/components/popup.css
+++ b/src/static/skins/colibris/src/components/popup.css
@@ -41,6 +41,19 @@
   min-width: 180px;
 }
 
+@media (prefers-reduced-motion) {
+  .popup>.popup-content {
+    transform: scale(1);
+    transition: none;
+  }
+  .nice-select .list {
+    transform: scale(1) translateY(0px);
+    -webkit-transform: scale(1) translateY(0px);
+    -ms-transform: scale(1) translateY(0px);
+    transition: none;
+  }
+}
+
 @media (max-width: 800px) {
   .popup-content {
     padding: 1rem;


### PR DESCRIPTION
Fix #4136 

Adds media queries to 3 CSS files in colibris skin folder, no changes outside of them. Tested on my installation & works well.

If you want to test it out quickly in Firefox, you can add `ui.prefersReducedMotion` to your about:config in Firefox and toggle the Boolean between 1 (on) and 0 (off).

New behavior for users with the setting enabled:

![Screencast of no animation popup](https://user-images.githubusercontent.com/67394526/85914031-b1203980-b7ee-11ea-9bac-ec47a94f2f4a.gif)
