### PR TITLE
tests: 10 sec maximum wait time for timeslider

### DIFF
--- a/tests/frontend/helper/methods.js
+++ b/tests/frontend/helper/methods.js
@@ -196,7 +196,7 @@ helper.gotoTimeslider = function(revision){
 
   return helper.waitForPromise(function(){
     return helper.timesliderTimerTime()
-      && !Number.isNaN(new Date(helper.timesliderTimerTime()).getTime()) },5000);
+      && !Number.isNaN(new Date(helper.timesliderTimerTime()).getTime()) },10000);
 }
 
 /**


### PR DESCRIPTION
This tries to work around one bug was with timeslider not loading properly:
https://app.saucelabs.com/tests/a2e793dffb5c4f07a2e52855fd0a4df1 at minute ~4:26 (I don't know how to link to specific frames and used ffmpeg to see the video frame-by-frame)

You can see the empty timeslider without locale strings, then locale strings are added ("No authors" and "Return") and then the timeout happens. I can reproduce the same behaviour when manually removing timeslider.js. Because you can see a delay between loading the timeslider's html and loading en.json there is probably also an delay for timeslider.js, so it's not loaded in time.

Better loading times should be achieved when https://github.com/ether/etherpad-lite/pull/4285 is ready, but there is some more work to do before that'll be finished.