### PR TITLE
docs: fix key in padUpdate context

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -169,7 +169,7 @@ Things in context:
 
 1. pad - the pad instance
 2. author - the id of the author who updated the pad
-3. newRev - the index of the new revision
+3. revs - the index of the new revision
 4. changeset - the changeset of this revision (see [Changeset Library](#index_changeset_library))
 
 This hook gets called when an existing pad was updated.


### PR DESCRIPTION
I accidentally describe the wrong key name in the docs during this merge request ["plugins: include more data within padUpdate hook" (#4425)](https://github.com/ether/etherpad-lite/pull/4425)

this fixes it.

There was the wish by @rhansen to change the name from `revs` to `rev`:
My main motivation is to merge some changes from the [BigBlueButton fork](https://github.com/bigbluebutton/etherpad-lite) upstream, so that it eventually could throw away the fork and use the official etherpad releases again. Changes the key would also require changes in the BigBlueButton code itself which would make the process way more difficult.
So I would prefer, even if it would make the key slightly more reasonable, to not change it :)
