### PR TITLE
import: Replace the `allowAnyoneToImport` check with `userCanModify`

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -497,19 +497,6 @@
    */
   "importMaxFileSize": 52428800, // 50 * 1024 * 1024
 
-
-  /*
-   * From Etherpad 1.8.3 onwards import was restricted to authors who had
-   * content within the pad.
-   *
-   * This setting will override that restriction and allow any user to import
-   * without the requirement to add content to a pad.
-   *
-   * This setting is useful for when you use a plugin for authentication so you
-   * can already trust each user.
-   */
-  "allowAnyoneToImport": false, 
-
   /*
    * From Etherpad 1.9.0 onwards, when Etherpad is in production mode commits from individual users are rate limited
    *

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -188,6 +188,5 @@
   "pad.impexp.importfailed": "Import failed",
   "pad.impexp.copypaste": "Please copy paste",
   "pad.impexp.exportdisabled": "Exporting as {{type}} format is disabled. Please contact your system administrator for details.",
-  "pad.impexp.maxFileSize": "File too big. Contact your site administrator to increase the allowed file size for import",
-  "pad.impexp.permission": "Import is disabled because you never contributed to this pad. Please contribute at least once before importing"
+  "pad.impexp.maxFileSize": "File too big. Contact your site administrator to increase the allowed file size for import"
 }

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -942,16 +942,6 @@ async function handleClientReady(client, message, authorID)
     });
   }));
 
-  let thisUserHasEditedThisPad = false;
-  if (historicalAuthorData[authorID]) {
-    /*
-     * This flag is set to true when a user contributes to a specific pad for
-     * the first time. It is used for deciding if importing to that pad is
-     * allowed or not.
-     */
-    thisUserHasEditedThisPad = true;
-  }
-
   // glue the clientVars together, send them and tell the other clients that a new one is there
 
   // Check that the client is still here. It might have disconnected between callbacks.
@@ -1135,8 +1125,6 @@ async function handleClientReady(client, message, authorID)
         "percentageToScrollWhenUserPressesArrowUp": settings.scrollWhenFocusLineIsOutOfViewport.percentageToScrollWhenUserPressesArrowUp,
       },
       "initialChangesets": [], // FIXME: REMOVE THIS SHIT
-      "thisUserHasEditedThisPad": thisUserHasEditedThisPad,
-      "allowAnyoneToImport": settings.allowAnyoneToImport
     }
 
     // Add a username to the clientVars if one avaiable

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -62,11 +62,6 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   // handle import requests
   args.app.use('/p/:pad/import', limiter);
   args.app.post('/p/:pad/import', async function(req, res, next) {
-    if (!(await padManager.doesPadExists(req.params.pad))) {
-      console.warn(`Someone tried to import into a pad that doesn't exist (${req.params.pad})`);
-      return next();
-    }
-
     const {session: {user} = {}} = req;
     const {accessStatus, authorID} = await securityManager.checkAccess(
         req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password, user);

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -8,6 +8,7 @@ var readOnlyManager = require("../../db/ReadOnlyManager");
 var authorManager = require("../../db/AuthorManager");
 const rateLimit = require("express-rate-limit");
 const securityManager = require("../../db/SecurityManager");
+const webaccess = require("./webaccess");
 
 settings.importExportRateLimiting.onLimitReached = function(req, res, options) {
   // when the rate limiter triggers, write a warning in the logs
@@ -63,36 +64,11 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   args.app.use('/p/:pad/import', limiter);
   args.app.post('/p/:pad/import', async function(req, res, next) {
     const {session: {user} = {}} = req;
-    const {accessStatus, authorID} = await securityManager.checkAccess(
+    const {accessStatus} = await securityManager.checkAccess(
         req.params.pad, req.cookies.sessionID, req.cookies.token, req.cookies.password, user);
-    if (accessStatus !== 'grant') return res.status(403).send('Forbidden');
-    assert(authorID);
-
-    /*
-     * Starting from Etherpad 1.8.3 onwards, importing into a pad is allowed
-     * only if a user has his browser opened and connected to the pad (i.e. a
-     * Socket.IO session is estabilished for him) and he has already
-     * contributed to that specific pad.
-     *
-     * Note that this does not have anything to do with the "session", used
-     * for logging into "group pads". That kind of session is not needed here.
-     *
-     * This behaviour does not apply to API requests, only to /p/$PAD$/import
-     *
-     * See: https://github.com/ether/etherpad-lite/pull/3833#discussion_r407490205
-     */
-    if (!settings.allowAnyoneToImport) {
-      const authorsPads = await authorManager.listPadsOfAuthor(authorID);
-      if (!authorsPads) {
-        console.warn(`Unable to import file into "${req.params.pad}". Author "${authorID}" exists but he never contributed to any pad`);
-        return next();
-      }
-      if (authorsPads.padIDs.indexOf(req.params.pad) === -1) {
-        console.warn(`Unable to import file into "${req.params.pad}". Author "${authorID}" exists but he never contributed to this pad`);
-        return next();
-      }
+    if (accessStatus !== 'grant' || !webaccess.userCanModify(req.params.pad, req)) {
+      return res.status(403).send('Forbidden');
     }
-
-    importHandler.doImport(req, res, req.params.pad);
+    await importHandler.doImport(req, res, req.params.pad);
   });
 }

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -64,7 +64,7 @@ exports.checkAccess = (req, res, next) => {
       if (!level) return fail();
       const user = req.session.user;
       if (user == null) return next(); // This will happen if authentication is not required.
-      const encodedPadId = (req.path.match(/^\/p\/(.*)$/) || [])[1];
+      const encodedPadId = (req.path.match(/^\/p\/([^/]*)/) || [])[1];
       if (encodedPadId == null) return next();
       const padId = decodeURIComponent(encodedPadId);
       // The user was granted access to a pad. Remember the authorization level in the user's

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -3,6 +3,7 @@ const log4js = require('log4js');
 const httpLogger = log4js.getLogger('http');
 const settings = require('../../utils/Settings');
 const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+const readOnlyManager = require('../../db/ReadOnlyManager');
 
 hooks.deprecationNotices.authFailure = 'use the authnFailure and authzFailure hooks instead';
 
@@ -31,6 +32,7 @@ exports.normalizeAuthzLevel = (level) => {
 };
 
 exports.userCanModify = (padId, req) => {
+  if (readOnlyManager.isReadOnlyId(padId)) return false;
   if (!settings.requireAuthentication) return true;
   const {session: {user} = {}} = req;
   assert(user); // If authn required and user == null, the request should have already been denied.

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -385,20 +385,6 @@ exports.commitRateLimiting = {
  */
 exports.importMaxFileSize = 50 * 1024 * 1024;
 
-
-/*
- * From Etherpad 1.8.3 onwards import was restricted to authors who had
- * content within the pad.
- *
- * This setting will override that restriction and allow any user to import
- * without the requirement to add content to a pad.
- *
- * This setting is useful for when you use a plugin for authentication so you
- * can already trust each user.
- */
-exports.allowAnyoneToImport = false,
-
-
 // checks if abiword is avaiable
 exports.abiwordAvailable = function()
 {

--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -71,7 +71,3 @@ input {
 @media (max-width: 800px) {
   .hide-for-mobile { display: none; }
 }
-
-#importmessagepermission {
-  display: none;
-}

--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -312,16 +312,6 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
     }
     else if (msg.type == "ACCEPT_COMMIT")
     {
-      /*
-       * this is the first time this user contributed to this pad. Let's record
-       * it, because it will be used for allowing import.
-       *
-       * TODO: here, we are changing this variable on the client side only. The
-       *       server has all the informations to make the same deduction, and
-       *       broadcast to the client.
-       */
-      clientVars.thisUserHasEditedThisPad = true;
-
       var newRev = msg.newRev;
       if (msgQueue.length > 0)
       {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -415,17 +415,6 @@ var padeditbar = (function()
 
     toolbar.registerCommand("import_export", function () {
       toolbar.toggleDropDown("import_export", function(){
-
-        if (clientVars.thisUserHasEditedThisPad || clientVars.allowAnyoneToImport) {
-          // the user has edited this pad historically or in this session
-          $('#importform').show();
-          $('#importmessagepermission').hide();
-        } else {
-          // this is the first time this user visits this pad
-          $('#importform').hide();
-          $('#importmessagepermission').show();
-        }
-
         // If Import file input exists then focus on it..
         if($('#importfileinput').length !== 0){
           setTimeout(function(){

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -195,7 +195,6 @@
                       </span>
                   </div>
               </form>
-              <div id="importmessagepermission" data-l10n-id="pad.impexp.permission"></div>
               <% e.end_block(); %>
           </div>
           <div id="exportColumn">

--- a/tests/backend/common.js
+++ b/tests/backend/common.js
@@ -1,0 +1,43 @@
+function m(mod) { return __dirname + '/../../src/' + mod; }
+
+const log4js = require(m('node_modules/log4js'));
+const server = require(m('node/server'));
+const settings = require(m('node/utils/Settings'));
+const supertest = require(m('node_modules/supertest'));
+const webaccess = require(m('node/hooks/express/webaccess'));
+
+const backups = {};
+let inited = false;
+
+exports.agent = null;
+exports.baseUrl = null;
+exports.httpServer = null;
+exports.logger = log4js.getLogger('test');
+
+exports.init = async function() {
+  if (inited) return exports.agent;
+  inited = true;
+
+  // Note: This is only a shallow backup.
+  backups.settings = Object.assign({}, settings);
+  // Start the Etherpad server on a random unused port.
+  settings.port = 0;
+  settings.ip = 'localhost';
+  exports.httpServer = await server.start();
+  exports.baseUrl = `http://localhost:${exports.httpServer.address().port}`;
+  exports.logger.debug(`HTTP server at ${exports.baseUrl}`);
+  // Create a supertest user agent for the HTTP server.
+  exports.agent = supertest(exports.baseUrl);
+  // Speed up authn tests.
+  backups.authnFailureDelayMs = webaccess.authnFailureDelayMs;
+  webaccess.authnFailureDelayMs = 0;
+
+  after(async function() {
+    webaccess.authnFailureDelayMs = backups.authnFailureDelayMs;
+    await server.stop();
+    // Note: This does not unset settings that were added.
+    Object.assign(settings, backups.settings);
+  });
+
+  return exports.agent;
+};

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -211,16 +211,6 @@ describe('Imports and Exports', function(){
         .expect(/<ul class="bullet"><li><ul class="bullet"><li>hello<\/ul><\/li><\/ul>/);
   });
 
-  it('tries to import Plain Text to a pad that does not exist', async function() {
-    const padId = testPadId + testPadId + testPadId;
-    await agent.post(`/p/${padId}/import`)
-        .attach('file', padText, {filename: '/test.txt', contentType: 'text/plain'})
-        .expect(405);
-    await agent.get(endPoint('getText') + `&padID=${padId}`)
-        .expect(200)
-        .expect((res) => assert.equal(res.body.code, 1));
-  });
-
   it('Tries to import unsupported file type', async function() {
     settings.allowUnknownFileEnds = false;
     await agent.post(`/p/${testPadId}/import`)

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -75,6 +75,18 @@ describe('Imports and Exports', function(){
     }
   });
 
+  const backups = {};
+
+  beforeEach(async function() {
+    // Note: This is a shallow copy.
+    backups.settings = Object.assign({}, settings);
+  });
+
+  afterEach(async function() {
+    // Note: This does not unset settings that were added.
+    Object.assign(settings, backups.settings);
+  });
+
   it('creates a new Pad, imports content to it, checks that content', async function() {
     await agent.get(endPoint('createPad') + `&padID=${testPadId}`)
         .expect(200)
@@ -210,10 +222,7 @@ describe('Imports and Exports', function(){
   });
 
   it('Tries to import unsupported file type', async function() {
-    if (settings.allowUnknownFileEnds === true) {
-      console.log('skipping test because allowUnknownFileEnds is true');
-      return this.skip();
-    }
+    settings.allowUnknownFileEnds = false;
     await agent.post(`/p/${testPadId}/import`)
         .attach('file', padText, {filename: '/test.xasdasdxx', contentType: 'weirdness/jobby'})
         .expect(200)

--- a/tests/backend/specs/api/importexportGetPost.js
+++ b/tests/backend/specs/api/importexportGetPost.js
@@ -3,12 +3,10 @@
  */
 
 const assert = require('assert').strict;
+const common = require('../../common');
 const superagent = require(__dirname+'/../../../../src/node_modules/superagent');
-const supertest = require(__dirname+'/../../../../src/node_modules/supertest');
 const fs = require('fs');
 const settings = require(__dirname+'/../../../../src/node/utils/Settings');
-const host = 'http://127.0.0.1:'+settings.port;
-const agent = supertest(`http://${settings.ip}:${settings.port}`);
 const path = require('path');
 const padText = fs.readFileSync("../tests/backend/specs/api/test.txt");
 const etherpadDoc = fs.readFileSync("../tests/backend/specs/api/test.etherpad");
@@ -18,10 +16,13 @@ const odtDoc = fs.readFileSync("../tests/backend/specs/api/test.odt");
 const pdfDoc = fs.readFileSync("../tests/backend/specs/api/test.pdf");
 var filePath = path.join(__dirname, '../../../../APIKEY.txt');
 
+let agent;
 var apiKey = fs.readFileSync(filePath,  {encoding: 'utf-8'});
 apiKey = apiKey.replace(/\n$/, "");
 var apiVersion = 1;
 var testPadId = makeid();
+
+before(async function() { agent = await common.init(); });
 
 describe('Connectivity', function(){
   it('can connect', async function() {

--- a/tests/backend/specs/webaccess.js
+++ b/tests/backend/specs/webaccess.js
@@ -1,32 +1,13 @@
 function m(mod) { return __dirname + '/../../../src/' + mod; }
 
 const assert = require('assert').strict;
-const log4js = require(m('node_modules/log4js'));
+const common = require('../common');
 const plugins = require(m('static/js/pluginfw/plugin_defs'));
-const server = require(m('node/server'));
 const settings = require(m('node/utils/Settings'));
-const supertest = require(m('node_modules/supertest'));
-const webaccess = require(m('node/hooks/express/webaccess'));
 
 let agent;
-const logger = log4js.getLogger('test');
-let authnFailureDelayMsBackup;
 
-before(async function() {
-  authnFailureDelayMsBackup = webaccess.authnFailureDelayMs;
-  webaccess.authnFailureDelayMs = 0; // Speed up tests.
-  settings.port = 0;
-  settings.ip = 'localhost';
-  const httpServer = await server.start();
-  const baseUrl = `http://localhost:${httpServer.address().port}`;
-  logger.debug(`HTTP server at ${baseUrl}`);
-  agent = supertest(baseUrl);
-});
-
-after(async function() {
-  webaccess.authnFailureDelayMs = authnFailureDelayMsBackup;
-  await server.stop();
-});
+before(async function() { agent = await common.init(); });
 
 describe('webaccess: without plugins', function() {
   const backup = {};

--- a/tests/frontend/travis/runnerBackend.sh
+++ b/tests/frontend/travis/runnerBackend.sh
@@ -12,11 +12,8 @@ cd "${MY_DIR}/../../../"
 # Set soffice to /usr/bin/soffice
 sed 's#\"soffice\": null,#\"soffice\":\"/usr/bin/soffice\",#g' settings.json.template > settings.json.soffice
 
-# Set allowAnyoneToImport to true
-sed 's/\"allowAnyoneToImport\": false,/\"allowAnyoneToImport\": true,/g' settings.json.soffice > settings.json.allowImport
-
 # Set "max": 10 to 100 to not agressively rate limit
-sed 's/\"max\": 10/\"max\": 100/g' settings.json.allowImport > settings.json.rateLimit
+sed 's/\"max\": 10/\"max\": 100/g' settings.json.soffice > settings.json.rateLimit
 
 # Set "points": 10 to 1000 to not agressively rate limit commits
 sed 's/\"points\": 10/\"points\": 1000/g' settings.json.rateLimit > settings.json


### PR DESCRIPTION
This PR removes the `allowAnyoneToImport` setting and replaces it with a call to the `webaccess.canUserModify` function. **Please do not squash merge this PR** because it has a few commits that are intentionally separate:

  * tests: Factor out common server setup/teardown
  * tests: Switch import/export tests to self-contained server
  * tests: Always run the import unsupported file type test
  * webaccess: Check for read-only pad ID in `userCanModify`
  * webaccess: Fix pad ID extraction for import and export paths
  * import: Allow import if pad does not yet exist
  * import: Replace the `allowAnyoneToImport` check with `userCanModify`

Fixes #4381.