### PR TITLE
pad: Pop up an error message on unhandled Promise rejection (and other improvements)

### DIFF
--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -479,13 +479,15 @@ padutils.setupGlobalExceptionHandler = () => {
   if (globalExceptionHandler == null) {
     globalExceptionHandler = (e) => {
       let type;
+      let err;
       let msg, url, lineno;
       if (e instanceof ErrorEvent) {
         type = 'Uncaught exception';
+        err = e.error || {};
         ({message: msg, filename: url, lineno: linenumber} = e);
       } else if (e instanceof PromiseRejectionEvent) {
         type = 'Unhandled Promise rejection';
-        const err = e.reason || {};
+        err = e.reason || {};
         ({message: msg = 'unknown', fileName: url = 'unknown', lineNumber: linenumber = -1} = err);
       } else {
         throw new Error(`unknown event: ${e.toString()}`);
@@ -534,6 +536,7 @@ padutils.setupGlobalExceptionHandler = () => {
           source: url,
           linenumber,
           userAgent: navigator.userAgent,
+          stack: err.stack,
         }),
       });
     };

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -512,8 +512,8 @@ function setupGlobalExceptionHandler() {
         });
       }
 
-      //send javascript errors to the server
-      var errObj = {
+      // send javascript errors to the server
+      $.post('../jserror', {
         errorInfo: JSON.stringify({
           errorId,
           msg,
@@ -522,11 +522,7 @@ function setupGlobalExceptionHandler() {
           linenumber,
           userAgent: navigator.userAgent,
         }),
-      };
-      var loc = document.location;
-      var url = loc.protocol + "//" + loc.hostname + ":" + loc.port + "/" + loc.pathname.substr(1, loc.pathname.indexOf("/p/")) + "jserror";
-
-      $.post(url, errObj);
+      });
 
       return false;
     };


### PR DESCRIPTION
Multiple commits:
* pad: Use a relative URL to simplify
* pad: Pop up an error message on unhandled Promise rejection
* pad: Include the stack in the data sent to `/jserror`
