### PR TITLE
i18n: Improve error logging when language JSON read fails

### DIFF
--- a/src/node/hooks/i18n.js
+++ b/src/node/hooks/i18n.js
@@ -50,7 +50,13 @@ function getAllLocales() {
     locales[langcode]={};
 
     files.forEach(function(file) {
-     var fileContents = JSON.parse(fs.readFileSync(file,'utf8'));
+      let fileContents;
+      try {
+        fileContents = JSON.parse(fs.readFileSync(file,'utf8'));
+      } catch (err) {
+        console.error(`failed to read JSON file ${file}: ${err}`);
+        throw err;
+      }
       _.extend(locales[langcode], fileContents);
     });
   });


### PR DESCRIPTION
Before it only logged an error like this:

    SyntaxError: Unexpected string in JSON at position XYZ

Now it also logs the filename, making it easier to figure out where
the bad data is:

    failed to read file /path/to/etherpad-lite/src/locales/en.json: SyntaxError: Unexpected string in JSON at position XYZ
