### PR TITLE
Ignore head tag on import

### DIFF
--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -203,17 +203,6 @@ async function doImport(req, res, padId) {
   if (!req.directDatabaseAccess) {
     text = await fsp_readFile(destFile, 'utf8');
 
-    /*
-     * The <title> tag needs to be stripped out, otherwise it is appended to the
-     * pad.
-     *
-     * Moreover, when using LibreOffice to convert the file, some classes are
-     * added to the <title> tag. This is a quick & dirty way of matching the
-     * title and comment it out independently on the classes that are set on it.
-     */
-    text = text.replace('<title', '<!-- <title');
-    text = text.replace('</title>', '</title>-->');
-
     // node on windows has a delay on releasing of the file lock.
     // We add a 100ms delay to work around this
     if (os.type().indexOf('Windows') > -1) {

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -36,7 +36,7 @@ exports.setPadHTML = async (pad, html) => {
   // below the last line of an import
   $('body').append('<p></p>');
 
-  const doc = $('html')[0];
+  const doc = $('body')[0];
   apiLogger.debug('html:');
   apiLogger.debug(html);
 

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -1,9 +1,12 @@
+'use strict';
 /*
  * ACHTUNG: there is a copied & modified version of this file in
  * <basedir>/tests/container/spacs/api/pad.js
  *
  * TODO: unify those two files, and merge in a single one.
  */
+
+/* eslint-disable max-len */
 
 const common = require('../../common');
 const supertest = require(`${__dirname}/../../../../src/node_modules/supertest`);
@@ -12,7 +15,6 @@ const api = supertest(`http://${settings.ip}:${settings.port}`);
 
 const apiKey = common.apiKey;
 const apiVersion = 1;
-const lastEdited = '';
 
 const testImports = {
   'malformed': {
@@ -59,8 +61,13 @@ const testImports = {
 describe(__filename, function () {
   Object.keys(testImports).forEach((testName) => {
     const testPadId = makeid();
-    test = testImports[testName];
-    describe('createPad', function () {
+    const test = testImports[testName];
+    if (test.disabled) {
+      return xit(`DISABLED: ${testName}`, function (done) {
+        done();
+      });
+    }
+    describe(`createPad ${testName}`, function () {
       it('creates a new Pad', function (done) {
         api.get(`${endPoint('createPad')}&padID=${testPadId}`)
             .expect((res) => {
@@ -71,9 +78,9 @@ describe(__filename, function () {
       });
     });
 
-    describe('setHTML', function () {
+    describe(`setHTML ${testName}`, function () {
       it('Sets the HTML', function (done) {
-        api.get(`${endPoint('setHTML')}&padID=${testPadId}&html=${test.input}`)
+        api.get(`${endPoint('setHTML')}&padID=${testPadId}&html=${encodeURIComponent(test.input)}`)
             .expect((res) => {
               if (res.body.code !== 0) throw new Error(`Error:${testName}`);
             })
@@ -82,7 +89,7 @@ describe(__filename, function () {
       });
     });
 
-    describe('getHTML', function () {
+    describe(`getHTML ${testName}`, function () {
       it('Gets back the HTML of a Pad', function (done) {
         api.get(`${endPoint('getHTML')}&padID=${testPadId}`)
             .expect((res) => {
@@ -93,10 +100,10 @@ describe(__filename, function () {
              ${testName}
 
              Received:
-             ${receivedHtml}
+             ${JSON.stringify(receivedHtml)}
 
              Expected:
-             ${test.expectedHTML}
+             ${JSON.stringify(test.expectedHTML)}
 
              Which is a different version of the originally imported one:
              ${test.input}`);
@@ -107,7 +114,7 @@ describe(__filename, function () {
       });
     });
 
-    describe('getText', function () {
+    describe(`getText ${testName}`, function () {
       it('Gets back the Text of a Pad', function (done) {
         api.get(`${endPoint('getText')}&padID=${testPadId}`)
             .expect((res) => {
@@ -118,10 +125,10 @@ describe(__filename, function () {
              ${testName}
 
              Received:
-             ${receivedText}
+             ${JSON.stringify(receivedText)}
 
              Expected:
-             ${test.expectedText}
+             ${JSON.stringify(test.expectedText)}
 
              Which is a different version of the originally imported one:
              ${test.input}`);
@@ -135,7 +142,7 @@ describe(__filename, function () {
 });
 
 
-var endPoint = function (point, version) {
+function endPoint(point, version) {
   version = version || apiVersion;
   return `/api/${version}/${point}?apikey=${apiKey}`;
 };
@@ -149,32 +156,3 @@ function makeid() {
   }
   return text;
 }
-
-function generateLongText() {
-  let text = '';
-  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-
-  for (let i = 0; i < 80000; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
-}
-
-// Need this to compare arrays (listSavedRevisions test)
-Array.prototype.equals = function (array) {
-  // if the other array is a falsy value, return
-  if (!array) return false;
-  // compare lengths - can save a lot of time
-  if (this.length != array.length) return false;
-  for (let i = 0, l = this.length; i < l; i++) {
-    // Check if we have nested arrays
-    if (this[i] instanceof Array && array[i] instanceof Array) {
-      // recurse into the nested arrays
-      if (!this[i].equals(array[i])) return false;
-    } else if (this[i] != array[i]) {
-      // Warning - two different object instances will never be equal: {x:20} != {x:20}
-      return false;
-    }
-  }
-  return true;
-};

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -56,6 +56,12 @@ const testImports = {
     expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n'
   }
   */
+  'ignoreAnyTagsOutsideBody': {
+    description: 'Content outside body should be ignored',
+    input: '<html><head><title>title</title><style></style></head><body>empty<br></body></html>',
+    expectedHTML: '<!DOCTYPE HTML><html><body>empty<br><br></body></html>',
+    expectedText: 'empty\n\n',
+  },
 };
 
 describe(__filename, function () {

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -107,7 +107,12 @@ const tests = {
     noteToSelf: "<p></p>should create a line break but not break numbering -- This is what I can't get working!",
     disabled: true,
   },
-
+  ignoreAnyTagsOutsideBody: {
+    description: 'Content outside body should be ignored',
+    html: '<html><head><title>title</title><style></style></head><body>empty<br></body></html>',
+    expectedLineAttribs: ['+5'],
+    expectedText: ['empty'],
+  },
 };
 
 describe(__filename, function () {
@@ -122,7 +127,7 @@ describe(__filename, function () {
 
       it(testObj.description, function (done) {
         const $ = cheerio.load(testObj.html); // Load HTML into Cheerio
-        const doc = $('html')[0]; // Creates a dom-like representation of HTML
+        const doc = $('body')[0]; // Creates a dom-like representation of HTML
         // Create an empty attribute pool
         const apool = new AttributePool();
         // Convert a dom tree into a list of lines and attribute liens

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -1,8 +1,10 @@
-const Changeset = require('../../../src/static/js/Changeset');
+'use strict';
+
+/* eslint-disable max-len */
+
 const contentcollector = require('../../../src/static/js/contentcollector');
 const AttributePool = require('../../../src/static/js/AttributePool');
 const cheerio = require('../../../src/node_modules/cheerio');
-const util = require('util');
 
 const tests = {
   nestedLi: {
@@ -89,7 +91,7 @@ const tests = {
     expectedText: ['a', '*b', '*c', 'notlist', 'foo'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
   },
-  nestedOl: {
+  nestedOl2: {
     description: 'First item being an UL then subsequent being OL will fail',
     html: '<html><body><ul><li>a<ol><li>b</li><li>c</li></ol></li></ul></body></html>',
     expectedLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1'],
@@ -109,7 +111,7 @@ const tests = {
 };
 
 describe(__filename, function () {
-  for (const test in tests) {
+  for (const test of Object.keys(tests)) {
     const testObj = tests[test];
     describe(test, function () {
       if (testObj.disabled) {


### PR DESCRIPTION
import should only use body. removes a workaround that results in empty pads if an empty title element is present.

The PR is based on another PR that enables the tests for importexport, so it needs rebasing in case the other gets merged in first. alternatively merge this without squashing, then the other PR can be closed.

It might be useful in the future to parse style tags inside <head> on import though