### PR TITLE
pluginfw: Always include the function name in `hook_fn_name`

### DIFF
--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -72,8 +72,12 @@ exports.callInit = function () {
   return Promise.all(p);
 }
 
-exports.pathNormalization = function (part, hook_fn_name) {
-  return path.normalize(path.join(path.dirname(exports.plugins[part.plugin].package.path), hook_fn_name));
+exports.pathNormalization = function (part, hook_fn_name, hook_name) {
+  const parts = hook_fn_name.split(':');
+  const functionName = (parts.length > 1) ? parts.pop() : hook_name;
+  const packageDir = path.dirname(exports.plugins[part.plugin].package.path);
+  const fileName = path.normalize(path.join(packageDir, parts.join(':')));
+  return fileName + ((functionName == null) ? '' : (':' + functionName));
 }
 
 exports.update = async function () {

--- a/src/static/js/pluginfw/shared.js
+++ b/src/static/js/pluginfw/shared.js
@@ -39,7 +39,7 @@ function extractHooks(parts, hook_set_name, normalizer) {
        * a dependency of another plugin! Bah, pesky little details of
        * npm... */
       if (normalizer) {
-        hook_fn_name = normalizer(part, hook_fn_name);
+        hook_fn_name = normalizer(part, hook_fn_name, hook_name);
       }
 
       try {


### PR DESCRIPTION
Plugin authors are allowed to omit the function name in the `ep.json` parts definition. For example:

```
{
  "parts": [
    {
      "name": "ep_example",
      "hooks": {
        "authenticate": "ep_example",
        "authFailure": "ep_example"
      }
    }
  ]
}
```

If omitted, the function name is assumed to be the same as the hook name. Before this change, `hook_fn_name` for the example hooks would both be `/opt/etherpad-lite/node_modules/ep_example`. Now they are suffixed with `:authenticate` and `:authFailure`. This improves logging, and it makes it possible to use `hook_fn_name` to uniquely identify a particular hook function.
