### PR TITLE
Various eejs cleanups

### DIFF
--- a/src/node/eejs/examples/bar.ejs
+++ b/src/node/eejs/examples/bar.ejs
@@ -1,9 +1,0 @@
-a
-<% e.begin_block("bar"); %>
-  A
-  <% e.begin_block("foo"); %>
-  XX
-  <% e.end_block(); %>
-  B
-<% e.end_block(); %>
-b

--- a/src/node/eejs/examples/foo.ejs
+++ b/src/node/eejs/examples/foo.ejs
@@ -1,7 +1,0 @@
-<% e.inherit("./bar.ejs"); %>
-
-<% e.begin_define_block("foo"); %>
-  YY
-  <% e.super(); %>
-  ZZ
-<% e.end_define_block(); %>

--- a/src/node/eejs/index.js
+++ b/src/node/eejs/index.js
@@ -83,21 +83,14 @@ exports.require = (name, args, mod) => {
   args.e = exports;
   args.require = require;
 
-  let template;
-  if (settings.maxAge !== 0) { // don't cache if maxAge is 0
-    if (!templateCache.has(ejspath)) {
-      template = `<% e._init(__output); %>${fs.readFileSync(ejspath).toString()}<% e._exit(); %>`;
-      templateCache.set(ejspath, template);
-    } else {
-      template = templateCache.get(ejspath);
-    }
-  } else {
-    template = `<% e._init(__output); %>${fs.readFileSync(ejspath).toString()}<% e._exit(); %>`;
-  }
+  const cache = settings.maxAge !== 0;
+  const template = cache && templateCache.get(ejspath) ||
+      `<% e._init(__output); %>${fs.readFileSync(ejspath).toString()}<% e._exit(); %>`;
+  if (cache) templateCache.set(ejspath, template);
 
   exports.info.args.push(args);
   exports.info.file_stack.push({path: ejspath});
-  const res = ejs.render(template, args, {cache: settings.maxAge !== 0, filename: ejspath});
+  const res = ejs.render(template, args, {cache, filename: ejspath});
   exports.info.file_stack.pop();
   exports.info.args.pop();
 

--- a/src/node/eejs/index.js
+++ b/src/node/eejs/index.js
@@ -84,13 +84,14 @@ exports.require = (name, args, mod) => {
   args.require = require;
 
   const cache = settings.maxAge !== 0;
-  const template = cache && templateCache.get(ejspath) ||
-      `<% e._init(__output); %>${fs.readFileSync(ejspath).toString()}<% e._exit(); %>`;
+  const template = cache && templateCache.get(ejspath) || ejs.compile(
+      `<% e._init(__output); %>${fs.readFileSync(ejspath).toString()}<% e._exit(); %>`,
+      {filename: ejspath});
   if (cache) templateCache.set(ejspath, template);
 
   exports.info.args.push(args);
   exports.info.file_stack.push({path: ejspath});
-  const res = ejs.render(template, args, {cache, filename: ejspath});
+  const res = template(args);
   exports.info.file_stack.pop();
   exports.info.args.pop();
 

--- a/src/node/eejs/index.js
+++ b/src/node/eejs/index.js
@@ -47,27 +47,19 @@ exports._exit = (b, recursive) => {
   exports.info.__output = exports.info.__output_stack.pop();
 };
 
-exports.begin_capture = () => {
-  exports.info.__output_stack.push(exports.info.__output.concat());
-  exports.info.__output.splice(0, exports.info.__output.length);
-};
-
-exports.end_capture = () => {
-  const res = exports.info.__output.join('');
-  exports.info.__output.splice(
-      0, exports.info.__output.length, ...exports.info.__output_stack.pop());
-  return res;
-};
-
 exports.begin_block = (name) => {
   exports.info.block_stack.push(name);
-  exports.begin_capture();
+  exports.info.__output_stack.push(exports.info.__output.concat());
+  exports.info.__output.splice(0, exports.info.__output.length);
 };
 
 exports.end_block = () => {
   const name = exports.info.block_stack.pop();
   const renderContext = exports.info.args[exports.info.args.length - 1];
-  const args = {content: exports.end_capture(), renderContext};
+  const content = exports.info.__output.join('');
+  exports.info.__output.splice(
+      0, exports.info.__output.length, ...exports.info.__output_stack.pop());
+  const args = {content, renderContext};
   hooks.callAll(`eejsBlock_${name}`, args);
   exports.info.__output.push(args.content);
 };

--- a/src/node/eejs/index.js
+++ b/src/node/eejs/index.js
@@ -17,7 +17,7 @@
 
 /* Basic usage:
  *
- * require("./index").require("./examples/foo.ejs")
+ * require("./index").require("./path/to/template.ejs")
  */
 
 const ejs = require('ejs');

--- a/src/node/eejs/index.js
+++ b/src/node/eejs/index.js
@@ -100,14 +100,7 @@ exports.require = (name, args, mod) => {
     paths = mod.paths;
   }
 
-  const ejspath = resolve.sync(
-      name,
-      {
-        paths,
-        basedir,
-        extensions: ['.html', '.ejs'],
-      }
-  );
+  const ejspath = resolve.sync(name, {paths, basedir, extensions: ['.html', '.ejs']});
 
   args.e = exports;
   args.require = require;


### PR DESCRIPTION
Multiple commits:
* eejs: Unwrap unnecessarily wrapped line
* eejs: Delete broken example
* eejs: Delete unused functions
* eejs: Inline `begin_capture`, `end_capture`
* eejs: Simplify cache lookup logic
* eejs: Cache the compiled template, not the template string
