### PR TITLE
utils: Fix commit checking on detached HEAD

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -423,8 +423,12 @@ exports.getGitCommit = function() {
       rootPath += '/.git';
     }
     var ref = fs.readFileSync(rootPath + "/HEAD", "utf-8");
-    var refPath = rootPath + "/" + ref.substring(5, ref.indexOf("\n"));
-    version = fs.readFileSync(refPath, "utf-8");
+    if (ref.startsWith("ref: ")) {
+      var refPath = rootPath + "/" + ref.substring(5, ref.indexOf("\n"));
+      version = fs.readFileSync(refPath, "utf-8");
+    } else {
+      version = ref;
+    }
     version = version.substring(0, 7);
   } catch(e) {
     console.warn("Can't get git version for server header\n" + e.message)


### PR DESCRIPTION
Closes https://github.com/ether/etherpad-lite/issues/4417

This makes it possible for Etherpad to find the latest commit when the HEAD is detached. Not sure what the right way to go about testing this is, or if tests are needed. 