### PR TITLE
frontend tests: fix trailing comma in runner.js

### DIFF
--- a/tests/frontend/runner.js
+++ b/tests/frontend/runner.js
@@ -143,7 +143,7 @@ $(() => {
   // http://stackoverflow.com/questions/1403888/get-url-parameter-with-jquery
   const getURLParameter = function (name) {
     return decodeURI(
-        (RegExp(`${name}=` + '(.+?)(&|$)').exec(location.search) || [, null])[1],
+        (RegExp(`${name}=` + '(.+?)(&|$)').exec(location.search) || [, null])[1]
     );
   };
 


### PR DESCRIPTION
another small typo that leads to hanging pads on saucelabs for some browsers