### PR TITLE
security: Fix authorization bypass vulnerability

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -228,24 +228,27 @@ following are true:
   different plugin has not already caused the post-authentication authorization
   to pass or fail.
 
-For pre-authentication invocations of your authorize function, calling the
-provided callback with `[true]` will immediately grant access without requiring
-the user to authenticate. Calling the provided callback with `[false]` will
-trigger authentication unless authentication is not required. Calling the
-provided callback with `[]` or `undefined` will defer the decision to the next
-authorization plugin (if any, otherwise it is the same as calling with
-`[false]`).
+For pre-authentication invocations of your authorize function, you can pass the
+following values to the provided callback:
+
+* `[true]` or `['create']` will immediately grant access without requiring the
+  user to authenticate.
+* `[false]` will trigger authentication unless authentication is not required.
+* `[]` or `undefined` will defer the decision to the next authorization plugin
+  (if any, otherwise it is the same as calling with `[false]`).
 
 **WARNING:** Your authorize function can be called for an `/admin` page even if
 the user has not yet authenticated. It is your responsibility to fail or defer
 authorization if you do not want to grant admin privileges to the general
 public.
 
-For post-authentication invocations of your authorize function, calling the
-provided callback with `[true]` or `[false]` will cause access to be granted or
-denied, respectively. Calling the callback with `[]` or `undefined` will defer
-the authorization decision to the next authorization plugin (if any, otherwise
-deny).
+For post-authentication invocations of your authorize function, you can pass the
+following values to the provided callback:
+
+* `[true]` or `['create']` will grant access.
+* `[false]` will deny access.
+* `[]` or `undefined` will defer the authorization decision to the next
+  authorization plugin (if any, otherwise deny).
 
 Example:
 

--- a/tests/backend/specs/socketio.js
+++ b/tests/backend/specs/socketio.js
@@ -178,7 +178,7 @@ describe('socket.io access checks', () => {
     settings.requireAuthentication = true;
     await assert.rejects(connect(null), {message: /signed express_sid cookie is required/i});
   });
-  xit('authorization bypass attempt -> error', async () => {
+  it('authorization bypass attempt -> error', async () => {
     plugins.hooks.authorize = [{hook_fn: (hookName, {req}, cb) => {
       if (req.session.user == null) return cb([]); // Hasn't authenticated yet.
       // Only allowed to access /p/pad.


### PR DESCRIPTION
Before, a malicious user could bypass authorization restrictions imposed by the authorize hook:

 * Step 1: Fetch any resource that the malicious user is authorized to access (e.g., static content).
 * Step 2: Use the signed express_sid cookie generated in step 1 to create a socket.io connection.
 * Step 3: Perform the CLIENT_READY handshake for the desired pad.
 * Step 4: Profit!

Now the authorization decision made by the authorize hook is propagated to SecurityManager so that it can approve or reject socket.io messages as appropriate.

This also sets up future support for per-user read-only and modify-only (no create) authorization levels.
