### PR TITLE
webaccess: Various cleanups

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -13,8 +13,8 @@ exports.basicAuth = function(req, res, next) {
   var hookResultMangle = function(cb) {
     return function(err, data) {
       return cb(!err && data.length && data[0]);
-    }
-  }
+    };
+  };
 
   var authorize = function(cb) {
     // Do not require auth for static paths and the API...this could be a bit brittle
@@ -28,12 +28,12 @@ exports.basicAuth = function(req, res, next) {
     if (req.session && req.session.user && req.session.user.is_admin) return cb(true);
 
     hooks.aCallFirst("authorize", {req: req, res: res, next: next, resource: req.path}, hookResultMangle(cb));
-  }
+  };
 
   var authenticate = function(cb) {
     // If auth headers are present use them to authenticate...
     if (req.headers.authorization && req.headers.authorization.search('Basic ') === 0) {
-      var userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(":")
+      var userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(":");
       var username = userpass.shift();
       var password = userpass.join(':');
       var fallback = function(success) {
@@ -54,7 +54,7 @@ exports.basicAuth = function(req, res, next) {
       return hooks.aCallFirst("authenticate", {req: req, res: res, next: next, username: username, password: password}, hookResultMangle(fallback));
     }
     hooks.aCallFirst("authenticate", {req: req, res: res, next: next}, hookResultMangle(cb));
-  }
+  };
 
 
   /* Authentication OR authorization failed. */
@@ -73,7 +73,7 @@ exports.basicAuth = function(req, res, next) {
         res.status(401).send('Authentication required');
       }
     }));
-  }
+  };
 
 
   /* This is the actual authentication/authorization hoop. It is done in four steps:
@@ -97,7 +97,7 @@ exports.basicAuth = function(req, res, next) {
       });
     });
   });
-}
+};
 
 exports.secret = null;
 
@@ -105,13 +105,13 @@ exports.expressConfigure = function(hook_name, args, cb) {
   // Measure response time
   args.app.use(function(req, res, next) {
     var stopWatch = stats.timer('httpRequests').start();
-    var sendFn = res.send
+    var sendFn = res.send;
     res.send = function() {
-      stopWatch.end()
-      sendFn.apply(res, arguments)
-    }
-    next()
-  })
+      stopWatch.end();
+      sendFn.apply(res, arguments);
+    };
+    next();
+  });
 
   // If the log level specified in the config file is WARN or ERROR the application server never starts listening to requests as reported in issue #158.
   // Not installing the log4js connect logger when the log level has a higher severity than INFO since it would not log at that level anyway.
@@ -176,4 +176,4 @@ exports.expressConfigure = function(hook_name, args, cb) {
   args.app.use(cookieParser(settings.sessionKey, {}));
 
   args.app.use(exports.basicAuth);
-}
+};

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -27,7 +27,7 @@ exports.basicAuth = (req, res, next) => {
 
     if (req.session && req.session.user && req.session.user.is_admin) return cb(true);
 
-    hooks.aCallFirst('authorize', {req: req, res: res, next: next, resource: req.path}, hookResultMangle(cb));
+    hooks.aCallFirst('authorize', {req, res, next, resource: req.path}, hookResultMangle(cb));
   };
 
   const authenticate = (cb) => {
@@ -51,15 +51,15 @@ exports.basicAuth = (req, res, next) => {
         req.session.user = settings.users[username];
         return cb(true);
       };
-      return hooks.aCallFirst('authenticate', {req: req, res: res, next: next, username: username, password: password}, hookResultMangle(fallback));
+      return hooks.aCallFirst('authenticate', {req, res, next, username, password}, hookResultMangle(fallback));
     }
-    hooks.aCallFirst('authenticate', {req: req, res: res, next: next}, hookResultMangle(cb));
+    hooks.aCallFirst('authenticate', {req, res, next}, hookResultMangle(cb));
   };
 
 
   /* Authentication OR authorization failed. */
   const failure = () => {
-    return hooks.aCallFirst('authFailure', {req: req, res: res, next: next}, hookResultMangle((ok) => {
+    return hooks.aCallFirst('authFailure', {req, res, next}, hookResultMangle((ok) => {
       if (ok) return;
       /* No plugin handler for invalid auth. Return Auth required
        * Headers, delayed for 1 second, if authentication failed

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -1,6 +1,6 @@
 var express = require('express');
 var log4js = require('log4js');
-var httpLogger = log4js.getLogger("http");
+var httpLogger = log4js.getLogger('http');
 var settings = require('../../utils/Settings');
 var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
 var ueberStore = require('../../db/SessionStore');
@@ -27,13 +27,13 @@ exports.basicAuth = function(req, res, next) {
 
     if (req.session && req.session.user && req.session.user.is_admin) return cb(true);
 
-    hooks.aCallFirst("authorize", {req: req, res: res, next: next, resource: req.path}, hookResultMangle(cb));
+    hooks.aCallFirst('authorize', {req: req, res: res, next: next, resource: req.path}, hookResultMangle(cb));
   };
 
   var authenticate = function(cb) {
     // If auth headers are present use them to authenticate...
     if (req.headers.authorization && req.headers.authorization.search('Basic ') === 0) {
-      var userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(":");
+      var userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(':');
       var username = userpass.shift();
       var password = userpass.join(':');
       var fallback = function(success) {
@@ -51,15 +51,15 @@ exports.basicAuth = function(req, res, next) {
         req.session.user = settings.users[username];
         return cb(true);
       };
-      return hooks.aCallFirst("authenticate", {req: req, res: res, next: next, username: username, password: password}, hookResultMangle(fallback));
+      return hooks.aCallFirst('authenticate', {req: req, res: res, next: next, username: username, password: password}, hookResultMangle(fallback));
     }
-    hooks.aCallFirst("authenticate", {req: req, res: res, next: next}, hookResultMangle(cb));
+    hooks.aCallFirst('authenticate', {req: req, res: res, next: next}, hookResultMangle(cb));
   };
 
 
   /* Authentication OR authorization failed. */
   var failure = function() {
-    return hooks.aCallFirst("authFailure", {req: req, res: res, next: next}, hookResultMangle(function(ok) {
+    return hooks.aCallFirst('authFailure', {req: req, res: res, next: next}, hookResultMangle(function(ok) {
       if (ok) return;
       /* No plugin handler for invalid auth. Return Auth required
        * Headers, delayed for 1 second, if authentication failed
@@ -115,7 +115,7 @@ exports.expressConfigure = function(hook_name, args, cb) {
 
   // If the log level specified in the config file is WARN or ERROR the application server never starts listening to requests as reported in issue #158.
   // Not installing the log4js connect logger when the log level has a higher severity than INFO since it would not log at that level anyway.
-  if (!(settings.loglevel === "WARN" || settings.loglevel == "ERROR"))
+  if (!(settings.loglevel === 'WARN' || settings.loglevel == 'ERROR'))
     args.app.use(log4js.connectLogger(httpLogger, {level: log4js.levels.DEBUG, format: ':status, :method :url'}));
 
   /* Do not let express create the session, so that we can retain a
@@ -129,9 +129,9 @@ exports.expressConfigure = function(hook_name, args, cb) {
   }
 
   if (settings.ssl) {
-    var sameSite = "Strict";
+    var sameSite = 'Strict';
   } else {
-    var sameSite = "Lax";
+    var sameSite = 'Lax';
   }
 
   args.app.sessionStore = exports.sessionStore;

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -1,22 +1,22 @@
-var express = require('express');
-var log4js = require('log4js');
-var httpLogger = log4js.getLogger('http');
-var settings = require('../../utils/Settings');
-var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
-var ueberStore = require('../../db/SessionStore');
-var stats = require('ep_etherpad-lite/node/stats');
-var sessionModule = require('express-session');
-var cookieParser = require('cookie-parser');
+const express = require('express');
+const log4js = require('log4js');
+const httpLogger = log4js.getLogger('http');
+const settings = require('../../utils/Settings');
+const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+const ueberStore = require('../../db/SessionStore');
+const stats = require('ep_etherpad-lite/node/stats');
+const sessionModule = require('express-session');
+const cookieParser = require('cookie-parser');
 
 // checks for basic http auth
 exports.basicAuth = (req, res, next) => {
-  var hookResultMangle = (cb) => {
+  const hookResultMangle = (cb) => {
     return (err, data) => {
       return cb(!err && data.length && data[0]);
     };
   };
 
-  var authorize = (cb) => {
+  const authorize = (cb) => {
     // Do not require auth for static paths and the API...this could be a bit brittle
     if (req.path.match(/^\/(static|javascripts|pluginfw|api)/)) return cb(true);
 
@@ -30,13 +30,13 @@ exports.basicAuth = (req, res, next) => {
     hooks.aCallFirst('authorize', {req: req, res: res, next: next, resource: req.path}, hookResultMangle(cb));
   };
 
-  var authenticate = (cb) => {
+  const authenticate = (cb) => {
     // If auth headers are present use them to authenticate...
     if (req.headers.authorization && req.headers.authorization.search('Basic ') === 0) {
-      var userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(':');
-      var username = userpass.shift();
-      var password = userpass.join(':');
-      var fallback = (success) => {
+      const userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(':');
+      const username = userpass.shift();
+      const password = userpass.join(':');
+      const fallback = (success) => {
         if (success) return cb(true);
         if (!(username in settings.users)) {
           httpLogger.info(`Failed authentication from IP ${req.ip} - no such user`);
@@ -58,7 +58,7 @@ exports.basicAuth = (req, res, next) => {
 
 
   /* Authentication OR authorization failed. */
-  var failure = () => {
+  const failure = () => {
     return hooks.aCallFirst('authFailure', {req: req, res: res, next: next}, hookResultMangle((ok) => {
       if (ok) return;
       /* No plugin handler for invalid auth. Return Auth required
@@ -104,8 +104,8 @@ exports.secret = null;
 exports.expressConfigure = (hook_name, args, cb) => {
   // Measure response time
   args.app.use((req, res, next) => {
-    var stopWatch = stats.timer('httpRequests').start();
-    var sendFn = res.send;
+    const stopWatch = stats.timer('httpRequests').start();
+    const sendFn = res.send;
     res.send = function() { // function, not arrow, due to use of 'arguments'
       stopWatch.end();
       sendFn.apply(res, arguments);
@@ -128,11 +128,7 @@ exports.expressConfigure = (hook_name, args, cb) => {
     exports.secret = settings.sessionKey;
   }
 
-  if (settings.ssl) {
-    var sameSite = 'Strict';
-  } else {
-    var sameSite = 'Lax';
-  }
+  const sameSite = settings.ssl ? 'Strict' : 'Lax';
 
   args.app.sessionStore = exports.sessionStore;
   args.app.use(sessionModule({

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -8,15 +8,15 @@ var stats = require('ep_etherpad-lite/node/stats');
 var sessionModule = require('express-session');
 var cookieParser = require('cookie-parser');
 
-//checks for basic http auth
-exports.basicAuth = function (req, res, next) {
-  var hookResultMangle = function (cb) {
-    return function (err, data) {
+// checks for basic http auth
+exports.basicAuth = function(req, res, next) {
+  var hookResultMangle = function(cb) {
+    return function(err, data) {
       return cb(!err && data.length && data[0]);
     }
   }
 
-  var authorize = function (cb) {
+  var authorize = function(cb) {
     // Do not require auth for static paths and the API...this could be a bit brittle
     if (req.path.match(/^\/(static|javascripts|pluginfw|api)/)) return cb(true);
 
@@ -27,10 +27,10 @@ exports.basicAuth = function (req, res, next) {
 
     if (req.session && req.session.user && req.session.user.is_admin) return cb(true);
 
-    hooks.aCallFirst("authorize", {req: req, res:res, next:next, resource: req.path}, hookResultMangle(cb));
+    hooks.aCallFirst("authorize", {req: req, res: res, next: next, resource: req.path}, hookResultMangle(cb));
   }
 
-  var authenticate = function (cb) {
+  var authenticate = function(cb) {
     // If auth headers are present use them to authenticate...
     if (req.headers.authorization && req.headers.authorization.search('Basic ') === 0) {
       var userpass = Buffer.from(req.headers.authorization.split(' ')[1], 'base64').toString().split(":")
@@ -51,22 +51,22 @@ exports.basicAuth = function (req, res, next) {
         req.session.user = settings.users[username];
         return cb(true);
       };
-      return hooks.aCallFirst("authenticate", {req: req, res:res, next:next, username: username, password: password}, hookResultMangle(fallback));
+      return hooks.aCallFirst("authenticate", {req: req, res: res, next: next, username: username, password: password}, hookResultMangle(fallback));
     }
-    hooks.aCallFirst("authenticate", {req: req, res:res, next:next}, hookResultMangle(cb));
+    hooks.aCallFirst("authenticate", {req: req, res: res, next: next}, hookResultMangle(cb));
   }
 
 
   /* Authentication OR authorization failed. */
-  var failure = function () {
-    return hooks.aCallFirst("authFailure", {req: req, res:res, next:next}, hookResultMangle(function (ok) {
-    if (ok) return;
+  var failure = function() {
+    return hooks.aCallFirst("authFailure", {req: req, res: res, next: next}, hookResultMangle(function(ok) {
+      if (ok) return;
       /* No plugin handler for invalid auth. Return Auth required
        * Headers, delayed for 1 second, if authentication failed
        * before. */
       res.header('WWW-Authenticate', 'Basic realm="Protected Area"');
       if (req.headers.authorization) {
-        setTimeout(function () {
+        setTimeout(function() {
           res.status(401).send('Authentication required');
         }, 1000);
       } else {
@@ -87,11 +87,11 @@ exports.basicAuth = function (req, res, next) {
 
   */
 
-  authorize(function (ok) {
+  authorize(function(ok) {
     if (ok) return next();
-    authenticate(function (ok) {
+    authenticate(function(ok) {
       if (!ok) return failure();
-      authorize(function (ok) {
+      authorize(function(ok) {
         if (ok) return next();
         failure();
       });
@@ -101,7 +101,7 @@ exports.basicAuth = function (req, res, next) {
 
 exports.secret = null;
 
-exports.expressConfigure = function (hook_name, args, cb) {
+exports.expressConfigure = function(hook_name, args, cb) {
   // Measure response time
   args.app.use(function(req, res, next) {
     var stopWatch = stats.timer('httpRequests').start();
@@ -116,7 +116,7 @@ exports.expressConfigure = function (hook_name, args, cb) {
   // If the log level specified in the config file is WARN or ERROR the application server never starts listening to requests as reported in issue #158.
   // Not installing the log4js connect logger when the log level has a higher severity than INFO since it would not log at that level anyway.
   if (!(settings.loglevel === "WARN" || settings.loglevel == "ERROR"))
-    args.app.use(log4js.connectLogger(httpLogger, { level: log4js.levels.DEBUG, format: ':status, :method :url'}));
+    args.app.use(log4js.connectLogger(httpLogger, {level: log4js.levels.DEBUG, format: ':status, :method :url'}));
 
   /* Do not let express create the session, so that we can retain a
    * reference to it for socket.io to use. Also, set the key (cookie
@@ -128,9 +128,9 @@ exports.expressConfigure = function (hook_name, args, cb) {
     exports.secret = settings.sessionKey;
   }
 
-  if(settings.ssl){
+  if (settings.ssl) {
     var sameSite = "Strict";
-  }else{
+  } else {
     var sameSite = "Lax";
   }
 

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -20,7 +20,7 @@ exports.basicAuth = (req, res, next) => {
     // Do not require auth for static paths and the API...this could be a bit brittle
     if (req.path.match(/^\/(static|javascripts|pluginfw|api)/)) return cb(true);
 
-    if (req.path.toLowerCase().indexOf('/admin') != 0) {
+    if (req.path.toLowerCase().indexOf('/admin') !== 0) {
       if (!settings.requireAuthentication) return cb(true);
       if (!settings.requireAuthorization && req.session && req.session.user) return cb(true);
     }
@@ -115,7 +115,7 @@ exports.expressConfigure = (hook_name, args, cb) => {
 
   // If the log level specified in the config file is WARN or ERROR the application server never starts listening to requests as reported in issue #158.
   // Not installing the log4js connect logger when the log level has a higher severity than INFO since it would not log at that level anyway.
-  if (!(settings.loglevel === 'WARN' || settings.loglevel == 'ERROR'))
+  if (!(settings.loglevel === 'WARN' || settings.loglevel === 'ERROR'))
     args.app.use(log4js.connectLogger(httpLogger, {level: log4js.levels.DEBUG, format: ':status, :method :url'}));
 
   /* Do not let express create the session, so that we can retain a

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -8,8 +8,7 @@ const stats = require('ep_etherpad-lite/node/stats');
 const sessionModule = require('express-session');
 const cookieParser = require('cookie-parser');
 
-// checks for basic http auth
-exports.basicAuth = (req, res, next) => {
+exports.checkAccess = (req, res, next) => {
   const hookResultMangle = (cb) => {
     return (err, data) => {
       return cb(!err && data.length && data[0]);
@@ -171,5 +170,5 @@ exports.expressConfigure = (hook_name, args, cb) => {
 
   args.app.use(cookieParser(settings.sessionKey, {}));
 
-  args.app.use(exports.basicAuth);
+  args.app.use(exports.checkAccess);
 };


### PR DESCRIPTION
This PR contains several commits that each do some minor cleanups to webaccess.js.

**PLEASE DO NOT SQUASH MERGE THIS PR—do a regular merge instead.**

  * Whitespace fixes
  * Add semicolons after statements
  * Use single quotes everywhere
  * Use arrow functions instead of `function` keyword
  * Use `const` or `let` instead of `var`
  * Simplify object construction
  * Use `===` instead of `==` for comparison
  * Rename `basicAuth` to `checkAccess`
  * Restructure for readability and future changes

Future PRs will build on this PR to add some new features required for an authentication plugin I am writing.