### PR TITLE
Command line argument for chromium test for fake webrtc

### DIFF
--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -90,6 +90,7 @@ sauceTestWorker.push({
     'platform'       : 'Windows 7'
   , 'browserName'    : 'chrome'
   , 'version'        : '55.0'
+  , 'args'           : ['--use-fake-device-for-media-stream']
 });
 
 // 3) Safari on OSX 10.15


### PR DESCRIPTION
This is more or less required (but probably not sufficient) for a successful test run of ep_webrtc on Chrome on Travis.