### PR TITLE
l10n: Minor string fixes

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,7 +88,7 @@
   "pad.importExport.abiword.innerHTML": "You only can import from plain text or HTML formats. For more advanced import features please <a href=\"https://github.com/ether/etherpad-lite/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-AbiWord\">install AbiWord or LibreOffice</a>.",
 
   "pad.modals.connected": "Connected.",
-  "pad.modals.reconnecting": "Reconnecting to your pad..",
+  "pad.modals.reconnecting": "Reconnecting to your pad…",
   "pad.modals.forcereconnect": "Force reconnect",
   "pad.modals.reconnecttimer": "Trying to reconnect in",
   "pad.modals.cancel": "Cancel",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -90,7 +90,7 @@
   "pad.modals.connected": "Connected.",
   "pad.modals.reconnecting": "Reconnecting to your pad..",
   "pad.modals.forcereconnect": "Force reconnect",
-  "pad.modals.reconnecttimer": "Trying to reconnect in ",
+  "pad.modals.reconnecttimer": "Trying to reconnect in",
   "pad.modals.cancel": "Cancel",
 
   "pad.modals.userdup": "Opened in another window",

--- a/src/static/js/pad_automatic_reconnect.js
+++ b/src/static/js/pad_automatic_reconnect.js
@@ -21,11 +21,21 @@ var createCountDownElementsIfNecessary = function($modal) {
     var $reconnectButton = $modal.find('#forcereconnect');
 
     // create extra DOM elements, if they don't exist
-    var $reconnectTimerMessage = $('<p class="reconnecttimer"> \
-                                      <span data-l10n-id="pad.modals.reconnecttimer">Trying to reconnect in </span> \
-                                      <span class="timetoexpire"></span> \
-                                    </p>');
-    var $cancelReconnect = $('<button id="cancelreconnect" data-l10n-id="pad.modals.cancel">Cancel</button>');
+    const $reconnectTimerMessage =
+        $('<p>')
+            .addClass('reconnecttimer')
+            .append(
+                $('<span>')
+                    .attr('data-l10n-id', 'pad.modals.reconnecttimer')
+                    .text('Trying to reconnect in '))
+            .append(
+                $('<span>')
+                    .addClass('timetoexpire'));
+    const $cancelReconnect =
+        $('<button>')
+            .attr('id', 'cancelreconnect')
+            .attr('data-l10n-id', 'pad.modals.cancel')
+            .text('Cancel');
 
     localize($reconnectTimerMessage);
     localize($cancelReconnect);

--- a/src/static/js/pad_automatic_reconnect.js
+++ b/src/static/js/pad_automatic_reconnect.js
@@ -27,7 +27,8 @@ var createCountDownElementsIfNecessary = function($modal) {
             .append(
                 $('<span>')
                     .attr('data-l10n-id', 'pad.modals.reconnecttimer')
-                    .text('Trying to reconnect in '))
+                    .text('Trying to reconnect in'))
+            .append(' ')
             .append(
                 $('<span>')
                     .addClass('timetoexpire'));


### PR DESCRIPTION
* Use jQuery methods to build DOM elements
* Move out pad.modals.reconnecttimer trailing space
* Use an ellipsis instead of two periods

cc @Nikerabbit 