### PR TITLE
plugins: include more data within padUpdate hook

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -169,6 +169,8 @@ Things in context:
 
 1. pad - the pad instance
 2. author - the id of the author who updated the pad
+3. newRev - the index of the new revision
+4. changeset - the changeset of this revision (see [Changeset Library](#index_changeset_library))
 
 This hook gets called when an existing pad was updated.
 

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -109,7 +109,7 @@ Pad.prototype.appendRevision = async function appendRevision(aChangeset, author)
   if (this.head == 0) {
     hooks.callAll("padCreate", {'pad':this, 'author': author});
   } else {
-    hooks.callAll("padUpdate", {'pad':this, 'author': author});
+    hooks.callAll("padUpdate", {'pad':this, 'author': author, 'revs': newRev, 'changeset': aChangeset});
   }
 
   await Promise.all(p);


### PR DESCRIPTION
### what it does
This PR gives additional access to `revs` and `changeset` within a `padUpdate` hook.

### where it comes from
It is actually a commit which is since 2019 already part (https://github.com/bigbluebutton/etherpad-lite/commit/5bc37fc92714e82165386dc0a5dd467609169a87) of the [BigBlueButton Etherpad fork](https://github.com/bigbluebutton/etherpad-lite) and is used there, along with [ep_redis_publisher](https://github.com/pedrobmarin/ep_redis_publisher), to create a nice live subtitles / closed captions feature.

### why to merge
I think it would be nice to merge this for following reasons:
1. Allows more possibilities for other use cases.
2. Gives BigBlueButton the opportunity to switch back to the official etherpad branch again instead of maintaining a, currently quite outdated, fork.