### PR TITLE
tests: Import/export test fixes and cleanups

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8235,6 +8235,77 @@
       "requires": {
         "methods": "^1.1.2",
         "superagent": "^3.8.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "superagent": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.2.0",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.3.5"
+          }
+        }
       }
     },
     "supports-color": {

--- a/src/package.json
+++ b/src/package.json
@@ -79,6 +79,7 @@
     "mocha-froth": "^0.2.10",
     "nyc": "15.0.1",
     "set-cookie-parser": "^2.4.6",
+    "superagent": "^3.8.3",
     "supertest": "4.0.2",
     "wd": "1.12.1"
   },

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -73,6 +73,7 @@ describe('Imports and Exports', function(){
   it('creates a new Pad, imports content to it, checks that content', function(done) {
     if(!settings.allowAnyoneToImport){
       console.warn("not anyone can import so not testing -- to include this test set allowAnyoneToImport to true in settings.json");
+      this.skip();
       done();
     }else{
       api.get(endPoint('createPad')+"&padID="+testPadId)
@@ -108,9 +109,10 @@ describe('Imports and Exports', function(){
   // For some reason word import does not work in testing..
   // TODO: fix support for .doc files..
   it('Tries to import .doc that uses soffice or abiword', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
 
@@ -134,9 +136,10 @@ describe('Imports and Exports', function(){
   });
 
   it('exports DOC', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
     try{
@@ -154,9 +157,10 @@ describe('Imports and Exports', function(){
   })
 
   it('Tries to import .docx that uses soffice or abiword', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
 
@@ -180,9 +184,10 @@ describe('Imports and Exports', function(){
   });
 
   it('exports DOC from imported DOCX', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
     request(host + '/p/'+testPadId+'/export/doc', function (err, res, body) {
@@ -196,9 +201,10 @@ describe('Imports and Exports', function(){
   })
 
   it('Tries to import .pdf that uses soffice or abiword', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
 
@@ -222,9 +228,10 @@ describe('Imports and Exports', function(){
   });
 
   it('exports PDF', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
     request(host + '/p/'+testPadId+'/export/pdf', function (err, res, body) {
@@ -238,9 +245,10 @@ describe('Imports and Exports', function(){
   })
 
   it('Tries to import .odt that uses soffice or abiword', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
 
@@ -264,9 +272,10 @@ describe('Imports and Exports', function(){
   });
 
   it('exports ODT', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
         (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      this.skip();
       return done();
     }
     request(host + '/p/'+testPadId+'/export/odt', function (err, res, body) {
@@ -280,7 +289,7 @@ describe('Imports and Exports', function(){
   })
 
   it('Tries to import .etherpad', function(done) {
-    if(!settings.allowAnyoneToImport) return done();
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
 
     var req = request.post(host + '/p/'+testPadId+'/import', function (err, res, body) {
       if (err) {
@@ -353,6 +362,7 @@ describe('Imports and Exports', function(){
   it('Tries to import unsupported file type', function(done) {
     if(settings.allowUnknownFileEnds === true){
       console.log("allowing unknown file ends so skipping this test");
+      this.skip();
       return done();
     }
 

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -311,6 +311,7 @@ describe('Imports and Exports', function(){
   });
 
   it('exports Etherpad', function(done) {
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     request(host + '/p/'+testPadId+'/export/etherpad', function (err, res, body) {
       // TODO: At some point checking that the contents is correct would be suitable
       if(body.indexOf("hello") !== -1){
@@ -323,6 +324,7 @@ describe('Imports and Exports', function(){
   })
 
   it('exports HTML for this Etherpad file', function(done) {
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     request(host + '/p/'+testPadId+'/export/html', function (err, res, body) {
 
       // broken pre fix export -- <ul class="bullet"></li><ul class="bullet"></ul></li></ul>
@@ -338,6 +340,7 @@ describe('Imports and Exports', function(){
   })
 
   it('tries to import Plain Text to a pad that does not exist', function(done) {
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     var req = request.post(host + '/p/'+testPadId+testPadId+testPadId+'/import', function (err, res, body) {
       if (res.statusCode === 200) {
         throw new Error("Was able to import to a pad that doesn't exist");
@@ -360,6 +363,7 @@ describe('Imports and Exports', function(){
   });
 
   it('Tries to import unsupported file type', function(done) {
+    if (!settings.allowAnyoneToImport) { this.skip(); return done(); }
     if(settings.allowUnknownFileEnds === true){
       console.log("allowing unknown file ends so skipping this test");
       this.skip();

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -109,7 +109,10 @@ describe('Imports and Exports', function(){
   // TODO: fix support for .doc files..
   it('Tries to import .doc that uses soffice or abiword', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
 
     var req = request.post(host + '/p/'+testPadId+'/import', function (err, res, body) {
       if (err) {
@@ -132,7 +135,10 @@ describe('Imports and Exports', function(){
 
   it('exports DOC', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
     try{
       request(host + '/p/'+testPadId+'/export/doc', function (err, res, body) {
         // TODO: At some point checking that the contents is correct would be suitable
@@ -149,7 +155,10 @@ describe('Imports and Exports', function(){
 
   it('Tries to import .docx that uses soffice or abiword', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
 
     var req = request.post(host + '/p/'+testPadId+'/import', function (err, res, body) {
       if (err) {
@@ -172,7 +181,10 @@ describe('Imports and Exports', function(){
 
   it('exports DOC from imported DOCX', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
     request(host + '/p/'+testPadId+'/export/doc', function (err, res, body) {
       // TODO: At some point checking that the contents is correct would be suitable
       if(body.length >= 9100){
@@ -185,7 +197,10 @@ describe('Imports and Exports', function(){
 
   it('Tries to import .pdf that uses soffice or abiword', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
 
     var req = request.post(host + '/p/'+testPadId+'/import', function (err, res, body) {
       if (err) {
@@ -208,7 +223,10 @@ describe('Imports and Exports', function(){
 
   it('exports PDF', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
     request(host + '/p/'+testPadId+'/export/pdf', function (err, res, body) {
       // TODO: At some point checking that the contents is correct would be suitable
       if(body.length >= 1000){
@@ -221,7 +239,10 @@ describe('Imports and Exports', function(){
 
   it('Tries to import .odt that uses soffice or abiword', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
 
     var req = request.post(host + '/p/'+testPadId+'/import', function (err, res, body) {
       if (err) {
@@ -244,7 +265,10 @@ describe('Imports and Exports', function(){
 
   it('exports ODT', function(done) {
     if(!settings.allowAnyoneToImport) return done();
-    if((settings.abiword && settings.abiword.indexOf("/" === -1)) && (settings.office && settings.soffice.indexOf("/" === -1))) return done();
+    if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
+        (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
+      return done();
+    }
     request(host + '/p/'+testPadId+'/export/odt', function (err, res, body) {
       // TODO: At some point checking that the contents is correct would be suitable
       if(body.length >= 7000){

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -9,7 +9,6 @@ const settings = require(__dirname+'/../../../../src/node/utils/Settings');
 const host = 'http://127.0.0.1:'+settings.port;
 const api = supertest('http://'+settings.ip+":"+settings.port);
 const path = require('path');
-const async = require(__dirname+'/../../../../src/node_modules/async');
 const request = require(__dirname+'/../../../../src/node_modules/request');
 const padText = fs.readFileSync("../tests/backend/specs/api/test.txt");
 const etherpadDoc = fs.readFileSync("../tests/backend/specs/api/test.etherpad");
@@ -23,8 +22,6 @@ var apiKey = fs.readFileSync(filePath,  {encoding: 'utf-8'});
 apiKey = apiKey.replace(/\n$/, "");
 var apiVersion = 1;
 var testPadId = makeid();
-var lastEdited = "";
-var text = generateLongText();
 
 describe('Connectivity', function(){
   it('can connect', function(done) {
@@ -375,36 +372,4 @@ function makeid()
     text += possible.charAt(Math.floor(Math.random() * possible.length));
   }
   return text;
-}
-
-function generateLongText(){
-  var text = "";
-  var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-  for( var i=0; i < 80000; i++ ){
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
-}
-
-// Need this to compare arrays (listSavedRevisions test)
-Array.prototype.equals = function (array) {
-    // if the other array is a falsy value, return
-    if (!array)
-        return false;
-    // compare lengths - can save a lot of time
-    if (this.length != array.length)
-        return false;
-    for (var i = 0, l=this.length; i < l; i++) {
-        // Check if we have nested arrays
-        if (this[i] instanceof Array && array[i] instanceof Array) {
-            // recurse into the nested arrays
-            if (!this[i].equals(array[i]))
-                return false;
-        } else if (this[i] != array[i]) {
-            // Warning - two different object instances will never be equal: {x:20} != {x:20}
-            return false;
-        }
-    }
-    return true;
 }


### PR DESCRIPTION
This PR contains some commits that improve the import and export tests. **Please do not squash merge this PR.**

  * Delete unused imports and code
  * Fix abiword/soffice check
  * Use `this.skip()` when skipping tests
  * Skip all import/export tests if `!allowAnyoneToImport`
  * Factor out common skip checks
  * Rewrite import/export tests to use async and supertest
