### PR TITLE
missing await in createClearStartAtext

### DIFF
--- a/src/node/utils/padDiff.js
+++ b/src/node/utils/padDiff.js
@@ -90,7 +90,7 @@ PadDiff.prototype._createClearAuthorship = async function (rev) {
 
 PadDiff.prototype._createClearStartAtext = async function (rev) {
   // get the atext of this revision
-  const atext = this._pad.getInternalRevisionAText(rev);
+  const atext = await this._pad.getInternalRevisionAText(rev);
 
   // create the clearAuthorship changeset
   const changeset = await this._createClearAuthorship(rev);


### PR DESCRIPTION
Missing await in call to this._pad.getInternalRevisionAText(rev). Function returns a promise (see call in line 81 of same file). This bug breaks the createDiffHTML API call (how I discovered it).

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
