### PR TITLE
HTML export: Move `padId` to context object property

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -661,22 +661,22 @@ function _analyzeLine(alineAttrs, apool) {
 }
 ```
 
-## exportHTMLAdditionalContent 
+## exportHTMLAdditionalContent
 Called from: src/node/utils/ExportHtml.js
 
 Things in context:
 
 1. padId
 
-This hook will allow a plug-in developer to include additional HTML content in the Body of the exported HTML
+This hook will allow a plug-in developer to include additional HTML content in
+the body of the exported HTML.
 
 Example:
-```
-exports.exportHTMLAdditionalContent = async (hookName, context) => {
-  let padId = context;
-  return "I am groot in " + padId;
-}
 
+```
+exports.exportHTMLAdditionalContent = async (hookName, {padId}) => {
+  return 'I am groot in ' + padId;
+};
 ```
 
 ## stylesForExport

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -498,10 +498,9 @@ exports.getPadHTMLDocument = async function (padId, revNum)
 
   let html = await getPadHTML(pad, revNum);
 
-  let exportHTMLAdditionalContent = await hooks.aCallAll("exportHTMLAdditionalContent", padId);
-  exportHTMLAdditionalContent.forEach(function(hookHtml){
+  for (const hookHtml of await hooks.aCallAll("exportHTMLAdditionalContent", {padId}) {
     html += hookHtml;
-  });
+  }
 
   return eejs.require("ep_etherpad-lite/templates/export_html.html", {
     body: html,


### PR DESCRIPTION
The ep_comments_page plugin will have to be updated. See: https://github.com/ether/ep_comments/pull/157