### PR TITLE
Plugin backendtests in ci

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -92,7 +92,7 @@
     "url": "https://github.com/ether/etherpad-lite.git"
   },
   "scripts": {
-    "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 5000 --recursive ../tests/backend/specs ../node_modules/ep_*/static/tests/backend",
+    "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 5000 --recursive ../tests/backend/specs ../node_modules/ep_*/static/tests/backend/specs",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
   "version": "1.8.5",

--- a/src/package.json
+++ b/src/package.json
@@ -92,7 +92,7 @@
     "url": "https://github.com/ether/etherpad-lite.git"
   },
   "scripts": {
-    "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 5000 --recursive ../tests/backend/specs",
+    "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 5000 --recursive ../tests/backend/specs ../node_modules/ep_*/static/tests/backend",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
   "version": "1.8.5",

--- a/src/package.json
+++ b/src/package.json
@@ -93,7 +93,6 @@
   },
   "scripts": {
     "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 5000 --recursive ../tests/backend/specs",
-    "test-contentcollector": "nyc mocha --timeout 5000 ../tests/backend/specs",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
   "version": "1.8.5",

--- a/tests/frontend/travis/runnerBackend.sh
+++ b/tests/frontend/travis/runnerBackend.sh
@@ -46,6 +46,5 @@ cd src
 
 failed=0
 npm run test || failed=1
-npm run test-contentcollector || failed=1
 
 exit $failed


### PR DESCRIPTION
the backend tests currently fail but are green (due to wtfnode added recently always exiting with 0 - I already asked @rhansen if the problem with non-exiting tests is still present)

fixes #4311 

It's probably not the best method. For frontend tests we iterate over all node_modules subdirectories to find static/tests/frontend and in the backend case I just look for ep_* - all plugins start with ep_ right?

It seems to work in every of the following cases:
- no plugins installed
- plugin installed via /admin
- plugin installed via `npm i ep_comments_page` (when https://github.com/ether/ep_comments/pull/135 is resolved)
- more than one plugin with backend tests (I tested ep_comments, ep_font_color. ep_webpack seems to work too, but also has dependency resolution problems like ep_comments when installed via plugin manager - maybe something is broken in my setup because I suppose it should work right away when installed via /admin or npm i, but it only works after I run `npm i` after installation inside node_modules/ep_webpack; ep_word_edit has backend tests too, but breaks other stuff


When possible, maybe include this branch into the CI pipeline of ep_comments and when it works, merge it? Or merge it and let's see if it was all that's needed for backend tests.