### PR TITLE
remove explicitly setting process.env.DEBUG

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -683,7 +683,6 @@ exports.reloadSettings = function reloadSettings() {
 
   log4js.configure(exports.logconfig);// Configure the logging appenders
   log4js.setGlobalLogLevel(exports.loglevel);// set loglevel
-  process.env.DEBUG = `socket.io:${exports.loglevel}`; // Used by SocketIO for Debug
   log4js.replaceConsole();
 
   if (!exports.skinName) {


### PR DESCRIPTION
The idea of this line is good: when we set loglevel DEBUG it should set socket.io into debug mode, too. However, that line is wrong (syntax is more like `socket.io:*` not `socket.io:DEBUG`) and it also blocks all other dependencies that use the debug package to print debug statements that'd be visible when using `DEBUG=* node src/node/server.js`.

If you find that enabling DEBUG logging should activate debug logging in *all* dependencies, that use the debug package, then changing this line to `if (loglevel === 'DEBUG') {process.env.DEBUG="*";}` would probable work. I'm okay with that, but in this PR I simply remove that line, so that DEBUG loglevel only applies to etherpad-internal logging and if someone wants the debug logs from dependencies that use the debug package, they need to set the environment variable themself