### PR TITLE
Use correct constructor for 404,501 error handlers

### DIFF
--- a/src/node/hooks/express/openapi.js
+++ b/src/node/hooks/express/openapi.js
@@ -575,10 +575,10 @@ exports.expressCreateServer = (hookName, args, cb) => {
       // register default handlers
       api.register({
         notFound: () => {
-          throw new createHTTPError.notFound('no such function');
+          throw new createHTTPError.NotFound('no such function');
         },
         notImplemented: () => {
-          throw new createHTTPError.notImplemented('function not implemented');
+          throw new createHTTPError.NotImplemented('function not implemented');
         },
       });
 

--- a/src/node/hooks/express/openapi.js
+++ b/src/node/hooks/express/openapi.js
@@ -604,7 +604,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
           // pass to api handler
           let data = await apiHandler.handle(version, funcName, fields, req, res).catch((err) => {
             // convert all errors to http errors
-            if (err instanceof createHTTPError.HttpError) {
+            if (createHTTPError.isHttpError(err)) {
               // pass http errors thrown by handler forward
               throw err;
             } else if (err.name == 'apierror') {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2370,15 +2370,22 @@
       }
     },
     "http-errors": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
+        "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        }
       }
     },
     "http-signature": {
@@ -7391,6 +7398,18 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
+        "http-errors": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -45,7 +45,7 @@
     "find-root": "1.1.0",
     "formidable": "1.2.1",
     "graceful-fs": "4.2.4",
-    "http-errors": "1.7.3",
+    "http-errors": "1.8.0",
     "js-cookie": "^2.2.1",
     "jsonminify": "0.4.1",
     "languages4translatewiki": "0.1.3",


### PR DESCRIPTION
Fixes error message mentioned in #4378, upgrades to `http-errors@1.8.0`, utilise new isHttpError utility introduced by the new version of the package.