### PR TITLE
add list-style:none for ul.indents in exported HTML

### DIFF
--- a/src/templates/export_html.html
+++ b/src/templates/export_html.html
@@ -33,7 +33,7 @@ ol ol > li:before {
 }
 
 ul.indent {
-  list-style: none;
+  list-style-type: none;
 }
 
 <%- extraCSS %>

--- a/src/templates/export_html.html
+++ b/src/templates/export_html.html
@@ -31,6 +31,11 @@ ol ol > li:before {
   content: counters(item, ".") ". ";
   margin-left: -20px;
 }
+
+ul.indent {
+  list-style: none;
+}
+
 <%- extraCSS %>
 </style>
 </head>

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -62,6 +62,12 @@ const testImports = {
     expectedHTML: '<!DOCTYPE HTML><html><body>empty<br><br></body></html>',
     expectedText: 'empty\n\n',
   },
+  'indentedListsAreNotBullets': {
+    description: 'Indented lists are represented with tabs and without bullets',
+    input: '<html><body><ul class="indent"><li>indent</li><li>indent</ul></body></html>',
+    expectedHTML: '<!DOCTYPE HTML><html><body><ul class="indent"><li>indent</li><li>indent</ul><br></body></html>',
+    expectedText: '\tindent\n\tindent\n\n'
+  }
 };
 
 describe(__filename, function () {


### PR DESCRIPTION
An indented list is rendered with bullets when exported as HTML. When exported as text, tabs are used (and no `*` is present, in contrast to bullet lists).

One solution is to include CSS for `list-style: none` on uls that have the indent class. That's what I did.
(Another would be to remove ul and adding tab/spaces instead)

When HTML is exported via API its up to the client to understand the semantics of the ul's class attribute.