### PR TITLE
bugfix/translations: Fix missing arg handling in html10n.js

### DIFF
--- a/src/static/css/pad/gritter.css
+++ b/src/static/css/pad/gritter.css
@@ -31,6 +31,8 @@
 .gritter-item .gritter-content {
   flex: 1 auto;
   text-align: center;
+  width: 95%;
+  overflow-wrap: break-word;
 }
 
 .gritter-item .gritter-close {

--- a/src/static/js/html10n.js
+++ b/src/static/js/html10n.js
@@ -779,16 +779,16 @@ window.html10n = (function(window, document, undefined) {
   function substArguments(str, args) {
     var reArgs = /\{\{\s*([a-zA-Z\.]+)\s*\}\}/
       , match
-
+    var translations = html10n.translations;
     while (match = reArgs.exec(str)) {
       if (!match || match.length < 2)
         return str // argument key not found
 
       var arg = match[1]
         , sub = ''
-      if (arg in args) {
+      if (args && arg in args) {
         sub = args[arg]
-      } else if (arg in translations) {
+      } else if (translations && arg in translations) {
         sub = translations[arg]
       } else {
         console.warn('Could not find argument {{' + arg + '}}')


### PR DESCRIPTION
When translation expects arguments to be replaced, but the arguments are missing big red error message is displayed. I believe that that kind of translation errors should be only visible in the console just as errors when a value is missing for the current translation key in the users current selected language. Also added style update to gritter.css as long error messages where overflowing the error popup and hard to read and close by the user:
![overflowin_error](https://user-images.githubusercontent.com/19904307/98229746-f7d32c80-1f62-11eb-93f8-15aba67231b4.JPG)
