### PR TITLE
pad: Fix wrong variable name in global exception handler

### DIFF
--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -333,7 +333,7 @@ padutils.setupGlobalExceptionHandler = () => {
     globalExceptionHandler = (e) => {
       let type;
       let err;
-      let msg, url, lineno;
+      let msg, url, linenumber;
       if (e instanceof ErrorEvent) {
         type = 'Uncaught exception';
         err = e.error || {};


### PR DESCRIPTION
This fixes a bug introduced in commit c845d985e0d6014f2c2474564c59f33cdc552de6.