### PR TITLE
socketio: Disconnect clients when closing HTTP server

### DIFF
--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -76,6 +76,25 @@ Things in context:
 
 This hook gets called after the application object has been created, but before it starts listening. This is similar to the expressConfigure hook, but it's not guaranteed that the application object will have all relevant configuration variables.
 
+## expressCloseServer
+
+Called from: src/node/hooks/express.js
+
+Things in context: Nothing
+
+This hook is called when the HTTP server is closing, which happens during
+shutdown (see the shutdown hook) and when the server restarts (e.g., when a
+plugin is installed via the `/admin/plugins` page). The HTTP server may or may
+not already be closed when this hook executes.
+
+Example:
+
+```
+exports.expressCloseServer = async () => {
+  await doSomeCleanup();
+};
+```
+
 ## eejsBlock_`<name>`
 Called from: src/node/eejs/index.js
 

--- a/src/ep.json
+++ b/src/ep.json
@@ -1,33 +1,122 @@
 {
   "parts": [
-    { "name": "DB", "hooks": { "shutdown": "ep_etherpad-lite/node/db/DB" } },
-    { "name": "Minify", "hooks": { "shutdown": "ep_etherpad-lite/node/utils/Minify" } },
-    { "name": "express", "hooks": {
-      "createServer": "ep_etherpad-lite/node/hooks/express",
-      "restartServer": "ep_etherpad-lite/node/hooks/express",
-      "shutdown": "ep_etherpad-lite/node/hooks/express"
-      } },
-    { "name": "static", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/static:expressCreateServer" } },
-    { "name": "stats", "hooks": { "shutdown": "ep_etherpad-lite/node/stats" } },
-    { "name": "i18n", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/i18n:expressCreateServer" } },
-    { "name": "specialpages", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/specialpages:expressCreateServer" } },
-    { "name": "padurlsanitize", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/padurlsanitize:expressCreateServer" } },
-    { "name": "padreadonly", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/padreadonly:expressCreateServer" } },
-    { "name": "webaccess", "hooks": { "expressConfigure": "ep_etherpad-lite/node/hooks/express/webaccess:expressConfigure" } },
-    { "name": "apicalls", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/apicalls:expressCreateServer" } },
-    { "name": "importexport", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/importexport:expressCreateServer" } },
-    { "name": "errorhandling", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/errorhandling:expressCreateServer" } },
-    { "name": "socketio", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/socketio:expressCreateServer" } },
-    { "name": "tests", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/tests:expressCreateServer" } },
-    { "name": "admin", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/admin:expressCreateServer" } },
-    { "name": "adminplugins", "hooks": {
-      "expressCreateServer": "ep_etherpad-lite/node/hooks/express/adminplugins:expressCreateServer",
-      "socketio": "ep_etherpad-lite/node/hooks/express/adminplugins:socketio" }
+    {
+      "name": "DB",
+      "hooks": {
+        "shutdown": "ep_etherpad-lite/node/db/DB"
+      }
     },
-    { "name": "adminsettings", "hooks": {
-      "expressCreateServer": "ep_etherpad-lite/node/hooks/express/adminsettings:expressCreateServer",
-      "socketio": "ep_etherpad-lite/node/hooks/express/adminsettings:socketio" }
+    {
+      "name": "Minify",
+      "hooks": {
+        "shutdown": "ep_etherpad-lite/node/utils/Minify"
+      }
     },
-    { "name": "openapi", "hooks": { "expressCreateServer": "ep_etherpad-lite/node/hooks/express/openapi:expressCreateServer" } }
+    {
+      "name": "express",
+      "hooks": {
+        "createServer": "ep_etherpad-lite/node/hooks/express",
+        "restartServer": "ep_etherpad-lite/node/hooks/express",
+        "shutdown": "ep_etherpad-lite/node/hooks/express"
+      }
+    },
+    {
+      "name": "static",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/static"
+      }
+    },
+    {
+      "name": "stats",
+      "hooks": {
+        "shutdown": "ep_etherpad-lite/node/stats"
+      }
+    },
+    {
+      "name": "i18n",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/i18n"
+      }
+    },
+    {
+      "name": "specialpages",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/specialpages"
+      }
+    },
+    {
+      "name": "padurlsanitize",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/padurlsanitize"
+      }
+    },
+    {
+      "name": "padreadonly",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/padreadonly"
+      }
+    },
+    {
+      "name": "webaccess",
+      "hooks": {
+        "expressConfigure": "ep_etherpad-lite/node/hooks/express/webaccess"
+      }
+    },
+    {
+      "name": "apicalls",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/apicalls"
+      }
+    },
+    {
+      "name": "importexport",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/importexport"
+      }
+    },
+    {
+      "name": "errorhandling",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/errorhandling"
+      }
+    },
+    {
+      "name": "socketio",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/socketio"
+      }
+    },
+    {
+      "name": "tests",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/tests"
+      }
+    },
+    {
+      "name": "admin",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/admin"
+      }
+    },
+    {
+      "name": "adminplugins",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/adminplugins",
+        "socketio": "ep_etherpad-lite/node/hooks/express/adminplugins"
+      }
+    },
+    {
+      "name": "adminsettings",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/adminsettings",
+        "socketio": "ep_etherpad-lite/node/hooks/express/adminsettings"
+      }
+    },
+    {
+      "name": "openapi",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/openapi"
+      }
+    }
   ]
 }

--- a/src/ep.json
+++ b/src/ep.json
@@ -83,6 +83,7 @@
     {
       "name": "socketio",
       "hooks": {
+        "expressCloseServer": "ep_etherpad-lite/node/hooks/express/socketio",
         "expressCreateServer": "ep_etherpad-lite/node/hooks/express/socketio"
       }
     },

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * The DB Module provides a database initalized with the settings
  * provided by the settings module
@@ -25,7 +27,8 @@ const log4js = require('log4js');
 const util = require('util');
 
 // set database settings
-const db = new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger('ueberDB'));
+const db =
+    new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger('ueberDB'));
 
 /**
  * The UeberDB Object that provides the database functions
@@ -36,41 +39,38 @@ exports.db = null;
  * Initalizes the database with the settings provided by the settings module
  * @param {Function} callback
  */
-exports.init = function () {
-  // initalize the database async
-  return new Promise((resolve, reject) => {
-    db.init((err) => {
-      if (err) {
-        // there was an error while initializing the database, output it and stop
-        console.error('ERROR: Problem while initalizing the database');
-        console.error(err.stack ? err.stack : err);
-        process.exit(1);
-      }
+exports.init = async () => await new Promise((resolve, reject) => {
+  db.init((err) => {
+    if (err) {
+      // there was an error while initializing the database, output it and stop
+      console.error('ERROR: Problem while initalizing the database');
+      console.error(err.stack ? err.stack : err);
+      process.exit(1);
+    }
 
-      // everything ok, set up Promise-based methods
-      ['get', 'set', 'findKeys', 'getSub', 'setSub', 'remove', 'doShutdown'].forEach((fn) => {
-        exports[fn] = util.promisify(db[fn].bind(db));
-      });
-
-      // set up wrappers for get and getSub that can't return "undefined"
-      const get = exports.get;
-      exports.get = async function (key) {
-        const result = await get(key);
-        return (result === undefined) ? null : result;
-      };
-
-      const getSub = exports.getSub;
-      exports.getSub = async function (key, sub) {
-        const result = await getSub(key, sub);
-        return (result === undefined) ? null : result;
-      };
-
-      // exposed for those callers that need the underlying raw API
-      exports.db = db;
-      resolve();
+    // everything ok, set up Promise-based methods
+    ['get', 'set', 'findKeys', 'getSub', 'setSub', 'remove', 'doShutdown'].forEach((fn) => {
+      exports[fn] = util.promisify(db[fn].bind(db));
     });
+
+    // set up wrappers for get and getSub that can't return "undefined"
+    const get = exports.get;
+    exports.get = async (key) => {
+      const result = await get(key);
+      return (result === undefined) ? null : result;
+    };
+
+    const getSub = exports.getSub;
+    exports.getSub = async (key, sub) => {
+      const result = await getSub(key, sub);
+      return (result === undefined) ? null : result;
+    };
+
+    // exposed for those callers that need the underlying raw API
+    exports.db = db;
+    resolve();
   });
-};
+});
 
 exports.shutdown = async (hookName, context) => {
   await exports.doShutdown();

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('underscore');
 const cookieParser = require('cookie-parser');
 const express = require('express');
@@ -5,9 +7,7 @@ const expressSession = require('express-session');
 const fs = require('fs');
 const hooks = require('../../static/js/pluginfw/hooks');
 const log4js = require('log4js');
-const npm = require('npm/lib/npm');
-const path = require('path');
-const sessionStore = require('../db/SessionStore');
+const SessionStore = require('../db/SessionStore');
 const settings = require('../utils/Settings');
 const stats = require('../stats');
 const util = require('util');
@@ -36,13 +36,16 @@ exports.createServer = async () => {
   if (!_.isEmpty(settings.users)) {
     console.log(`The plugin admin page is at http://${settings.ip}:${settings.port}/admin/plugins`);
   } else {
-    console.warn("Admin username and password not set in settings.json.  To access admin please uncomment and edit 'users' in settings.json");
+    console.warn('Admin username and password not set in settings.json. ' +
+                 'To access admin please uncomment and edit "users" in settings.json');
   }
 
   const env = process.env.NODE_ENV || 'development';
 
   if (env !== 'production') {
-    console.warn('Etherpad is running in Development mode.  This mode is slower for users and less secure than production mode.  You should set the NODE_ENV environment variable to production by using: export NODE_ENV=production');
+    console.warn('Etherpad is running in Development mode. This mode is slower for users and ' +
+                 'less secure than production mode. You should set the NODE_ENV environment ' +
+                 'variable to production by using: export NODE_ENV=production');
   }
 };
 
@@ -138,7 +141,7 @@ exports.restartServer = async () => {
 
   exports.sessionMiddleware = expressSession({
     secret: settings.sessionKey,
-    store: new sessionStore(),
+    store: new SessionStore(),
     resave: false,
     saveUninitialized: true,
     // Set the cookie name to a javascript identifier compatible string. Makes code handling it

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -20,7 +20,10 @@ exports.server = null;
 const closeServer = async () => {
   if (exports.server == null) return;
   logger.info('Closing HTTP server...');
-  await util.promisify(exports.server.close.bind(exports.server))();
+  await Promise.all([
+    util.promisify(exports.server.close.bind(exports.server))(),
+    hooks.aCallAll('expressCloseServer'),
+  ]);
   exports.server = null;
   logger.info('HTTP server closed');
 };

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -17,6 +17,14 @@ let serverName;
 
 exports.server = null;
 
+const closeServer = async () => {
+  if (exports.server == null) return;
+  logger.info('Closing HTTP server...');
+  await util.promisify(exports.server.close.bind(exports.server))();
+  exports.server = null;
+  logger.info('HTTP server closed');
+};
+
 exports.createServer = async () => {
   console.log('Report bugs at https://github.com/ether/etherpad-lite/issues');
 
@@ -50,10 +58,7 @@ exports.createServer = async () => {
 };
 
 exports.restartServer = async () => {
-  if (exports.server) {
-    console.log('Restarting express server');
-    await util.promisify(exports.server.close).bind(exports.server)();
-  }
+  await closeServer();
 
   const app = express(); // New syntax for express v3
 
@@ -181,6 +186,5 @@ exports.restartServer = async () => {
 };
 
 exports.shutdown = async (hookName, context) => {
-  if (!exports.server) return;
-  await util.promisify(exports.server.close).bind(exports.server)();
+  await closeServer();
 };

--- a/src/node/hooks/express/adminsettings.js
+++ b/src/node/hooks/express/adminsettings.js
@@ -1,9 +1,11 @@
-const eejs = require('ep_etherpad-lite/node/eejs');
-const settings = require('ep_etherpad-lite/node/utils/Settings');
-const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
-const fs = require('fs');
+'use strict';
 
-exports.expressCreateServer = function (hook_name, args, cb) {
+const eejs = require('../../eejs');
+const fs = require('fs');
+const hooks = require('../../../static/js/pluginfw/hooks');
+const settings = require('../../utils/Settings');
+
+exports.expressCreateServer = (hookName, args, cb) => {
   args.app.get('/admin/settings', (req, res) => {
     res.send(eejs.require('ep_etherpad-lite/templates/admin/settings.html', {
       req,
@@ -14,10 +16,11 @@ exports.expressCreateServer = function (hook_name, args, cb) {
   return cb();
 };
 
-exports.socketio = function (hook_name, args, cb) {
+exports.socketio = (hookName, args, cb) => {
   const io = args.io.of('/settings');
   io.on('connection', (socket) => {
-    if (!socket.conn.request.session || !socket.conn.request.session.user || !socket.conn.request.session.user.is_admin) return;
+    const {session: {user: {is_admin: isAdmin} = {}} = {}} = socket.conn.request;
+    if (!isAdmin) return;
 
     socket.on('load', (query) => {
       fs.readFile('settings.json', 'utf8', (err, data) => {

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -1,13 +1,15 @@
+'use strict';
+
 const express = require('../express');
 const proxyaddr = require('proxy-addr');
 const settings = require('../../utils/Settings');
 const socketio = require('socket.io');
 const socketIORouter = require('../../handler/SocketIORouter');
-const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+const hooks = require('../../../static/js/pluginfw/hooks');
 
 const padMessageHandler = require('../../handler/PadMessageHandler');
 
-exports.expressCreateServer = function (hook_name, args, cb) {
+exports.expressCreateServer = (hookName, args, cb) => {
   // init socket.io and redirect all requests to the MessageHandler
   // there shouldn't be a browser that isn't compatible to all
   // transports in this list at once

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict';
+
 /**
  * This module is started with bin/run.sh. It sets up a Express HTTP and a Socket.IO Server.
  * Static file Requests are answered directly from this module, Socket.IO messages are passed
@@ -35,9 +38,9 @@ NodeVersion.checkDeprecationStatus('10.13.0', '1.8.3');
 const UpdateCheck = require('./utils/UpdateCheck');
 const db = require('./db/DB');
 const express = require('./hooks/express');
-const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+const hooks = require('../static/js/pluginfw/hooks');
 const npm = require('npm/lib/npm.js');
-const plugins = require('ep_etherpad-lite/static/js/pluginfw/plugins');
+const plugins = require('../static/js/pluginfw/plugins');
 const settings = require('./utils/Settings');
 const util = require('util');
 

--- a/src/node/stats.js
+++ b/src/node/stats.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const measured = require('measured-core');
 
 module.exports = measured.createCollection();

--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -22,6 +22,7 @@
   , "excanvas.js"
   , "farbtastic.js"
   , "skin_variants.js"
+  , "socketio.js"
   ]
 , "timeslider.js": [
     "timeslider.js"
@@ -45,6 +46,7 @@
   , "broadcast.js"
   , "broadcast_slider.js"
   , "broadcast_revisions.js"
+  , "socketio.js"
   ]
 , "ace2_inner.js": [
     "ace2_inner.js"

--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -7,11 +7,10 @@ $(document).ready(() => {
   const pathComponents = location.pathname.split('/');
   // Strip admin/plugins
   const baseURL = `${pathComponents.slice(0, pathComponents.length - 2).join('/')}/`;
-  const resource = `${baseURL.substring(1)}socket.io`;
 
   // connect
   const room = `${url}pluginfw/installer`;
-  const socket = io.connect(room, {path: `${baseURL}socket.io`, resource});
+  const socket = io.connect(room, {path: `${baseURL}socket.io`});
 
   const search = (searchTerm, limit) => {
     if (search.searchTerm !== searchTerm) {

--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -1,16 +1,9 @@
 'use strict';
 
-$(document).ready(() => {
-  const loc = document.location;
-  const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
-  const url = `${loc.protocol}//${loc.hostname}:${port}/`;
-  const pathComponents = location.pathname.split('/');
-  // Strip admin/plugins
-  const baseURL = `${pathComponents.slice(0, pathComponents.length - 2).join('/')}/`;
+/* global socketio */
 
-  // connect
-  const room = `${url}pluginfw/installer`;
-  const socket = io.connect(room, {path: `${baseURL}socket.io`});
+$(document).ready(() => {
+  const socket = socketio.connect('..', '/pluginfw/installer');
 
   const search = (searchTerm, limit) => {
     if (search.searchTerm !== searchTerm) {

--- a/src/static/js/admin/plugins.js
+++ b/src/static/js/admin/plugins.js
@@ -4,6 +4,11 @@
 
 $(document).ready(() => {
   const socket = socketio.connect('..', '/pluginfw/installer');
+  socket.on('disconnect', (reason) => {
+    // The socket.io client will automatically try to reconnect for all reasons other than "io
+    // server disconnect".
+    if (reason === 'io server disconnect') socket.connect();
+  });
 
   const search = (searchTerm, limit) => {
     if (search.searchTerm !== searchTerm) {
@@ -253,10 +258,12 @@ $(document).ready(() => {
     search.results = [];
   });
 
-  // init
-  updateHandlers();
-  socket.emit('getInstalled');
-  search('');
+  socket.on('connect', () => {
+    updateHandlers();
+    socket.emit('getInstalled');
+    search.searchTerm = null;
+    search($('#search-query').val());
+  });
 
   // check for updates every 5mins
   setInterval(() => {

--- a/src/static/js/admin/settings.js
+++ b/src/static/js/admin/settings.js
@@ -7,11 +7,10 @@ $(document).ready(() => {
   const pathComponents = location.pathname.split('/');
   // Strip admin/plugins
   const baseURL = `${pathComponents.slice(0, pathComponents.length - 2).join('/')}/`;
-  const resource = `${baseURL.substring(1)}socket.io`;
 
   // connect
   const room = `${url}settings`;
-  const socket = io.connect(room, {path: `${baseURL}socket.io`, resource});
+  const socket = io.connect(room, {path: `${baseURL}socket.io`});
 
   socket.on('settings', (settings) => {
     /* Check whether the settings.json is authorized to be viewed */

--- a/src/static/js/admin/settings.js
+++ b/src/static/js/admin/settings.js
@@ -1,7 +1,8 @@
+'use strict';
+
 $(document).ready(() => {
-  let socket;
   const loc = document.location;
-  const port = loc.port == '' ? (loc.protocol == 'https:' ? 443 : 80) : loc.port;
+  const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
   const url = `${loc.protocol}//${loc.hostname}:${port}/`;
   const pathComponents = location.pathname.split('/');
   // Strip admin/plugins
@@ -10,7 +11,7 @@ $(document).ready(() => {
 
   // connect
   const room = `${url}settings`;
-  socket = io.connect(room, {path: `${baseURL}socket.io`, resource});
+  const socket = io.connect(room, {path: `${baseURL}socket.io`, resource});
 
   socket.on('settings', (settings) => {
     /* Check whether the settings.json is authorized to be viewed */
@@ -58,18 +59,13 @@ $(document).ready(() => {
 });
 
 
-function isJSONClean(data) {
+const isJSONClean = (data) => {
   let cleanSettings = JSON.minify(data);
   // this is a bit naive. In theory some key/value might contain the sequences ',]' or ',}'
   cleanSettings = cleanSettings.replace(',]', ']').replace(',}', '}');
   try {
-    var response = jQuery.parseJSON(cleanSettings);
+    return typeof jQuery.parseJSON(cleanSettings) === 'object';
   } catch (e) {
     return false; // the JSON failed to be parsed
   }
-  if (typeof response !== 'object') {
-    return false;
-  } else {
-    return true;
-  }
-}
+};

--- a/src/static/js/admin/settings.js
+++ b/src/static/js/admin/settings.js
@@ -1,16 +1,9 @@
 'use strict';
 
-$(document).ready(() => {
-  const loc = document.location;
-  const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
-  const url = `${loc.protocol}//${loc.hostname}:${port}/`;
-  const pathComponents = location.pathname.split('/');
-  // Strip admin/plugins
-  const baseURL = `${pathComponents.slice(0, pathComponents.length - 2).join('/')}/`;
+/* global socketio */
 
-  // connect
-  const room = `${url}settings`;
-  const socket = io.connect(room, {path: `${baseURL}socket.io`});
+$(document).ready(() => {
+  const socket = socketio.connect('..', '/settings');
 
   socket.on('settings', (settings) => {
     /* Check whether the settings.json is authorized to be viewed */

--- a/src/static/js/admin/settings.js
+++ b/src/static/js/admin/settings.js
@@ -5,6 +5,16 @@
 $(document).ready(() => {
   const socket = socketio.connect('..', '/settings');
 
+  socket.on('connect', () => {
+    socket.emit('load');
+  });
+
+  socket.on('disconnect', (reason) => {
+    // The socket.io client will automatically try to reconnect for all reasons other than "io
+    // server disconnect".
+    if (reason === 'io server disconnect') socket.connect();
+  });
+
   socket.on('settings', (settings) => {
     /* Check whether the settings.json is authorized to be viewed */
     if (settings.results === 'NOT_ALLOWED') {
@@ -46,8 +56,6 @@ $(document).ready(() => {
     $('#response').text(progress);
     $('#response').fadeOut('slow');
   });
-
-  socket.emit('load'); // Load the JSON from the server
 });
 
 

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -223,13 +223,10 @@ const handshake = () => {
   const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
   // create the url
   const url = `${loc.protocol}//${loc.hostname}:${port}/`;
-  // find out in which subfolder we are
-  const resource = `${exports.baseURL.substring(1)}socket.io`;
   // connect
   socket = pad.socket = io.connect(url, {
     // Allow deployers to host Etherpad on a non-root path
     path: `${exports.baseURL}socket.io`,
-    resource,
     reconnectionAttempts: 5,
     reconnection: true,
     reconnectionDelay: 1000,

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -238,14 +238,24 @@ const handshake = () => {
     sendClientReady(receivedClientVars);
   });
 
-  socket.on('reconnecting', () => {
+  const socketReconnecting = () => {
     // pad.collabClient might be null if the hanshake failed (or it never got that far).
     if (pad.collabClient != null) {
       pad.collabClient.setStateIdle();
       pad.collabClient.setIsPendingRevision(true);
       pad.collabClient.setChannelState('RECONNECTING');
     }
+  };
+
+  socket.on('disconnect', (reason) => {
+    // The socket.io client will automatically try to reconnect for all reasons other than "io
+    // server disconnect".
+    if (reason !== 'io server disconnect') return;
+    socketReconnecting();
+    socket.connect();
   });
+
+  socket.on('reconnecting', socketReconnecting);
 
   socket.on('reconnect_failed', (error) => {
     // pad.collabClient might be null if the hanshake failed (or it never got that far).

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -29,6 +29,7 @@ let socket;
 require('./jquery');
 require('./farbtastic');
 require('./excanvas');
+require('./gritter');
 
 const Cookies = require('./pad_utils').Cookies;
 const chat = require('./chat').chat;
@@ -44,7 +45,7 @@ const paduserlist = require('./pad_userlist').paduserlist;
 const padutils = require('./pad_utils').padutils;
 const colorutils = require('./colorutils').colorutils;
 const randomString = require('./pad_utils').randomString;
-require('./gritter'); // Mutates the jQuery object to make $.gritter available.
+const socketio = require('./socketio');
 
 const hooks = require('./pluginfw/hooks');
 
@@ -218,15 +219,7 @@ const sendClientReady = (isReconnect, messageType) => {
 };
 
 const handshake = () => {
-  const loc = document.location;
-  // get the correct port
-  const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
-  // create the url
-  const url = `${loc.protocol}//${loc.hostname}:${port}/`;
-  // connect
-  socket = pad.socket = io.connect(url, {
-    // Allow deployers to host Etherpad on a non-root path
-    path: `${exports.baseURL}socket.io`,
+  socket = pad.socket = socketio.connect(exports.baseURL, '/', {
     reconnectionAttempts: 5,
     reconnection: true,
     reconnectionDelay: 1000,

--- a/src/static/js/socketio.js
+++ b/src/static/js/socketio.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Creates a socket.io connection.
+ * @param etherpadBaseUrl - Etherpad URL. If relative, it is assumed to be relative to
+ *     window.location.
+ * @param namespace - socket.io namespace.
+ * @param options - socket.io client options. See
+ *     https://socket.io/docs/v2/client-api/#new-Manager-url-options
+ * @return socket.io Socket object
+ */
+const connect = (etherpadBaseUrl, namespace = '/', options = {}) => {
+  // The API for socket.io's io() function is awkward. The documentation says that the first
+  // argument is a URL, but it is not the URL of the socket.io endpoint. The URL's path part is used
+  // as the name of the socket.io namespace to join, and the rest of the URL (including query
+  // parameters, if present) is combined with the `path` option (which defaults to '/socket.io', but
+  // is overridden here to allow users to host Etherpad at something like '/etherpad') to get the
+  // URL of the socket.io endpoint.
+  const baseUrl = new URL(etherpadBaseUrl, window.location);
+  const socketioUrl = new URL('socket.io', baseUrl);
+  const namespaceUrl = new URL(namespace, new URL('/', baseUrl));
+  return io(namespaceUrl.href, Object.assign({path: socketioUrl.pathname}, options));
+};
+
+if (typeof exports === 'object') {
+  exports.connect = connect;
+} else {
+  window.socketio = {connect};
+}

--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -29,6 +29,7 @@ require('./jquery');
 const Cookies = require('./pad_utils').Cookies;
 const randomString = require('./pad_utils').randomString;
 const hooks = require('./pluginfw/hooks');
+const socketio = require('./socketio');
 
 let token, padId, exportLinks, socket, changesetLoader, BroadcastSlider;
 
@@ -51,14 +52,7 @@ const init = () => {
       Cookies.set('token', token, {expires: 60});
     }
 
-    const loc = document.location;
-    // get the correct port
-    const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
-    // create the url
-    const url = `${loc.protocol}//${loc.hostname}:${port}/`;
-
-    // build up the socket io connection
-    socket = io.connect(url, {path: `${exports.baseURL}socket.io`});
+    socket = socketio.connect(exports.baseURL);
 
     // send the ready message once we're connected
     socket.on('connect', () => {

--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -59,8 +59,11 @@ const init = () => {
       sendSocketMsg('CLIENT_READY', {});
     });
 
-    socket.on('disconnect', () => {
+    socket.on('disconnect', (reason) => {
       BroadcastSlider.showReconnectUI();
+      // The socket.io client will automatically try to reconnect for all reasons other than "io
+      // server disconnect".
+      if (reason === 'io server disconnect') socket.connect();
     });
 
     // route the incoming messages

--- a/src/static/js/timeslider.js
+++ b/src/static/js/timeslider.js
@@ -56,11 +56,9 @@ const init = () => {
     const port = loc.port === '' ? (loc.protocol === 'https:' ? 443 : 80) : loc.port;
     // create the url
     const url = `${loc.protocol}//${loc.hostname}:${port}/`;
-    // find out in which subfolder we are
-    const resource = `${exports.baseURL.substring(1)}socket.io`;
 
     // build up the socket io connection
-    socket = io.connect(url, {path: `${exports.baseURL}socket.io`, resource});
+    socket = io.connect(url, {path: `${exports.baseURL}socket.io`});
 
     // send the ready message once we're connected
     socket.on('connect', () => {

--- a/src/templates/admin/plugins.html
+++ b/src/templates/admin/plugins.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="../static/css/admin.css">
     <script src="../static/js/jquery.js"></script>
     <script src="../socket.io/socket.io.js"></script>
+    <script src="../static/js/socketio.js"></script>
     <script src="../static/js/admin/plugins.js"></script>
     <link rel="localizations" type="application/l10n+json" href="../locales.json" />
     <script src="../static/js/html10n.js"></script>

--- a/src/templates/admin/settings.html
+++ b/src/templates/admin/settings.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="../static/css/admin.css">
     <script src="../static/js/jquery.js"></script>
     <script src="../socket.io/socket.io.js"></script>
+    <script src="../static/js/socketio.js"></script>
     <script src="../static/js/admin/minify.json.js"></script>
     <script src="../static/js/admin/settings.js"></script>
     <script src="../static/js/admin/jquery.autosize.js"></script>

--- a/tests/backend/common.js
+++ b/tests/backend/common.js
@@ -1,14 +1,12 @@
-/* global __dirname, exports, require */
+'use strict';
 
-function m(mod) { return `${__dirname}/../../src/${mod}`; }
-
-const apiHandler = require(m('node/handler/APIHandler'));
-const log4js = require(m('node_modules/log4js'));
+const apiHandler = require('ep_etherpad-lite/node/handler/APIHandler');
+const log4js = require('ep_etherpad-lite/node_modules/log4js');
 const process = require('process');
-const server = require(m('node/server'));
-const settings = require(m('node/utils/Settings'));
-const supertest = require(m('node_modules/supertest'));
-const webaccess = require(m('node/hooks/express/webaccess'));
+const server = require('ep_etherpad-lite/node/server');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
+const supertest = require('ep_etherpad-lite/node_modules/supertest');
+const webaccess = require('ep_etherpad-lite/node/hooks/express/webaccess');
 
 const backups = {};
 let inited = false;

--- a/tests/backend/specs/socketio.js
+++ b/tests/backend/specs/socketio.js
@@ -1,14 +1,12 @@
-/* global __dirname, __filename, afterEach, before, beforeEach, clearTimeout, describe, it, require, setTimeout */
-
-function m(mod) { return `${__dirname}/../../../src/${mod}`; }
+'use strict';
 
 const assert = require('assert').strict;
 const common = require('../common');
-const io = require(m('node_modules/socket.io-client'));
-const padManager = require(m('node/db/PadManager'));
-const plugins = require(m('static/js/pluginfw/plugin_defs'));
-const setCookieParser = require(m('node_modules/set-cookie-parser'));
-const settings = require(m('node/utils/Settings'));
+const io = require('ep_etherpad-lite/node_modules/socket.io-client');
+const padManager = require('ep_etherpad-lite/node/db/PadManager');
+const plugins = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
+const setCookieParser = require('ep_etherpad-lite/node_modules/set-cookie-parser');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 const logger = common.logger;
 
@@ -50,7 +48,8 @@ const getSocketEvent = async (socket, event) => {
 const connect = async (res) => {
   // Convert the `set-cookie` header(s) into a `cookie` header.
   const resCookies = (res == null) ? {} : setCookieParser.parse(res, {map: true});
-  const reqCookieHdr = Object.entries(resCookies).map(([name, cookie]) => `${name}=${encodeURIComponent(cookie.value)}`).join('; ');
+  const reqCookieHdr = Object.entries(resCookies).map(
+      ([name, cookie]) => `${name}=${encodeURIComponent(cookie.value)}`).join('; ');
 
   logger.debug('socket.io connecting...');
   const socket = io(`${common.baseUrl}/`, {


### PR DESCRIPTION
Multiple commits:
* lint: Fix some straightforward ESLint errors
* express: Factor out common server shutdown logic
* express: New expressCloseServer hook
* Reformat `src/ep.json`
* socket.io: Delete ignored `resource` option
* socket.io: Factor out client connection logic
* socket.io: Reconnect if the server disconnects
* socket.io: Disconnect clients when closing HTTP server

Fixes #4546.

TODO:
  * [x] The client-side `/admin/*` code doesn't react well to the socket.io connection closing. Make the client code detect error and disconnect events and re-query the status so that the page doesn't get stuck on "Installing..." or "Uninstalling..."
  * [x] Document the new expressCloseServer hook, or decide that this is an internal-only hook that plugin authors don't need to know about.
  * [ ] Add tests. In particular: Make sure clients visiting a pad automatically reconnect after a plugin is installed or uninstalled.
