### PR TITLE
WIP: Run node 10 with '--experimental_worker' flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ COPY --chown=etherpad:0 ./settings.json.docker /opt/etherpad-lite/settings.json
 RUN chmod -R g=u .
 
 EXPOSE 9001
-CMD ["node", "node_modules/ep_etherpad-lite/node/server.js"]
+CMD ["node", "--experimental-worker", "node_modules/ep_etherpad-lite/node/server.js"]

--- a/bin/cleanRun.sh
+++ b/bin/cleanRun.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
-#Move to the folder where ep-lite is installed
-cd $(dirname $0)
+# Move to the folder where ep-lite is installed
+cd "$(dirname "$0")"/..
+
+# Source constants and usefull functions
+. bin/functions.sh
 
 #Was this script started in the bin folder? if yes move out
 if [ -d "../bin" ]; then
@@ -38,4 +41,4 @@ bin/installDeps.sh "$@" || exit 1
 echo "Started Etherpad..."
 
 SCRIPTPATH=$(pwd -P)
-node "${SCRIPTPATH}/node_modules/ep_etherpad-lite/node/server.js" "$@"
+node $(compute_node_args) "${SCRIPTPATH}/node_modules/ep_etherpad-lite/node/server.js" "$@"

--- a/bin/debugRun.sh
+++ b/bin/debugRun.sh
@@ -3,6 +3,9 @@
 # Move to the folder where ep-lite is installed
 cd "$(dirname "$0")"/..
 
+# Source constants and usefull functions
+. bin/functions.sh
+
 # Prepare the environment
 bin/installDeps.sh || exit 1
 
@@ -12,4 +15,4 @@ echo "Open 'chrome://inspect' on Chrome to start debugging."
 
 # Use 0.0.0.0 to allow external connections to the debugger
 # (ex: running Etherpad on a docker container). Use default port # (9229)
-node --inspect=0.0.0.0:9229 node_modules/ep_etherpad-lite/node/server.js "$@"
+node $(compute_node_args) --inspect=0.0.0.0:9229 node_modules/ep_etherpad-lite/node/server.js "$@"

--- a/bin/fastRun.sh
+++ b/bin/fastRun.sh
@@ -12,6 +12,9 @@ set -eu
 # source: https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself#246128
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Source constants and usefull functions
+. ${DIR}/../bin/functions.sh
+
 echo "Running directly, without checking/installing dependencies"
 
 # move to the base Etherpad directory. This will be necessary until Etherpad
@@ -19,4 +22,4 @@ echo "Running directly, without checking/installing dependencies"
 cd "${DIR}/.."
 
 # run Etherpad main class
-node "${DIR}/../node_modules/ep_etherpad-lite/node/server.js" "${@}"
+node $(compute_node_args) "${DIR}/../node_modules/ep_etherpad-lite/node/server.js" "$@"

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -12,45 +12,63 @@ error() { log "ERROR: $@" >&2; }
 fatal() { error "$@"; exit 1; }
 is_cmd() { command -v "$@" >/dev/null 2>&1; }
 
-compute_node_args() {
-  NODE_VERSION_STRING=$(node --version)
-  NODE_VERSION_STRING=${NODE_VERSION_STRING#"v"}
-  DETECTED_MAJOR=$(pecho "$NODE_VERSION_STRING" | cut -s -d "." -f 1)
-  ARGS=""
 
-  [ -n "$DETECTED_MAJOR" ] || fatal "Cannot extract $PROGRAM_LABEL major version from version string \"$VERSION_STRING\""
+get_program_version() {
+  PROGRAM="$1"
+  KIND="${2:-full}"
+  PROGRAM_VERSION_STRING=$($PROGRAM --version)
+  PROGRAM_VERSION_STRING=${PROGRAM_VERSION_STRING#"v"}
 
-  [ "$DETECTED_MAJOR" -eq "10" ] && ARGS="$ARGS --experimental-worker"
-
-  echo $ARGS
-}
-
-require_minimal_version() {
-  PROGRAM_LABEL="$1"
-  VERSION_STRING="$2"
-  REQUIRED_MAJOR="$3"
-  REQUIRED_MINOR="$4"
-
-  # Flag -s (--only-delimited on GNU cut) ensures no string is returned
-  # when there is no match
-  DETECTED_MAJOR=$(pecho "$VERSION_STRING" | cut -s -d "." -f 1)
-  DETECTED_MINOR=$(pecho "$VERSION_STRING" | cut -s -d "." -f 2)
-
-  [ -n "$DETECTED_MAJOR" ] || fatal "Cannot extract $PROGRAM_LABEL major version from version string \"$VERSION_STRING\""
-
-  [ -n "$DETECTED_MINOR" ] || fatal "Cannot extract $PROGRAM_LABEL minor version from version string \"$VERSION_STRING\""
-
+  DETECTED_MAJOR=$(pecho "$PROGRAM_VERSION_STRING" | cut -s -d "." -f 1)
+  [ -n "$DETECTED_MAJOR" ] || fatal "Cannot extract $PROGRAM major version from version string \"$PROGRAM_VERSION_STRING\""
   case "$DETECTED_MAJOR" in
       ''|*[!0-9]*)
         fatal "$PROGRAM_LABEL major version from \"$VERSION_STRING\" is not a number. Detected: \"$DETECTED_MAJOR\""
         ;;
   esac
 
+  DETECTED_MINOR=$(pecho "$PROGRAM_VERSION_STRING" | cut -s -d "." -f 2)
+  [ -n "$DETECTED_MINOR" ] || fatal "Cannot extract $PROGRAM minor version from version string \"$PROGRAM_VERSION_STRING\""
   case "$DETECTED_MINOR" in
       ''|*[!0-9]*)
         fatal "$PROGRAM_LABEL minor version from \"$VERSION_STRING\" is not a number. Detected: \"$DETECTED_MINOR\""
   esac
 
-  [ "$DETECTED_MAJOR" -gt "$REQUIRED_MAJOR" ] || ([ "$DETECTED_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$DETECTED_MINOR" -ge "$REQUIRED_MINOR" ]) \
-    || fatal "Your $PROGRAM_LABEL version \"$VERSION_STRING\" is too old. $PROGRAM_LABEL $REQUIRED_MAJOR.$REQUIRED_MINOR.x or higher is required."
+  case $KIND in
+    major)
+      echo $DETECTED_MAJOR
+      exit;;
+    minor)
+      echo $DETECTED_MINOR
+      exit;;
+    *)
+      echo $DETECTED_MAJOR.$DETECTED_MINOR
+      exit;;
+  esac
+
+  echo $VERSION
+}
+
+
+compute_node_args() {
+  ARGS=""
+
+  NODE_MAJOR=$(get_program_version "node" "major")
+  [ "$NODE_MAJOR" -eq "10" ] && ARGS="$ARGS --experimental-worker"
+
+  echo $ARGS
+}
+
+
+require_minimal_version() {
+  PROGRAM_LABEL="$1"
+  VERSION="$2"
+  REQUIRED_MAJOR="$3"
+  REQUIRED_MINOR="$4"
+
+  VERSION_MAJOR=$(pecho "$VERSION" | cut -s -d "." -f 1)
+  VERSION_MINOR=$(pecho "$VERSION" | cut -s -d "." -f 2)
+
+  [ "$VERSION_MAJOR" -gt "$REQUIRED_MAJOR" ] || ([ "$VERSION_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$VERSION_MINOR" -ge "$REQUIRED_MINOR" ]) \
+    || fatal "Your $PROGRAM_LABEL version \"$VERSION_MAJOR.$VERSION_MINOR\" is too old. $PROGRAM_LABEL $REQUIRED_MAJOR.$REQUIRED_MINOR.x or higher is required."
 }

--- a/bin/functions.sh
+++ b/bin/functions.sh
@@ -1,0 +1,56 @@
+# minimum required node version
+REQUIRED_NODE_MAJOR=10
+REQUIRED_NODE_MINOR=13
+
+# minimum required npm version
+REQUIRED_NPM_MAJOR=5
+REQUIRED_NPM_MINOR=5
+
+pecho() { printf %s\\n "$*"; }
+log() { pecho "$@"; }
+error() { log "ERROR: $@" >&2; }
+fatal() { error "$@"; exit 1; }
+is_cmd() { command -v "$@" >/dev/null 2>&1; }
+
+compute_node_args() {
+  NODE_VERSION_STRING=$(node --version)
+  NODE_VERSION_STRING=${NODE_VERSION_STRING#"v"}
+  DETECTED_MAJOR=$(pecho "$NODE_VERSION_STRING" | cut -s -d "." -f 1)
+  ARGS=""
+
+  [ -n "$DETECTED_MAJOR" ] || fatal "Cannot extract $PROGRAM_LABEL major version from version string \"$VERSION_STRING\""
+
+  [ "$DETECTED_MAJOR" -eq "10" ] && ARGS="$ARGS --experimental-worker"
+
+  echo $ARGS
+}
+
+require_minimal_version() {
+  PROGRAM_LABEL="$1"
+  VERSION_STRING="$2"
+  REQUIRED_MAJOR="$3"
+  REQUIRED_MINOR="$4"
+
+  # Flag -s (--only-delimited on GNU cut) ensures no string is returned
+  # when there is no match
+  DETECTED_MAJOR=$(pecho "$VERSION_STRING" | cut -s -d "." -f 1)
+  DETECTED_MINOR=$(pecho "$VERSION_STRING" | cut -s -d "." -f 2)
+
+  [ -n "$DETECTED_MAJOR" ] || fatal "Cannot extract $PROGRAM_LABEL major version from version string \"$VERSION_STRING\""
+
+  [ -n "$DETECTED_MINOR" ] || fatal "Cannot extract $PROGRAM_LABEL minor version from version string \"$VERSION_STRING\""
+
+  case "$DETECTED_MAJOR" in
+      ''|*[!0-9]*)
+        fatal "$PROGRAM_LABEL major version from \"$VERSION_STRING\" is not a number. Detected: \"$DETECTED_MAJOR\""
+        ;;
+  esac
+
+  case "$DETECTED_MINOR" in
+      ''|*[!0-9]*)
+        fatal "$PROGRAM_LABEL minor version from \"$VERSION_STRING\" is not a number. Detected: \"$DETECTED_MINOR\""
+  esac
+
+  [ "$DETECTED_MAJOR" -gt "$REQUIRED_MAJOR" ] || ([ "$DETECTED_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$DETECTED_MINOR" -ge "$REQUIRED_MINOR" ]) \
+    || fatal "Your $PROGRAM_LABEL version \"$VERSION_STRING\" is too old. $PROGRAM_LABEL $REQUIRED_MAJOR.$REQUIRED_MINOR.x or higher is required."
+}

--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -14,15 +14,10 @@ is_cmd node || fatal "Please install node.js ( https://nodejs.org )"
 is_cmd npm || fatal "Please install npm ( https://npmjs.org )"
 
 # Check npm version
-NPM_VERSION_STRING=$(npm --version)
-
-require_minimal_version "npm" "$NPM_VERSION_STRING" "$REQUIRED_NPM_MAJOR" "$REQUIRED_NPM_MINOR"
+require_minimal_version "npm" $(get_program_version "npm") "$REQUIRED_NPM_MAJOR" "$REQUIRED_NPM_MINOR"
 
 # Check node version
-NODE_VERSION_STRING=$(node --version)
-NODE_VERSION_STRING=${NODE_VERSION_STRING#"v"}
-
-require_minimal_version "nodejs" "$NODE_VERSION_STRING" "$REQUIRED_NODE_MAJOR" "$REQUIRED_NODE_MINOR"
+require_minimal_version "nodejs" $(get_program_version "node") "$REQUIRED_NODE_MAJOR" "$REQUIRED_NODE_MINOR"
 
 # Get the name of the settings file
 settings="settings.json"

--- a/bin/installDeps.sh
+++ b/bin/installDeps.sh
@@ -1,51 +1,10 @@
 #!/bin/sh
 
-# minimum required node version
-REQUIRED_NODE_MAJOR=10
-REQUIRED_NODE_MINOR=13
-
-# minimum required npm version
-REQUIRED_NPM_MAJOR=5
-REQUIRED_NPM_MINOR=5
-
-pecho() { printf %s\\n "$*"; }
-log() { pecho "$@"; }
-error() { log "ERROR: $@" >&2; }
-fatal() { error "$@"; exit 1; }
-is_cmd() { command -v "$@" >/dev/null 2>&1; }
-
-require_minimal_version() {
-  PROGRAM_LABEL="$1"
-  VERSION_STRING="$2"
-  REQUIRED_MAJOR="$3"
-  REQUIRED_MINOR="$4"
-
-  # Flag -s (--only-delimited on GNU cut) ensures no string is returned
-  # when there is no match
-  DETECTED_MAJOR=$(pecho "$VERSION_STRING" | cut -s -d "." -f 1)
-  DETECTED_MINOR=$(pecho "$VERSION_STRING" | cut -s -d "." -f 2)
-
-  [ -n "$DETECTED_MAJOR" ] || fatal "Cannot extract $PROGRAM_LABEL major version from version string \"$VERSION_STRING\""
-
-  [ -n "$DETECTED_MINOR" ] || fatal "Cannot extract $PROGRAM_LABEL minor version from version string \"$VERSION_STRING\""
-
-  case "$DETECTED_MAJOR" in
-      ''|*[!0-9]*)
-        fatal "$PROGRAM_LABEL major version from \"$VERSION_STRING\" is not a number. Detected: \"$DETECTED_MAJOR\""
-        ;;
-  esac
-
-  case "$DETECTED_MINOR" in
-      ''|*[!0-9]*)
-        fatal "$PROGRAM_LABEL minor version from \"$VERSION_STRING\" is not a number. Detected: \"$DETECTED_MINOR\""
-  esac
-
-  [ "$DETECTED_MAJOR" -gt "$REQUIRED_MAJOR" ] || ([ "$DETECTED_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$DETECTED_MINOR" -ge "$REQUIRED_MINOR" ]) \
-    || fatal "Your $PROGRAM_LABEL version \"$VERSION_STRING\" is too old. $PROGRAM_LABEL $REQUIRED_MAJOR.$REQUIRED_MINOR.x or higher is required."
-}
-
 # Move to the folder where ep-lite is installed
 cd "$(dirname "$0")"/..
+
+# Source constants and usefull functions
+. bin/functions.sh
 
 # Is node installed?
 # Not checking io.js, default installation creates a symbolic link to node

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,12 +1,10 @@
 #!/bin/sh
 
-pecho() { printf %s\\n "$*"; }
-log() { pecho "$@"; }
-error() { log "ERROR: $@" >&2; }
-fatal() { error "$@"; exit 1; }
-
 # Move to the folder where ep-lite is installed
 cd "$(dirname "$0")"/..
+
+# Source constants and usefull functions
+. bin/functions.sh
 
 ignoreRoot=0
 for ARG in "$@"; do
@@ -34,4 +32,4 @@ bin/installDeps.sh "$@" || exit 1
 log "Starting Etherpad..."
 
 SCRIPTPATH=$(pwd -P)
-exec node "$SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js" "$@"
+exec node $(compute_node_args) "$SCRIPTPATH/node_modules/ep_etherpad-lite/node/server.js" "$@"


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

Fixes: #4335 for both Docker and Linux setup:
- add `--experimental-worker` to Dockerfile
- move common constants and functions to `functions.sh` adding a new `compute_node_args` that may compute additionals node arguments based on several tests. Here, use this function to add `--experimental-worker` when node 10 is detected.
- source `functions.sh` in all startup scripts, and use `compute_node_args` as a node argument

I did not check Windows environment since I don't have any
