### PR TITLE
plugins: Various minor improvements

### DIFF
--- a/doc/api/pluginfw.md
+++ b/doc/api/pluginfw.md
@@ -1,14 +1,22 @@
 # Plugin Framework
+
 `require("ep_etherpad-lite/static/js/plugingfw/plugins")`
 
 ## plugins.update
-`require("ep_etherpad-lite/static/js/plugingfw/plugins").update()` will use npm to list all installed modules and read their ep.json files, registering the contained hooks.
-A hook registration is a pair of a hook name and a function reference (filename for require() plus function name)
+
+`require("ep_etherpad-lite/static/js/plugingfw/plugins").update()` will use npm
+to list all installed modules and read their ep.json files, registering the
+contained hooks. A hook registration is a pair of a hook name and a function
+reference (filename for require() plus function name)
 
 ## hooks.callAll
-`require("ep_etherpad-lite/static/js/plugingfw/hooks").callAll("hook_name", {argname:value})` will call all hook functions registered for `hook_name` with `{argname:value}`.
+
+`require("ep_etherpad-lite/static/js/plugingfw/hooks").callAll("hook_name",
+{argname:value})` will call all hook functions registered for `hook_name` with
+`{argname:value}`.
 
 ## hooks.aCallAll
+
 ?
 
 ## ...

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,12 +1,23 @@
 # Plugins
-Etherpad allows you to extend its functionality with plugins. A plugin registers hooks (functions) for certain events (thus certain features) in Etherpad-lite to execute its own functionality based on these events.
 
-Publicly available plugins can be found in the npm registry (see <https://npmjs.org>). Etherpad-lite's naming convention for plugins is to prefix your plugins with `ep_`. So, e.g. it's `ep_flubberworms`. Thus you can install plugins from npm, using `npm install ep_flubberworm` in etherpad-lite's root directory.
+Etherpad allows you to extend its functionality with plugins. A plugin registers
+hooks (functions) for certain events (thus certain features) in Etherpad-lite to
+execute its own functionality based on these events.
 
-You can also browse to `http://yourEtherpadInstan.ce/admin/plugins`, which will list all installed plugins  and those available on npm. It even provides functionality to search through all available plugins.
+Publicly available plugins can be found in the npm registry (see
+<https://npmjs.org>). Etherpad-lite's naming convention for plugins is to prefix
+your plugins with `ep_`. So, e.g. it's `ep_flubberworms`. Thus you can install
+plugins from npm, using `npm install ep_flubberworm` in etherpad-lite's root
+directory.
+
+You can also browse to `http://yourEtherpadInstan.ce/admin/plugins`, which will
+list all installed plugins and those available on npm. It even provides
+functionality to search through all available plugins.
 
 ## Folder structure
+
 A basic plugin usually has the following folder structure:
+
 ```
 ep_<plugin>/
  | static/
@@ -15,14 +26,27 @@ ep_<plugin>/
  + ep.json
  + package.json
 ```
-If your plugin includes client-side hooks, put them in `static/js/`. If you're adding in CSS or image files, you should put those files in `static/css/ `and `static/image/`, respectively, and templates go into `templates/`. Translations go into `locales/`
 
-A Standard directory structure like this makes it easier to navigate through your code. That said, do note, that this is not actually *required* to make your plugin run. If you want to make use of our i18n system, you need to put your translations into `locales/`, though, in order to have them integrated. (See "Localization" for more info on how to localize your plugin)
+If your plugin includes client-side hooks, put them in `static/js/`. If you're
+adding in CSS or image files, you should put those files in `static/css/ `and
+`static/image/`, respectively, and templates go into `templates/`. Translations
+go into `locales/`
+
+A Standard directory structure like this makes it easier to navigate through
+your code. That said, do note, that this is not actually *required* to make your
+plugin run. If you want to make use of our i18n system, you need to put your
+translations into `locales/`, though, in order to have them integrated. (See
+"Localization" for more info on how to localize your plugin)
 
 ## Plugin definition
-Your plugin definition goes into `ep.json`. In this file you register your hooks, indicate the parts of your plugin and the order of execution. (A documentation of all available events to hook into can be found in chapter [hooks](#all_hooks).)
 
-A hook registration is a pairs of a hook name and a function reference (filename to require() + exported function name)
+Your plugin definition goes into `ep.json`. In this file you register your
+hooks, indicate the parts of your plugin and the order of execution. (A
+documentation of all available events to hook into can be found in chapter
+[hooks](#all_hooks).)
+
+A hook registration is a pairs of a hook name and a function reference (filename
+to require() + exported function name)
 
 ```json
 {
@@ -41,22 +65,40 @@ A hook registration is a pairs of a hook name and a function reference (filename
 }
 ```
 
-Etherpad-lite will expect the part of the hook definition before the colon to be a javascript file and will try to require it. The part after the colon is expected to be a valid function identifier of that module. So, you have to export your hooks, using [`module.exports`](https://nodejs.org/docs/latest/api/modules.html#modules_modules) and register it in `ep.json` as `ep_<plugin>/path/to/<file>:FUNCTIONNAME`.
-You can omit the `FUNCTIONNAME` part, if the exported function has got the same name as the hook. So `"authorize" : "ep_flubberworm/foo"` will call the function `exports.authorize` in `ep_flubberworm/foo.js`
+Etherpad-lite will expect the part of the hook definition before the colon to be
+a javascript file and will try to require it. The part after the colon is
+expected to be a valid function identifier of that module. So, you have to
+export your hooks, using
+[`module.exports`](https://nodejs.org/docs/latest/api/modules.html#modules_modules)
+and register it in `ep.json` as `ep_<plugin>/path/to/<file>:FUNCTIONNAME`. You
+can omit the `FUNCTIONNAME` part, if the exported function has got the same name
+as the hook. So `"authorize" : "ep_flubberworm/foo"` will call the function
+`exports.authorize` in `ep_flubberworm/foo.js`
 
 ### Client hooks and server hooks
-There are server hooks, which will be executed on the server (e.g. `expressCreateServer`), and there are client hooks, which are executed on the client (e.g. `acePopulateDomLine`). Be sure to not make assumptions about the environment your code is running in, e.g. don't try to access `process`, if you know your code will be run on the client, and likewise, don't try to access `window` on the server...
+
+There are server hooks, which will be executed on the server (e.g.
+`expressCreateServer`), and there are client hooks, which are executed on the
+client (e.g. `acePopulateDomLine`). Be sure to not make assumptions about the
+environment your code is running in, e.g. don't try to access `process`, if you
+know your code will be run on the client, and likewise, don't try to access
+`window` on the server...
 
 ### Styling
-When you install a client-side plugin (e.g. one that implements at least one client-side hook), the plugin name is added to the `class` attribute of the div `#editorcontainerbox` in the main window.
-This gives you the opportunity of tuning the appearance of the main UI in your plugin.
+
+When you install a client-side plugin (e.g. one that implements at least one
+client-side hook), the plugin name is added to the `class` attribute of the div
+`#editorcontainerbox` in the main window. This gives you the opportunity of
+tuning the appearance of the main UI in your plugin.
 
 For example, this is the markup with no plugins installed:
+
 ```html
 <div id="editorcontainerbox" class="">
 ```
 
 and this is the contents after installing `someplugin`:
+
 ```html
 <div id="editorcontainerbox" class="ep_someplugin">
 ```
@@ -64,7 +106,11 @@ and this is the contents after installing `someplugin`:
 This feature was introduced in Etherpad **1.8**.
 
 ### Parts
-As your plugins become more and more complex, you will find yourself in the need to manage dependencies between plugins. E.g. you want the hooks of a certain plugin to be executed before (or after) yours. You can also manage these dependencies in your plugin definition file `ep.json`:
+
+As your plugins become more and more complex, you will find yourself in the need
+to manage dependencies between plugins. E.g. you want the hooks of a certain
+plugin to be executed before (or after) yours. You can also manage these
+dependencies in your plugin definition file `ep.json`:
 
 ```json
 {
@@ -91,21 +137,41 @@ As your plugins become more and more complex, you will find yourself in the need
 }
 ```
 
-Usually a plugin will add only one functionality at a time, so it will probably only use one `part` definition to register its hooks. However, sometimes you have to put different (unrelated) functionalities into one plugin. For this you will want use parts, so other plugins can depend on them.
+Usually a plugin will add only one functionality at a time, so it will probably
+only use one `part` definition to register its hooks. However, sometimes you
+have to put different (unrelated) functionalities into one plugin. For this you
+will want use parts, so other plugins can depend on them.
 
 #### pre/post
-The `"pre"` and `"post"` definitions, affect the order in which parts of a plugin are executed. This ensures that plugins and their hooks are executed in the correct order.
 
-`"pre"` lists parts that must be executed *before* the defining part. `"post"` lists parts that must be executed *after* the defining part.
+The `"pre"` and `"post"` definitions, affect the order in which parts of a
+plugin are executed. This ensures that plugins and their hooks are executed in
+the correct order.
 
-You can, on a basic level, think of this as double-ended dependency listing. If you have a dependency on another plugin, you can make sure it loads before yours by putting it in `"pre"`. If you are setting up things that might need to be used by a plugin later, you can ensure proper order by putting it in `"post"`.
+`"pre"` lists parts that must be executed *before* the defining part. `"post"`
+lists parts that must be executed *after* the defining part.
 
-Note that it would be far more sane to use `"pre"` in almost any case, but if you want to change config variables for another plugin, or maybe modify its environment, `"post"` could definitely be useful.
+You can, on a basic level, think of this as double-ended dependency listing. If
+you have a dependency on another plugin, you can make sure it loads before yours
+by putting it in `"pre"`. If you are setting up things that might need to be
+used by a plugin later, you can ensure proper order by putting it in `"post"`.
 
-Also, note that dependencies should *also* be listed in your package.json, so they can be `npm install`'d automagically when your plugin gets installed.
+Note that it would be far more sane to use `"pre"` in almost any case, but if
+you want to change config variables for another plugin, or maybe modify its
+environment, `"post"` could definitely be useful.
+
+Also, note that dependencies should *also* be listed in your package.json, so
+they can be `npm install`'d automagically when your plugin gets installed.
 
 ## Package definition
-Your plugin must also contain a [package definition file](https://docs.npmjs.com/files/package.json), called package.json, in the project root - this file contains various metadata relevant to your plugin, such as the name and version number, author, project hompage, contributors, a short description, etc. If you publish your plugin on npm, these metadata are used for package search etc., but it's necessary for Etherpad-lite plugins, even if you don't publish your plugin.
+
+Your plugin must also contain a [package definition
+file](https://docs.npmjs.com/files/package.json), called package.json, in the
+project root - this file contains various metadata relevant to your plugin, such
+as the name and version number, author, project hompage, contributors, a short
+description, etc. If you publish your plugin on npm, these metadata are used for
+package search etc., but it's necessary for Etherpad-lite plugins, even if you
+don't publish your plugin.
 
 ```json
 {
@@ -120,7 +186,12 @@ Your plugin must also contain a [package definition file](https://docs.npmjs.com
 ```
 
 ## Templates
-If your plugin adds or modifies the front end HTML (e.g. adding buttons or changing their functions), you should put the necessary HTML code for such operations in `templates/`, in files of type ".ejs", since Etherpad uses EJS for HTML templating. See the following link for more information about EJS: <https://github.com/visionmedia/ejs>.
+
+If your plugin adds or modifies the front end HTML (e.g. adding buttons or
+changing their functions), you should put the necessary HTML code for such
+operations in `templates/`, in files of type ".ejs", since Etherpad uses EJS for
+HTML templating. See the following link for more information about EJS:
+<https://github.com/visionmedia/ejs>.
 
 ## Writing and running front-end tests for your plugin
 
@@ -130,6 +201,7 @@ Etherpad allows you to easily create front-end tests for plugins.
 ```
 %your_plugin%/static/tests/frontend/specs
 ```
-2. Put your spec file in here (Example spec files are visible in %etherpad_root_folder%/frontend/tests/specs)
+2. Put your spec file in here (Example spec files are visible in
+   %etherpad_root_folder%/frontend/tests/specs)
 
 3. Visit http://yourserver.com/frontend/tests your front-end tests will run.

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -90,22 +90,34 @@ name of a function exported by the named module. See
 for how to export a function.
 
 For the module name you can omit the `.js` suffix, and if the file is `index.js`
-you can use just the directory name.
+you can use just the directory name. You can also omit the module name entirely,
+in which case it defaults to the plugin name (e.g., `ep_example`).
 
-You can also omit the function name and separating colon. If you do, Etherpad
-will look for an exported function whose name matches the name of the hook
-(e.g., `authenticate`). You cannot omit the function name if the module name
-contains a colon.
+You can also omit the function name. If you do, Etherpad will look for an
+exported function whose name matches the name of the hook (e.g.,
+`authenticate`).
 
-For example, all of the following will cause the `authorize` hook to call the
-`exports.authorize` function in `index.js` from the `ep_example` plugin:
+If either the module name or the function name is omitted (or both), the colon
+may also be omitted unless the provided module name contains a colon. (So if the
+module name is `C:\foo.js` then the hook function specification with the
+function name omitted would be `"C:\\foo.js:"`.)
+
+Examples: Suppose the plugin name is `ep_example`. All of the following are
+equivalent, and will cause the `authorize` hook to call the `exports.authorize`
+function in `index.js` from the `ep_example` plugin:
 
 * `"authorize": "ep_example/index.js:authorize"`
+* `"authorize": "ep_example/index.js:"`
 * `"authorize": "ep_example/index.js"`
 * `"authorize": "ep_example/index:authorize"`
+* `"authorize": "ep_example/index:"`
 * `"authorize": "ep_example/index"`
 * `"authorize": "ep_example:authorize"`
+* `"authorize": "ep_example:"`
 * `"authorize": "ep_example"`
+* `"authorize": ":authorize"`
+* `"authorize": ":"`
+* `"authorize": ""`
 
 ### Client hooks and server hooks
 

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -19,7 +19,7 @@ function checkDeprecation(hook) {
   const notice = exports.deprecationNotices[hook.hook_name];
   if (notice == null) return;
   if (deprecationWarned[hook.hook_fn_name]) return;
-  console.warn(`${hook.hook_name} hook used by the ${hook.part.name} plugin ` +
+  console.warn(`${hook.hook_name} hook used by the ${hook.part.plugin} plugin ` +
                `(${hook.hook_fn_name}) is deprecated: ${notice}`);
   deprecationWarned[hook.hook_fn_name] = true;
 }
@@ -121,7 +121,7 @@ function callHookFnSync(hook, context) {
     if (outcome != null) {
       // It was already settled, which indicates a bug.
       const action = err == null ? 'resolve' : 'reject';
-      const msg = (`DOUBLE SETTLE BUG IN HOOK FUNCTION (plugin: ${hook.part.name}, ` +
+      const msg = (`DOUBLE SETTLE BUG IN HOOK FUNCTION (plugin: ${hook.part.plugin}, ` +
                    `function name: ${hook.hook_fn_name}, hook: ${hook.hook_name}): ` +
                    `Attempt to ${action} via ${how} but it already ${outcome.state} ` +
                    `via ${outcome.how}. Ignoring this attempt to ${action}.`);
@@ -135,7 +135,7 @@ function callHookFnSync(hook, context) {
     }
     outcome = {state, err, val, how};
     if (val && typeof val.then === 'function') {
-      console.error(`PROHIBITED PROMISE BUG IN HOOK FUNCTION (plugin: ${hook.part.name}, ` +
+      console.error(`PROHIBITED PROMISE BUG IN HOOK FUNCTION (plugin: ${hook.part.plugin}, ` +
                     `function name: ${hook.hook_fn_name}, hook: ${hook.hook_name}): ` +
                     'The hook function provided a "thenable" (e.g., a Promise) which is ' +
                     'prohibited because the hook expects to get the value synchronously.');
@@ -170,7 +170,7 @@ function callHookFnSync(hook, context) {
   if (val === undefined) {
     if (outcome != null) return outcome.val; // Already settled via callback.
     if (hook.hook_fn.length >= 3) {
-      console.error(`UNSETTLED FUNCTION BUG IN HOOK FUNCTION (plugin: ${hook.part.name}, ` +
+      console.error(`UNSETTLED FUNCTION BUG IN HOOK FUNCTION (plugin: ${hook.part.plugin}, ` +
                     `function name: ${hook.hook_fn_name}, hook: ${hook.hook_name}): ` +
                     'The hook function neither called the callback nor returned a non-undefined ' +
                     'value. This is prohibited because it will result in freezes when a future ' +
@@ -261,7 +261,7 @@ async function callHookFnAsync(hook, context) {
       if (outcome != null) {
         // It was already settled, which indicates a bug.
         const action = err == null ? 'resolve' : 'reject';
-        const msg = (`DOUBLE SETTLE BUG IN HOOK FUNCTION (plugin: ${hook.part.name}, ` +
+        const msg = (`DOUBLE SETTLE BUG IN HOOK FUNCTION (plugin: ${hook.part.plugin}, ` +
                      `function name: ${hook.hook_fn_name}, hook: ${hook.hook_name}): ` +
                      `Attempt to ${action} via ${how} but it already ${outcome.state} ` +
                      `via ${outcome.how}. Ignoring this attempt to ${action}.`);

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -1,3 +1,4 @@
+const log4js = require('log4js');
 var plugins = require("ep_etherpad-lite/static/js/pluginfw/plugins");
 var hooks = require("ep_etherpad-lite/static/js/pluginfw/hooks");
 var npm = require("npm");
@@ -9,7 +10,7 @@ const loadNpm = async () => {
   if (npmIsLoaded) return;
   await util.promisify(npm.load)({});
   npmIsLoaded = true;
-  npm.on('log', (message) => console.log('npm: ', message));
+  npm.on('log', log4js.getLogger('npm').log);
 };
 
 var tasks = 0

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -58,11 +58,13 @@ const callInit = async () => {
 }
 
 exports.pathNormalization = function (part, hook_fn_name, hook_name) {
-  const parts = hook_fn_name.split(':');
-  const functionName = (parts.length > 1) ? parts.pop() : hook_name;
+  const tmp = hook_fn_name.split(':'); // hook_fn_name might be something like 'C:\\foo.js:myFunc'.
+  // If there is a single colon assume it's 'filename:funcname' not 'C:\\filename'.
+  const functionName = (tmp.length > 1 ? tmp.pop() : null) || hook_name;
+  const moduleName = tmp.join(':') || part.plugin;
   const packageDir = path.dirname(defs.plugins[part.plugin].package.path);
-  const fileName = path.normalize(path.join(packageDir, parts.join(':')));
-  return fileName + ((functionName == null) ? '' : (':' + functionName));
+  const fileName = path.normalize(path.join(packageDir, moduleName));
+  return `${fileName}:${functionName}`;
 }
 
 exports.update = async function () {

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -13,14 +13,6 @@ var defs = require('./plugin_defs');
 
 exports.prefix = 'ep_';
 
-// @TODO RPB this appears to be unused
-exports.ensure = function (cb) {
-  if (!defs.loaded)
-    exports.update(cb);
-  else
-    cb();
-};
-
 exports.formatPlugins = function () {
   return _.keys(defs.plugins).join(", ");
 };

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -1,7 +1,7 @@
+const fs = require('fs').promises;
 var npm = require("npm/lib/npm.js");
 var readInstalled = require("./read-installed.js");
 var path = require("path");
-var fs = require("fs");
 var tsort = require("./tsort");
 var util = require("util");
 var _ = require("underscore");
@@ -52,16 +52,13 @@ exports.formatHooks = function (hook_set_name) {
 };
 
 exports.callInit = function () {
-  const fsp_stat = util.promisify(fs.stat);
-  const fsp_writeFile = util.promisify(fs.writeFile);
-
   var hooks = require("./hooks");
 
   let p = Object.keys(defs.plugins).map(function(plugin_name) {
     let plugin = defs.plugins[plugin_name];
     let ep_init = path.normalize(path.join(plugin.package.path, ".ep_initialized"));
-    return fsp_stat(ep_init).catch(async function() {
-      await fsp_writeFile(ep_init, "done");
+    return fs.stat(ep_init).catch(async function() {
+      await fs.writeFile(ep_init, 'done');
       await hooks.aCallAll("init_" + plugin_name, {});
     });
   });
@@ -123,11 +120,9 @@ exports.getPackages = async function () {
 };
 
 async function loadPlugin(packages, plugin_name, plugins, parts) {
-  let fsp_readFile = util.promisify(fs.readFile);
-
   var plugin_path = path.resolve(packages[plugin_name].path, "ep.json");
   try {
-    let data = await fsp_readFile(plugin_path);
+    let data = await fs.readFile(plugin_path);
     try {
       var plugin = JSON.parse(data);
       plugin['package'] = packages[plugin_name];

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -1,4 +1,5 @@
 const fs = require('fs').promises;
+const hooks = require('./hooks');
 var npm = require("npm/lib/npm.js");
 var readInstalled = require("./read-installed.js");
 var path = require("path");
@@ -52,8 +53,6 @@ exports.formatHooks = function (hook_set_name) {
 };
 
 exports.callInit = function () {
-  var hooks = require("./hooks");
-
   let p = Object.keys(defs.plugins).map(function(plugin_name) {
     let plugin = defs.plugins[plugin_name];
     let ep_init = path.normalize(path.join(plugin.package.path, ".ep_initialized"));

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -52,7 +52,7 @@ exports.formatHooks = function (hook_set_name) {
   return "<dl>" + res.join("\n") + "</dl>";
 };
 
-exports.callInit = function () {
+const callInit = () => {
   let p = Object.keys(defs.plugins).map(function(plugin_name) {
     let plugin = defs.plugins[plugin_name];
     let ep_init = path.normalize(path.join(plugin.package.path, ".ep_initialized"));
@@ -88,7 +88,7 @@ exports.update = async function () {
     defs.parts = sortParts(parts);
     defs.hooks = pluginUtils.extractHooks(defs.parts, 'hooks', exports.pathNormalization);
     defs.loaded = true;
-  }).then(exports.callInit);
+  }).then(callInit);
 }
 
 exports.getPackages = async function () {

--- a/src/static/js/pluginfw/shared.js
+++ b/src/static/js/pluginfw/shared.js
@@ -51,9 +51,9 @@ function extractHooks(parts, hook_set_name, normalizer) {
       const disabledReason = (disabledHookReasons[hook_set_name] || {})[hook_name];
       if (disabledReason) {
         console.error(`Hook ${hook_set_name}/${hook_name} is disabled. Reason: ${disabledReason}`);
-        console.error(`The hook function ${hook_fn_name} from plugin ${part.name} ` +
+        console.error(`The hook function ${hook_fn_name} from plugin ${part.plugin} ` +
                       'will never be called, which may cause the plugin to fail');
-        console.error(`Please update the ${part.name} plugin to not use the ${hook_name} hook`);
+        console.error(`Please update the ${part.plugin} plugin to not use the ${hook_name} hook`);
         return;
       }
 

--- a/tests/backend/specs/hooks.js
+++ b/tests/backend/specs/hooks.js
@@ -45,7 +45,7 @@ describe(__filename, function() {
       // change behavior depending on the number of parameters.
       hook_fn: (hn, ctx, cb) => cb(ret),
       hook_fn_name: hookFnName,
-      part: {name: 'testPluginName'},
+      part: {plugin: 'testPluginName'},
     };
   };
 


### PR DESCRIPTION
Multiple commits:
* docs: Wrap long lines
* docs: Revise plugin documentation
* plugins: Fix plugin name in error messages
* plugins: Use functions from `fs.promises`
* plugins: Call `require('./hooks')` at top level
* plugins: Don't export `callInit`
* plugins: Delete unused `ensure` function
* plugins: `async`ify more functions
* plugins: Use a log4js logger for npm messages
* plugins: Default the module name to the plugin name
