### PR TITLE
frontend test improvements

### DIFF
--- a/tests/frontend/runner.js
+++ b/tests/frontend/runner.js
@@ -60,7 +60,7 @@ $(function(){
       stats.tests = stats.tests || 0;
       stats.tests++;
       if ('passed' == test.state) {
-        append("->","[green]PASSED[clear] :", test.title);
+        append("->","[green]PASSED[clear] :", test.title," ",test.speed,"ms");
       } else if (test.pending) {
         append("->","[yellow]PENDING[clear]:", test.title);
       } else {

--- a/tests/frontend/runner.js
+++ b/tests/frontend/runner.js
@@ -60,7 +60,7 @@ $(function(){
       stats.tests = stats.tests || 0;
       stats.tests++;
       if ('passed' == test.state) {
-        append("->","[green]PASSED[clear] :", test.title," ",test.speed,"ms");
+        append("->","[green]PASSED[clear] :", test.title," ",test.duration,"ms");
       } else if (test.pending) {
         append("->","[yellow]PENDING[clear]:", test.title);
       } else {

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -39,7 +39,7 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
         var testResult = knownConsoleText.replace(/\[red\]/g,'\x1B[31m').replace(/\[yellow\]/g,'\x1B[33m')
                          .replace(/\[green\]/g,'\x1B[32m').replace(/\[clear\]/g, '\x1B[39m');
         testResult = testResult.split("\\n").map(function(line){
-          return "[" + testSettings.browserName + (testSettings.version === "" ? '' : (" " + testSettings.version)) + "] " + line;
+          return "[" + testSettings.browserName + " " + testSettings.platform + (testSettings.version === "" ? '' : (" " + testSettings.version)) + "] " + line;
         }).join("\n");
 
         console.log(testResult);

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -20,8 +20,6 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
   testSettings["extendedDebugging"] = true; // console.json can be downloaded via saucelabs, don't know how to print them into output of the tests
   testSettings["tunnelIdentifier"] = process.env.TRAVIS_JOB_NUMBER;
 
-  // we wait 10 seconds here with the hope it was enough time for the minified files to be built etc.
-  setTimeout(function(){
     browser.init(testSettings).get("http://localhost:9001/tests/frontend/", function(){
       var url = "https://saucelabs.com/jobs/" + browser.sessionID;
       console.log("Remote sauce test '" + name + "' started! " + url);
@@ -77,8 +75,6 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
         });
       }, 5000);
     });
-
-  }, 10000);
 
 }, 1); //run 1 test in parrallel
 

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -120,7 +120,7 @@ sauceTestWorker.push({
   , 'browserName'    : 'microsoftedge'
   , 'version'        : '83.0'
 });
-// 6) Chrome on Win 7
+// 6) Firefox on Win 7
 sauceTestWorker.push({
     'platform'       : 'Windows 7'
   , 'browserName'    : 'firefox'

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -17,6 +17,7 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
   testSettings.name = name;
   testSettings["public"] = true;
   testSettings["build"] = process.env.GIT_HASH;
+  testSettings["tunnelIdentifier"] = process.env.TRAVIS_JOB_NUMBER;
 
   // we wait 10 seconds here with the hope it was enough time for the minified files to be built etc.
   setTimeout(function(){

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -66,8 +66,13 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
           knownConsoleText = consoleText;
 
           if(knownConsoleText.indexOf("FINISHED") > 0){
-            var success = knownConsoleText.indexOf("FAILED") === -1;
-            stopSauce(success);
+            let match = knownConsoleText.match(/FINISHED - ([0-9]+) tests passed, ([0-9]+) tests failed/);
+            if (match[2] && match[2] == 0){
+              stopSauce(true);
+            }
+            else {
+              stopSauce(false);
+            }
           }
         });
       }, 5000);

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -76,7 +76,7 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
       }, 5000);
     });
 
-}, 1); //run 1 test in parrallel
+}, 4); //run 4 test in parrallel
 
 // 1) Firefox on Linux
 sauceTestWorker.push({

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -49,7 +49,10 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
         callback();
       }
 
-      //timeout for the case the test hangs
+      /**
+       * timeout for the case the test hangs
+       * @todo this should be configured in testSettings, see https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
+       */
       var timeout = setTimeout(function(){
         stopSauce(false);
       }, 1200000 * 10);

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -17,6 +17,7 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
   testSettings.name = name;
   testSettings["public"] = true;
   testSettings["build"] = process.env.GIT_HASH;
+  testSettings["extendedDebugging"] = true; // console.json can be downloaded via saucelabs, don't know how to print them into output of the tests
   testSettings["tunnelIdentifier"] = process.env.TRAVIS_JOB_NUMBER;
 
   // we wait 10 seconds here with the hope it was enough time for the minified files to be built etc.

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -76,27 +76,34 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
       }, 5000);
     });
 
-}, 4); //run 4 test in parrallel
+}, 6); //run 6 tests in parrallel
 
 // 1) Firefox on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
   , 'browserName'    : 'firefox'
-  , 'version'        : 'latest'
+  , 'version'        : '45.0'
 });
 
 // 2) Chrome on Linux
 sauceTestWorker.push({
     'platform'       : 'Linux'
-  , 'browserName'    : 'googlechrome'
-  , 'version'        : 'latest'
+  , 'browserName'    : 'chrome'
+  , 'version'        : '48.0'
 });
 
 // 3) Safari on OSX 10.15
 sauceTestWorker.push({
     'platform'       : 'OS X 10.15'
   , 'browserName'    : 'safari'
-  , 'version'        : 'latest'
+  , 'version'        : '13.1'
+});
+
+// 4) Safari on OSX 10.14
+sauceTestWorker.push({
+    'platform'       : 'OS X 10.14'
+  , 'browserName'    : 'safari'
+  , 'version'        : '12.0'
 });
 // IE 10 doesn't appear to be working anyway
 /*
@@ -111,7 +118,13 @@ sauceTestWorker.push({
 sauceTestWorker.push({
     'platform'       : 'Windows 10'
   , 'browserName'    : 'microsoftedge'
-  , 'version'        : 'latest'
+  , 'version'        : '83.0'
+});
+// 6) Chrome on Win 7
+sauceTestWorker.push({
+    'platform'       : 'Windows 7'
+  , 'browserName'    : 'firefox'
+  , 'version'        : '78.0'
 });
 
 sauceTestWorker.drain = function() {

--- a/tests/frontend/travis/sauce_tunnel.sh
+++ b/tests/frontend/travis/sauce_tunnel.sh
@@ -9,7 +9,7 @@
 if [ -z "${SAUCE_USERNAME}" ]; then echo "SAUCE_USERNAME is unset - exiting"; exit 1; fi
 if [ -z "${SAUCE_ACCESS_KEY}" ]; then echo "SAUCE_ACCESS_KEY is unset - exiting"; exit 1; fi
 
-curl https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz > /tmp/sauce.tar.gz
+curl https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz > /tmp/sauce.tar.gz
 tar zxf /tmp/sauce.tar.gz --directory /tmp
 mv /tmp/sc-*-linux /tmp/sauce_connect
 

--- a/tests/frontend/travis/sauce_tunnel.sh
+++ b/tests/frontend/travis/sauce_tunnel.sh
@@ -14,7 +14,7 @@ tar zxf /tmp/sauce.tar.gz --directory /tmp
 mv /tmp/sc-*-linux /tmp/sauce_connect
 
 # start the sauce connector in background and make sure it doesn't output the secret key
-(/tmp/sauce_connect/bin/sc --user "${SAUCE_USERNAME}" --key "${SAUCE_ACCESS_KEY}" --pidfile /tmp/sauce.pid --readyfile /tmp/tunnel > /dev/null )&
+(/tmp/sauce_connect/bin/sc --user "${SAUCE_USERNAME}" --key "${SAUCE_ACCESS_KEY}" -i "${TRAVIS_JOB_NUMBER}" --pidfile /tmp/sauce.pid --readyfile /tmp/tunnel > /dev/null )&
 
 # wait for the tunnel to build up
 while [ ! -e "/tmp/tunnel" ]


### PR DESCRIPTION
1. prints duration of every test case to travis console
2. saves browser's console output in saucelabs (better way would be to print it too, but I don't know how to do that right now) - this will help in the future to detect warnings/errors printed to browser console during test runs - maybe we should also include ep server logs in travis?
3. sends sauce connect proxy tunnelIdentifier during test runs
4. sets parallel runs to ~~4~~ 6 again - this seems to work now (because of tunnelIdentifier?)
5. removes hard coded 10 seconds wait time for minification
6. update sauce connect proxy to 4.6.2
7. fixes the behaviour how we check, if a test run has succeeded. When the [killTimeout in runner.js](https://github.com/ether/etherpad-lite/blob/develop/tests/frontend/runner.js#L72) stops our tests like in https://travis-ci.org/github/ether/etherpad-lite/jobs/706938845#L715 our tests should fail. In the past this was not the case
8. includes MacOS 10.14-safari and Win7-firefox
9. pinned browser versions