### PR TITLE
Performance bigfix: minify fixes

### DIFF
--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -367,7 +367,7 @@ function getFileCompressed(filename, contentType, callback) {
   getFile(filename, function (error, content) {
     if (error || !content || !settings.minify) {
       callback(error, content);
-    } else if (contentType == 'text/javascript') {
+    } else if (contentType == 'application/javascript') {
       threadsPool.queue(async ({ compressJS }) => {
         try {
           logger.info('Compress JS file %s.', filename)


### PR DESCRIPTION
Terser is not called because of a mime type mismatch.
Please do not merge yet! I have more minify stuff coming in. I have struggled a while with testing this and finally made puppeteer-tests, because it allowed me to easily spy on requests. However, the recent webaccess tests from @rhansen made me think again and now I want to include more unit-style tests instead.

The reason not to merge yet: there is a performance degradation with caching middleware and minify regarding file system access. With this terser-fix caching_middleware would always regenerate packages. Will fix this.

another thing: static assets are directly served in Minify. Minify stats files on every request, which is good, when we want to serve updated files directly without restart. However, the caching_middleware does the opposite. It caches packages and serves them from the cache.
So in theory its possible to request a file directly via /static/js/filename and if the file happens to be included in a package also via /javascripts/lib/. For instance, collab_client can be requested via /static/js/collab_client.js and via package pad.js (/javascripts/lib/ep_etherpad-lite/static/js/collab_client.js). When we update collab_client.js a request to /static... would yield the updated version, while the package pad.js would still return the old version. This is probably not wanted.