### PR TITLE
Fix bad paren placement in `/javascript` handler

### DIFF
--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -20,7 +20,7 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   //serve javascript.html
   args.app.get('/javascript', function(req, res)
   {
-    res.send(eejs.require('ep_etherpad-lite/templates/javascript.html'), {req});
+    res.send(eejs.require('ep_etherpad-lite/templates/javascript.html', {req}));
   });
 
 

--- a/tests/backend/specs/specialpages.js
+++ b/tests/backend/specs/specialpages.js
@@ -1,0 +1,25 @@
+const common = require('../common');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
+
+describe(__filename, function() {
+  let agent;
+  const backups = {};
+  before(async function() { agent = await common.init(); });
+  beforeEach(async function() {
+    backups.settings = {};
+    for (const setting of ['requireAuthentication', 'requireAuthorization']) {
+      backups.settings[setting] = settings[setting];
+    }
+    settings.requireAuthentication = false;
+    settings.requireAuthorization = false;
+  });
+  afterEach(async function() {
+    Object.assign(settings, backups.settings);
+  });
+
+  describe('/javascript', function() {
+    it('/javascript -> 200', async function() {
+      await agent.get('/javascript').expect(200);
+    });
+  });
+});

--- a/tests/backend/specs/webaccess.js
+++ b/tests/backend/specs/webaccess.js
@@ -36,6 +36,11 @@ describe(__filename, function() {
   });
 
   describe('webaccess: without plugins', function() {
+    it('regression test for issue #4495, getting /javascript should not result in 500', async function() {
+      settings.requireAuthentication = false;
+      settings.requireAuthorization = false;
+      await agent.get('/javascript').expect(200);
+    });
     it('!authn !authz anonymous / -> 200', async function() {
       settings.requireAuthentication = false;
       settings.requireAuthorization = false;

--- a/tests/backend/specs/webaccess.js
+++ b/tests/backend/specs/webaccess.js
@@ -36,11 +36,6 @@ describe(__filename, function() {
   });
 
   describe('webaccess: without plugins', function() {
-    it('regression test for issue #4495, getting /javascript should not result in 500', async function() {
-      settings.requireAuthentication = false;
-      settings.requireAuthorization = false;
-      await agent.get('/javascript').expect(200);
-    });
     it('!authn !authz anonymous / -> 200', async function() {
       settings.requireAuthentication = false;
       settings.requireAuthorization = false;


### PR DESCRIPTION
This fixes a bug introduced in commit ed5a635f4c113ba7a535b51b30245adc5cfb6cf0.

Fixes #4495

cc @webzwo0i 

Also:
* add regression test for #4495
* Move `/javascript` test to `specialpages.js`
