### PR TITLE
Pad: Disable toolbar and import/export when reconnecting

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -222,7 +222,6 @@ function handshake()
   });
 
   socket.on('reconnecting', function() {
-    padeditor.disable();
     pad.collabClient.setStateIdle();
     pad.collabClient.setIsPendingRevision(true);
     pad.collabClient.setChannelState("RECONNECTING");
@@ -752,10 +751,15 @@ var pad = {
     if (newState == "CONNECTED")
     {
       padeditor.enable();
+      padeditbar.enable();
+      padimpexp.enable();
       padconnectionstatus.connected();
     }
     else if (newState == "RECONNECTING")
     {
+      padeditor.disable();
+      padeditbar.disable();
+      padimpexp.disable();
       padconnectionstatus.reconnecting();
     }
     else if (newState == "DISCONNECTED")

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -146,7 +146,7 @@ var padeditbar = (function()
       self.dropdowns = [];
 
       $("#editbar .editbarbutton").attr("unselectable", "on"); // for IE
-      $("#editbar").removeClass("disabledtoolbar").addClass("enabledtoolbar");
+      this.enable();
       $("#editbar [data-key]").each(function () {
         $(this).unbind("click");
         (new ToolbarItem($(this))).bind(function (command, item) {
@@ -193,6 +193,10 @@ var padeditbar = (function()
     disable: function()
     {
       $("#editbar").addClass('disabledtoolbar').removeClass("enabledtoolbar");
+    },
+    enable: function()
+    {
+      $('#editbar').addClass('enabledtoolbar').removeClass('disabledtoolbar');
     },
     commands: {},
     registerCommand: function (cmd, callback) {


### PR DESCRIPTION
I noticed this while troubleshooting a difficult-to-reproduce reconnect problem. If you know how to simulate a disconnect please let me know.