### PR TITLE
tests: Frontend test infrastructure low-hanging fruit

### DIFF
--- a/src/node/hooks/express/tests.js
+++ b/src/node/hooks/express/tests.js
@@ -13,8 +13,8 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     // merge the two sets of results
     let files = [].concat(coreTests, pluginTests).sort();
 
-    // Remove swap files from tests
-    files = files.filter(el => !/\.swp$/.test(el))
+    // Keep only *.js files
+    files = files.filter((f) => f.endsWith('.js'));
 
     console.debug("Sent browser the following test specs:", files);
     res.setHeader('content-type', 'text/javascript');

--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -197,6 +197,17 @@ var helper = {};
     return deferred;
   };
 
+  /**
+   * Same as `waitFor` but using Promises
+   *
+   */
+  helper.waitForPromise = async function(...args) {
+    // Note: waitFor() has a strange API: On timeout it rejects, but it also throws an uncatchable
+    // exception unless .fail() has been called. That uncatchable exception is disabled here by
+    // passing a no-op function to .fail().
+    return await this.waitFor(...args).fail(() => {});
+  };
+
   helper.selectLines = function($startLine, $endLine, startOffset, endOffset){
     // if no offset is provided, use beginning of start line and end of end line
     startOffset = startOffset || 0;

--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -164,12 +164,12 @@ var helper = {};
 
     var deferred = $.Deferred();
 
-    var _fail = deferred.fail;
+    const _fail = deferred.fail.bind(deferred);
     var listenForFail = false;
-    deferred.fail = function(){
+    deferred.fail = (...args) => {
       listenForFail = true;
-      _fail.apply(this, arguments);
-    }
+      return _fail(...args);
+    };
 
     var intervalCheck = setInterval(function(){
       var passed = false;

--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -169,16 +169,14 @@ var helper = {};
     };
 
     var intervalCheck = setInterval(function(){
-      var passed = false;
-
-      passed = conditionFunc();
-
-      if(passed){
-        clearInterval(intervalCheck);
-        clearTimeout(timeout);
-
+      try {
+        if (!conditionFunc()) return;
         deferred.resolve();
+      } catch (err) {
+        deferred.reject(err);
       }
+      clearInterval(intervalCheck);
+      clearTimeout(timeout);
     }, intervalTime);
 
     var timeout = setTimeout(function(){

--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -158,10 +158,7 @@ var helper = {};
     return padName;
   }
 
-  helper.waitFor = function(conditionFunc, _timeoutTime, _intervalTime){
-    var timeoutTime = _timeoutTime || 1900;
-    var intervalTime = _intervalTime || 10;
-
+  helper.waitFor = function(conditionFunc, timeoutTime = 1900, intervalTime = 10) {
     var deferred = $.Deferred();
 
     const _fail = deferred.fail.bind(deferred);

--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -259,16 +259,4 @@ var helper = {};
   /* Ensure console.log doesn't blow up in IE, ugly but ok for a test framework imho*/
   window.console = window.console || {};
   window.console.log = window.console.log || function(){}
-
-  //force usage of callbacks in it
-  var _it = it;
-  it = function(name, func){
-    if(func && func.length !== 1){
-      func = function(){
-        throw new Error("Please use always a callback with it() - " + func.toString());
-      }
-    }
-
-    _it(name, func);
-  }
 })()

--- a/tests/frontend/helper.js
+++ b/tests/frontend/helper.js
@@ -168,7 +168,7 @@ var helper = {};
       return _fail(...args);
     };
 
-    var intervalCheck = setInterval(function(){
+    const check = () => {
       try {
         if (!conditionFunc()) return;
         deferred.resolve();
@@ -177,9 +177,11 @@ var helper = {};
       }
       clearInterval(intervalCheck);
       clearTimeout(timeout);
-    }, intervalTime);
+    };
 
-    var timeout = setTimeout(function(){
+    const intervalCheck = setInterval(check, intervalTime);
+
+    const timeout = setTimeout(() => {
       clearInterval(intervalCheck);
       var error = new Error("wait for condition never became true " + conditionFunc.toString());
       deferred.reject(error);
@@ -189,8 +191,11 @@ var helper = {};
       }
     }, timeoutTime);
 
+    // Check right away to avoid an unnecessary sleep if the condition is already true.
+    check();
+
     return deferred;
-  }
+  };
 
   helper.selectLines = function($startLine, $endLine, startOffset, endOffset){
     // if no offset is provided, use beginning of start line and end of end line

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -155,6 +155,15 @@ describe("the test helper", function(){
       });
     });
 
+    it('rejects if the predicate throws', async function() {
+      let err;
+      await helper.waitFor(() => { throw new Error('test exception'); })
+          .fail(() => {}) // Suppress the redundant uncatchable exception.
+          .catch((e) => { err = e; });
+      expect(err).to.be.an(Error);
+      expect(err.message).to.be('test exception');
+    });
+
     describe("returns a deferred object", function(){
       it("it calls done after success", function(done){
         helper.waitFor(function(){

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -215,6 +215,53 @@ describe("the test helper", function(){
     });
   });
 
+  describe('the waitForPromise method', function() {
+    it('takes a timeout and waits long enough', async function() {
+      this.timeout(2000);
+      var startTime = Date.now();
+      await helper.waitForPromise(function() {
+        return false;
+      }, 1500).catch(function() {
+        var duration = Date.now() - startTime;
+        expect(duration).to.be.greaterThan(1490);
+      });
+    });
+
+    it('takes an interval and checks on every interval', async function() {
+      this.timeout(4000);
+      var checks = 0;
+      await helper.waitForPromise(function() {
+        checks++;
+        return false;
+      }, 2000, 100).catch(function() {
+        expect(checks).to.be.greaterThan(15);
+        expect(checks).to.be.lessThan(21);
+      });
+    });
+
+    describe('returns a Promise', function() {
+      it('calls then after success', async function() {
+        let called = false;
+        await helper.waitForPromise(function() {
+          return true;
+        }).then(function() {
+          called = true;
+        });
+        expect(called).to.be(true);
+      });
+
+      it('calls catch on failure', async function() {
+        let called = false;
+        await helper.waitForPromise(function() {
+          return false;
+        },0).catch(function() {
+          called = true;
+        });
+        expect(called).to.be(true);
+      });
+    });
+  });
+
   describe("the selectLines method", function(){
     // function to support tests, use a single way to represent whitespaces
     var cleanText = function(text){

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -216,49 +216,30 @@ describe("the test helper", function(){
   });
 
   describe('the waitForPromise method', function() {
+    it('returns a Promise', async function() {
+      expect(helper.waitForPromise(() => true)).to.be.a(Promise);
+    });
+
     it('takes a timeout and waits long enough', async function() {
       this.timeout(2000);
-      var startTime = Date.now();
-      await helper.waitForPromise(function() {
-        return false;
-      }, 1500).catch(function() {
-        var duration = Date.now() - startTime;
-        expect(duration).to.be.greaterThan(1490);
-      });
+      const startTime = Date.now();
+      let rejected;
+      await helper.waitForPromise(() => false, 1500)
+          .catch(() => { rejected = true; });
+      expect(rejected).to.be(true);
+      const duration = Date.now() - startTime;
+      expect(duration).to.be.greaterThan(1490);
     });
 
     it('takes an interval and checks on every interval', async function() {
       this.timeout(4000);
-      var checks = 0;
-      await helper.waitForPromise(function() {
-        checks++;
-        return false;
-      }, 2000, 100).catch(function() {
-        expect(checks).to.be.greaterThan(15);
-        expect(checks).to.be.lessThan(21);
-      });
-    });
-
-    describe('returns a Promise', function() {
-      it('calls then after success', async function() {
-        let called = false;
-        await helper.waitForPromise(function() {
-          return true;
-        }).then(function() {
-          called = true;
-        });
-        expect(called).to.be(true);
-      });
-
-      it('calls catch on failure', async function() {
-        let called = false;
-        await helper.waitForPromise(function() {
-          return false;
-        },0).catch(function() {
-          called = true;
-        });
-        expect(called).to.be(true);
-      });
+      let checks = 0;
+      let rejected;
+      await helper.waitForPromise(() => { checks++; return false; }, 2000, 100)
+          .catch(() => { rejected = true; });
+      expect(rejected).to.be(true);
+      expect(checks).to.be.greaterThan(15);
+      expect(checks).to.be.lessThan(21);
     });
   });
 

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -193,6 +193,26 @@ describe("the test helper", function(){
         },100);
       });
     });
+
+    describe('checks first then sleeps', function() {
+      it('resolves quickly if the predicate is immediately true', async function() {
+        const before = Date.now();
+        await helper.waitFor(() => true, 1000, 900);
+        expect(Date.now() - before).to.be.lessThan(800);
+      });
+
+      it('polls exactly once if timeout < interval', async function() {
+        let calls = 0;
+        await helper.waitFor(() => { calls++; }, 1, 1000)
+            .fail(() => {}) // Suppress the redundant uncatchable exception.
+            .catch(() => {}); // Don't throw an exception -- we know it rejects.
+        expect(calls).to.be(1);
+      });
+
+      it('resolves if condition is immediately true even if timeout is 0', async function() {
+        await helper.waitFor(() => true, 0);
+      });
+    });
   });
 
   describe("the selectLines method", function(){


### PR DESCRIPTION
This PR contains several of the easy fixes from #4408, plus some additional fixes. I wanted to get them in quickly because some of the test work I'm doing depends on them.

**Please do not squash merge** because the commits are intentionally separate:

* Aggressively filter out non-.js files
* Fix unchainable `helper.waitFor().fail()`
* Use default arguments for `helper.waitFor`
* Teach `waitFor()` to reject if the predicate throws
* Change `waitFor()` to check before first sleep
* don't force a callback in it, so we can use async in tests
* add waitForPromise method and test for it
* `waitForPromise()` test improvements

cc @webzwo0i 