### PR TITLE
performance/bugfix: remove broken async inclusion in tar.json

### DIFF
--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -71,7 +71,6 @@
   , "jquery.js"
   , "rjquery.js"
   , "$async.js"
-  , "$async/lib/async.js"
   , "underscore.js"
   , "$underscore.js"
   , "$underscore/underscore.js"


### PR DESCRIPTION
I can't get to the bottom of it because of time constraints, but the inclusion of async in tar.json is problematic. Without this PR caching_middleware.js won't add max-age, last-modified and expires headers. As a result this file will never be cached. It's even worse, because the file is downloaded two times resulting in 700kb+. (The problem is also present on video.etherpad.com)
The reason, why the file is downloaded two times is probably connected with iframes/pad.html not sharing javascript when a pad loads. (e.g. https://github.com/ether/etherpad-lite/blob/develop/src/static/js/ace.js#L266-L269 needs ace2_common.js). 

With this PR proper headers are added, so all subsequent requests are served from browser cache.

