### PR TITLE
tests: Delete trailing commas in function arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9921,9 +9921,9 @@
       }
     },
     "eslint-config-etherpad": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/eslint-config-etherpad/-/eslint-config-etherpad-1.0.9.tgz",
-      "integrity": "sha512-g/yRRKiNL3k/VO6zizq13CKNEIHOQli6LpenSCGhfolZid3TVe/8D9mnFML3gtNcqTNZj5L15N2U/05ip7sD7Q==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-config-etherpad/-/eslint-config-etherpad-1.0.11.tgz",
+      "integrity": "sha512-/MPV8rtPB/mRbfX/Xtw4IulERSj14IWHLp2dU+0a5lz3qfLl8ZKTkp6WHCcj3Uf+mQh4yWEACeqRYZ77ErNtzw==",
       "dev": true
     },
     "eslint-plugin-es": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "eslint": "^7.13.0",
-    "eslint-config-etherpad": "^1.0.9",
+    "eslint-config-etherpad": "^1.0.11",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prefer-arrow": "^1.2.2",

--- a/tests/frontend/runner.js
+++ b/tests/frontend/runner.js
@@ -143,7 +143,7 @@ $(() => {
   // http://stackoverflow.com/questions/1403888/get-url-parameter-with-jquery
   const getURLParameter = function (name) {
     return decodeURI(
-        (RegExp(`${name}=` + '(.+?)(&|$)').exec(location.search) || [, null])[1],
+        (RegExp(`${name}=` + '(.+?)(&|$)').exec(location.search) || [, null])[1]
     );
   };
 

--- a/tests/frontend/specs/change_user_color.js
+++ b/tests/frontend/specs/change_user_color.js
@@ -93,7 +93,7 @@ describe('change user color', function () {
     $chatInput.sendkeys('{enter}'); // simulate a keypress of enter actually does evt.which = 10 not 13
 
     // check if chat shows up
-    helper.waitFor(() => chrome$('#chattext').children('p').length !== 0, // wait until the chat message shows up
+    helper.waitFor(() => chrome$('#chattext').children('p').length !== 0 // wait until the chat message shows up
     ).done(() => {
       const $firstChatMessage = chrome$('#chattext').children('p');
       expect($firstChatMessage.css('background-color')).to.be(testColorRGB); // expect the first chat message to be of the user's color

--- a/tests/frontend/specs/change_user_name.js
+++ b/tests/frontend/specs/change_user_name.js
@@ -60,7 +60,7 @@ describe('change username value', function () {
     $chatInput.sendkeys('{enter}'); // simulate a keypress of enter actually does evt.which = 10 not 13
 
     // check if chat shows up
-    helper.waitFor(() => chrome$('#chattext').children('p').length !== 0, // wait until the chat message shows up
+    helper.waitFor(() => chrome$('#chattext').children('p').length !== 0 // wait until the chat message shows up
     ).done(() => {
       const $firstChatMessage = chrome$('#chattext').children('p');
       const containsJohnMcLear = $firstChatMessage.text().indexOf('John McLear') !== -1; // does the string contain John McLear

--- a/tests/frontend/specs/clear_authorship_colors.js
+++ b/tests/frontend/specs/clear_authorship_colors.js
@@ -28,7 +28,7 @@ describe('clear authorship colors button', function () {
     $firstTextElement.sendkeys(sentText);
     $firstTextElement.sendkeys('{rightarrow}');
 
-    helper.waitFor(() => inner$('div span').first().attr('class').indexOf('author') !== -1, // wait until we have the full value available
+    helper.waitFor(() => inner$('div span').first().attr('class').indexOf('author') !== -1 // wait until we have the full value available
     ).done(() => {
       // IE hates you if you don't give focus to the inner frame bevore you do a clearAuthorship
       inner$('div').first().focus();
@@ -80,7 +80,7 @@ describe('clear authorship colors button', function () {
     $firstTextElement.sendkeys(sentText);
     $firstTextElement.sendkeys('{rightarrow}');
 
-    helper.waitFor(() => inner$('div span').first().attr('class').indexOf('author') !== -1, // wait until we have the full value available
+    helper.waitFor(() => inner$('div span').first().attr('class').indexOf('author') !== -1 // wait until we have the full value available
     ).done(() => {
       // IE hates you if you don't give focus to the inner frame bevore you do a clearAuthorship
       inner$('div').first().focus();

--- a/tests/frontend/specs/importexport.js
+++ b/tests/frontend/specs/importexport.js
@@ -136,7 +136,7 @@ describe('import functionality', function () {
     const htmlWithBullets = '<html><body><ul class="list-bullet1"><li>bullet line 1</li></ul><ul class="list-bullet1"><li>bullet line 2</li><ul class="list-bullet2"><li>bullet2 line 1</li></ul></ul><ul class="list-bullet1"><ul class="list-bullet2"><ul class="list-bullet3"><ul class="list-bullet4"><li>bullet4 line 2</li><li>bullet4 line 2</li><li>bullet4 line 2</li></ul><li>bullet3 line 1</li></ul></ul><li>bullet2 line 1</li></ul></body></html>';
     importrequest(htmlWithBullets, importurl, 'html');
     const oldtext = getinnertext();
-    helper.waitFor(() => oldtext != getinnertext(),
+    helper.waitFor(() => oldtext != getinnertext()
         //      return expect(getinnertext()).to.be('\
         // <ul class="list-bullet1"><li><span class="">bullet line 1</span></li></ul>\n\
         // <ul class="list-bullet1"><li><span class="">bullet line 2</span></li></ul>\n\

--- a/tests/frontend/specs/responsiveness.js
+++ b/tests/frontend/specs/responsiveness.js
@@ -53,7 +53,7 @@ xdescribe('Responsiveness of Editor', function () {
     inner$('div').first().text(text); // Put the text contents into the pad
 
     helper.waitFor(() => // Wait for the new contents to be on the pad
-      inner$('div').text().length > length,
+      inner$('div').text().length > length
     ).done(() => {
       expect(inner$('div').text().length).to.be.greaterThan(length); // has the text changed?
       const start = Date.now(); // get the start time

--- a/tests/frontend/specs/timeslider.js
+++ b/tests/frontend/specs/timeslider.js
@@ -18,7 +18,7 @@ xdescribe('timeslider button takes you to the timeslider of a pad', function () 
     const modifiedValue = $firstTextElement.text(); // get the modified value
     expect(modifiedValue).not.to.be(originalValue); // expect the value to change
 
-    helper.waitFor(() => modifiedValue !== originalValue, // The value has changed so  we can..
+    helper.waitFor(() => modifiedValue !== originalValue // The value has changed so  we can..
     ).done(() => {
       const $timesliderButton = chrome$('#timesliderlink');
       $timesliderButton.click(); // So click the timeslider link

--- a/tests/frontend/specs/timeslider_follow.js
+++ b/tests/frontend/specs/timeslider_follow.js
@@ -42,7 +42,7 @@ describe('timeslider follow', function () {
     const lines = helper.linesDiv();
     helper.selectLines(lines[0], lines[lines.length - 1]); // select all lines
     // probably unnecessary, but wait for the selection to be Range not Caret
-    await helper.waitForPromise(() => !helper.padInner$.document.getSelection().isCollapsed,
+    await helper.waitForPromise(() => !helper.padInner$.document.getSelection().isCollapsed
         // only supported in FF57+
         // return helper.padInner$.document.getSelection().type === 'Range';
     );

--- a/tests/frontend/travis/remote_runner.js
+++ b/tests/frontend/travis/remote_runner.js
@@ -15,10 +15,10 @@ var allTestsPassed = true;
 // and the script would silently exit with error code 0
 process.exitCode = 2;
 process.on('exit', (code) => {
-  if (code === 2){
-    console.log("\x1B[31mFAILED\x1B[39m Not all saucelabs runner have been started.");
+  if (code === 2) {
+    console.log('\x1B[31mFAILED\x1B[39m Not all saucelabs runner have been started.');
   }
-})
+});
 
 var sauceTestWorker = async.queue((testSettings, callback) => {
   const browser = wd.promiseChainRemote(config.host, config.port, config.username, config.accessKey);


### PR DESCRIPTION
Trailing commas in function arguments is only supported in ECMAScript 2017 and later. https://github.com/ether/eslint-config-etherpad/commit/673ab07acfdf9df5eb6e6580703e7715c7cb1354 reconfigured the `comma-dangle` rule to prohibit such commas. This PR applies that rule change.

Multiple commits:
* lint: Bump eslint-config-etherpad to 1.0.11
* lint: Rerun `eslint --fix` to nuke trailing function call commas

cc @webzwo0i 