### PR TITLE
WIP fix(settings): Reloading after removing settings keys

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -39,22 +39,24 @@ const suppressDisableMsg = ' -- To suppress these warning messages change ' +
     'suppressErrorsInPadText to true in your settings.json\n';
 const _ = require('underscore');
 
+const defaultSettings = {}
+
 /* Root path of the installation */
-exports.root = absolutePaths.findEtherpadRoot();
+defaultSettings.root = absolutePaths.findEtherpadRoot();
 console.log('All relative paths will be interpreted relative to the identified ' +
-            `Etherpad base dir: ${exports.root}`);
+            `Etherpad base dir: ${defaultSettings.root}`);
 
 /**
  * The app title, visible e.g. in the browser window
  */
-exports.title = 'Etherpad';
+defaultSettings.title = 'Etherpad';
 
 /**
  * The app favicon fully specified url, visible e.g. in the browser window
  */
-exports.favicon = 'favicon.ico';
-exports.faviconPad = `../${exports.favicon}`;
-exports.faviconTimeslider = `../../${exports.favicon}`;
+defaultSettings.favicon = 'favicon.ico';
+defaultSettings.faviconPad = `../${defaultSettings.favicon}`;
+defaultSettings.faviconTimeslider = `../../${defaultSettings.favicon}`;
 
 /*
  * Skin name.
@@ -62,37 +64,37 @@ exports.faviconTimeslider = `../../${exports.favicon}`;
  * Initialized to null, so we can spot an old configuration file and invite the
  * user to update it before falling back to the default.
  */
-exports.skinName = null;
+defaultSettings.skinName = null;
 
-exports.skinVariants = 'super-light-toolbar super-light-editor light-background';
+defaultSettings.skinVariants = 'super-light-toolbar super-light-editor light-background';
 
 /**
  * The IP ep-lite should listen to
  */
-exports.ip = '0.0.0.0';
+defaultSettings.ip = '0.0.0.0';
 
 /**
  * The Port ep-lite should listen to
  */
-exports.port = process.env.PORT || 9001;
+defaultSettings.port = process.env.PORT || 9001;
 
 /**
  * Should we suppress Error messages from being in Pad Contents
  */
-exports.suppressErrorsInPadText = false;
+defaultSettings.suppressErrorsInPadText = false;
 
 /**
  * The SSL signed server key and the Certificate Authority's own certificate
  * default case: ep-lite does *not* use SSL. A signed server key is not required in this case.
  */
-exports.ssl = false;
+defaultSettings.ssl = false;
 
 /**
  * socket.io transport methods
  **/
-exports.socketTransportProtocols = ['xhr-polling', 'jsonp-polling', 'htmlfile'];
+defaultSettings.socketTransportProtocols = ['xhr-polling', 'jsonp-polling', 'htmlfile'];
 
-exports.socketIo = {
+defaultSettings.socketIo = {
   /**
    * Maximum permitted client message size (in bytes).
    *
@@ -107,16 +109,16 @@ exports.socketIo = {
 /*
  * The Type of the database
  */
-exports.dbType = 'dirty';
+defaultSettings.dbType = 'dirty';
 /**
  * This setting is passed with dbType to ueberDB to set up the database
  */
-exports.dbSettings = {filename: path.join(exports.root, 'var/dirty.db')};
+defaultSettings.dbSettings = {filename: path.join(defaultSettings.root, 'var/dirty.db')};
 
 /**
  * The default Text of a new pad
  */
-exports.defaultPadText = [
+defaultSettings.defaultPadText = [
   'Welcome to Etherpad!',
   '',
   'This pad text is synchronized as you type, so that everyone viewing this page sees the same ' +
@@ -128,7 +130,7 @@ exports.defaultPadText = [
 /**
  * The default Pad Settings for a user (Can be overridden by changing the setting
  */
-exports.padOptions = {
+defaultSettings.padOptions = {
   noColors: false,
   showControls: true,
   showChat: true,
@@ -145,7 +147,7 @@ exports.padOptions = {
 /**
  * Whether certain shortcut keys are enabled for a user in the pad
  */
-exports.padShortcutEnabled = {
+defaultSettings.padShortcutEnabled = {
   altF9: true,
   altC: true,
   delete: true,
@@ -173,7 +175,7 @@ exports.padShortcutEnabled = {
 /**
  * The toolbar buttons and order.
  */
-exports.toolbar = {
+defaultSettings.toolbar = {
   left: [
     ['bold', 'italic', 'underline', 'strikethrough'],
     ['orderedlist', 'unorderedlist', 'indent', 'outdent'],
@@ -193,87 +195,87 @@ exports.toolbar = {
 /**
  * A flag that requires any user to have a valid session (via the api) before accessing a pad
  */
-exports.requireSession = false;
+defaultSettings.requireSession = false;
 
 /**
  * A flag that prevents users from creating new pads
  */
-exports.editOnly = false;
+defaultSettings.editOnly = false;
 
 /**
  * Max age that responses will have (affects caching layer).
  */
-exports.maxAge = 1000 * 60 * 60 * 6; // 6 hours
+defaultSettings.maxAge = 1000 * 60 * 60 * 6; // 6 hours
 
 /**
  * A flag that shows if minification is enabled or not
  */
-exports.minify = true;
+defaultSettings.minify = true;
 
 /**
  * The path of the abiword executable
  */
-exports.abiword = null;
+defaultSettings.abiword = null;
 
 /**
  * The path of the libreoffice executable
  */
-exports.soffice = null;
+defaultSettings.soffice = null;
 
 /**
  * The path of the tidy executable
  */
-exports.tidyHtml = null;
+defaultSettings.tidyHtml = null;
 
 /**
  * Should we support none natively supported file types on import?
  */
-exports.allowUnknownFileEnds = true;
+defaultSettings.allowUnknownFileEnds = true;
 
 /**
  * The log level of log4js
  */
-exports.loglevel = 'INFO';
+defaultSettings.loglevel = 'INFO';
 
 /**
  * Disable IP logging
  */
-exports.disableIPlogging = false;
+defaultSettings.disableIPlogging = false;
 
 /**
  * Number of seconds to automatically reconnect pad
  */
-exports.automaticReconnectionTimeout = 0;
+defaultSettings.automaticReconnectionTimeout = 0;
 
 /**
  * Disable Load Testing
  */
-exports.loadTest = false;
+defaultSettings.loadTest = false;
 
 /**
  * Enable indentation on new lines
  */
-exports.indentationOnNewLine = true;
+defaultSettings.indentationOnNewLine = true;
 
 /*
  * log4js appender configuration
  */
-exports.logconfig = {appenders: [{type: 'console'}]};
+defaultSettings.logconfig = {appenders: [{type: 'console'}]};
 
 /*
  * Session Key, do not sure this.
  */
-exports.sessionKey = false;
+defaultSettings.sessionKey = false;
 
 /*
  * Trust Proxy, whether or not trust the x-forwarded-for header.
  */
-exports.trustProxy = false;
+defaultSettings.trustProxy = false;
 
 /*
  * Settings controlling the session cookie issued by Etherpad.
  */
-exports.cookie = {
+defaultSettings.cookie = {
   /*
    * Value of the SameSite cookie property. "Lax" is recommended unless
    * Etherpad will be embedded in an iframe from another site, in which case
@@ -293,20 +295,20 @@ exports.cookie = {
  * authorization. Note: /admin always requires authentication, and
  * either authorization by a module, or a user with is_admin set
  */
-exports.requireAuthentication = false;
-exports.requireAuthorization = false;
-exports.users = {};
+defaultSettings.requireAuthentication = false;
+defaultSettings.requireAuthorization = false;
+defaultSettings.users = {};
 
 /*
  * Show settings in admin page, by default it is true
  */
-exports.showSettingsInAdminPage = true;
+defaultSettings.showSettingsInAdminPage = true;
 
 /*
  * By default, when caret is moved out of viewport, it scrolls the minimum
  * height needed to make this line visible.
  */
-exports.scrollWhenFocusLineIsOutOfViewport = {
+defaultSettings.scrollWhenFocusLineIsOutOfViewport = {
   /*
    * Percentage of viewport height to be additionally scrolled.
    */
@@ -339,12 +341,12 @@ exports.scrollWhenFocusLineIsOutOfViewport = {
  *
  * Do not enable on production machines.
  */
-exports.exposeVersion = false;
+defaultSettings.exposeVersion = false;
 
 /*
  * Override any strings found in locale directories
  */
-exports.customLocaleStrings = {};
+defaultSettings.customLocaleStrings = {};
 
 /*
  * From Etherpad 1.8.3 onwards, import and export of pads is always rate
@@ -355,7 +357,7 @@ exports.customLocaleStrings = {};
  *
  * See https://github.com/nfriedly/express-rate-limit for more options
  */
-exports.importExportRateLimiting = {
+defaultSettings.importExportRateLimiting = {
   // duration of the rate limit window (milliseconds)
   windowMs: 90000,
 
@@ -371,7 +373,7 @@ exports.importExportRateLimiting = {
  *
  * See https://github.com/animir/node-rate-limiter-flexible/wiki/Overall-example#websocket-single-connection-prevent-flooding for more options
  */
-exports.commitRateLimiting = {
+defaultSettings.commitRateLimiting = {
   // duration of the rate limit window (seconds)
   duration: 1,
 
@@ -385,17 +387,17 @@ exports.commitRateLimiting = {
  *
  * File size is specified in bytes. Default is 50 MB.
  */
-exports.importMaxFileSize = 50 * 1024 * 1024;
+defaultSettings.importMaxFileSize = 50 * 1024 * 1024;
 
 /*
  * Disable Admin UI tests
  */
-exports.enableAdminUITests = false;
+defaultSettings.enableAdminUITests = false;
 
 
 // checks if abiword is avaiable
 exports.abiwordAvailable = () => {
-  if (exports.abiword != null) {
+  if (defaultSettings.abiword != null) { // TODO wait do I want this?
     return os.type().indexOf('Windows') !== -1 ? 'withoutPDF' : 'yes';
   } else {
     return 'no';
@@ -403,7 +405,7 @@ exports.abiwordAvailable = () => {
 };
 
 exports.sofficeAvailable = () => {
-  if (exports.soffice != null) {
+  if (defaultSettings.soffice != null) { // TODO wait do I want this?
     return os.type().indexOf('Windows') !== -1 ? 'withoutPDF' : 'yes';
   } else {
     return 'no';
@@ -428,7 +430,7 @@ exports.exportAvailable = () => {
 exports.getGitCommit = () => {
   let version = '';
   try {
-    let rootPath = exports.root;
+    let rootPath = defaultSettings.root;
     if (fs.lstatSync(`${rootPath}/.git`).isFile()) {
       rootPath = fs.readFileSync(`${rootPath}/.git`, 'utf8');
       rootPath = rootPath.split(' ').pop().trim();
@@ -453,6 +455,38 @@ exports.getGitCommit = () => {
 exports.getEpVersion = () => require('../../package.json').version;
 
 /**
+ * Sets all settings to the defaults defined in this file. (Does not set any plugin settings).
+ * This way we get a fresh start before merging in custom settings via storeSettings. We
+ * previously had some problems when removing items from custom settings and reloading via
+ * admin.
+ */
+function setDefaults() {
+  for (var i in defaultSettings) {
+    // Test if the setting starts with a lowercase character or looks like a plugin name
+    // These would fail only based on what we set to `defaults`, but it's a good sanity
+    // check.
+    if (i.charAt(0).search("[a-z]") !== 0) {
+      console.warn(`Settings should start with a lowercase character: '${i}'`);
+    } else if (i.indexOf('ep_') === 0) {
+      console.warn(`Settings should not start with 'ep_' so as to not confuse them with plugin settings`);
+    } else {
+      // TODO - do we want to make a copy of this, to make sure the default isn't modified?
+      // Or will the `_.defaults` used below help us in this regard?
+      exports[i] = defaultSettings[i];
+    }
+  }
+  // Wipe out settings for plugins in case we're reloading with
+  // new settings (via admin change, etc) that deleted settings for this plugin.
+  // TODO - is there anything like "defaults" for plugin settings?
+  //   If so, I want to make sure I'm not nuking them here.
+  for (var i in exports) {
+    if (i.indexOf('ep_') === 0) {
+      exports[i] = undefined
+    }
+  }
+}
+
+/**
  * Receives a settingsObj and, if the property name is a valid configuration
  * item, stores it in the module's exported properties via a side effect.
  *
@@ -468,7 +502,7 @@ const storeSettings = (settingsObj) => {
 
     // we know this setting, so we overwrite it
     // or it's a settings hash, specific to a plugin
-    if (exports[i] !== undefined || i.indexOf('ep_') === 0) {
+    if (defaultSettings[i] !== undefined || i.indexOf('ep_') === 0) {
       if (_.isObject(settingsObj[i]) && !Array.isArray(settingsObj[i])) {
         exports[i] = _.defaults(settingsObj[i], exports[i]);
       } else {
@@ -694,6 +728,7 @@ exports.reloadSettings = () => {
   // try to parse the credentials
   const credentials = parseSettings(credentialsFilename, false);
 
+  setDefaults()
   storeSettings(settings);
   storeSettings(credentials);
 

--- a/src/tests/backend/specs/settings.js
+++ b/src/tests/backend/specs/settings.js
@@ -1,0 +1,214 @@
+let settings
+const assert = require('assert').strict;
+const argv = require('../../../node/utils/Cli').argv;
+const fs = require('fs');
+const TEST_SETTINGS_FILE = 'settings.js.test'
+
+// Set the content of the settings file to be loaded by the settings module
+function setSettingsFile(testSettings) {
+  fs.writeFileSync(TEST_SETTINGS_FILE, JSON.stringify(testSettings));
+  argv.settings = 'src/' + TEST_SETTINGS_FILE
+}
+
+function setEmptySettingsFile() {
+  // It won't accept a totally empty file so we make an irrelevant dummy field
+  fs.writeFileSync(TEST_SETTINGS_FILE, JSON.stringify({irrelevant_dummy_field: null}));
+  argv.settings = 'src/' + TEST_SETTINGS_FILE
+}
+
+// Don't trust settings.reloadSettings(), since we're testing it in the
+// first place. Make sure that any mistakes here don't mess up other tests.
+function reloadSettingsModule() {
+  delete require.cache[require.resolve('../../../node/utils/Settings')]
+  settings = require('../../../node/utils/Settings');
+}
+
+describe(__filename, function () {
+  this.timeout(200);
+
+  let originalSettingsFile
+
+  before(async function () {
+    originalSettingsFile = argv.settings
+  })
+
+  beforeEach(async function () {
+    // Start from scratch each time
+    reloadSettingsModule()
+  })
+
+  after(async function () {
+    // after all the tests make sure we're back to normal
+    argv.settings = originalSettingsFile
+    reloadSettingsModule()
+  })
+
+  describe('hard-coded defaults are set', function () {
+    it('for individual values', async function () {
+      setEmptySettingsFile()
+      settings.reloadSettings()
+      assert.equal(settings.loglevel, 'INFO')
+    })
+
+    it('for arrays', async function () {
+      setEmptySettingsFile()
+      settings.reloadSettings()
+      assert.deepEqual(settings.socketTransportProtocols, ['xhr-polling', 'jsonp-polling', 'htmlfile'])
+    })
+
+    it('for objects', async function () {
+      setEmptySettingsFile()
+      settings.reloadSettings()
+      assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90000, max: 10})
+    })
+  })
+
+
+  // `reloadSettings` is used in the admin panel, wherein the user can change the settings file
+  // and reload to actiate the new settings. It has had some strange issues related to removing
+  // values, or objects within values. These tests aim to test various such scenarios.
+  describe('reloadSettings', function () {
+    describe('sets and updates the settings', function () {
+      it('for individual values', async function () {
+        setSettingsFile({loglevel: 'WARNING'})
+        settings.reloadSettings()
+        assert.equal(settings.loglevel, 'WARNING')
+        setSettingsFile({loglevel: 'ERROR'})
+        settings.reloadSettings()
+        assert.equal(settings.loglevel, 'ERROR')
+      })
+      it('for arrays', async function () {
+        setSettingsFile({socketTransportProtocols: ['a', 'b', 'c']})
+        settings.reloadSettings()
+        assert.deepEqual(settings.socketTransportProtocols, ['a', 'b', 'c'])
+        setSettingsFile({socketTransportProtocols: ['x', 'y', 'z']})
+        settings.reloadSettings()
+        assert.deepEqual(settings.socketTransportProtocols, ['x', 'y', 'z'])
+      })
+      it('for objects', async function () {
+        // setting only one fields
+        setSettingsFile({importExportRateLimiting: {max: 11}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90000, max: 11})
+
+        // setting the same field again
+        setSettingsFile({importExportRateLimiting: {max: 12}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90000, max: 12})
+
+        // setting both fields, twice
+        setSettingsFile({importExportRateLimiting: {windowMs: 90003, max: 13}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90003, max: 13})
+        setSettingsFile({importExportRateLimiting: {windowMs: 90004, max: 14}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90004, max: 14})
+      })
+    })
+
+    describe('returns setting fields and subfields to default values after removal from settings file', function () {
+      it('when setting individual value', async function () {
+        setSettingsFile({loglevel: 'WARNING'})
+        settings.reloadSettings()
+        assert.equal(settings.loglevel, 'WARNING')
+
+        setEmptySettingsFile()
+        settings.reloadSettings()
+        assert.equal(settings.loglevel, 'INFO') // The hard-coded default
+      })
+
+      it('when setting an array', async function () {
+        setSettingsFile({socketTransportProtocols: ['a', 'b', 'c']})
+        settings.reloadSettings()
+        assert.deepEqual(settings.socketTransportProtocols, ['a', 'b', 'c'])
+
+        setEmptySettingsFile()
+        settings.reloadSettings()
+        assert.deepEqual(settings.socketTransportProtocols, ['xhr-polling', 'jsonp-polling', 'htmlfile'])
+      })
+
+      it('when changing all fields of an object with specified fields', async function () {
+        // Set both fields
+        setSettingsFile({importExportRateLimiting: {windowMs: 90001, max: 11}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90001, max: 11})
+
+        // Set only one field
+        setSettingsFile({importExportRateLimiting: {max: 11}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90000, max: 11})
+
+        // Set only the other field
+        setSettingsFile({importExportRateLimiting: {windowMs: 90001}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90001, max: 10})
+
+        setEmptySettingsFile()
+        settings.reloadSettings()
+        assert.deepEqual(settings.importExportRateLimiting, {windowMs: 90000, max: 10})
+      })
+
+      it('when setting an object that is empty by default', async function () {
+        setSettingsFile({users: {user_1: {password: 'password_1'}, user_2: {password: 'password_2'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.users, {user_1: {password: 'password_1'}, user_2: {password: 'password_2'}})
+
+        // Remove a field from the object; make sure it goes away
+        setSettingsFile({users: {user_1: {password: 'password_1'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.users, {user_1: {password: 'password_1'}})
+
+        // Change to a different field; make sure the old one goes away
+        setSettingsFile({users: {user_3: {password: 'password_3'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.users, {user_3: {password: 'password_3'}})
+
+        // Change a sub-field; make sure the old one goes away
+        setSettingsFile({users: {user_3: {is_admin: false}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.users, {user_3: {is_admin: false}})
+
+        setEmptySettingsFile()
+        settings.reloadSettings()
+        assert.deepEqual(settings.users, {})
+      })
+
+      // I think this should also be empty by default
+      it('when setting an object that represents plugin settings', async function () {
+        setSettingsFile({ep_example: {key_1: {subkey_1: 'val_1'}, key_2: {subkey_1: 'val_1'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.ep_example, {key_1: {subkey_1: 'val_1'}, key_2: {subkey_1: 'val_1'}})
+
+        // Remove a field from the object; make sure it goes away
+        setSettingsFile({ep_example: {key_1: {subkey_1: 'val_1'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.ep_example, {key_1: {subkey_1: 'val_1'}})
+
+        // Change to a different field; make sure the old one goes away
+        setSettingsFile({ep_example: {key_2: {subkey_1: 'val_1'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.ep_example, {key_2: {subkey_1: 'val_1'}})
+
+        // Change a sub-field; make sure the old one goes away
+        setSettingsFile({ep_example: {key_2: {subkey_2: 'val_1'}}})
+        settings.reloadSettings()
+        assert.deepEqual(settings.ep_example, {key_2: {subkey_2: 'val_1'}})
+
+        setEmptySettingsFile()
+        settings.reloadSettings()
+        assert.deepEqual(settings.ep_example, undefined)
+      })
+    })
+
+    // TO TEST
+    //
+    // Array stuff? _.defaults?
+    // Unknown setting - warning, gets ignored
+    // ep_ settiing - i feel like there was something special about how the innards of this behaved. not just the struct itself.
+    //
+    // TODO - go through setDefaults, and maybe some others,
+    // and make a note to test all edge cases and other things I could test
+    //
+    // TODO - reducing existing objects, particularly the ep_ ones, reducing lists
+  });
+});


### PR DESCRIPTION
Addressing issue in #4217 

# The Problem

If you have a field in settings with a default value (hardcoded in `src/node/utils/Settings.js`), you can override it in a custom setting in `settings.json`. The settings admin (`/admin/settings`) lets you edit that custom setting, and click "save" and "reload" and it takes effect as expected. However if in the settings admin you _remove_ that setting, it doesn't go back to the default value; the value just stays the same. However if you do a hard restart of the server, the value does go back to the default.

# The Explanation

When you call `reloadSettings()` from the settings.json editor admin, it will take the your new settings and merge it, more or less, with the _currently loaded_ settings, not the _default_ settings. When you remove a key and reload within the settings admin, it overrides that now-missing key with the existing value, which is the custom value you had there before you removed it. If you do a hard reset, the previous custom value is flushed from memory, and it goes through the usual process of loading the default before loading any custom values.

This phenomenon happens at different levels of the `settings.json` object hierarchy, but I'm not sure if it happens at all of them, because of the merging method used. This may also depend on whether it's a plugin setting or not.

# The Proposed Fix

For my fix, I make a new function called `setDefaults()` which overwrites all of the settings with the defaults. I call it within `reloadSettings()` before `storeSettings(settings)` and `storeSettings(credentials)`. This also involves putting the defaults into its own easily identified object.

Assuming this is the desired path (per core developers' opinion(s)), I'll see if I can write some tests, and then clean up some confusing comments.