### PR TITLE
More checkPlugin.js enhancements

### DIFF
--- a/bin/plugins/README.md
+++ b/bin/plugins/README.md
@@ -24,7 +24,7 @@ node bin/plugins/checkPlugin.js ep_whatever autofix
 ## Autocommitting, push, npm minor patch and npm publish (highly dangerous)
 
 ```
-node bin/plugins/checkPlugin.js ep_whatever autofix autocommit
+node bin/plugins/checkPlugin.js ep_whatever autocommit
 ```
 
 # All the plugins
@@ -41,7 +41,7 @@ cd ..
 for dir in node_modules/ep_*; do
   dir=${dir#node_modules/}
   [ "$dir" != ep_etherpad-lite ] || continue
-  node bin/plugins/checkPlugin.js "$dir" autofix autocommit
+  node bin/plugins/checkPlugin.js "$dir" autocommit
 done
 ```
 

--- a/bin/plugins/README.md
+++ b/bin/plugins/README.md
@@ -2,28 +2,33 @@ The files in this folder are for Plugin developers.
 
 # Get suggestions to improve your Plugin
 
-This code will check your plugin for known usual issues and some suggestions for improvements.  No changes will be made to your project.
+This code will check your plugin for known usual issues and some suggestions for
+improvements. No changes will be made to your project.
 
 ```
 node bin/plugins/checkPlugin.js $PLUGIN_NAME$
 ```
 
 # Basic Example:
+
 ```
 node bin/plugins/checkPlugin.js ep_webrtc
 ```
 
 ## Autofixing - will autofix any issues it can
+
 ```
 node bin/plugins/checkPlugin.js ep_whatever autofix
 ```
 
 ## Autocommitting, push, npm minor patch and npm publish (highly dangerous)
+
 ```
 node bin/plugins/checkPlugin.js ep_whatever autofix autocommit
 ```
 
 # All the plugins
+
 Replace johnmclear with your github username
 
 ```
@@ -33,19 +38,15 @@ GHUSER=johnmclear; curl "https://api.github.com/users/$GHUSER/repos?per_page=100
 cd ..
 
 # autofixes and autocommits /pushes & npm publishes
-for dir in `ls node_modules`;
-do
-# echo $0
-if [[ $dir == *"ep_"* ]]; then
-if [[ $dir != "ep_etherpad-lite" ]]; then
-node bin/plugins/checkPlugin.js $dir autofix autocommit
-fi
-fi
-# echo $dir
+for dir in node_modules/ep_*; do
+  dir=${dir#node_modules/}
+  [ "$dir" != ep_etherpad-lite ] || continue
+  node bin/plugins/checkPlugin.js "$dir" autofix autocommit
 done
 ```
 
 # Automating update of ether organization plugins
+
 ```
 getCorePlugins.sh
 updateCorePlugins.sh

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -37,8 +37,6 @@ const autoUpdate = optArgs.indexOf('autoupdate') !== -1;
 // Should we automcommit and npm publish?!
 const autoCommit = optArgs.indexOf('autocommit') !== -1;
 
-let hasAutoFixed = false;
-
 const execSync = (cmd, opts = {}) => (childProcess.execSync(cmd, {
   cwd: `${pluginPath}/`,
   ...opts,
@@ -68,7 +66,6 @@ const updateDeps = (parsedPackageJson, key, wantDeps) => {
     }
   }
   if (changed) {
-    hasAutoFixed = true;
     parsedPackageJson[key] = deps;
     writePackageJson(parsedPackageJson);
   }
@@ -135,7 +132,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
             fs.readFileSync('bin/plugins/lib/npmpublish.yml', {encoding: 'utf8', flag: 'r'});
         fs.mkdirSync(`${pluginPath}/.github/workflows`, {recursive: true});
         fs.writeFileSync(path, npmpublish);
-        hasAutoFixed = true;
         console.log("If you haven't already, setup autopublish for this plugin https://github.com/ether/etherpad-lite/wiki/Plugins:-Automatically-publishing-to-npm-on-commit-to-Github-Repo");
       } else {
         console.log('Setup autopublish for this plugin https://github.com/ether/etherpad-lite/wiki/Plugins:-Automatically-publishing-to-npm-on-commit-to-Github-Repo');
@@ -159,7 +155,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
             fs.readFileSync('bin/plugins/lib/npmpublish.yml', {encoding: 'utf8', flag: 'r'});
         fs.mkdirSync(`${pluginPath}/.github/workflows`, {recursive: true});
         fs.writeFileSync(path, npmpublish);
-        hasAutoFixed = true;
       }
     }
   } catch (err) {
@@ -177,7 +172,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
             fs.readFileSync('bin/plugins/lib/backend-tests.yml', {encoding: 'utf8', flag: 'r'});
         fs.mkdirSync(`${pluginPath}/.github/workflows`, {recursive: true});
         fs.writeFileSync(path, backendTests);
-        hasAutoFixed = true;
       }
     } else {
       // autopublish exists, we should check the version..
@@ -198,7 +192,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
             fs.readFileSync('bin/plugins/lib/backend-tests.yml', {encoding: 'utf8', flag: 'r'});
         fs.mkdirSync(`${pluginPath}/.github/workflows`, {recursive: true});
         fs.writeFileSync(path, backendTests);
-        hasAutoFixed = true;
       }
     }
   } catch (err) {
@@ -223,7 +216,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         };
       }
       if (updatedPackageJSON) {
-        hasAutoFixed = true;
         writePackageJson(parsedPackageJSON);
       }
     }
@@ -261,7 +253,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
           root: true,
           extends: 'etherpad/plugin',
         };
-        hasAutoFixed = true;
         parsedPackageJSON.eslintConfig = eslintConfig;
         writePackageJson(parsedPackageJSON);
       }
@@ -274,7 +265,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
           'lint': 'eslint .',
           'lint:fix': 'eslint --fix .',
         };
-        hasAutoFixed = true;
         parsedPackageJSON.scripts = scripts;
         writePackageJson(parsedPackageJSON);
       }
@@ -286,7 +276,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         const engines = {
           node: '>=10.13.0',
         };
-        hasAutoFixed = true;
         parsedPackageJSON.engines = engines;
         writePackageJson(parsedPackageJSON);
       }
@@ -343,7 +332,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
   if (files.indexOf('license') === -1 && files.indexOf('license.md') === -1) {
     console.warn('LICENSE.md file not found, please create');
     if (autoFix) {
-      hasAutoFixed = true;
       console.log('Autofixing missing LICENSE.md file, including Apache 2 license.');
       let license = fs.readFileSync('bin/plugins/lib/LICENSE.md', {encoding: 'utf8', flag: 'r'});
       license = license.replace('[yyyy]', new Date().getFullYear());
@@ -359,7 +347,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
     console.warn('.travis.yml file not found, please create.  .travis.yml is used for automatically CI testing Etherpad.  It is useful to know if your plugin breaks another feature for example.');
     // TODO: Make it check version of the .travis file to see if it needs an update.
     if (autoFix) {
-      hasAutoFixed = true;
       console.log('Autofixing missing .travis.yml file');
       fs.writeFileSync(`${pluginPath}/.travis.yml`, travisConfig);
       console.log('Travis file created, please sign into travis and enable this repository');
@@ -380,14 +367,12 @@ fs.readdir(pluginPath, (err, rootFiles) => {
     } else if (newValue > existingValue) {
       console.log('updating .travis.yml');
       fs.writeFileSync(`${pluginPath}/.travis.yml`, travisConfig);
-      hasAutoFixed = true;
     }//
   }
 
   if (files.indexOf('.gitignore') === -1) {
     console.warn(".gitignore file not found, please create.  .gitignore files are useful to ensure files aren't incorrectly commited to a repository.");
     if (autoFix) {
-      hasAutoFixed = true;
       console.log('Autofixing missing .gitignore file');
       const gitignore = fs.readFileSync('bin/plugins/lib/gitignore', {encoding: 'utf8', flag: 'r'});
       fs.writeFileSync(`${pluginPath}/.gitignore`, gitignore);
@@ -400,7 +385,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
       if (autoFix) {
         gitignore += 'node_modules/';
         fs.writeFileSync(`${pluginPath}/.gitignore`, gitignore);
-        hasAutoFixed = true;
       }
     }
   }
@@ -414,7 +398,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
   if (files.indexOf('.ep_initialized') !== -1) {
     console.warn('.ep_initialized found, please remove.  .ep_initialized should never be commited to git and should only exist once the plugin has been executed one time.');
     if (autoFix) {
-      hasAutoFixed = true;
       console.log('Autofixing incorrectly existing .ep_initialized file');
       fs.unlinkSync(`${pluginPath}/.ep_initialized`);
     }
@@ -423,7 +406,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
   if (files.indexOf('npm-debug.log') !== -1) {
     console.warn('npm-debug.log found, please remove.  npm-debug.log should never be commited to your repository.');
     if (autoFix) {
-      hasAutoFixed = true;
       console.log('Autofixing incorrectly existing npm-debug.log file');
       fs.unlinkSync(`${pluginPath}/npm-debug.log`);
     }
@@ -453,32 +435,32 @@ fs.readdir(pluginPath, (err, rootFiles) => {
     console.log('Linting...');
     const lintCmd = autoFix ? 'npx eslint --fix .' : 'npx eslint';
     execSync(lintCmd, {stdio: 'inherit'});
-    if (autoFix) {
-      // todo: if npm run lint doesn't do anything no need for...
-      hasAutoFixed = true;
-    }
   } catch (e) {
     // it is gonna throw an error anyway
     console.log('Manual linting probably required, check with: npm run lint');
   }
   // linting ends.
 
-  if (hasAutoFixed) {
-    // bump npm Version
-    const cmd = [
-      'git rm -rf node_modules --ignore-unmatch',
-      'git add -A',
-      '{ ! git diff-index --cached --quiet HEAD || exit 0; }',
-      'git commit -m "autofixes from Etherpad checkPlugin.js"',
-      'git push',
-    ].join(' && ');
-    if (autoCommit) {
-      // holy shit you brave.
-      console.log('Attempting autocommit and auto publish to npm');
-      execSync(cmd, {stdio: 'inherit'});
+  if (autoFix) {
+    const unchanged = JSON.parse(execSync(
+        'untracked=$(git ls-files -o --exclude-standard) || exit 1; ' +
+        'git diff-files --quiet && [ -z "$untracked" ] && echo true || echo false'));
+    if (!unchanged) {
+      const cmd = [
+        'git rm -rf node_modules --ignore-unmatch',
+        'git add -A',
+        'git commit -m "autofixes from Etherpad checkPlugin.js"',
+        'git push',
+      ].join(' && ');
+      if (autoCommit) {
+        console.log('Attempting autocommit and auto publish to npm');
+        execSync(cmd, {stdio: 'inherit'});
+      } else {
+        console.log('Fixes applied, please check git diff then run the following command:');
+        console.log(`(cd node_modules/${pluginName} && ${cmd})`);
+      }
     } else {
-      console.log('Fixes applied, please check git diff then run the following command:');
-      console.log(`(cd node_modules/${pluginName} && ${cmd})`);
+      console.log('No changes.');
     }
   }
 

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -441,8 +441,10 @@ fs.readdir(pluginPath, (err, rootFiles) => {
   // if autoFix is enabled.
   const npmInstall = `npm install${autoFix ? '' : ' --no-package-lock'}`;
   execSync(npmInstall, {stdio: 'inherit'});
-  // The ep_etherpad-lite peer dep must be installed last otherwise `npm install` will nuke it.
-  execSync(`${npmInstall} --no-save ep_etherpad-lite@file:../../src`, {stdio: 'inherit'});
+  // The ep_etherpad-lite peer dep must be installed last otherwise `npm install` will nuke it. An
+  // absolute path to etherpad-lite/src is used here so that pluginPath can be a symlink.
+  execSync(
+      `${npmInstall} --no-save ep_etherpad-lite@file:${__dirname}/../../src`, {stdio: 'inherit'});
 
   // linting begins
   try {

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -42,8 +42,11 @@ const execSync = (cmd, opts = {}) => (childProcess.execSync(cmd, {
   ...opts,
 }) || '').toString().replace(/\n+$/, '');
 
-const writePackageJson =
-    (obj) => fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(obj, null, 2));
+const writePackageJson = (obj) => {
+  let s = JSON.stringify(obj, null, 2);
+  if (s.length && s.slice(s.length - 1) !== '\n') s += '\n';
+  return fs.writeFileSync(`${pluginPath}/package.json`, s);
+};
 
 const prepareRepo = () => {
   let branch = execSync('git symbolic-ref HEAD');

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -1,15 +1,13 @@
 'use strict';
 
 /*
-*
-* Usage -- see README.md
-*
-* Normal usage:                node bin/plugins/checkPlugin.js ep_whatever
-* Auto fix the things it can:  node bin/plugins/checkPlugin.js ep_whatever autofix
-* Auto commit, push and publish(to npm) * highly dangerous:
-node bin/plugins/checkPlugin.js ep_whatever autofix autocommit
-
-*/
+ * Usage -- see README.md
+ *
+ * Normal usage:                node bin/plugins/checkPlugin.js ep_whatever
+ * Auto fix the things it can:  node bin/plugins/checkPlugin.js ep_whatever autofix
+ * Auto commit, push and publish to npm (highly dangerous):
+ *                              node bin/plugins/checkPlugin.js ep_whatever autocommit
+ */
 
 const fs = require('fs');
 const childProcess = require('child_process');
@@ -27,15 +25,9 @@ const pluginPath = `node_modules/${pluginName}`;
 console.log(`Checking the plugin: ${pluginName}`);
 
 const optArgs = process.argv.slice(3);
-
-// Should we autofix?
-const autoFix = optArgs.indexOf('autofix') !== -1;
-
-// Should we update files where possible?
-const autoUpdate = optArgs.indexOf('autoupdate') !== -1;
-
-// Should we automcommit and npm publish?!
 const autoCommit = optArgs.indexOf('autocommit') !== -1;
+const autoUpdate = autoCommit || optArgs.indexOf('autoupdate') !== -1;
+const autoFix = autoUpdate || optArgs.indexOf('autofix') !== -1;
 
 const execSync = (cmd, opts = {}) => (childProcess.execSync(cmd, {
   cwd: `${pluginPath}/`,

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -42,6 +42,9 @@ const execSync = (cmd, opts = {}) => (childProcess.execSync(cmd, {
   ...opts,
 }) || '').toString().replace(/\n+$/, '');
 
+const writePackageJson =
+    (obj) => fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(obj, null, 2));
+
 const prepareRepo = () => {
   let branch = execSync('git symbolic-ref HEAD');
   if (branch !== 'refs/heads/master' && branch !== 'refs/heads/main') {
@@ -193,7 +196,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
       }
       if (updatedPackageJSON) {
         hasAutoFixed = true;
-        fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(parsedPackageJSON, null, 2));
+        writePackageJson(parsedPackageJSON);
       }
     }
 
@@ -230,7 +233,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
     if (lintDepsNeedUpdating && autoFix) {
       hasAutoFixed = true;
       parsedPackageJSON.devDependencies = Object.assign(devDependencies, lintDeps);
-      fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(parsedPackageJSON, null, 2));
+      writePackageJson(parsedPackageJSON);
       try {
         execSync('npm install', {stdio: 'inherit'});
       } catch (err) {
@@ -247,7 +250,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         };
         hasAutoFixed = true;
         parsedPackageJSON.peerDependencies = peerDependencies;
-        fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(parsedPackageJSON, null, 2));
+        writePackageJson(parsedPackageJSON);
         try {
           execSync('npm install --no-save ep_etherpad-lite@file:../../src', {stdio: 'inherit'});
           hasAutoFixed = true;
@@ -266,7 +269,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         };
         hasAutoFixed = true;
         parsedPackageJSON.eslintConfig = eslintConfig;
-        fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(parsedPackageJSON, null, 2));
+        writePackageJson(parsedPackageJSON);
       }
     }
 
@@ -279,7 +282,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         };
         hasAutoFixed = true;
         parsedPackageJSON.scripts = scripts;
-        fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(parsedPackageJSON, null, 2));
+        writePackageJson(parsedPackageJSON);
       }
     }
 
@@ -291,7 +294,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         };
         hasAutoFixed = true;
         parsedPackageJSON.engines = engines;
-        fs.writeFileSync(`${pluginPath}/package.json`, JSON.stringify(parsedPackageJSON, null, 2));
+        writePackageJson(parsedPackageJSON);
       }
     }
   }

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -26,8 +26,7 @@ console.log(`Checking the plugin: ${pluginName}`);
 
 const optArgs = process.argv.slice(3);
 const autoCommit = optArgs.indexOf('autocommit') !== -1;
-const autoUpdate = autoCommit || optArgs.indexOf('autoupdate') !== -1;
-const autoFix = autoUpdate || optArgs.indexOf('autofix') !== -1;
+const autoFix = autoCommit || optArgs.indexOf('autofix') !== -1;
 
 const execSync = (cmd, opts = {}) => (childProcess.execSync(cmd, {
   cwd: `${pluginPath}/`,
@@ -344,7 +343,7 @@ fs.readdir(pluginPath, (err, rootFiles) => {
       console.log('Travis file created, please sign into travis and enable this repository');
     }
   }
-  if (autoFix && autoUpdate) {
+  if (autoFix) {
     // checks the file versioning of .travis and updates it to the latest.
     const existingConfig = fs.readFileSync(`${pluginPath}/.travis.yml`, {encoding: 'utf8', flag: 'r'});
     const existingConfigLocation = existingConfig.indexOf('##ETHERPAD_TRAVIS_V=');

--- a/bin/plugins/checkPlugin.js
+++ b/bin/plugins/checkPlugin.js
@@ -447,7 +447,6 @@ fs.readdir(pluginPath, (err, rootFiles) => {
         'git diff-files --quiet && [ -z "$untracked" ] && echo true || echo false'));
     if (!unchanged) {
       const cmd = [
-        'git rm -rf node_modules --ignore-unmatch',
         'git add -A',
         'git commit -m "autofixes from Etherpad checkPlugin.js"',
         'git push',


### PR DESCRIPTION
Multiple commits:
* checkPlugin: New `writePackageJson()` convenience function
* checkPlugin: Make sure `package.json` ends with a newline
* checkPlugin: Unconditionally run `npm install`
* checkPlugin: Use absolute path when installing `ep_etherpad-lite`
* checkPlugin: Move dependency update logic to a generic function
* checkPlugin: Ensure that a peer dep for `ep_etherpad-lite` exists
* checkPlugin: Use git to determine whether there were changes
* checkPlugin: Don't nuke `node_modules/`
* checkPlugin: Display a diff of the changes
* checkPlugin: Revise README.md
* checkPlugin: Make `autocommit` imply `autoupdate`, `autoupdate` imply `autofix`
* checkPlugin: Merge the `autoupdate` option into `autofix`
