### PR TITLE
fix: fix async code inside of loop

### DIFF
--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -82,17 +82,16 @@ async function aCallAll(hook_name, args, cb) {
   if (!cb) cb = function () {};
   if (exports.plugins.hooks[hook_name] === undefined) return cb(null, []);
 
-  var newArray = [];
-  // This should be a map.
-  await exports.plugins.hooks[hook_name].forEach(async function(hook, index){
-    let test = await hookCallWrapper(hook, hook_name, args, function (res) {
+  var hooksPromises = exports.plugins.hooks[hook_name].map(async function(hook, index){
+    return await hookCallWrapper(hook, hook_name, args, function (res) {
       return Promise.resolve(res);
     });
-    newArray.push(test)
   });
 
+  var result = await Promise.all(hooksPromises);
+
   // after forEach
-  cb(null, _.flatten(newArray, true));
+  cb(null, _.flatten(result, true));
 }
 
 /* return a Promise if cb is not supplied */


### PR DESCRIPTION
This PR fixes the error of not waiting the async code to finish.
As the forEach did not wait until the async code finish we may get a
hook set up incorrectly. To fix it, we use an "Array.map" to iterate and
wait the promises to be resolved and then return the values.
Fixes #4193
A better explanation why this should avoided can found here
https://codeburst.io/javascript-async-await-with-foreach-b6ba62bbf404
