### PR TITLE
tests: re-enable docker tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,14 +47,13 @@ jobs:
         - "cd src && npm install && cd -"
       script:
         - "tests/frontend/travis/runnerBackend.sh"
-## Temporarily commented out the Dockerfile tests
-#    - name: "Test the Dockerfile"
-#      install:
-#        - "cd src && npm install && cd -"
-#      script:
-#        - "docker build -t etherpad:test ."
-#        - "docker run -d -p 9001:9001 etherpad:test && sleep 3"
-#        - "cd src && npm run test-container"
+    - name: "Test the Dockerfile"
+      install:
+        - "cd src && npm install && cd -"
+      script:
+        - "docker build -t etherpad:test ."
+        - "docker run -d -p 9001:9001 etherpad:test && sleep 3"
+        - "cd src && npm run test-container"
     - name: "Load test Etherpad without Plugins"
       install:
         - "bin/installDeps.sh"
@@ -83,14 +82,13 @@ jobs:
         - "cd src && npm install && cd -"
       script:
         - "tests/frontend/travis/runnerBackend.sh"
-## Temporarily commented out the Dockerfile tests
-#    - name: "Test the Dockerfile"
-#      install:
-#        - "cd src && npm install && cd -"
-#      script:
-#        - "docker build -t etherpad:test ."
-#        - "docker run -d -p 9001:9001 etherpad:test && sleep 3"
-#        - "cd src && npm run test-container"
+    - name: "Test the Dockerfile"
+      install:
+        - "cd src && npm install && cd -"
+      script:
+        - "docker build -t etherpad:test ."
+        - "docker run -d -p 9001:9001 etherpad:test && sleep 3"
+        - "cd src && npm run test-container"
     - name: "Load test Etherpad with Plugins"
       install:
         - "bin/installDeps.sh"

--- a/tests/frontend/travis/runner.sh
+++ b/tests/frontend/travis/runner.sh
@@ -16,7 +16,7 @@ cd "${MY_DIR}/../../../"
 # This is possible because the "install" section of .travis.yml already contains
 # a call to bin/installDeps.sh
 echo "Running Etherpad directly, assuming bin/installDeps.sh has already been run"
-node node_modules/ep_etherpad-lite/node/server.js "${@}" &
+node node_modules/ep_etherpad-lite/node/server.js --experimental-worker "${@}" &
 
 echo "Now I will try for 15 seconds to connect to Etherpad on http://localhost:9001"
 


### PR DESCRIPTION
We should now be able to re-run the travis tests due to node 10 being fixed.