### PR TITLE
tests: Use wtfnode to determine why mocha isn't exiting

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8835,6 +8835,12 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
       "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
     },
+    "wtfnode": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.3.tgz",
+      "integrity": "sha512-Ll7iH8MbRQTE+QTw20Xax/0PM5VeSVSOhsmoR3+knWuJkEWTV5d9yPO6Sb+IDbt9I4UCrKpvHuF9T9zteRNOuA==",
+      "dev": true
+    },
     "xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -80,7 +80,8 @@
     "nyc": "15.0.1",
     "set-cookie-parser": "^2.4.6",
     "supertest": "4.0.2",
-    "wd": "1.12.1"
+    "wd": "1.12.1",
+    "wtfnode": "^0.8.3"
   },
   "engines": {
     "node": ">=10.13.0",
@@ -91,7 +92,7 @@
     "url": "https://github.com/ether/etherpad-lite.git"
   },
   "scripts": {
-    "test": "nyc mocha --timeout 5000 --recursive ../tests/backend/specs",
+    "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 5000 --recursive ../tests/backend/specs",
     "test-contentcollector": "nyc mocha --timeout 5000 ../tests/backend/specs",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },


### PR DESCRIPTION
If mocha hangs after running the tests, hit Ctrl-C and wtfnode will print open files, open sockets, running timers, and running intervals. Adding an `after` function that closes/stops all of those things will ensure that mocha exits when it finishes running the tests.