### PR TITLE
hooks: Always return a list from `aCallFirst` and `callFirst`

### DIFF
--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -34,14 +34,14 @@ exports.syncMapFirst = function (lst, fn) {
     result = fn(lst[i])
     if (result.length) return result;
   }
-  return undefined;
+  return [];
 }
 
 exports.mapFirst = function (lst, fn, cb) {
   var i = 0;
 
   var next = function () {
-    if (i >= lst.length) return cb(undefined);
+    if (i >= lst.length) return cb(null, []);
     fn(lst[i++], function (err, result) {
       if (err) return cb(err);
       if (result.length) return cb(null, result);


### PR DESCRIPTION
Every existing caller of `aCallFirst` expects a list and will throw an exception if given `undefined`. (Nobody calls `callFirst`, except maybe plugins.)