### PR TITLE
Fix name of ueberdb constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,7 @@
         "threads": "^1.4.0",
         "tiny-worker": "^2.3.0",
         "tinycon": "0.0.1",
-        "ueberdb2": "^0.5.6",
+        "ueberdb2": "^1.2.3",
         "underscore": "1.8.3",
         "unorm": "1.4.1"
       },

--- a/src/node/db/DB.js
+++ b/src/node/db/DB.js
@@ -28,7 +28,7 @@ const util = require('util');
 
 // set database settings
 const db =
-    new ueberDB.Database(settings.dbType, settings.dbSettings, null, log4js.getLogger('ueberDB'));
+    new ueberDB.database(settings.dbType, settings.dbSettings, null, log4js.getLogger('ueberDB'));
 
 /**
  * The UeberDB Object that provides the database functions


### PR DESCRIPTION
Multiple commits:
* Revert "db: Capitalize `Database` constructor"
* Sync top-level `package-lock.json`
