### PR TITLE
admin/plugins: Don't keep adding more Update buttons

### DIFF
--- a/src/node/hooks/express/adminplugins.js
+++ b/src/node/hooks/express/adminplugins.js
@@ -11,7 +11,6 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     res.send(eejs.require('ep_etherpad-lite/templates/admin/plugins.html', {
       plugins: plugins.plugins,
       req,
-      search_results: {},
       errors: [],
     }));
   });

--- a/src/node/hooks/express/adminsettings.js
+++ b/src/node/hooks/express/adminsettings.js
@@ -8,7 +8,6 @@ exports.expressCreateServer = function (hook_name, args, cb) {
     res.send(eejs.require('ep_etherpad-lite/templates/admin/settings.html', {
       req,
       settings: '',
-      search_results: {},
       errors: [],
     }));
   });

--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -220,8 +220,7 @@ $(document).ready(() => {
 
   socket.on('results:updatable', (data) => {
     data.updatable.forEach((pluginName) => {
-      const $row = $(`#installed-plugins > tr.${pluginName}`);
-      const actions = $row.find('.actions');
+      const actions = $(`#installed-plugins > tr.${pluginName} .actions`);
       actions.append('<input class="do-update" type="button" value="Update" />');
     });
     updateHandlers();

--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -221,7 +221,8 @@ $(document).ready(() => {
   socket.on('results:updatable', (data) => {
     data.updatable.forEach((pluginName) => {
       const actions = $(`#installed-plugins > tr.${pluginName} .actions`);
-      actions.append('<input class="do-update" type="button" value="Update" />');
+      actions.append(
+          $('<input>').addClass('do-update').attr('type', 'button').attr('value', 'Update'));
     });
     updateHandlers();
   });

--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -221,6 +221,7 @@ $(document).ready(() => {
   socket.on('results:updatable', (data) => {
     data.updatable.forEach((pluginName) => {
       const actions = $(`#installed-plugins > tr.${pluginName} .actions`);
+      actions.find('.do-update').remove();
       actions.append(
           $('<input>').addClass('do-update').attr('type', 'button').attr('value', 'Update'));
     });


### PR DESCRIPTION
Multiple commits:
* admin: Delete unused `search_results`
* lint: Fix ESLint errors in `/admin/plugins` code
* admin/plugins: Simplify jQuery search for plugin actions
* admin/plugins: Use jQuery to build the Update button
* admin/plugins: Don't keep adding more Update buttons
