### PR TITLE
pluginfw: Export .etherpad hooks

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -751,6 +751,21 @@ exports.exportHtmlAdditionalTagsWithData = function(hook, pad, cb){
 };
 ```
 
+## exportEtherpadAdditionalContent
+Called from src/node/utils/ExportEtherpad.js and src/node/utils/ImportEtherpad.js
+
+Things in context:
+
+Useful for exporting and importing non-pad centric data stored about a pad.  For example in ep_comments_page the comments are stored as comments:padId:uniqueIdOfComment and as such when you export .etherpad this data is not included.
+
+Example:
+```
+// Add support for exporting comments metadata
+exports.exportEtherpadAdditionalContent = function(hook_name, context, callback){
+  return callback(["comments"]);
+};
+```
+
 ## userLeave
 Called from src/node/handler/PadMessageHandler.js
 

--- a/src/node/utils/ExportEtherpad.js
+++ b/src/node/utils/ExportEtherpad.js
@@ -66,7 +66,7 @@ exports.getPadRaw = async function(padId) {
     hooks.aCallAll('exportEtherpadAdditionalContent').then((prefixes) => {
       prefixes.forEach(async function(prefix) {
         let pluginContent = await db.get(prefix + ":" + padId);
-        data[prefix] = pluginContent;
+        data[prefix + ":" + padId] = pluginContent;
       });
     })
   ]);

--- a/src/node/utils/ExportEtherpad.js
+++ b/src/node/utils/ExportEtherpad.js
@@ -24,7 +24,6 @@ exports.getPadRaw = async function(padId) {
   let padcontent = await db.get(padKey);
 
   let records = [ padKey ];
-
   for (let i = 0; i <= padcontent.head; i++) {
     records.push(padKey + ":revs:" + i);
   }

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -71,7 +71,7 @@ exports.setPadRaw = function(padId, records)
         hooks.aCallAll('exportEtherpadAdditionalContent').then((prefixes) => {
           prefixes.forEach(async function(prefix) {
             if(key.split(":")[0] === prefix){
-              newKey = "comments:" + padId;
+              newKey = prefix + ":" + padId;
             }
           });
         })


### PR DESCRIPTION
The goal of this PR is to include the ability for .etherpad exports and imports to be extended by plugins which want to export and import additional data as well as padIds..  

Still to do 
- [x] proper import support 
- [x] testing / test coverage.

Opinions on approach invited.

Also worth noting that comments exportHTML.js tests are broken, they are only defining a selection as a comment but not storing the actual comment contents rendering setHTML pretty much useless for these tests..... :\  

For me I can use preformatted JSON to import pre-created .etherpad blobs which contain comments and test against those...

Tests are included in ep_comments which runs in travis so will be covered.