### PR TITLE
Cherry-pick important v1.8.6 fixes to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 
 # 1.8.6
 * IMPORTANT: This fixes a severe problem with postgresql in 1.8.5
-* SECURITY: Fix authentication bypass vulnerability
+* SECURITY: Fix authentication and authorization bypass vulnerabilities
 * API: Update version to 1.2.15
-* FEATURE: Add copyPadWithoutHistory API (#4295) 
+* FEATURE: Add copyPadWithoutHistory API (#4295)
 * FEATURE: Package more asset files to save http requests (#4286)
 * MINOR: Improve UI when reconnecting
 * TESTS: Improve tests

--- a/src/node/db/SecurityManager.js
+++ b/src/node/db/SecurityManager.js
@@ -126,7 +126,7 @@ exports.checkAccess = async function(padID, sessionCookie, token, password, user
     return DENY;
   }
 
-  const passwordExempt = settings.sessionNoPassword && sesionAuthorID != null;
+  const passwordExempt = settings.sessionNoPassword && sessionAuthorID != null;
   const requirePassword = pad.isPasswordProtected() && !passwordExempt;
   if (requirePassword) {
     if (password == null) {

--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -72,7 +72,7 @@ exports.findAuthorID = async (groupID, sessionCookie) => {
     return undefined;
   });
   const now = Math.floor(Date.now() / 1000);
-  const isMatch = (si) => (si != null && si.groupID === groupID && si.validUntil <= now);
+  const isMatch = (si) => (si != null && si.groupID === groupID && now < si.validUntil);
   const sessionInfo = await promises.firstSatisfies(sessionInfoPromises, isMatch);
   if (sessionInfo == null) return undefined;
   return sessionInfo.authorID;


### PR DESCRIPTION
v1.8.6 was released with a couple of critical session bugs. Cherry-pick the fixes to `master` so that users checking out `master` can use sessions.

Fixes #4454.