### PR TITLE
Revert "tests: Use wtfnode to determine why mocha isn't exiting"

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8835,12 +8835,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
       "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
     },
-    "wtfnode": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.3.tgz",
-      "integrity": "sha512-Ll7iH8MbRQTE+QTw20Xax/0PM5VeSVSOhsmoR3+knWuJkEWTV5d9yPO6Sb+IDbt9I4UCrKpvHuF9T9zteRNOuA==",
-      "dev": true
-    },
     "xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -80,8 +80,7 @@
     "nyc": "15.0.1",
     "set-cookie-parser": "^2.4.6",
     "supertest": "4.0.2",
-    "wd": "1.12.1",
-    "wtfnode": "^0.8.3"
+    "wd": "1.12.1"
   },
   "engines": {
     "node": ">=10.13.0",
@@ -92,7 +91,7 @@
     "url": "https://github.com/ether/etherpad-lite.git"
   },
   "scripts": {
-    "test": "nyc wtfnode node_modules/.bin/_mocha --timeout 30000 --recursive ../tests/backend/specs ../node_modules/ep_*/static/tests/backend/specs",
+    "test": "nyc mocha --timeout 30000 --recursive ../tests/backend/specs ../node_modules/ep_*/static/tests/backend/specs",
     "test-container": "nyc mocha --timeout 5000 ../tests/container/specs/api"
   },
   "version": "1.8.6",


### PR DESCRIPTION
This reverts commit ae1142a799b91f20c9a54c233b8c1a80ca99d0a5.

According to https://github.com/ether/etherpad-lite/pull/4304#issuecomment-694833456 wtfnode always seems to exit with 0 even if the tests fail.