### PR TITLE
cookies: Improve experience for third-party iframes

### DIFF
--- a/settings.json.docker
+++ b/settings.json.docker
@@ -337,6 +337,24 @@
   "trustProxy": "${TRUST_PROXY:false}",
 
   /*
+   * Settings controlling the session cookie issued by Etherpad.
+   */
+  "cookie": {
+    /*
+     * Value of the SameSite cookie property. "Lax" is recommended unless
+     * Etherpad will be embedded in an iframe from another site, in which case
+     * this must be set to "None". Note: "None" will not work (the browser will
+     * not send the cookie to Etherpad) unless https is used to access Etherpad
+     * (either directly or via a reverse proxy with "trustProxy" set to true).
+     *
+     * "Strict" is not recommended because it has few security benefits but
+     * significant usability drawbacks vs. "Lax". See
+     * https://stackoverflow.com/q/41841880 for discussion.
+     */
+    "sameSite": "${COOKIE_SAME_SITE:Lax}"
+  },
+
+  /*
    * Privacy: disable IP logging
    */
   "disableIPlogging": "${DISABLE_IP_LOGGING:false}",

--- a/settings.json.template
+++ b/settings.json.template
@@ -340,6 +340,24 @@
   "trustProxy": false,
 
   /*
+   * Settings controlling the session cookie issued by Etherpad.
+   */
+  "cookie": {
+    /*
+     * Value of the SameSite cookie property. "Lax" is recommended unless
+     * Etherpad will be embedded in an iframe from another site, in which case
+     * this must be set to "None". Note: "None" will not work (the browser will
+     * not send the cookie to Etherpad) unless https is used to access Etherpad
+     * (either directly or via a reverse proxy with "trustProxy" set to true).
+     *
+     * "Strict" is not recommended because it has few security benefits but
+     * significant usability drawbacks vs. "Lax". See
+     * https://stackoverflow.com/q/41841880 for discussion.
+     */
+    "sameSite": "Lax"
+  },
+
+  /*
    * Privacy: disable IP logging
    */
   "disableIPlogging": false,

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -228,8 +228,6 @@ exports.expressConfigure = (hook_name, args, cb) => {
     exports.secret = settings.sessionKey;
   }
 
-  const sameSite = settings.ssl ? 'Strict' : 'Lax';
-
   args.app.sessionStore = exports.sessionStore;
   args.app.use(sessionModule({
     secret: exports.secret,
@@ -239,12 +237,9 @@ exports.expressConfigure = (hook_name, args, cb) => {
     name: 'express_sid',
     proxy: true,
     cookie: {
-      /*
-       * Firefox started enforcing sameSite, see https://github.com/ether/etherpad-lite/issues/3989
-       * for details.  In response we set it based on if SSL certs are set in Etherpad.  Note that if
-       * You use Nginx or so for reverse proxy this may cause problems.  Use Certificate pinning to remedy.
-       */
-      sameSite: sameSite,
+      // `Strict` is not used because it has few security benefits but significant usability
+      // drawbacks vs. `Lax`. See https://stackoverflow.com/q/41841880 for discussion.
+      sameSite: 'Lax',
       /*
        * The automatic express-session mechanism for determining if the
        * application is being served over ssl is similar to the one used for

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -237,9 +237,7 @@ exports.expressConfigure = (hook_name, args, cb) => {
     name: 'express_sid',
     proxy: true,
     cookie: {
-      // `Strict` is not used because it has few security benefits but significant usability
-      // drawbacks vs. `Lax`. See https://stackoverflow.com/q/41841880 for discussion.
-      sameSite: 'Lax',
+      sameSite: settings.cookie.sameSite,
       /*
        * The automatic express-session mechanism for determining if the
        * application is being served over ssl is similar to the one used for

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -44,12 +44,13 @@ var threadsPool = Threads.Pool(function () {
 }, 2)
 
 var LIBRARY_WHITELIST = [
-      'async'
-    , 'security'
-    , 'tinycon'
-    , 'underscore'
-    , 'unorm'
-    ];
+  'async',
+  'js-cookie',
+  'security',
+  'tinycon',
+  'underscore',
+  'unorm',
+];
 
 // Rewrite tar to include modules with no extensions and proper rooted paths.
 var LIBRARY_PREFIX = 'ep_etherpad-lite/static/js';

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -269,6 +269,24 @@ exports.sessionKey = false;
 exports.trustProxy = false;
 
 /*
+ * Settings controlling the session cookie issued by Etherpad.
+ */
+exports.cookie = {
+  /*
+   * Value of the SameSite cookie property. "Lax" is recommended unless
+   * Etherpad will be embedded in an iframe from another site, in which case
+   * this must be set to "None". Note: "None" will not work (the browser will
+   * not send the cookie to Etherpad) unless https is used to access Etherpad
+   * (either directly or via a reverse proxy with "trustProxy" set to true).
+   *
+   * "Strict" is not recommended because it has few security benefits but
+   * significant usability drawbacks vs. "Lax". See
+   * https://stackoverflow.com/q/41841880 for discussion.
+   */
+  sameSite: 'Lax',
+};
+
+/*
  * This setting is used if you need authentication and/or
  * authorization. Note: /admin always requires authentication, and
  * either authorization by a module, or a user with is_admin set

--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -17,6 +17,7 @@
   , "pad_connectionstatus.js"
   , "chat.js"
   , "gritter.js"
+  , "$js-cookie/src/js.cookie.js"
   , "$tinycon/tinycon.js"
   , "excanvas.js"
   , "farbtastic.js"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2656,6 +2656,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -46,6 +46,7 @@
     "formidable": "1.2.1",
     "graceful-fs": "4.2.4",
     "http-errors": "1.7.3",
+    "js-cookie": "^2.2.1",
     "jsonminify": "0.4.1",
     "languages4translatewiki": "0.1.3",
     "lodash.clonedeep": "4.5.0",

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -30,6 +30,7 @@ require('./jquery');
 require('./farbtastic');
 require('./excanvas');
 
+const Cookies = require('./pad_utils').Cookies;
 var chat = require('./chat').chat;
 var getCollabClient = require('./collab_client').getCollabClient;
 var padconnectionstatus = require('./pad_connectionstatus').padconnectionstatus;
@@ -42,8 +43,6 @@ var padsavedrevs = require('./pad_savedrevs');
 var paduserlist = require('./pad_userlist').paduserlist;
 var padutils = require('./pad_utils').padutils;
 var colorutils = require('./colorutils').colorutils;
-var createCookie = require('./pad_utils').createCookie;
-var readCookie = require('./pad_utils').readCookie;
 var randomString = require('./pad_utils').randomString;
 var gritter = require('./gritter').gritter;
 
@@ -83,7 +82,7 @@ var getParameters = [
   { name: "rtl",              checkVal: "true",  callback: function(val) { settings.rtlIsTrue = true } },
   { name: "alwaysShowChat",   checkVal: "true",  callback: function(val) { if(!settings.hideChat) chat.stickToScreen(); } },
   { name: "chatAndUsers",     checkVal: "true",  callback: function(val) { chat.chatAndUsers(); } },
-  { name: "lang",             checkVal: null,    callback: function(val) { window.html10n.localize([val, 'en']); createCookie('language', val); } }
+  { name: "lang",             checkVal: null,    callback: function(val) { window.html10n.localize([val, 'en']); Cookies.set('language', val); } },
 ];
 
 function getParams()
@@ -130,7 +129,7 @@ function getUrlVars()
 function savePassword()
 {
   //set the password cookie
-  createCookie("password",$("#passwordinput").val(),null,document.location.pathname);
+  Cookies.set('password', $('#passwordinput').val(), {path: document.location.pathname});
   //reload
   document.location=document.location;
   return false;
@@ -149,25 +148,21 @@ function sendClientReady(isReconnect, messageType)
     document.title = padId.replace(/_+/g, ' ') + " | " + title;
   }
 
-  var token = readCookie("token");
+  let token = Cookies.get('token');
   if (token == null)
   {
     token = "t." + randomString();
-    createCookie("token", token, 60);
+    Cookies.set('token', token, {expires: 60});
   }
 
-  var encodedSessionID = readCookie('sessionID');
-  var sessionID = encodedSessionID == null ? null : decodeURIComponent(encodedSessionID);
-  var password = readCookie("password");
-
-  var msg = {
-    "component": "pad",
-    "type": messageType,
-    "padId": padId,
-    "sessionID": sessionID,
-    "password": password,
-    "token": token,
-    "protocolVersion": 2
+  const msg = {
+    component: 'pad',
+    type: messageType,
+    padId: padId,
+    sessionID: Cookies.get('sessionID'),
+    password: Cookies.get('password'),
+    token: token,
+    protocolVersion: 2
   };
 
   // this is a reconnect, lets tell the server our revisionnumber
@@ -456,7 +451,6 @@ var pad = {
   {
     pad.collabClient.sendClientMessage(msg);
   },
-  createCookie: createCookie,
 
   init: function()
   {
@@ -957,8 +951,6 @@ var settings = {
 pad.settings = settings;
 exports.baseURL = '';
 exports.settings = settings;
-exports.createCookie = createCookie;
-exports.readCookie = readCookie;
 exports.randomString = randomString;
 exports.getParams = getParams;
 exports.getUrlVars = getUrlVars;

--- a/src/static/js/pad_cookie.js
+++ b/src/static/js/pad_cookie.js
@@ -1,10 +1,4 @@
 /**
- * This code is mostly from the old Etherpad. Please help us to comment this code.
- * This helps other people to understand this code better and helps them to improve it.
- * TL;DR COMMENTS ON THIS FILE ARE HIGHLY APPRECIATED
- */
-
-/**
  * Copyright 2009 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,130 +14,51 @@
  * limitations under the License.
  */
 
+const createCookie = require('./pad_utils').createCookie;
+const readCookie = require('./pad_utils').readCookie;
 
-var padcookie = (function()
-{
-  var cookieName = isHttpsScheme() ? "prefs" : "prefsHttp";
-
-  function getRawCookie()
-  {
-    // returns null if can't get cookie text
-    if (!document.cookie)
-    {
-      return null;
-    }
-    // look for (start of string OR semicolon) followed by whitespace followed by prefs=(something);
-    var regexResult = document.cookie.match(new RegExp("(?:^|;)\\s*" + cookieName + "=([^;]*)(?:;|$)"));
-    if ((!regexResult) || (!regexResult[1]))
-    {
-      return null;
-    }
-    return regexResult[1];
+exports.padcookie = new class {
+  constructor() {
+    this.cookieName_ = window.location.protocol === 'https:' ? 'prefs' : 'prefsHttp';
+    const prefs = this.readPrefs_() || {};
+    delete prefs.userId;
+    delete prefs.name;
+    delete prefs.colorId;
+    this.prefs_ = prefs;
+    this.savePrefs_();
   }
 
-  function setRawCookie(safeText)
-  {
-    var expiresDate = new Date();
-    expiresDate.setFullYear(3000);
-    var secure = isHttpsScheme() ? ";secure" : "";
-    var sameSite = isHttpsScheme() ?  ";sameSite=Strict": ";sameSite=Lax";
-    document.cookie = (cookieName + "=" + safeText + ";expires=" + expiresDate.toGMTString() + secure + sameSite);
-  }
-
-  function parseCookie(text)
-  {
-    // returns null if can't parse cookie.
-    try
-    {
-      var cookieData = JSON.parse(unescape(text));
-      return cookieData;
-    }
-    catch (e)
-    {
-      return null;
-    }
-  }
-
-  function stringifyCookie(data)
-  {
-    return escape(JSON.stringify(data));
-  }
-
-  function saveCookie()
-  {
-    if (!inited)
-    {
-      return;
-    }
-    setRawCookie(stringifyCookie(cookieData));
-
-    if ((!getRawCookie()) && (!alreadyWarnedAboutNoCookies))
-    {
+  init() {
+    if (this.readPrefs_() == null) {
       $.gritter.add({
-        title: "Error",
-        text: html10n.get("pad.noCookie"),
+        title: 'Error',
+        text: html10n.get('pad.noCookie'),
         sticky: true,
-        class_name: "error"
+        class_name: 'error',
       });
-      alreadyWarnedAboutNoCookies = true;
     }
   }
 
-  function isHttpsScheme() {
-    return window.location.protocol == "https:";
+  readPrefs_() {
+    const jsonEsc = readCookie(this.cookieName_);
+    if (jsonEsc == null) return null;
+    try {
+      return JSON.parse(unescape(jsonEsc));
+    } catch (e) {
+      return null;
+    }
   }
 
-  var wasNoCookie = true;
-  var cookieData = {};
-  var alreadyWarnedAboutNoCookies = false;
-  var inited = false;
+  savePrefs_() {
+    createCookie(this.cookieName_, escape(JSON.stringify(this.prefs_)), 365 * 100);
+  }
 
-  var pad = undefined;
-  var self = {
-    init: function(prefsToSet, _pad)
-    {
-      pad = _pad;
+  getPref(prefName) {
+    return this.prefs_[prefName];
+  }
 
-      var rawCookie = getRawCookie();
-      if (rawCookie)
-      {
-        var cookieObj = parseCookie(rawCookie);
-        if (cookieObj)
-        {
-          wasNoCookie = false; // there was a cookie
-          delete cookieObj.userId;
-          delete cookieObj.name;
-          delete cookieObj.colorId;
-          cookieData = cookieObj;
-        }
-      }
-
-      for (var k in prefsToSet)
-      {
-        cookieData[k] = prefsToSet[k];
-      }
-
-      inited = true;
-      saveCookie();
-    },
-    wasNoCookie: function()
-    {
-      return wasNoCookie;
-    },
-    isCookiesEnabled: function() {
-      return !!getRawCookie();
-    },
-    getPref: function(prefName)
-    {
-      return cookieData[prefName];
-    },
-    setPref: function(prefName, value)
-    {
-      cookieData[prefName] = value;
-      saveCookie();
-    }
-  };
-  return self;
-}());
-
-exports.padcookie = padcookie;
+  setPref(prefName, value) {
+    this.prefs_[prefName] = value;
+    this.savePrefs_();
+  }
+}();

--- a/src/static/js/pad_cookie.js
+++ b/src/static/js/pad_cookie.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-const createCookie = require('./pad_utils').createCookie;
-const readCookie = require('./pad_utils').readCookie;
+const Cookies = require('./pad_utils').Cookies;
 
 exports.padcookie = new class {
   constructor() {
@@ -40,17 +39,17 @@ exports.padcookie = new class {
   }
 
   readPrefs_() {
-    const jsonEsc = readCookie(this.cookieName_);
-    if (jsonEsc == null) return null;
     try {
-      return JSON.parse(unescape(jsonEsc));
+      const json = Cookies.get(this.cookieName_);
+      if (json == null) return null;
+      return JSON.parse(json);
     } catch (e) {
       return null;
     }
   }
 
   savePrefs_() {
-    createCookie(this.cookieName_, escape(JSON.stringify(this.prefs_)), 365 * 100);
+    Cookies.set(this.cookieName_, JSON.stringify(this.prefs_), {expires: 365 * 100});
   }
 
   getPref(prefName) {

--- a/src/static/js/pad_editor.js
+++ b/src/static/js/pad_editor.js
@@ -20,6 +20,7 @@
  * limitations under the License.
  */
 
+const Cookies = require('./pad_utils').Cookies;
 var padcookie = require('./pad_cookie').padcookie;
 var padutils = require('./pad_utils').padutils;
 
@@ -108,7 +109,7 @@ var padeditor = (function()
       })
       $("#languagemenu").val(html10n.getLanguage());
       $("#languagemenu").change(function() {
-        pad.createCookie("language",$("#languagemenu").val(),null,'/');
+        Cookies.set('language', $('#languagemenu').val());
         window.html10n.localize([$("#languagemenu").val(), 'en']);
       });
     },

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -528,13 +528,28 @@ padutils.setupGlobalExceptionHandler = setupGlobalExceptionHandler;
 
 padutils.binarySearch = require('./ace2_common').binarySearch;
 
+// https://stackoverflow.com/a/42660748
+function inThirdPartyIframe() {
+  try {
+    return (!window.top.location.hostname);
+  } catch (e) {
+    return true;
+  }
+}
+
 // This file is included from Node so that it can reuse randomString, but Node doesn't have a global
 // window object.
 if (typeof window !== 'undefined') {
   exports.Cookies = require('js-cookie/src/js.cookie');
+  // Use `SameSite=Lax`, unless Etherpad is embedded in an iframe from another site in which case
+  // use `SameSite=None`. For iframes from another site, only `None` has a chance of working
+  // because the cookies are third-party (not same-site). Many browsers/users block third-party
+  // cookies, but maybe blocked is better than definitely blocked (which would happen with `Lax`
+  // or `Strict`). Note: `None` will not work unless secure is true.
+  //
   // `Strict` is not used because it has few security benefits but significant usability drawbacks
   // vs. `Lax`. See https://stackoverflow.com/q/41841880 for discussion.
-  exports.Cookies.defaults.sameSite = 'Lax';
+  exports.Cookies.defaults.sameSite = inThirdPartyIframe() ? 'None' : 'Lax';
   exports.Cookies.defaults.secure = window.location.protocol === 'https:';
 }
 exports.randomString = randomString;

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -532,7 +532,9 @@ padutils.binarySearch = require('./ace2_common').binarySearch;
 // window object.
 if (typeof window !== 'undefined') {
   exports.Cookies = require('js-cookie/src/js.cookie');
-  exports.Cookies.defaults.sameSite = window.location.protocol === 'https:' ? 'Strict' : 'Lax';
+  // `Strict` is not used because it has few security benefits but significant usability drawbacks
+  // vs. `Lax`. See https://stackoverflow.com/q/41841880 for discussion.
+  exports.Cookies.defaults.sameSite = 'Lax';
   exports.Cookies.defaults.secure = window.location.protocol === 'https:';
 }
 exports.randomString = randomString;

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -39,49 +39,6 @@ function randomString(len)
   return randomstring;
 }
 
-function createCookie(name, value, days, path){ /* Used by IE */
-  if (days)
-  {
-    var date = new Date();
-    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    var expires = "; expires=" + date.toGMTString();
-  }
-  else{
-    var expires = "";
-  }
-
-  if(!path){ // IF the Path of the cookie isn't set then just create it on root
-    path = "/";
-  }
-
-  //Check if we accessed the pad over https
-  var secure = window.location.protocol == "https:" ? ";secure" : "";
-  var isHttpsScheme = window.location.protocol === "https:";
-  var sameSite = isHttpsScheme ?  ";sameSite=Strict": ";sameSite=Lax";
-
-  //Check if the browser is IE and if so make sure the full path is set in the cookie
-  if((navigator.appName == 'Microsoft Internet Explorer') || ((navigator.appName == 'Netscape') && (new RegExp("Trident/.*rv:([0-9]{1,}[\.0-9]{0,})").exec(navigator.userAgent) != null))){
-    document.cookie = name + "=" + value + expires + "; path=/" + secure + sameSite; /* Note this bodge fix for IE is temporary until auth is rewritten */
-  }
-  else{
-    document.cookie = name + "=" + value + expires + "; path=" + path + secure + sameSite;
-  }
-
-}
-
-function readCookie(name)
-{
-  var nameEQ = name + "=";
-  var ca = document.cookie.split(';');
-  for (var i = 0; i < ca.length; i++)
-  {
-    var c = ca[i];
-    while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
-  }
-  return null;
-}
-
 var padutils = {
   escapeHtml: function(x)
   {
@@ -571,7 +528,12 @@ padutils.setupGlobalExceptionHandler = setupGlobalExceptionHandler;
 
 padutils.binarySearch = require('./ace2_common').binarySearch;
 
+// This file is included from Node so that it can reuse randomString, but Node doesn't have a global
+// window object.
+if (typeof window !== 'undefined') {
+  exports.Cookies = require('js-cookie/src/js.cookie');
+  exports.Cookies.defaults.sameSite = window.location.protocol === 'https:' ? 'Strict' : 'Lax';
+  exports.Cookies.defaults.secure = window.location.protocol === 'https:';
+}
 exports.randomString = randomString;
-exports.createCookie = createCookie;
-exports.readCookie = readCookie;
 exports.padutils = padutils;

--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -24,8 +24,7 @@
 // assigns to the global `$` and augments it with plugins.
 require('./jquery');
 
-var createCookie = require('./pad_utils').createCookie;
-var readCookie = require('./pad_utils').readCookie;
+const Cookies = require('./pad_utils').Cookies;
 var randomString = require('./pad_utils').randomString;
 var hooks = require('./pluginfw/hooks');
 
@@ -45,11 +44,11 @@ function init() {
     document.title = padId.replace(/_+/g, ' ') + " | " + document.title;
 
     //ensure we have a token
-    token = readCookie("token");
+    token = Cookies.get('token');
     if(token == null)
     {
       token = "t." + randomString();
-      createCookie("token", token, 60);
+      Cookies.set('token', token, {expires: 60});
     }
 
     var loc = document.location;
@@ -107,19 +106,16 @@ function init() {
 //sends a message over the socket
 function sendSocketMsg(type, data)
 {
-  var sessionID = decodeURIComponent(readCookie("sessionID"));
-  var password = readCookie("password");
-
-  var msg = { "component" : "pad", // FIXME: Remove this stupidity!
-              "type": type,
-              "data": data,
-              "padId": padId,
-              "token": token,
-              "sessionID": sessionID,
-              "password": password,
-              "protocolVersion": 2};
-
-  socket.json.send(msg);
+  socket.json.send({
+    component: 'pad', // FIXME: Remove this stupidity!
+    type,
+    data,
+    padId,
+    token,
+    sessionID: Cookies.get('sessionID'),
+    password: Cookies.get('password'),
+    protocolVersion: 2,
+  });
 }
 
 var fireWhenAllScriptsAreLoaded = [];


### PR DESCRIPTION
This PR contains a few commits to improve cookie handling:

  * Embedding Etherpad in an iframe from another site should work better, especially if the user sets `cookie.sameSite` to `"None"` in `settings.json`. Using `None` for `SameSite` allows the cookies to be used as third-party cookies.
  * `SameSite` is set to `Lax` by default, which should provide a better user experience vs. `Strict`.
  * Special characters in cookie values and properties (semicolon in particular) are properly escaped, which should help prevent some XSS vulnerabilities.

**Please do not squash merge this PR** because the commits are intentionally separate:

  * Refactor `pad_cookie.js`
  * Use js-cookie to read and write cookies
  * Use `Lax` instead of `Strict` for `SameSite`
  * Use `SameSite=None` if in an iframe from another site