### PR TITLE
Feature: copy without history

### DIFF
--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -530,7 +530,7 @@ copies a pad with full history and chat. If force is true and the destination pa
 * API >= 1.2.15
 
 copies a pad without copying the history and chat. If force is true and the destination pad exists, it will be overwritten.
-Note, all the revisions will be lost! In most of the cases one should user `copyPad` instead.
+Note that all the revisions will be lost! In most of the cases one should use `copyPad` API instead.
 
 *Example returns:*
 * `{code: 0, message:"ok", data: null}`

--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -526,6 +526,16 @@ copies a pad with full history and chat. If force is true and the destination pa
   * `{code: 0, message:"ok", data: null}`
   * `{code: 1, message:"padID does not exist", data: null}`
 
+#### copyPadWithoutHistory(sourceID, destinationID[, force=false])
+* API >= 1.2.15
+
+copies a pad without copying the history and chat. If force is true and the destination pad exists, it will be overwritten.
+Note, all the revisions will be lost! In most of the cases one should user `copyPad` instead.
+
+*Example returns:*
+* `{code: 0, message:"ok", data: null}`
+* `{code: 1, message:"padID does not exist", data: null}`
+
 #### movePad(sourceID, destinationID[, force=false])
  * API >= 1.2.8
 

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -609,7 +609,7 @@ Example returns:
 exports.copyPadWithoutHistory = async function(sourceID, destinationID, force)
 {
   let pad = await getPadSafe(sourceID, true);
-  await pad.copyWithoutHistory(destinationID, force);
+  await pad.copyPadWithoutHistory(destinationID, force);
 }
 
 /**

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -598,6 +598,21 @@ exports.copyPad = async function(sourceID, destinationID, force)
 }
 
 /**
+copyPadWithoutHistory(sourceID, destinationID[, force=false]) copies a pad. If force is true,
+  the destination will be overwritten if it exists.
+
+Example returns:
+
+{code: 0, message:"ok", data: {padID: destinationID}}
+{code: 1, message:"padID does not exist", data: null}
+*/
+exports.copyPadWithoutHistory = async function(sourceID, destinationID, force)
+{
+  let pad = await getPadSafe(sourceID, true);
+  await pad.copyWithoutHistory(destinationID, force);
+}
+
+/**
 movePad(sourceID, destinationID[, force=false]) moves a pad. If force is true,
   the destination will be overwritten if it exists.
 

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -513,8 +513,7 @@ Pad.prototype.copyWithoutHistory = async function copyWithoutHistory(destination
 
   // based on Changeset.makeSplice
   let assem = Changeset.smartOpAssembler();
-  let initialApool = new AttributePool();
-  assem.appendOpWithText('=', '', [], initialApool);
+  assem.appendOpWithText('=', '');
   Changeset.appendATextToAssembler(oldAText, assem);
   assem.endDocument();
 

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -357,6 +357,7 @@ Pad.prototype.init = async function init(text) {
 }
 
 Pad.prototype.copy = async function copy(destinationID, force) {
+  let destGroupID;
   let sourceID = this.id;
 
   // Kick everyone from this pad.
@@ -367,11 +368,16 @@ Pad.prototype.copy = async function copy(destinationID, force) {
   // flush the source pad:
   this.saveToDatabase();
 
-  // if it's a group pad, let's make sure the group exists.
-  let destGroupID = await this.checkIfGroupExistAndReturnIt(destinationID);
 
-  // if force is true and already exists a Pad with the same id, remove that Pad
-  await this.removePadIfForceIsTrueAndAlreadyExist(destinationID, force);
+  try {
+    // if it's a group pad, let's make sure the group exists.
+    destGroupID = await this.checkIfGroupExistAndReturnIt(destinationID);
+
+    // if force is true and already exists a Pad with the same id, remove that Pad
+    await this.removePadIfForceIsTrueAndAlreadyExist(destinationID, force);
+  } catch(err) {
+    throw err;
+  }
 
   // copy the 'pad' entry
   let pad = await db.get("pad:" + sourceID);
@@ -467,16 +473,21 @@ Pad.prototype.copyAuthorInfoToDestinationPad = function copyAuthorInfoToDestinat
 }
 
 Pad.prototype.copyPadWithoutHistory = async function copyPadWithoutHistory(destinationID, force) {
+  let destGroupID;
   let sourceID = this.id;
 
   // flush the source pad
   this.saveToDatabase();
 
-  // if it's a group pad, let's make sure the group exists.
-  let destGroupID = await this.checkIfGroupExistAndReturnIt(destinationID);
+  try {
+    // if it's a group pad, let's make sure the group exists.
+    destGroupID = await this.checkIfGroupExistAndReturnIt(destinationID);
 
-  // if force is true and already exists a Pad with the same id, remove that Pad
-  await this.removePadIfForceIsTrueAndAlreadyExist(destinationID, force);
+    // if force is true and already exists a Pad with the same id, remove that Pad
+    await this.removePadIfForceIsTrueAndAlreadyExist(destinationID, force);
+  } catch(err) {
+    throw err;
+  }
 
   let sourcePad = await padManager.getPad(sourceID);
 

--- a/src/node/handler/APIHandler.js
+++ b/src/node/handler/APIHandler.js
@@ -142,8 +142,13 @@ version["1.2.14"] = Object.assign({}, version["1.2.13"],
   }
 );
 
+version["1.2.15"] = Object.assign({}, version["1.2.14"],
+  { "copyPadWithoutHistory"    : ["sourceID", "destinationID", "force"]
+  }
+);
+
 // set the latest available API version here
-exports.latestApiVersion = '1.2.14';
+exports.latestApiVersion = '1.2.15';
 
 // exports the versions so it can be used by the new Swagger endpoint
 exports.version = version;

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1265,6 +1265,8 @@ async function handleChangesetRequest(client, message)
   // build the requested rough changesets and send them back
   try {
     let data = await getChangesetInfo(padIds.padId, start, end, granularity);
+    console.log('data');
+    console.log(data);
     data.requestID = message.data.requestID;
     client.json.send({ type: "CHANGESET_REQ", data });
   } catch (err) {
@@ -1278,6 +1280,7 @@ async function handleChangesetRequest(client, message)
  */
 async function getChangesetInfo(padId, startNum, endNum, granularity)
 {
+  debugger
   let pad = await padManager.getPad(padId);
   let head_revision = pad.getHeadRevisionNumber();
 

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -1265,8 +1265,6 @@ async function handleChangesetRequest(client, message)
   // build the requested rough changesets and send them back
   try {
     let data = await getChangesetInfo(padIds.padId, start, end, granularity);
-    console.log('data');
-    console.log(data);
     data.requestID = message.data.requestID;
     client.json.send({ type: "CHANGESET_REQ", data });
   } catch (err) {
@@ -1280,7 +1278,6 @@ async function handleChangesetRequest(client, message)
  */
 async function getChangesetInfo(padId, startNum, endNum, granularity)
 {
-  debugger
   let pad = await padManager.getPad(padId);
   let head_revision = pad.getHeadRevisionNumber();
 

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -427,6 +427,7 @@ describe('deletePad', function(){
 
 var originalPadId = testPadId;
 var newPadId = makeid();
+var copiedPadId = makeid();
 
 describe('createPad', function(){
   it('creates a new Pad with text', function(done) {
@@ -681,6 +682,16 @@ describe('createPad', function(){
   });
 })
 
+describe('copyPad', function(){
+  it('copies the content of a existent pad id', function(done) {
+    api.get(endPoint('copyPad')+"&sourceID="+testPadId+"&destinationID="+copiedPadId+"&force=true")
+      .expect(function(res){
+        if(res.body.code !== 0) throw new Error("Copy Pad Failed")
+      })
+      .expect('Content-Type', /json/)
+      .expect(200, done)
+  });
+})
 
 /*
                           -> movePadForce Test

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -683,10 +683,21 @@ describe('createPad', function(){
 })
 
 describe('copyPad', function(){
-  it('copies the content of a existent pad id', function(done) {
+  it('copies the content of a existent pad', function(done) {
     api.get(endPoint('copyPad')+"&sourceID="+testPadId+"&destinationID="+copiedPadId+"&force=true")
       .expect(function(res){
         if(res.body.code !== 0) throw new Error("Copy Pad Failed")
+      })
+      .expect('Content-Type', /json/)
+      .expect(200, done)
+  });
+})
+
+describe('copyPadWithoutHistory', function(){
+  it('copies the content of a existent pad without the history', function(done) {
+    api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+testPadId+"&destinationID="+copiedPadId+"&force=true")
+      .expect(function(res){
+        if(res.body.code !== 0) throw new Error("Copy Pad Without History Failed")
       })
       .expect('Content-Type', /json/)
       .expect(200, done)

--- a/tests/backend/specs/api/pad.js
+++ b/tests/backend/specs/api/pad.js
@@ -695,13 +695,18 @@ describe('copyPad', function(){
 
 describe('copyPadWithoutHistory', function(){
   var sourcePadId = makeid();
-  var newPad = makeid();
+  var newPad;
+
   before(function(done) {
     createNewPadWithHtml(sourcePadId, ulHtml, done);
+  });
+
+  beforeEach(function() {
+    newPad = makeid();
   })
 
   it('returns a successful response', function(done) {
-    api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+copiedPadId+"&force=true")
+    api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+newPad+"&force=false")
       .expect(function(res){
         if(res.body.code !== 0) throw new Error("Copy Pad Without History Failed")
       })
@@ -711,7 +716,7 @@ describe('copyPadWithoutHistory', function(){
 
   // this test validates if the source pad's text and attributes are kept
   it('creates a new pad with the same content as the source pad', function(done) {
-    api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+newPad+"&force=true")
+    api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+newPad+"&force=false")
       .expect(function(res){
         if(res.body.code !== 0) throw new Error("Copy Pad Without History Failed")
       })
@@ -734,6 +739,49 @@ describe('copyPadWithoutHistory', function(){
           })
         .expect(200, done);
       });
+  });
+
+  context('when try copy a pad with a group that does not exist', function() {
+    var padId = makeid();
+    var padWithNonExistentGroup = `notExistentGroup$${padId}`
+    it('throws an error', function(done) {
+      api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+padWithNonExistentGroup+"&force=true")
+        .expect(function(res){
+          // code 1, it means an error has happened
+          if(res.body.code !== 1) throw new Error("It should report an error")
+        })
+        .expect(200, done);
+    })
+  });
+
+  context('when try copy a pad and destination pad already exist', function() {
+    var padIdExistent = makeid();
+
+    before(function(done) {
+      createNewPadWithHtml(padIdExistent, ulHtml, done);
+    });
+
+    context('and force is false', function() {
+      it('throws an error', function(done) {
+        api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+padIdExistent+"&force=false")
+          .expect(function(res){
+            // code 1, it means an error has happened
+            if(res.body.code !== 1) throw new Error("It should report an error")
+          })
+          .expect(200, done);
+      });
+    });
+
+    context('and force is true', function() {
+      it('returns a successful response', function(done) {
+        api.get(endPoint('copyPadWithoutHistory')+"&sourceID="+sourcePadId+"&destinationID="+padIdExistent+"&force=true")
+          .expect(function(res){
+            // code 1, it means an error has happened
+            if(res.body.code !== 0) throw new Error("Copy pad without history with force true failed")
+          })
+          .expect(200, done);
+      });
+    });
   })
 })
 


### PR DESCRIPTION
This PR is an implementation of https://github.com/ether/etherpad-lite/issues/4242
With this change we provide a way to copy pads without bringing all the history information (revisions, chats).

### Motivation
Etherpad is such a great tool, but in our instance we were having some problems with the current mechanism of pads duplication. A pad with 100k revisions has to perform 200k operations at least - get 100k information on the source pad and save 100k into the new pad. Although Etherpad provides a good mechanism of caching, that amount of operation occupies the CPU time too much. 
In our case we could use small instances of AWS machines t2.micro* to host Etherpad without a hitch if it wasn't that problem. As we have lots of users duplicating their pads, we had to increase our server capacity to a t2.large* instance. That means a cost of 10x. One of the greatest things about Etherpad is how lightweight it is! With that in mind this PR provides a lightweight alternative to duplicate pads.

### Observations
This method should **NOT** be preferable over `copyPad`. The `copyPad` API brings all the information so we have an exact copy of the pad. We can think the "copyWithoutHistory" as a copy/paste from one pad to another one.

### Tests
We implemented some missing tests on the copyPad on this PR as well. Due to limitations on the test suite we couldn't provide an automated way to check if the Timeslider works. I did a manual smoke test with a large pad, 11.000 lines, and everything worked properly.

### CPU usage
<img width="1175" alt="example" src="https://user-images.githubusercontent.com/4945372/93139415-0b76bb00-f6b7-11ea-9b74-6e4adf857fdb.png">

##### That's an example of the CPU usage with pad with less than 7k revision

#### AWS t2 types
* https://aws.amazon.com/ec2/instance-types/t2/

closes https://github.com/ether/etherpad-lite/issues/4242