### PR TITLE
import: Ajaxify pad import

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -99,16 +99,15 @@ const doImport = async (req, res, padId) => {
 
         // I hate doing indexOf here but I can't see anything to use...
         if (err && err.stack && err.stack.indexOf('maxFileSize') !== -1) {
-          reject('maxFileSize');
+          return reject('maxFileSize');
         }
 
-        reject('uploadFailed');
+        return reject('uploadFailed');
       }
       if (!files.file) { // might not be a graceful fix but it works
-        reject('uploadFailed');
-      } else {
-        resolve(files.file.path);
+        return reject('uploadFailed');
       }
+      resolve(files.file.path);
     });
   });
 
@@ -177,7 +176,7 @@ const doImport = async (req, res, padId) => {
           // catch convert errors
           if (err) {
             console.warn('Converting Error:', err);
-            reject('convertFailed');
+            return reject('convertFailed');
           }
           resolve();
         });

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -34,10 +34,17 @@ const log4js = require('log4js');
 const hooks = require('../../static/js/pluginfw/hooks.js');
 const util = require('util');
 
-const fsp_exists = util.promisify(fs.exists);
 const fsp_rename = util.promisify(fs.rename);
 const fsp_readFile = util.promisify(fs.readFile);
 const fsp_unlink = util.promisify(fs.unlink);
+
+const rm = async (path) => {
+  try {
+    await fsp_unlink(path);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+};
 
 let convertor = null;
 let exportExtension = 'htm';
@@ -239,19 +246,8 @@ const doImport = async (req, res, padId) => {
   await padMessageHandler.updatePadClients(pad);
 
   // clean up temporary files
-
-  /*
-   * TODO: directly delete the file and handle the eventual error. Checking
-   * before for existence is prone to race conditions, and does not handle any
-   * errors anyway.
-   */
-  if (await fsp_exists(srcFile)) {
-    fsp_unlink(srcFile);
-  }
-
-  if (await fsp_exists(destFile)) {
-    fsp_unlink(destFile);
-  }
+  rm(srcFile);
+  rm(destFile);
 };
 
 exports.doImport = (req, res, padId) => {

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -152,7 +152,6 @@ const doImport = async (req, res, padId) => {
       throw 'padHasData';
     }
 
-    const fsp_readFile = util.promisify(fs.readFile);
     const _text = await fsp_readFile(srcFile, 'utf8');
     req.directDatabaseAccess = true;
     await importEtherpad.setPadRaw(padId, _text);

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -174,7 +174,7 @@ const doImport = async (req, res, padId) => {
     // See https://github.com/ether/etherpad-lite/issues/2572
     if (fileIsHTML || !useConvertor) {
       // if no convertor only rename
-      fs.renameSync(srcFile, destFile);
+      await fsp_rename(srcFile, destFile);
     } else {
       // @TODO - no Promise interface for convertors (yet)
       await new Promise((resolve, reject) => {

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -276,7 +276,7 @@ exports.doImport = (req, res, padId) => {
       '<script>',
       "document.addEventListener('DOMContentLoaded', () => {",
       '  window.parent.padimpexp.handleFrameCall(',
-      `      '${req.directDatabaseAccess}', '${status}');`,
+      `      ${JSON.stringify(!!req.directDatabaseAccess)}, ${JSON.stringify(status)});`,
       '});',
       '</script>',
     ].join('\n'));

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -272,6 +272,13 @@ exports.doImport = (req, res, padId) => {
     status = err.status;
   }).then(() => {
     // close the connection
-    res.send(`<script>document.addEventListener('DOMContentLoaded', function(){ var impexp = window.parent.padimpexp.handleFrameCall('${req.directDatabaseAccess}', '${status}'); })</script>`);
+    res.send([
+      '<script>',
+      "document.addEventListener('DOMContentLoaded', () => {",
+      '  window.parent.padimpexp.handleFrameCall(',
+      `      '${req.directDatabaseAccess}', '${status}');`,
+      '});',
+      '</script>',
+    ].join('\n'));
   });
 };

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -33,6 +33,8 @@ const importEtherpad = require('../utils/ImportEtherpad');
 const log4js = require('log4js');
 const hooks = require('../../static/js/pluginfw/hooks.js');
 
+const logger = log4js.getLogger('ImportHandler');
+
 // `status` must be a string supported by `importErrorMessage()` in `src/static/js/pad_impexp.js`.
 class ImportError extends Error {
   constructor(status, ...args) {
@@ -73,8 +75,6 @@ const tmpDirectory = os.tmpdir();
  * do a requested import
  */
 const doImport = async (req, res, padId) => {
-  const apiLogger = log4js.getLogger('ImportHandler');
-
   // pipe to a file
   // convert file to html via abiword or soffice
   // set html in the pad
@@ -161,7 +161,7 @@ const doImport = async (req, res, padId) => {
     const headCount = _pad.head;
 
     if (headCount >= 10) {
-      apiLogger.warn('Aborting direct database import attempt of a pad that already has content');
+      logger.warn('Aborting direct database import attempt of a pad that already has content');
       throw new ImportError('padHasData');
     }
 
@@ -230,7 +230,7 @@ const doImport = async (req, res, padId) => {
       try {
         await importHtml.setPadHTML(pad, text);
       } catch (e) {
-        apiLogger.warn('Error importing, possibly caused by malformed HTML');
+        logger.warn('Error importing, possibly caused by malformed HTML');
       }
     } else {
       await pad.setText(text);

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -21,58 +21,62 @@ const limiter = rateLimit(settings.importExportRateLimiting);
 exports.expressCreateServer = (hookName, args, cb) => {
   // handle export requests
   args.app.use('/p/:pad/:rev?/export/:type', limiter);
-  args.app.get('/p/:pad/:rev?/export/:type', async (req, res, next) => {
-    const types = ['pdf', 'doc', 'txt', 'html', 'odt', 'etherpad'];
-    // send a 404 if we don't support this filetype
-    if (types.indexOf(req.params.type) === -1) {
-      return next();
-    }
-
-    // if abiword is disabled, and this is a format we only support with abiword, output a message
-    if (settings.exportAvailable() === 'no' &&
-       ['odt', 'pdf', 'doc'].indexOf(req.params.type) !== -1) {
-      console.error(`Impossible to export pad "${req.params.pad}" in ${req.params.type} format.` +
-          ' There is no converter configured');
-
-      // ACHTUNG: do not include req.params.type in res.send() because there is
-      // no HTML escaping and it would lead to an XSS
-      res.send('This export is not enabled at this Etherpad instance. Set the path to Abiword' +
-          ' or soffice (LibreOffice) in settings.json to enable this feature');
-      return;
-    }
-
-    res.header('Access-Control-Allow-Origin', '*');
-
-    if (await hasPadAccess(req, res)) {
-      let padId = req.params.pad;
-
-      let readOnlyId = null;
-      if (readOnlyManager.isReadOnlyId(padId)) {
-        readOnlyId = padId;
-        padId = await readOnlyManager.getPadId(readOnlyId);
-      }
-
-      const exists = await padManager.doesPadExists(padId);
-      if (!exists) {
-        console.warn(`Someone tried to export a pad that doesn't exist (${padId})`);
+  args.app.get('/p/:pad/:rev?/export/:type', (req, res, next) => {
+    (async () => {
+      const types = ['pdf', 'doc', 'txt', 'html', 'odt', 'etherpad'];
+      // send a 404 if we don't support this filetype
+      if (types.indexOf(req.params.type) === -1) {
         return next();
       }
 
-      console.log(`Exporting pad "${req.params.pad}" in ${req.params.type} format`);
-      exportHandler.doExport(req, res, padId, readOnlyId, req.params.type);
-    }
+      // if abiword is disabled, and this is a format we only support with abiword, output a message
+      if (settings.exportAvailable() === 'no' &&
+          ['odt', 'pdf', 'doc'].indexOf(req.params.type) !== -1) {
+        console.error(`Impossible to export pad "${req.params.pad}" in ${req.params.type} format.` +
+                      ' There is no converter configured');
+
+        // ACHTUNG: do not include req.params.type in res.send() because there is
+        // no HTML escaping and it would lead to an XSS
+        res.send('This export is not enabled at this Etherpad instance. Set the path to Abiword' +
+                 ' or soffice (LibreOffice) in settings.json to enable this feature');
+        return;
+      }
+
+      res.header('Access-Control-Allow-Origin', '*');
+
+      if (await hasPadAccess(req, res)) {
+        let padId = req.params.pad;
+
+        let readOnlyId = null;
+        if (readOnlyManager.isReadOnlyId(padId)) {
+          readOnlyId = padId;
+          padId = await readOnlyManager.getPadId(readOnlyId);
+        }
+
+        const exists = await padManager.doesPadExists(padId);
+        if (!exists) {
+          console.warn(`Someone tried to export a pad that doesn't exist (${padId})`);
+          return next();
+        }
+
+        console.log(`Exporting pad "${req.params.pad}" in ${req.params.type} format`);
+        exportHandler.doExport(req, res, padId, readOnlyId, req.params.type);
+      }
+    })().catch((err) => next(err || new Error(err)));
   });
 
   // handle import requests
   args.app.use('/p/:pad/import', limiter);
-  args.app.post('/p/:pad/import', async (req, res, next) => {
-    const {session: {user} = {}} = req;
-    const {accessStatus} = await securityManager.checkAccess(
-        req.params.pad, req.cookies.sessionID, req.cookies.token, user);
-    if (accessStatus !== 'grant' || !webaccess.userCanModify(req.params.pad, req)) {
-      return res.status(403).send('Forbidden');
-    }
-    await importHandler.doImport(req, res, req.params.pad);
+  args.app.post('/p/:pad/import', (req, res, next) => {
+    (async () => {
+      const {session: {user} = {}} = req;
+      const {accessStatus} = await securityManager.checkAccess(
+          req.params.pad, req.cookies.sessionID, req.cookies.token, user);
+      if (accessStatus !== 'grant' || !webaccess.userCanModify(req.params.pad, req)) {
+        return res.status(403).send('Forbidden');
+      }
+      await importHandler.doImport(req, res, req.params.pad);
+    })().catch((err) => next(err || new Error(err)));
   });
 
   return cb();

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -720,10 +720,6 @@ const pad = {
         .val(JSON.stringify(pad.collabClient.getMissedChanges()));
     $('form#reconnectform').submit();
   },
-  // this is called from code put into a frame from the server:
-  handleImportExportFrameCall: (callName, varargs) => {
-    padimpexp.handleFrameCall.call(padimpexp, callName, Array.prototype.slice.call(arguments, 1));
-  },
   callWhenNotCommitting: (f) => {
     pad.collabClient.callWhenNotCommitting(f);
   },

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -44,31 +44,29 @@ const padimpexp = (() => {
 
   const fileInputSubmit = () => {
     $('#importmessagefail').fadeOut('fast');
-    const ret = window.confirm(html10n.get('pad.impexp.confirmimport'));
-    if (ret) {
-      currentImportTimer = window.setTimeout(() => {
-        if (!currentImportTimer) {
-          return;
-        }
-        currentImportTimer = null;
-        importErrorMessage('Request timed out.');
-        importDone();
-      }, 25000); // time out after some number of seconds
-      $('#importsubmitinput').attr(
+    if (!window.confirm(html10n.get('pad.impexp.confirmimport'))) return false;
+    currentImportTimer = window.setTimeout(() => {
+      if (!currentImportTimer) {
+        return;
+      }
+      currentImportTimer = null;
+      importErrorMessage('Request timed out.');
+      importDone();
+    }, 25000); // time out after some number of seconds
+    $('#importsubmitinput').attr(
+        {
+          disabled: true,
+        }).val(html10n.get('pad.impexp.importing'));
+
+    window.setTimeout(() => {
+      $('#importfileinput').attr(
           {
             disabled: true,
-          }).val(html10n.get('pad.impexp.importing'));
-
-      window.setTimeout(() => {
-        $('#importfileinput').attr(
-            {
-              disabled: true,
-            });
-      }, 0);
-      $('#importarrow').stop(true, true).hide();
-      $('#importstatusball').show();
-    }
-    return ret;
+          });
+    }, 0);
+    $('#importarrow').stop(true, true).hide();
+    $('#importstatusball').show();
+    return true;
   };
 
   const importDone = () => {

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -171,7 +171,6 @@ const padimpexp = (() => {
       $('.disabledexport').click(cantExport);
     },
     handleFrameCall: (directDatabaseAccess, status) => {
-      if (directDatabaseAccess === 'undefined') directDatabaseAccess = false;
       if (status !== 'ok') {
         importErrorMessage(status);
       } else {

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -46,24 +46,13 @@ const padimpexp = (() => {
     $('#importmessagefail').fadeOut('fast');
     if (!window.confirm(html10n.get('pad.impexp.confirmimport'))) return false;
     currentImportTimer = window.setTimeout(() => {
-      if (!currentImportTimer) {
-        return;
-      }
+      if (!currentImportTimer) return;
       currentImportTimer = null;
       importErrorMessage('Request timed out.');
       importDone();
     }, 25000); // time out after some number of seconds
-    $('#importsubmitinput').attr(
-        {
-          disabled: true,
-        }).val(html10n.get('pad.impexp.importing'));
-
-    window.setTimeout(() => {
-      $('#importfileinput').attr(
-          {
-            disabled: true,
-          });
-    }, 0);
+    $('#importsubmitinput').attr({disabled: true}).val(html10n.get('pad.impexp.importing'));
+    window.setTimeout(() => $('#importfileinput').attr({disabled: true}), 0);
     $('#importarrow').stop(true, true).hide();
     $('#importstatusball').show();
     return true;
@@ -71,9 +60,7 @@ const padimpexp = (() => {
 
   const importDone = () => {
     $('#importsubmitinput').removeAttr('disabled').val(html10n.get('pad.impexp.importbutton'));
-    window.setTimeout(() => {
-      $('#importfileinput').removeAttr('disabled');
-    }, 0);
+    window.setTimeout(() => $('#importfileinput').removeAttr('disabled'), 0);
     $('#importstatusball').hide();
     importClearTimeout();
     addImportFrames();
@@ -109,9 +96,7 @@ const padimpexp = (() => {
 
     if ($('#importexport .importmessage').is(':visible')) {
       $('#importmessagesuccess').fadeOut('fast');
-      $('#importmessagefail').fadeOut('fast', () => {
-        showError(true);
-      });
+      $('#importmessagefail').fadeOut('fast', () => showError(true));
     } else {
       showError();
     }

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -84,9 +84,12 @@ const padimpexp = (() => {
     const msg = html10n.get(`pad.impexp.${known.indexOf(status) !== -1 ? status : 'copypaste'}`);
 
     const showError = (fade) => {
-      $('#importmessagefail').html(
-          `<strong style="color: red">${html10n.get('pad.impexp.importfailed')}:</strong> ` +
-          `${msg}`)[(fade ? 'fadeIn' : 'show')]();
+      const popup = $('#importmessagefail').empty()
+          .append($('<strong>')
+              .css('color', 'red')
+              .text(`${html10n.get('pad.impexp.importfailed')}: `))
+          .append(document.createTextNode(msg));
+      popup[(fade ? 'fadeIn' : 'show')]();
     };
 
     if ($('#importexport .importmessage').is(':visible')) {

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -74,24 +74,19 @@ const padimpexp = (() => {
   };
 
   const importErrorMessage = (status) => {
-    let msg = '';
-
-    if (status === 'convertFailed') {
-      msg = html10n.get('pad.impexp.convertFailed');
-    } else if (status === 'uploadFailed') {
-      msg = html10n.get('pad.impexp.uploadFailed');
-    } else if (status === 'padHasData') {
-      msg = html10n.get('pad.impexp.padHasData');
-    } else if (status === 'maxFileSize') {
-      msg = html10n.get('pad.impexp.maxFileSize');
-    } else if (status === 'permission') {
-      msg = html10n.get('pad.impexp.permission');
-    }
+    const known = [
+      'convertFailed',
+      'uploadFailed',
+      'padHasData',
+      'maxFileSize',
+      'permission',
+    ];
+    const msg = html10n.get(`pad.impexp.${known.indexOf(status) !== -1 ? status : 'copypaste'}`);
 
     const showError = (fade) => {
       $('#importmessagefail').html(
           `<strong style="color: red">${html10n.get('pad.impexp.importfailed')}:</strong> ` +
-          `${msg || html10n.get('pad.impexp.copypaste', '')}`)[(fade ? 'fadeIn' : 'show')]();
+          `${msg}`)[(fade ? 'fadeIn' : 'show')]();
     };
 
     if ($('#importexport .importmessage').is(':visible')) {

--- a/src/static/js/pad_impexp.js
+++ b/src/static/js/pad_impexp.js
@@ -51,7 +51,7 @@ const padimpexp = (() => {
           return;
         }
         currentImportTimer = null;
-        importFailed('Request timed out.');
+        importErrorMessage('Request timed out.');
         importDone();
       }, 25000); // time out after some number of seconds
       $('#importsubmitinput').attr(
@@ -69,10 +69,6 @@ const padimpexp = (() => {
       $('#importstatusball').show();
     }
     return ret;
-  };
-
-  const importFailed = (msg) => {
-    importErrorMessage(msg);
   };
 
   const importDone = () => {
@@ -196,7 +192,7 @@ const padimpexp = (() => {
     handleFrameCall: (directDatabaseAccess, status) => {
       if (directDatabaseAccess === 'undefined') directDatabaseAccess = false;
       if (status !== 'ok') {
-        importFailed(status);
+        importErrorMessage(status);
       } else {
         $('#import_export').removeClass('popup-show');
       }

--- a/src/tests/backend/specs/api/importexportGetPost.js
+++ b/src/tests/backend/specs/api/importexportGetPost.js
@@ -127,6 +127,8 @@ describe(__filename, function () {
 
 
     describe('Import/Export tests requiring AbiWord/LibreOffice', function () {
+      this.timeout(60000);
+
       before(async function () {
         if ((!settings.abiword || settings.abiword.indexOf('/') === -1) &&
             (!settings.soffice || settings.soffice.indexOf('/') === -1)) {
@@ -141,7 +143,12 @@ describe(__filename, function () {
         await agent.post(`/p/${testPadId}/import`)
             .attach('file', wordDoc, {filename: '/test.doc', contentType: 'application/msword'})
             .expect(200)
-            .expect(/FrameCall\('undefined', 'ok'\);/);
+            .expect('Content-Type', /json/)
+            .expect((res) => assert.deepEqual(res.body, {
+              code: 0,
+              message: 'ok',
+              data: {directDatabaseAccess: false},
+            }));
       });
 
       it('exports DOC', async function () {
@@ -161,7 +168,12 @@ describe(__filename, function () {
                   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             })
             .expect(200)
-            .expect(/FrameCall\('undefined', 'ok'\);/);
+            .expect('Content-Type', /json/)
+            .expect((res) => assert.deepEqual(res.body, {
+              code: 0,
+              message: 'ok',
+              data: {directDatabaseAccess: false},
+            }));
       });
 
       it('exports DOC from imported DOCX', async function () {
@@ -177,7 +189,12 @@ describe(__filename, function () {
         await agent.post(`/p/${testPadId}/import`)
             .attach('file', pdfDoc, {filename: '/test.pdf', contentType: 'application/pdf'})
             .expect(200)
-            .expect(/FrameCall\('undefined', 'ok'\);/);
+            .expect('Content-Type', /json/)
+            .expect((res) => assert.deepEqual(res.body, {
+              code: 0,
+              message: 'ok',
+              data: {directDatabaseAccess: false},
+            }));
       });
 
       it('exports PDF', async function () {
@@ -193,7 +210,12 @@ describe(__filename, function () {
         await agent.post(`/p/${testPadId}/import`)
             .attach('file', odtDoc, {filename: '/test.odt', contentType: 'application/odt'})
             .expect(200)
-            .expect(/FrameCall\('undefined', 'ok'\);/);
+            .expect('Content-Type', /json/)
+            .expect((res) => assert.deepEqual(res.body, {
+              code: 0,
+              message: 'ok',
+              data: {directDatabaseAccess: false},
+            }));
       });
 
       it('exports ODT', async function () {
@@ -213,7 +235,12 @@ describe(__filename, function () {
             contentType: 'application/etherpad',
           })
           .expect(200)
-          .expect(/FrameCall\('true', 'ok'\);/);
+          .expect('Content-Type', /json/)
+          .expect((res) => assert.deepEqual(res.body, {
+            code: 0,
+            message: 'ok',
+            data: {directDatabaseAccess: true},
+          }));
     });
 
     it('exports Etherpad', async function () {
@@ -237,8 +264,12 @@ describe(__filename, function () {
       settings.allowUnknownFileEnds = false;
       await agent.post(`/p/${testPadId}/import`)
           .attach('file', padText, {filename: '/test.xasdasdxx', contentType: 'weirdness/jobby'})
-          .expect(200)
-          .expect((res) => assert.doesNotMatch(res.text, /FrameCall\('undefined', 'ok'\);/));
+          .expect(400)
+          .expect('Content-Type', /json/)
+          .expect((res) => {
+            assert.equal(res.body.code, 1);
+            assert.equal(res.body.message, 'uploadFailed');
+          });
     });
 
     describe('Import authorization checks', function () {


### PR DESCRIPTION
**Please do not squash merge** because the commits in this PR are intentionally separate:

* import/export: Make sure Express sees async errors
* pad: Delete dead code
* pad_impexp: Delete unnecessary `importFailed` wrapper
* pad_impexp: Invert logic to improve readability
* pad_impexp: Style fixes to improve readability
* pad_impexp: Simplify creation of import failure message
* pad_impexp: Use jQuery to build the import failure popup
* ImportHandler: Delete redundant variable
* ImportHandler: Avoid deprecated `fs.exists()` function
* ImportHandler: Use asynchronous rename instead of `fs.renameSync()`
* ImportHandler: Switch to `fs/promises` API
* ImportHandler: Use `return reject(...)` to avoid double settle
* ImportHandler: Throw Errors, not strings
* ImportHandler: Lint the response script sent to the browser
* ImportHandler: Use `JSON.stringify()` to properly escape characters
* ImportHandler: Move the logger up
* ImportHandler: Refactor `doImport()` for readability
* import: Ajaxify pad import
