### PR TITLE
Speed up and fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
-        - "travis_wait 20 tests/frontend/travis/runner.sh"
+        - "travis_wait 15 tests/frontend/travis/runner.sh"
     - name: "Run the Backend tests without Plugins"
       install:
         - "sudo add-apt-repository -y ppa:libreoffice/ppa"
@@ -77,7 +77,7 @@ jobs:
         - *install_plugins
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
-        - "travis_wait 20 tests/frontend/travis/runner.sh"
+        - "travis_wait 15 tests/frontend/travis/runner.sh"
     - name: "Lint test package-lock.json"
       install:
         - "npm install lockfile-lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
-        - "tests/frontend/travis/runner.sh"
+        - "travis_wait -n 20 tests/frontend/travis/runner.sh"
     - name: "Run the Backend tests without Plugins"
       install:
         - "sudo add-apt-repository -y ppa:libreoffice/ppa"
@@ -77,7 +77,7 @@ jobs:
         - *install_plugins
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
-        - "tests/frontend/travis/runner.sh"
+        - "travis_wait -n 20 tests/frontend/travis/runner.sh"
     - name: "Lint test package-lock.json"
       install:
         - "npm install lockfile-lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ jobs:
         - npx lockfile-lint --path src/package-lock.json --validate-https --allowed-hosts npm
     - name: "Run the Backend tests with Plugins"
       install:
+        - "sudo add-apt-repository -y ppa:libreoffice/ppa"
+        - "sudo apt-get update"
+        - "sudo apt-get -y install libreoffice"
+        - "sudo apt-get -y install libreoffice-pdfimport"
         - "bin/installDeps.sh"
         - *install_plugins
         - "cd src && npm install && cd -"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,6 @@ services:
 
 cache: false
 
-before_install:
-  - sudo add-apt-repository -y ppa:libreoffice/ppa
-  - sudo apt-get update
-  - sudo apt-get -y install libreoffice
-  - sudo apt-get -y install libreoffice-pdfimport
-
-install:
-  - "bin/installDeps.sh"
-  - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
-  # Installing some plugins
-
-script:
-  - "tests/frontend/travis/runner.sh"
-
 env:
   global:
     - secure: "WMGxFkOeTTlhWB+ChMucRtIqVmMbwzYdNHuHQjKCcj8HBEPdZLfCuK/kf4rG\nVLcLQiIsyllqzNhBGVHG1nyqWr0/LTm8JRqSCDDVIhpyzp9KpCJQQJG2Uwjk\n6/HIJJh/wbxsEdLNV2crYU/EiVO3A4Bq0YTHUlbhUqG3mSCr5Ec="
@@ -56,6 +42,10 @@ jobs:
         - "tests/frontend/travis/runner.sh"
     - name: "Run the Backend tests without Plugins"
       install:
+        - "sudo add-apt-repository -y ppa:libreoffice/ppa"
+        - "sudo apt-get update"
+        - "sudo apt-get -y install libreoffice"
+        - "sudo apt-get -y install libreoffice-pdfimport"
         - "bin/installDeps.sh"
         - "cd src && npm install && cd -"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
         - "bin/installDeps.sh"
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
-        - "travis_wait -n 20 tests/frontend/travis/runner.sh"
+        - "travis_wait 20 tests/frontend/travis/runner.sh"
     - name: "Run the Backend tests without Plugins"
       install:
         - "sudo add-apt-repository -y ppa:libreoffice/ppa"
@@ -77,7 +77,7 @@ jobs:
         - *install_plugins
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
-        - "travis_wait -n 20 tests/frontend/travis/runner.sh"
+        - "travis_wait 20 tests/frontend/travis/runner.sh"
     - name: "Lint test package-lock.json"
       install:
         - "npm install lockfile-lint"

--- a/tests/frontend/specs/helper.js
+++ b/tests/frontend/specs/helper.js
@@ -151,7 +151,7 @@ describe("the test helper", function(){
       }, 2000, 100).fail(function(){
         // One at the beginning, and 19-20 more depending on whether it's the timeout or the final
         // poll that wins at 2000ms.
-        expect(checks).to.be.greaterThan(17);
+        expect(checks).to.be.greaterThan(15);
         expect(checks).to.be.lessThan(24);
         done();
       });
@@ -243,7 +243,7 @@ describe("the test helper", function(){
        // `checks` is expected to be 20 or 21: one at the beginning, plus 19 or 20 more depending on
        // whether it's the timeout or the final poll that wins at 2000ms. Margin is added to reduce
        // flakiness on slow test machines.
-      expect(checks).to.be.greaterThan(17);
+      expect(checks).to.be.greaterThan(15);
       expect(checks).to.be.lessThan(24);
     });
   });

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -53,13 +53,13 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
       }
 
       /**
-       * timeout if a test hangs or the job exceeds 9.5 minutes
+       * timeout if a test hangs or the job exceeds 19.5 minutes
        * It's necessary because if travis kills the saucelabs session due to inactivity, we don't get any output
        * @todo this should be configured in testSettings, see https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
        */
       var timeout = setTimeout(function(){
         stopSauce(false,true);
-      }, 570000); // travis timeout is 10 minutes, set this to a slightly lower value
+      }, 1170000); // travis timeout is 20 minutes, set this to a slightly lower value
 
       var knownConsoleText = "";
       var getStatusInterval = setInterval(function(){

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -10,6 +10,10 @@ var config = {
 }
 
 var allTestsPassed = true;
+// overwrite the default exit code
+// in case not all worker can be run (due to saucelabs limits), `queue.drain` below will not be called
+// and the script would silently exit with error code 0
+process.exitCode = 1;
 
 var sauceTestWorker = async.queue(function (testSettings, callback) {
   var browser = wd.promiseChainRemote(config.host, config.port, config.username, config.accessKey);

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -57,13 +57,13 @@ var sauceTestWorker = async.queue(function (testSettings, callback) {
       }
 
       /**
-       * timeout if a test hangs or the job exceeds 19.5 minutes
+       * timeout if a test hangs or the job exceeds 14.5 minutes
        * It's necessary because if travis kills the saucelabs session due to inactivity, we don't get any output
        * @todo this should be configured in testSettings, see https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
        */
       var timeout = setTimeout(function(){
         stopSauce(false,true);
-      }, 1170000); // travis timeout is 20 minutes, set this to a slightly lower value
+      }, 870000); // travis timeout is 15 minutes, set this to a slightly lower value
 
       var knownConsoleText = "";
       var getStatusInterval = setInterval(function(){


### PR DESCRIPTION
- set default exit code of the frontend tests (remote_runner.js) to 1. In case saucelabs runner aren't started (limit of parallel worker) the callback of the worker that is pushed to `async#queue` won't be called. This results in `queue#drain` to never be called and the script just silently exits with a default exit code (cf https://travis-ci.com/github/ether/ep_comments/jobs/413945558)

- Increase the "no messages received" timeout of travis from 10 to 15 minutes. (frontend tests would start to exceed the limit very soon) - I did not see builds that hang for more than ten minutes recently, but if this would happen again and 15 minutes delay for a hanging test would be too much, we certainly can lower it again.

- libreoffice is only used during backend tests at the moment. instead of installing it on every job just do this for the 2 backend jobs. also cleanup travis hooks that are overwritten by job specific ones 

- fix flaky helper test: unfortunately setInterval seems flaky on saucelabs.