### PR TITLE
New user-specific `readOnly` and `canCreate` settings

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -288,10 +288,13 @@ set in the settings file or by the authenticate hook.
 You can pass the following values to the provided callback:
 
 * `[true]` or `['create']` will grant access to modify or create the pad if the
-  request is for a pad, otherwise access is simply granted. (Access will be
-  downgraded to modify-only if `settings.editOnly` is true.)
-* `['modify']` will grant access to modify but not create the pad if the
-  request is for a pad, otherwise access is simply granted.
+  request is for a pad, otherwise access is simply granted. Access to a pad will
+  be downgraded to modify-only if `settings.editOnly` is true or the user's
+  `canCreate` setting is set to `false`, and downgraded to read-only if the
+  user's `readOnly` setting is `true`.
+* `['modify']` will grant access to modify but not create the pad if the request
+  is for a pad, otherwise access is simply granted. Access to a pad will be
+  downgraded to read-only if the user's `readOnly` setting is `true`.
 * `['readOnly']` will grant read-only access.
 * `[false]` will deny access.
 * `[]` or `undefined` will defer the authorization decision to the next

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -391,10 +391,22 @@
   },
 
   /*
-   * Users for basic authentication.
+   * User accounts. These accounts are used by:
+   *   - default HTTP basic authentication if no plugin handles authentication
+   *   - some but not all authentication plugins
+   *   - some but not all authorization plugins
    *
-   * is_admin = true gives access to /admin.
-   * If you do not uncomment this, /admin will not be available!
+   * User properties:
+   *   - password: The user's password. Some authentication plugins will ignore
+   *     this.
+   *   - is_admin: true gives access to /admin. Defaults to false. If you do not
+   *     uncomment this, /admin will not be available!
+   *   - readOnly: If true, this user will not be able to create new pads or
+   *     modify existing pads. Defaults to false.
+   *   - canCreate: If this is true and readOnly is false, this user can create
+   *     new pads. Defaults to true.
+   *
+   * Authentication and authorization plugins may define additional properties.
    *
    * WARNING: passwords should not be stored in plaintext in this file.
    *          If you want to mitigate this, please install ep_hash_auth and

--- a/settings.json.template
+++ b/settings.json.template
@@ -394,10 +394,22 @@
   },
 
   /*
-   * Users for basic authentication.
+   * User accounts. These accounts are used by:
+   *   - default HTTP basic authentication if no plugin handles authentication
+   *   - some but not all authentication plugins
+   *   - some but not all authorization plugins
    *
-   * is_admin = true gives access to /admin.
-   * If you do not uncomment this, /admin will not be available!
+   * User properties:
+   *   - password: The user's password. Some authentication plugins will ignore
+   *     this.
+   *   - is_admin: true gives access to /admin. Defaults to false. If you do not
+   *     uncomment this, /admin will not be available!
+   *   - readOnly: If true, this user will not be able to create new pads or
+   *     modify existing pads. Defaults to false.
+   *   - canCreate: If this is true and readOnly is false, this user can create
+   *     new pads. Defaults to true.
+   *
+   * Authentication and authorization plugins may define additional properties.
    *
    * WARNING: passwords should not be stored in plaintext in this file.
    *          If you want to mitigate this, please install ep_hash_auth and

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -67,8 +67,12 @@ exports.checkAccess = async function(padID, sessionCookie, token, password, user
       authLogger.debug('access denied: authentication is required');
       return DENY;
     }
-    // Check whether the user is authorized. Note that userSettings.padAuthorizations will still be
-    // populated even if settings.requireAuthorization is false.
+
+    // Check whether the user is authorized to create the pad if it doesn't exist.
+    if (userSettings.canCreate != null && !userSettings.canCreate) canCreate = false;
+    if (userSettings.readOnly) canCreate = false;
+    // Note: userSettings.padAuthorizations should still be populated even if
+    // settings.requireAuthorization is false.
     const padAuthzs = userSettings.padAuthorizations || {};
     const level = webaccess.normalizeAuthzLevel(padAuthzs[padID]);
     if (!level) {

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -30,6 +30,7 @@ exports.userCanModify = (padId, req) => {
   if (!settings.requireAuthentication) return true;
   const {session: {user} = {}} = req;
   assert(user); // If authn required and user == null, the request should have already been denied.
+  if (user.readOnly) return false;
   assert(user.padAuthorizations); // This is populated even if !settings.requireAuthorization.
   const level = exports.normalizeAuthzLevel(user.padAuthorizations[padId]);
   assert(level); // If !level, the request should have already been denied.


### PR DESCRIPTION
Also:
  * Group the tests for readability.
  * Factor out some common test setup.

Fixes #4325 