### PR TITLE
editor: throw error and dont hang browser if selection is no longer present

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2245,25 +2245,14 @@ function Ace2Inner(){
 
     // Failing to add attribute to non present selection, see
     // https://github.com/ether/ep_comments/issues/133 for details.
-    var notPresent = false;
     try{
       var line = rep.lines.atIndex(rep.selEnd[0]);
     }catch(e){
-      notPresent = true;
+      throw new Error("Failed to add attribute to selection that does not exist");
     }
-    if(notPresent){
-      parent.parent.$.gritter.add({
-        // (string | mandatory) the heading of the notification
-        title: 'Selection no longer present',
-        // (string | mandatory) the text inside the notification
-        text: 'Unable to modify this content because the selection is no longer present in the pad',
-        // (bool | optional) if you want it to fade out on its own or just $
-        sticky: false,
-        // (int | optional) the time you want it to be alive for before fad$
-        time: '4000'
-      });
-      throw new Error("Failed to add attribute to selection");
-      return;
+    // we know the line exists so let's see if the character exists
+    if(rep.selEnd[1] > rep.lines.atIndex(rep.selEnd[0]).width){
+      throw new Error("Failed to add attribute to selection that does not exist");
     }
 
     documentAttributeManager.setAttributesOnRange(rep.selStart, rep.selEnd, [

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2240,7 +2240,31 @@ function Ace2Inner(){
 
   function setAttributeOnSelection(attributeName, attributeValue)
   {
+    // if there isn't a selection
     if (!(rep.selStart && rep.selEnd)) return;
+
+    // Failing to add attribute to non present selection, see
+    // https://github.com/ether/ep_comments/issues/133 for details.
+    var notPresent = false;
+    try{
+      var line = rep.lines.atIndex(rep.selEnd[0]);
+    }catch(e){
+      notPresent = true;
+    }
+    if(notPresent){
+      parent.parent.$.gritter.add({
+        // (string | mandatory) the heading of the notification
+        title: 'Selection no longer present',
+        // (string | mandatory) the text inside the notification
+        text: 'Unable to modify this content because the selection is no longer present in the pad',
+        // (bool | optional) if you want it to fade out on its own or just $
+        sticky: false,
+        // (int | optional) the time you want it to be alive for before fad$
+        time: '4000'
+      });
+      throw new Error("Failed to add attribute to selection");
+      return;
+    }
 
     documentAttributeManager.setAttributesOnRange(rep.selStart, rep.selEnd, [
       [attributeName, attributeValue]

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2246,7 +2246,7 @@ function Ace2Inner(){
     // Failing to add attribute to non present selection, see
     // https://github.com/ether/ep_comments/issues/133 for details.
     try{
-      var line = rep.lines.atIndex(rep.selEnd[0]);
+      rep.lines.atIndex(rep.selEnd[0]);
     }catch(e){
       throw new Error("Failed to add attribute to selection that does not exist");
     }


### PR DESCRIPTION
Details at: https://github.com/ether/ep_comments/issues/133

Currently it semi-gracefully handles things, I think core should be more responsible tho and throw a gritter msg if a plugin tries to modify a non existing selection...