### PR TITLE
Use `null`, not `"null"`, if `sessionID` cookie doesn't exist

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -156,7 +156,8 @@ function sendClientReady(isReconnect, messageType)
     createCookie("token", token, 60);
   }
 
-  var sessionID = decodeURIComponent(readCookie("sessionID"));
+  var encodedSessionID = readCookie('sessionID');
+  var sessionID = encodedSessionID == null ? null : decodeURIComponent(encodedSessionID);
   var password = readCookie("password");
 
   var msg = {


### PR DESCRIPTION
`decodeURIComponent(null)` returns the string `'null'`, which we don't want.
