### PR TITLE
webaccess: Enforce creation of `req.session.user` by authn plugins

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -94,6 +94,11 @@ exports.checkAccess = (req, res, next) => {
         settings.users[ctx.username].username = ctx.username;
         req.session.user = settings.users[ctx.username];
       }
+      if (req.session.user == null) {
+        httpLogger.error('authenticate hook failed to add user settings to session');
+        res.status(500).send('Internal Server Error');
+        return;
+      }
       step3Authorize();
     }));
   };


### PR DESCRIPTION
The authorization logic determines whether the user has already successfully authenticated by looking to see if `req.session.user` exists. If an authentication plugin says that it successfully authenticated the user but it did not create `req.session.user` then authentication will re-run for every access, and authorization plugins will be unable to determine whether the user has been authenticated. Return a 500 internal server error to prevent these problems.