### PR TITLE
Remove `src/static/js/jquery.js` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ var/dirty.db
 bin/convertSettings.json
 *~
 *.patch
-src/static/js/jquery.js
 npm-debug.log
 *.DS_Store
 .ep_initialized


### PR DESCRIPTION
That file is checked in so there's no reason to ignore it.

Fixes #4460.

cc @mcblum