### PR TITLE
plugins: Delete noisy and useless debug message

### DIFF
--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -287,7 +287,6 @@ function findUnmet (obj) {
       }
 
     })
-  log.debug([obj._id], "returning")
   return obj
 }
 


### PR DESCRIPTION
The debug statement mostly printed the following useless message over and over, causing Travis CI logs to become truncated:

    [DEBUG] pluginfw - [ undefined ] returning
