### PR TITLE
webaccess: Fix syntax error (missing close curly brace)

### DIFF
--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -31,7 +31,7 @@ exports.checkAccess = (req, res, next) => {
     hooks.aCallFirst('authorize', {req, res, next, resource: req.path}, hookResultMangle((ok) => {
       if (ok) return next();
       return fail();
-    ));
+    }));
   };
 
   /* Authentication OR authorization failed. */


### PR DESCRIPTION
Somehow I introduced this bug in commit 2bc26b8ef89ea0a5b447ad12586b694c6a830d4e but never noticed.