### PR TITLE
backend tests: change loglevel to WARN

### DIFF
--- a/tests/frontend/travis/runnerBackend.sh
+++ b/tests/frontend/travis/runnerBackend.sh
@@ -16,7 +16,7 @@ s!"soffice":[^,]*!"soffice": "/usr/bin/soffice"!
 # Reduce rate limit aggressiveness
 s!"max":[^,]*!"max": 100!
 s!"points":[^,]*!"points": 1000!
-#github does not like our output
+# GitHub does not like our output
 s!"loglevel":[^,]*!"loglevel": "WARN"!
 ' settings.json.template >settings.json
 

--- a/tests/frontend/travis/runnerBackend.sh
+++ b/tests/frontend/travis/runnerBackend.sh
@@ -16,6 +16,8 @@ s!"soffice":[^,]*!"soffice": "/usr/bin/soffice"!
 # Reduce rate limit aggressiveness
 s!"max":[^,]*!"max": 100!
 s!"points":[^,]*!"points": 1000!
+#github does not like our output
+s!"loglevel":[^,]*!"loglevel": "WARN"!
 ' settings.json.template >settings.json
 
 log "Assuming bin/installDeps.sh has already been run"


### PR DESCRIPTION
On loglevel INFO, when running the backend tests, etherpad prints blob of 80k length text and lots of emojis & their HTML entities.

Github does not like that and takes forever. Setting loglevel to WARN seems to fix it.