### PR TITLE
Add `req` to EJS render args when possible

### DIFF
--- a/src/node/hooks/express/admin.js
+++ b/src/node/hooks/express/admin.js
@@ -3,7 +3,7 @@ var eejs = require('ep_etherpad-lite/node/eejs');
 exports.expressCreateServer = function (hook_name, args, cb) {
   args.app.get('/admin', function(req, res) {
     if('/' != req.path[req.path.length-1]) return res.redirect('./admin/');
-    res.send( eejs.require("ep_etherpad-lite/templates/admin/index.html", {}) );
+    res.send(eejs.require('ep_etherpad-lite/templates/admin/index.html', {req}));
   });
   return cb();
 }

--- a/src/node/hooks/express/adminplugins.js
+++ b/src/node/hooks/express/adminplugins.js
@@ -8,13 +8,12 @@ const UpdateCheck = require('ep_etherpad-lite/node/utils/UpdateCheck');
 
 exports.expressCreateServer = function(hook_name, args, cb) {
   args.app.get('/admin/plugins', function(req, res) {
-    var render_args = {
+    res.send(eejs.require('ep_etherpad-lite/templates/admin/plugins.html', {
       plugins: plugins.plugins,
+      req,
       search_results: {},
       errors: [],
-    };
-
-    res.send(eejs.require("ep_etherpad-lite/templates/admin/plugins.html", render_args));
+    }));
   });
 
   args.app.get('/admin/plugins/info', function(req, res) {
@@ -24,7 +23,8 @@ exports.expressCreateServer = function(hook_name, args, cb) {
     res.send(eejs.require("ep_etherpad-lite/templates/admin/plugins-info.html", {
       gitCommit: gitCommit,
       epVersion: epVersion,
-      latestVersion: UpdateCheck.getLatestVersion()
+      latestVersion: UpdateCheck.getLatestVersion(),
+      req,
     }));
   });
 

--- a/src/node/hooks/express/adminsettings.js
+++ b/src/node/hooks/express/adminsettings.js
@@ -5,15 +5,12 @@ var fs = require('fs');
 
 exports.expressCreateServer = function (hook_name, args, cb) {
   args.app.get('/admin/settings', function(req, res) {
-
-    var render_args = {
+    res.send(eejs.require('ep_etherpad-lite/templates/admin/settings.html', {
+      req,
       settings: "",
       search_results: {},
       errors: []
-    };
-
-    res.send( eejs.require("ep_etherpad-lite/templates/admin/settings.html", render_args) );
-
+    }));
   });
   return cb();
 }

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -14,13 +14,13 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   //serve index.html under /
   args.app.get('/', function(req, res)
   {
-    res.send(eejs.require("ep_etherpad-lite/templates/index.html"));
+    res.send(eejs.require('ep_etherpad-lite/templates/index.html', {req}));
   });
 
   //serve javascript.html
   args.app.get('/javascript', function(req, res)
   {
-    res.send(eejs.require("ep_etherpad-lite/templates/javascript.html"));
+    res.send(eejs.require('ep_etherpad-lite/templates/javascript.html'), {req});
   });
 
 


### PR DESCRIPTION
This makes it possible for EJS templates and `eejsBlock_*` hook functions to access the user's express-session state.