### PR TITLE
WIP: Revert "made url relative"

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -855,7 +855,7 @@ var pad = {
       $.ajax(
       {
         type: 'post',
-        url: 'ep/pad/connection-diagnostic-info',
+        url: '/ep/pad/connection-diagnostic-info',
         data: {
           diagnosticInfo: JSON.stringify(pad.diagnosticInfo)
         },


### PR DESCRIPTION
This reverts commit d26df864902510ca7f325b786183dc9031e04e42.
See https://github.com/ether/etherpad-lite/issues/4191 for the problem. In case you think it's better to include logic for subdirectory in settings.json and make express endpoints listen to a subdirectory-prefix (e.g. https://yourhost.org/specific/path/for/etherpad/jserror, https://yourhost.org/specific/path/for/etherpad/locales.json when subdirectory="/specific/path/for/etherpad") then just close this and I will probably issue a PR for that