### PR TITLE
Express and express-session middleware cleanup

### DIFF
--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -60,15 +60,15 @@ exports.checkAccess = async function(padID, sessionCookie, token, password, user
 
   let canCreate = !settings.editOnly;
 
-  if (settings.requireAuthentication) {
-    // Make sure the user has authenticated if authentication is required. The caller should have
-    // already performed this check, but it is repeated here just in case.
+  // Authentication and authorization checks.
+  if (settings.loadTest) {
+    console.warn(
+        'bypassing socket.io authentication and authorization checks due to settings.loadTest');
+  } else if (settings.requireAuthentication) {
     if (userSettings == null) {
       authLogger.debug('access denied: authentication is required');
       return DENY;
     }
-
-    // Check whether the user is authorized to create the pad if it doesn't exist.
     if (userSettings.canCreate != null && !userSettings.canCreate) canCreate = false;
     if (userSettings.readOnly) canCreate = false;
     // Note: userSettings.padAuthorizations should still be populated even if

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -1,13 +1,13 @@
-var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");
-var express = require('express');
-var settings = require('../utils/Settings');
-var fs = require('fs');
-var path = require('path');
-var npm = require("npm/lib/npm.js");
-var  _ = require("underscore");
+const _ = require('underscore');
+const express = require('express');
+const fs = require('fs');
+const hooks = require('../../static/js/pluginfw/hooks');
+const npm = require('npm/lib/npm');
+const path = require('path');
+const settings = require('../utils/Settings');
 const util = require('util');
 
-var serverName;
+let serverName;
 
 exports.server = null;
 
@@ -33,7 +33,7 @@ exports.createServer = async () => {
     console.warn("Admin username and password not set in settings.json.  To access admin please uncomment and edit 'users' in settings.json");
   }
 
-  var env = process.env.NODE_ENV || 'development';
+  const env = process.env.NODE_ENV || 'development';
 
   if (env !== 'production') {
     console.warn("Etherpad is running in Development mode.  This mode is slower for users and less secure than production mode.  You should set the NODE_ENV environment variable to production by using: export NODE_ENV=production");
@@ -46,30 +46,30 @@ exports.restartServer = async () => {
     await util.promisify(exports.server.close).bind(exports.server)();
   }
 
-  var app = express(); // New syntax for express v3
+  const app = express(); // New syntax for express v3
 
   if (settings.ssl) {
     console.log("SSL -- enabled");
     console.log(`SSL -- server key file: ${settings.ssl.key}`);
     console.log(`SSL -- Certificate Authority's certificate file: ${settings.ssl.cert}`);
 
-    var options = {
+    const options = {
       key: fs.readFileSync( settings.ssl.key ),
       cert: fs.readFileSync( settings.ssl.cert )
     };
 
     if (settings.ssl.ca) {
       options.ca = [];
-      for (var i = 0; i < settings.ssl.ca.length; i++) {
-        var caFileName = settings.ssl.ca[i];
+      for (let i = 0; i < settings.ssl.ca.length; i++) {
+        const caFileName = settings.ssl.ca[i];
         options.ca.push(fs.readFileSync(caFileName));
       }
     }
 
-    var https = require('https');
+    const https = require('https');
     exports.server = https.createServer(options, app);
   } else {
-    var http = require('http');
+    const http = require('http');
     exports.server = http.createServer(app);
   }
 

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -1,12 +1,18 @@
 const _ = require('underscore');
+const cookieParser = require('cookie-parser');
 const express = require('express');
+const expressSession = require('express-session');
 const fs = require('fs');
 const hooks = require('../../static/js/pluginfw/hooks');
+const log4js = require('log4js');
 const npm = require('npm/lib/npm');
 const path = require('path');
+const sessionStore = require('../db/SessionStore');
 const settings = require('../utils/Settings');
+const stats = require('../stats');
 const util = require('util');
 
+const logger = log4js.getLogger('http');
 let serverName;
 
 exports.server = null;
@@ -110,6 +116,60 @@ exports.restartServer = async () => {
      */
     app.enable('trust proxy');
   }
+
+  // Measure response time
+  app.use((req, res, next) => {
+    const stopWatch = stats.timer('httpRequests').start();
+    const sendFn = res.send.bind(res);
+    res.send = (...args) => { stopWatch.end(); sendFn(...args); };
+    next();
+  });
+
+  // If the log level specified in the config file is WARN or ERROR the application server never
+  // starts listening to requests as reported in issue #158. Not installing the log4js connect
+  // logger when the log level has a higher severity than INFO since it would not log at that level
+  // anyway.
+  if (!(settings.loglevel === 'WARN' && settings.loglevel === 'ERROR')) {
+    app.use(log4js.connectLogger(logger, {
+      level: log4js.levels.DEBUG,
+      format: ':status, :method :url',
+    }));
+  }
+
+  exports.sessionMiddleware = expressSession({
+    secret: settings.sessionKey,
+    store: new sessionStore(),
+    resave: false,
+    saveUninitialized: true,
+    // Set the cookie name to a javascript identifier compatible string. Makes code handling it
+    // cleaner :)
+    name: 'express_sid',
+    proxy: true,
+    cookie: {
+      sameSite: settings.cookie.sameSite,
+
+      // The automatic express-session mechanism for determining if the application is being served
+      // over ssl is similar to the one used for setting the language cookie, which check if one of
+      // these conditions is true:
+      //
+      //   1. we are directly serving the nodejs application over SSL, using the "ssl" options in
+      //      settings.json
+      //
+      //   2. we are serving the nodejs application in plaintext, but we are using a reverse proxy
+      //      that terminates SSL for us. In this case, the user has to set trustProxy = true in
+      //      settings.json, and the information wheter the application is over SSL or not will be
+      //      extracted from the X-Forwarded-Proto HTTP header
+      //
+      // Please note that this will not be compatible with applications being served over http and
+      // https at the same time.
+      //
+      // reference: https://github.com/expressjs/session/blob/v1.17.0/README.md#cookiesecure
+      secure: 'auto',
+    }
+  });
+  app.use(exports.sessionMiddleware);
+
+  app.use(cookieParser(settings.sessionKey, {}));
 
   hooks.callAll("expressConfigure", {"app": app});
   hooks.callAll('expressCreateServer', {app, server: exports.server});

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -49,8 +49,8 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   // check whether the user has authenticated, then any random person on the Internet can read,
   // modify, or create any pad (unless the pad is password protected or an HTTP API session is
   // required).
-  const cookieParserFn = util.promisify(cookieParser(webaccess.secret, {}));
-  const getSession = util.promisify(args.app.sessionStore.get).bind(args.app.sessionStore);
+  const cookieParserFn = util.promisify(cookieParser(settings.sessionKey, {}));
+  const getSession = util.promisify(webaccess.sessionStore.get).bind(webaccess.sessionStore);
   io.use(async (socket, next) => {
     const req = socket.request;
     if (!req.headers.cookie) {

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -40,15 +40,6 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     cookie: false,
   });
 
-  // REQUIRE a signed express-session cookie to be present, then load the session. See
-  // http://www.danielbaulig.de/socket-ioexpress for more info. After the session is loaded, ensure
-  // that the user has authenticated (if authentication is required).
-  //
-  // !!!WARNING!!! Requests to /socket.io are NOT subject to the checkAccess middleware in
-  // webaccess.js. If this handler fails to check for a signed express-session cookie or fails to
-  // check whether the user has authenticated, then any random person on the Internet can read,
-  // modify, or create any pad (unless the pad is password protected or an HTTP API session is
-  // required).
   const cookieParserFn = util.promisify(cookieParser(settings.sessionKey, {}));
   const getSession = util.promisify(webaccess.sessionStore.get).bind(webaccess.sessionStore);
   io.use(async (socket, next) => {
@@ -58,24 +49,14 @@ exports.expressCreateServer = function (hook_name, args, cb) {
       // token and express_sid cookies have to be passed via a query parameter for unit tests.
       req.headers.cookie = socket.handshake.query.cookie;
     }
-    if (!req.headers.cookie && settings.loadTest) {
-      console.warn('bypassing socket.io authentication check due to settings.loadTest');
-      return next(null, true);
+    await cookieParserFn(req, {});
+    const expressSid = req.signedCookies.express_sid;
+    if (expressSid) {
+      const session = await getSession(expressSid);
+      if (session) req.session = new sessionModule.Session(req, session);
     }
-    try {
-      await cookieParserFn(req, {});
-      const expressSid = req.signedCookies.express_sid;
-      const needAuthn = settings.requireAuthentication;
-      if (needAuthn && !expressSid) throw new Error('signed express_sid cookie is required');
-      if (expressSid) {
-        const session = await getSession(expressSid);
-        if (!session) throw new Error('bad session or session has expired');
-        req.session = new sessionModule.Session(req, session);
-        if (needAuthn && req.session.user == null) throw new Error('authentication required');
-      }
-    } catch (err) {
-      return next(new Error(`access denied: ${err}`), false);
-    }
+    // Note: PadMessageHandler.handleMessage calls SecurityMananger.checkAccess which will perform
+    // authentication and authorization checks.
     return next(null, true);
   });
 

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -1,8 +1,8 @@
+const express = require("../express");
 var settings = require('../../utils/Settings');
 var socketio = require('socket.io');
 var socketIORouter = require("../../handler/SocketIORouter");
 var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");
-var webaccess = require("ep_etherpad-lite/node/hooks/express/webaccess");
 
 var padMessageHandler = require("../../handler/PadMessageHandler");
 
@@ -44,7 +44,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
       req.headers.cookie = socket.handshake.query.cookie;
     }
     // See: https://socket.io/docs/faq/#Usage-with-express-session
-    webaccess.sessionMiddleware(req, {}, next);
+    express.sessionMiddleware(req, {}, next);
   });
 
   // var socketIOLogger = log4js.getLogger("socket.io");

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -1,13 +1,8 @@
 const assert = require('assert').strict;
-const express = require('express');
 const log4js = require('log4js');
 const httpLogger = log4js.getLogger('http');
 const settings = require('../../utils/Settings');
 const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
-const ueberStore = require('../../db/SessionStore');
-const stats = require('ep_etherpad-lite/node/stats');
-const sessionModule = require('express-session');
-const cookieParser = require('cookie-parser');
 
 hooks.deprecationNotices.authFailure = 'use the authnFailure and authzFailure hooks instead';
 
@@ -200,62 +195,5 @@ exports.checkAccess = (req, res, next) => {
 };
 
 exports.expressConfigure = (hook_name, args, cb) => {
-  // Measure response time
-  args.app.use((req, res, next) => {
-    const stopWatch = stats.timer('httpRequests').start();
-    const sendFn = res.send.bind(res);
-    res.send = (...args) => { stopWatch.end(); sendFn(...args); };
-    next();
-  });
-
-  // If the log level specified in the config file is WARN or ERROR the application server never
-  // starts listening to requests as reported in issue #158. Not installing the log4js connect
-  // logger when the log level has a higher severity than INFO since it would not log at that level
-  // anyway.
-  if (!(settings.loglevel === 'WARN' && settings.loglevel === 'ERROR')) {
-    args.app.use(log4js.connectLogger(httpLogger, {
-      level: log4js.levels.DEBUG,
-      format: ':status, :method :url',
-    }));
-  }
-
-  exports.sessionMiddleware = sessionModule({
-    secret: settings.sessionKey,
-    store: new ueberStore(),
-    resave: false,
-    saveUninitialized: true,
-    // Set the cookie name to a javascript identifier compatible string. Makes code handling it
-    // cleaner :)
-    name: 'express_sid',
-    proxy: true,
-    cookie: {
-      sameSite: settings.cookie.sameSite,
-      /*
-       * The automatic express-session mechanism for determining if the
-       * application is being served over ssl is similar to the one used for
-       * setting the language cookie, which check if one of these conditions is
-       * true:
-       *
-       * 1. we are directly serving the nodejs application over SSL, using the
-       *    "ssl" options in settings.json
-       *
-       * 2. we are serving the nodejs application in plaintext, but we are using
-       *    a reverse proxy that terminates SSL for us. In this case, the user
-       *    has to set trustProxy = true in settings.json, and the information
-       *    wheter the application is over SSL or not will be extracted from the
-       *    X-Forwarded-Proto HTTP header
-       *
-       * Please note that this will not be compatible with applications being
-       * served over http and https at the same time.
-       *
-       * reference: https://github.com/expressjs/session/blob/v1.17.0/README.md#cookiesecure
-       */
-      secure: 'auto',
-    }
-  });
-  args.app.use(exports.sessionMiddleware);
-
-  args.app.use(cookieParser(settings.sessionKey, {}));
-
   args.app.use(exports.checkAccess);
 };

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -213,10 +213,16 @@ exports.expressConfigure = (hook_name, args, cb) => {
     next();
   });
 
-  // If the log level specified in the config file is WARN or ERROR the application server never starts listening to requests as reported in issue #158.
-  // Not installing the log4js connect logger when the log level has a higher severity than INFO since it would not log at that level anyway.
-  if (!(settings.loglevel === 'WARN' || settings.loglevel === 'ERROR'))
-    args.app.use(log4js.connectLogger(httpLogger, {level: log4js.levels.DEBUG, format: ':status, :method :url'}));
+  // If the log level specified in the config file is WARN or ERROR the application server never
+  // starts listening to requests as reported in issue #158. Not installing the log4js connect
+  // logger when the log level has a higher severity than INFO since it would not log at that level
+  // anyway.
+  if (!(settings.loglevel === 'WARN' && settings.loglevel === 'ERROR')) {
+    args.app.use(log4js.connectLogger(httpLogger, {
+      level: log4js.levels.DEBUG,
+      format: ':status, :method :url',
+    }));
+  }
 
   /* Do not let express create the session, so that we can retain a
    * reference to it for socket.io to use. Also, set the key (cookie

--- a/src/node/hooks/express/webaccess.js
+++ b/src/node/hooks/express/webaccess.js
@@ -219,13 +219,9 @@ exports.expressConfigure = (hook_name, args, cb) => {
     }));
   }
 
-  // Do not let express create the session, so that we can retain a reference to it for socket.io to
-  // use.
-  exports.sessionStore = new ueberStore();
-
-  args.app.use(sessionModule({
+  exports.sessionMiddleware = sessionModule({
     secret: settings.sessionKey,
-    store: exports.sessionStore,
+    store: new ueberStore(),
     resave: false,
     saveUninitialized: true,
     // Set the cookie name to a javascript identifier compatible string. Makes code handling it
@@ -256,7 +252,8 @@ exports.expressConfigure = (hook_name, args, cb) => {
        */
       secure: 'auto',
     }
-  }));
+  });
+  args.app.use(exports.sessionMiddleware);
 
   args.app.use(cookieParser(settings.sessionKey, {}));
 


### PR DESCRIPTION
This PR contains a few commits to simplify and improve the Express and express-session middleware setup. **Please do not squash merge this PR** because the commits are intentionally separate:

  * webaccess: Wrap long lines
  * webaccess: Simplify Express and express-session setup
  * express: Use `const` and `let` instead of `var`
  * socketio: Delete redundant authentication check
  * socketio: Reuse the `express-session` middleware
  * express: Move general Express setup from `webaccess.js`
