### PR TITLE
Use `contentEditable` for all browsers

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -1103,10 +1103,6 @@ function Ace2Inner(){
 
   var idleWorkTimer = makeIdleAction(function()
   {
-
-    //if (! top.BEFORE) top.BEFORE = [];
-    //top.BEFORE.push(magicdom.root.dom.innerHTML);
-    //if (! isEditable) return; // and don't reschedule
     if (inInternationalComposition)
     {
       // don't do idle input incorporation during international input composition
@@ -1161,9 +1157,6 @@ function Ace2Inner(){
         }
       }
     });
-
-    //if (! top.AFTER) top.AFTER = [];
-    //top.AFTER.push(magicdom.root.dom.innerHTML);
   });
 
   var _nextId = 1;
@@ -3572,7 +3565,6 @@ function Ace2Inner(){
 
   function handleKeyEvent(evt)
   {
-    // if (DEBUG && window.DONT_INCORP) return;
     if (!isEditable) return;
     var type = evt.type;
     var charCode = evt.charCode;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -605,19 +605,9 @@ function Ace2Inner(){
     recolorLinesInRange(0, rep.alltext.length);
   }
 
-  function setEditable(newVal)
-  {
+  function setEditable(newVal) {
     isEditable = newVal;
-
-    // the following may fail, e.g. if iframe is hidden
-    if (!isEditable)
-    {
-      setDesignMode(false);
-    }
-    else
-    {
-      setDesignMode(true);
-    }
+    root.contentEditable = isEditable ? 'true' : 'false';
     root.classList.toggle('static', !isEditable);
   }
 
@@ -4672,40 +4662,6 @@ function Ace2Inner(){
     {
       a();
     });
-  }
-
-  function setDesignMode(newVal)
-  {
-    try
-    {
-      function setIfNecessary(target, prop, val)
-      {
-        if (String(target[prop]).toLowerCase() != val)
-        {
-          target[prop] = val;
-          return true;
-        }
-        return false;
-      }
-      if (browser.msie || browser.safari)
-      {
-        setIfNecessary(root, 'contentEditable', (newVal ? 'true' : 'false'));
-      }
-      else
-      {
-        var wasSet = setIfNecessary(doc, 'designMode', (newVal ? 'on' : 'off'));
-        if (wasSet && newVal && browser.opera)
-        {
-          // turning on designMode clears event handlers
-          bindTheEventHandlers();
-        }
-      }
-      return true;
-    }
-    catch (e)
-    {
-      return false;
-    }
   }
 
   var iePastedLines = null;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -556,7 +556,7 @@ function Ace2Inner(){
   {
     doesWrap = newVal;
     var dwClass = "doesWrap";
-    setClassPresence(root, "doesWrap", doesWrap);
+    root.classList.toggle('doesWrap', doesWrap);
     scheduler.setTimeout(function()
     {
       inCallStackIfNecessary("setWraps", function()
@@ -618,7 +618,7 @@ function Ace2Inner(){
     {
       setDesignMode(true);
     }
-    setClassPresence(root, "static", !isEditable);
+    root.classList.toggle('static', !isEditable);
   }
 
   function enforceEditability()
@@ -890,25 +890,17 @@ function Ace2Inner(){
   // @param value the value to set to
   editorInfo.ace_setProperty = function(key, value)
   {
-
-    // Convinience function returning a setter for a class on an element
-    var setClassPresenceNamed = function(element, cls){
-      return function(value){
-         setClassPresence(element, cls, !! value)
-      }
-    };
-
     // These properties are exposed
     var setters = {
       wraps: setWraps,
-      showsauthorcolors: setClassPresenceNamed(root, "authorColors"),
-      showsuserselections: setClassPresenceNamed(root, "userSelections"),
+      showsauthorcolors: (val) => root.classList.toggle('authorColors', !!val),
+      showsuserselections: (val) => root.classList.toggle('userSelections', !!val),
       showslinenumbers : function(value){
         hasLineNumbers = !! value;
-        setClassPresence(sideDiv.parentNode, "line-numbers-hidden", !hasLineNumbers);
+        sideDiv.parentNode.classList.toggle('line-numbers-hidden', !hasLineNumbers);
         fixView();
       },
-      grayedout: setClassPresenceNamed(outerWin.document.body, "grayedout"),
+      grayedout: (val) => outerWin.document.body.classList.toggle('grayedout', !!val),
       dmesg: function(){ dmesg = window.dmesg = value; },
       userauthor: function(value){
         thisAuthor = String(value);
@@ -917,8 +909,8 @@ function Ace2Inner(){
       styled: setStyled,
       textface: setTextFace,
       rtlistrue: function(value) {
-        setClassPresence(root, "rtl", value)
-        setClassPresence(root, "ltr", !value)
+        root.classList.toggle('rtl', value);
+        root.classList.toggle('ltr', !value);
         document.documentElement.dir = value? 'rtl' : 'ltr'
       }
     };
@@ -4916,12 +4908,6 @@ function Ace2Inner(){
     elem.className = array.join(' ');
   }
 
-  function setClassPresence(elem, className, present)
-  {
-    if (present) $(elem).addClass(className);
-    else $(elem).removeClass(className);
-  }
-
   function focus()
   {
     window.focus();
@@ -5335,8 +5321,8 @@ function Ace2Inner(){
         if (browser.firefox) $(root).addClass("mozilla");
         if (browser.safari) $(root).addClass("safari");
         if (browser.msie) $(root).addClass("msie");
-        setClassPresence(root, "authorColors", true);
-        setClassPresence(root, "doesWrap", doesWrap);
+        root.classList.toggle('authorColors', true);
+        root.classList.toggle('doesWrap', doesWrap);
 
         initDynamicCSS();
 


### PR DESCRIPTION
This makes it possible to disable `contentEditable` for certain elements in some circumstances (e.g., on links so that users can click on them normally).

Addresses (but does not fix) #4456.

Also some cleanups (**multiple commits**):
* Delete commented-out code
* Replace `setClassPresence(x, ...)` with `x.classList.toggle(...)`
