### PR TITLE
enable our errorhandling for all routes

### DIFF
--- a/src/ep.json
+++ b/src/ep.json
@@ -21,6 +21,12 @@
       }
     },
     {
+      "name": "errorhandling",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/errorhandling"
+      }
+    },
+    {
       "name": "static",
       "hooks": {
         "expressCreateServer": "ep_etherpad-lite/node/hooks/express/static"
@@ -72,12 +78,6 @@
       "name": "importexport",
       "hooks": {
         "expressCreateServer": "ep_etherpad-lite/node/hooks/express/importexport"
-      }
-    },
-    {
-      "name": "errorhandling",
-      "hooks": {
-        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/errorhandling"
       }
     },
     {

--- a/src/node/hooks/express/errorhandling.js
+++ b/src/node/hooks/express/errorhandling.js
@@ -2,17 +2,22 @@
 
 const stats = require('../../stats');
 
-exports.expressCreateServer = (hook_name, args, cb) => {
-  exports.app = args.app;
-
-  // Handle errors
+/**
+ * Express already comes with an error handler that is attached
+ * as the last middleware. Within all routes it's possible to call
+ * `next(err)` where `err` is an Error object. You can specify
+ * `statusCode` and `statusMessage`.
+ * For more details see "The default error handler" section on
+ * https://expressjs.com/en/guide/error-handling.html
+ *
+ * This method is only used for metrics
+ *
+ */
+exports.expressCreateServer = (hookName, args, cb) => {
   args.app.use((err, req, res, next) => {
-    // if an error occurs Connect will pass it down
-    // through these "error-handling" middleware
-    // allowing you to respond however you like
-    res.status(500).send({error: 'Sorry, something bad happened!'});
-    console.error(err.stack ? err.stack : err.toString());
-    stats.meter('http500').mark();
+    const status = err.statusCode || err.status;
+    stats.meter(`http${status}`).mark();
+    next(err);
   });
 
   return cb();


### PR DESCRIPTION
This makes errorhandling the last route that's registered in the `expressCreateServer` hook. Because the hooks are called in reverse order this means it must move to the upper most position.

With this in place, errorhandling is called on every `next(new Error('somethings forbidden').status = 403)` etc. Before it was only called when the route, in which the next handler is called with an error happens to have been registered before errorhandler (e.g. this was not the case for any static routes, caching_middleware etc).

Now it forwards all errors to express' internal error handler, while up to now it would convert any error that reaches the errorhandler to an 500. The error logging has been removed, as this is already the default with the internal error handler.

New is, that now any error is counted in the stats metrics.