### PR TITLE
WIP: fix truncated travis log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
         - "travis_wait 15 tests/frontend/travis/runner.sh"
-      #output 300 lines at once to prevent travis from truncating the log
+      #output 100 lines at once to prevent travis from truncating the log
       after_script:
         - "cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
     - name: "Run the Backend tests without Plugins"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
         - "travis_wait 15 tests/frontend/travis/runner.sh"
       #output 100 lines at once to prevent travis from truncating the log
       after_script:
-        - "cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
+        - "travis_fold end after_script && cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
     - name: "Run the Backend tests without Plugins"
       install:
         - "sudo add-apt-repository -y ppa:libreoffice/ppa"
@@ -83,7 +83,7 @@ jobs:
         - "travis_wait 15 tests/frontend/travis/runner.sh"
       #output 100 lines/sec to prevent travis from truncating the log
       after_script:
-        - "cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
+        - "travis_fold end after_script && cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
     - name: "Lint test package-lock.json"
       install:
         - "npm install lockfile-lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ jobs:
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
         - "travis_wait 15 tests/frontend/travis/runner.sh"
+      #output 300 lines at once to prevent travis from truncating the log
+      after_script:
+        - "cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
     - name: "Run the Backend tests without Plugins"
       install:
         - "sudo add-apt-repository -y ppa:libreoffice/ppa"
@@ -78,6 +81,9 @@ jobs:
         - "export GIT_HASH=$(git rev-parse --verify --short HEAD)"
       script:
         - "travis_wait 15 tests/frontend/travis/runner.sh"
+      #output 100 lines/sec to prevent travis from truncating the log
+      after_script:
+        - "cat /tmp/remote_runner.log | (lines=0; while read line; do echo -e \"${line}\"; if [ $((++lines % 100)) -eq 0 ]; then sleep 1; fi; done)"
     - name: "Lint test package-lock.json"
       install:
         - "npm install lockfile-lint"

--- a/tests/frontend/travis/runner.sh
+++ b/tests/frontend/travis/runner.sh
@@ -17,6 +17,7 @@ cd "${MY_DIR}/../../../"
 # a call to bin/installDeps.sh
 echo "Running Etherpad directly, assuming bin/installDeps.sh has already been run"
 node node_modules/ep_etherpad-lite/node/server.js --experimental-worker "${@}" &
+ep_pid=$!
 
 echo "Now I will try for 15 seconds to connect to Etherpad on http://localhost:9001"
 
@@ -40,9 +41,10 @@ cd "${MY_DIR}"
 
 # start the remote runner
 echo "Now starting the remote runner"
-node remote_runner.js
+node remote_runner.js >/tmp/remote_runner.log 2>&1
 exit_code=$?
 
 kill $(cat /tmp/sauce.pid)
+kill $ep_pid
 
 exit $exit_code


### PR DESCRIPTION
Travis log is truncated on nearly every frontend job. I observed it for a long time on about 1/10 of the builds, but now it seems to happen on nearly every build that runs the frontend tests.

The problem is probably related to the way travis parses the logs to remove secure environment vars - but I am not 100% sure about this. (The assumption is based on https://github.com/travis-ci/travis-ci/issues/6018#issuecomment-370023238 )
I asked on https://travis-ci.community/t/build-log-truncated/10395 and maybe someone from Travis will show us a way, but until then I think I found a workaround - the remote_runner's log from the frontend tests is now redirected to a file and in an after_script hook I output that file at a rate of 100 lines/sec.

The exit code of the jobs is not changed by adding an after_script hook so it should be save. It worked two times now, while before it was truncated 10 times in a row.