### PR TITLE
contentcollector fixes

### DIFF
--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -421,7 +421,20 @@ Things in context:
 4. text - the text for that line
 
 This hook allows you to validate/manipulate the text before it's sent to the
-server side. The return value should be the validated/manipulated text.
+server side. To change the text, either:
+
+* Set the `text` context property to the desired value and return `undefined`.
+* (Deprecated) Return a string. If a hook function changes the `text` context
+  property, the return value is ignored. If no hook function changes `text` but
+  multiple hook functions return a string, the first one wins.
+
+Example:
+
+```
+exports.collectContentLineText = (hookName, context) => {
+  context.text = tweakText(context.text);
+};
+```
 
 ## collectContentLineBreak
 

--- a/src/node/hooks/express/openapi.js
+++ b/src/node/hooks/express/openapi.js
@@ -391,9 +391,9 @@ const defaultResponseRefs = {
 
 // convert to a dictionary of operation objects
 const operations = {};
-for (const resource in resources) {
-  for (const action in resources[resource]) {
-    const {operationId, responseSchema, ...operation} = resources[resource][action];
+for (const [resource, actions] of Object.entries(resources)) {
+  for (const [action, spec] of Object.entries(actions)) {
+    const {operationId, responseSchema, ...operation} = spec;
 
     // add response objects
     const responses = {...defaultResponseRefs};

--- a/src/node/hooks/express/openapi.js
+++ b/src/node/hooks/express/openapi.js
@@ -623,7 +623,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
             } else {
               // an unknown error happened
               // log it and throw internal error
-              apiLogger.error(err);
+              apiLogger.error(err.stack || err.toString());
               throw new createHTTPError.InternalError('internal error');
             }
           });

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -1139,7 +1139,7 @@ function Ace2Inner() {
 
       lastDirtyNode = (lastDirtyNode && isNodeDirty(lastDirtyNode) && lastDirtyNode);
       if (firstDirtyNode && lastDirtyNode) {
-        const cc = makeContentCollector(isStyled, browser, rep.apool, null, className2Author);
+        const cc = makeContentCollector(isStyled, browser, rep.apool, className2Author);
         cc.notifySelection(selection);
         const dirtyNodes = [];
         for (let n = firstDirtyNode; n &&

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -251,24 +251,23 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
   const _recalcAttribString = (state) => {
     const lst = [];
     for (const [a, count] of Object.entries(state.attribs)) {
-      if (count) {
-        // The following splitting of the attribute name is a workaround
-        // to enable the content collector to store key-value attributes
-        // see https://github.com/ether/etherpad-lite/issues/2567 for more information
-        // in long term the contentcollector should be refactored to get rid of this workaround
-        const ATTRIBUTE_SPLIT_STRING = '::';
+      if (!count) continue;
+      // The following splitting of the attribute name is a workaround
+      // to enable the content collector to store key-value attributes
+      // see https://github.com/ether/etherpad-lite/issues/2567 for more information
+      // in long term the contentcollector should be refactored to get rid of this workaround
+      const ATTRIBUTE_SPLIT_STRING = '::';
 
-        // see if attributeString is splittable
-        const attributeSplits = a.split(ATTRIBUTE_SPLIT_STRING);
-        if (attributeSplits.length > 1) {
-          // the attribute name follows the convention key::value
-          // so save it as a key value attribute
-          lst.push([attributeSplits[0], attributeSplits[1]]);
-        } else {
-          // the "normal" case, the attribute is just a switch
-          // so set it true
-          lst.push([a, 'true']);
-        }
+      // see if attributeString is splittable
+      const attributeSplits = a.split(ATTRIBUTE_SPLIT_STRING);
+      if (attributeSplits.length > 1) {
+        // the attribute name follows the convention key::value
+        // so save it as a key value attribute
+        lst.push([attributeSplits[0], attributeSplits[1]]);
+      } else {
+        // the "normal" case, the attribute is just a switch
+        // so set it true
+        lst.push([a, 'true']);
       }
     }
     if (state.authorLevel > 0) {
@@ -498,12 +497,9 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             if (!rr && !type) {
               for (let i = 0; i < dom.numChildNodes(node); i++) {
                 const child = dom.childNode(node, i);
-                if (child.name === 'ul') {
-                  type = dom.getAttribute(child, 'class');
-                  if (type) {
-                    break;
-                  }
-                }
+                if (child.name !== 'ul') continue;
+                type = dom.getAttribute(child, 'class');
+                if (type) break;
               }
             }
             if (rr && rr[1]) {

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -32,8 +32,8 @@ const hooks = require('./pluginfw/hooks');
 
 const sanitizeUnicode = (s) => UNorm.nfc(s);
 
-const makeContentCollector = (collectStyles, abrowser, apool, domInterface, className2Author) => {
-  const dom = domInterface || {
+const makeContentCollector = (collectStyles, abrowser, apool, className2Author) => {
+  const dom = {
     isNodeText: (n) => n.nodeType === 3,
     nodeTagName: (n) => n.tagName,
     nodeValue: (n) => n.nodeValue,

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -425,7 +425,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
       if (tname === 'br') {
         this.breakLine = true;
         const tvalue = dom.getAttribute(node, 'value');
-        const induceLineBreak = hooks.callAll('collectContentLineBreak', {
+        const [startNewLine = true] = hooks.callAll('collectContentLineBreak', {
           cc: this,
           state,
           tname,
@@ -433,9 +433,6 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
           styl: null,
           cls: null,
         });
-        const startNewLine = (
-          typeof (induceLineBreak) === 'object' &&
-            induceLineBreak.length === 0) ? true : induceLineBreak[0];
         if (startNewLine) {
           cc.startNewLine(state);
         }

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -491,14 +491,14 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             cc.doAttrib(state, 'strikethrough');
           }
           if (tname === 'ul' || tname === 'ol') {
-            let type = node.attribs ? node.attribs.class : null;
+            let type = dom.nodeAttr(node, 'class');
             const rr = cls && /(?:^| )list-([a-z]+[0-9]+)\b/.exec(cls);
             // lists do not need to have a type, so before we make a wrong guess
             // check if we find a better hint within the node's children
             if (!rr && !type) {
               for (const i in node.children) {
                 if (node.children[i] && node.children[i].name === 'ul') {
-                  type = node.children[i].attribs.class;
+                  type = dom.nodeAttr(node.children[i], 'class');
                   if (type) {
                     break;
                   }
@@ -509,8 +509,8 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
               type = rr[1];
             } else {
               if (tname === 'ul') {
-                if ((type && type.match('indent')) ||
-                    (node.attribs && node.attribs.class && node.attribs.class.match('indent'))) {
+                const cls = dom.nodeAttr(node, 'class');
+                if ((type && type.match('indent')) || (cls && cls.match('indent'))) {
                   type = 'indent';
                 } else {
                   type = 'bullet';

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -509,7 +509,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             // This has undesirable behavior in Chrome but is right in other browsers.
             // See https://github.com/ether/etherpad-lite/issues/2412 for reasoning
             if (!abrowser.chrome) oldListTypeOrNull = (_enterList(state, undefined) || 'none');
-          } else if ((tname === 'li')) {
+          } else if (tname === 'li') {
             state.lineAttributes.start = state.start || 0;
             _recalcAttribString(state);
             if (state.lineAttributes.list.indexOf('number') !== -1) {

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -498,7 +498,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             if (!rr && !type) {
               for (let i = 0; i < dom.numChildNodes(node); i++) {
                 const child = dom.childNode(node, i);
-                if (child && child.name === 'ul') {
+                if (child.name === 'ul') {
                   type = dom.getAttribute(child, 'class');
                   if (type) {
                     break;

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -484,7 +484,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             if (!rr && !type) {
               for (let i = 0; i < dom.numChildNodes(node); i++) {
                 const child = dom.childNode(node, i);
-                if (child.name !== 'ul') continue;
+                if (dom.tagName(child) !== 'ul') continue;
                 type = dom.getAttribute(child, 'class');
                 if (type) break;
               }
@@ -519,7 +519,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
                Note how the <ol> item has to be inside a <li>
                Because of this we don't increment the start number
               */
-              if (node.parentNode && node.parentNode.name !== 'ol') {
+              if (node.parentNode && dom.tagName(node.parentNode) !== 'ol') {
                 /*
                 TODO: start number has to increment based on indentLevel(numberX)
                 This means we have to build an object IE
@@ -536,7 +536,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
               }
             }
             // UL list items never modify the start value.
-            if (node.parentNode && node.parentNode.name === 'ul') {
+            if (node.parentNode && dom.tagName(node.parentNode) === 'ul') {
               state.start++;
               // TODO, this is hacky.
               // Because if the first item is an UL it will increment a list no?

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -338,24 +338,14 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     _reachBlockPoint(node, 0, state);
 
     if (dom.isTextNode(node)) {
-      let txt = dom.nodeValue(node);
       const tname = dom.getAttribute(node.parentNode, 'name');
-
-      const txtFromHook = hooks.callAll('collectContentLineText', {
-        cc: this,
-        state,
-        tname,
-        node,
-        text: txt,
-        styl: null,
-        cls: null,
-      });
-
-      if (typeof (txtFromHook) === 'object') {
-        txt = dom.nodeValue(node);
-      } else if (txtFromHook) {
-        txt = txtFromHook;
-      }
+      const context = {cc: this, state, tname, node, text: dom.nodeValue(node)};
+      // Hook functions may either return a string (deprecated) or modify context.text. If any hook
+      // function modifies context.text then all returned strings are ignored. If no hook functions
+      // modify context.text, the first hook function to return a string wins.
+      const [hookTxt] =
+          hooks.callAll('collectContentLineText', context).filter((s) => typeof s === 'string');
+      let txt = context.text === dom.nodeValue(node) && hookTxt != null ? hookTxt : context.text;
 
       let rest = '';
       let x = 0; // offset into original text

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -519,7 +519,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
                Note how the <ol> item has to be inside a <li>
                Because of this we don't increment the start number
               */
-              if (node.parent && node.parent.name !== 'ol') {
+              if (node.parentNode && node.parentNode.name !== 'ol') {
                 /*
                 TODO: start number has to increment based on indentLevel(numberX)
                 This means we have to build an object IE
@@ -536,7 +536,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
               }
             }
             // UL list items never modify the start value.
-            if (node.parent && node.parent.name === 'ul') {
+            if (node.parentNode && node.parentNode.name === 'ul') {
               state.start++;
               // TODO, this is hacky.
               // Because if the first item is an UL it will increment a list no?

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -43,7 +43,8 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     // .tagName works with DOM and cheerio 0.22.0, but:
     //   * With DOM, .tagName is an uppercase string.
     //   * With cheerio 0.22.0, .tagName is a lowercase string.
-    nodeTagName: (n) => n.tagName,
+    // For consistency, this function always returns a lowercase string.
+    nodeTagName: (n) => n.tagName && n.tagName.toLowerCase(),
     // .nodeValue works with DOM and cheerio 0.22.0.
     nodeValue: (n) => n.nodeValue,
     // Returns the number of Node children (n.childNodes.length), not the number of Element children
@@ -88,7 +89,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     _blockElems[element] = 1;
   });
 
-  const isBlockElement = (n) => !!_blockElems[(dom.nodeTagName(n) || '').toLowerCase()];
+  const isBlockElement = (n) => !!_blockElems[dom.nodeTagName(n) || ''];
 
   const textify = (str) => sanitizeUnicode(
       str.replace(/(\n | \n)/g, ' ')
@@ -406,7 +407,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
         }
       }
     } else {
-      const tname = (dom.nodeTagName(node) || '').toLowerCase();
+      const tname = dom.nodeTagName(node) || '';
 
       if (tname === 'img') {
         hooks.callAll('collectContentImage', {

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -39,6 +39,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
   const dom = {
     // .nodeType works with DOM and cheerio 0.22.0. Note: Cheerio 0.22.0 does not provide the
     // Node.*_NODE constants, so they cannot be used here.
+    isElementNode: (n) => n.nodeType === 1, // Node.ELEMENT_NODE
     isTextNode: (n) => n.nodeType === 3, // Node.TEXT_NODE
     // .tagName works with DOM and cheerio 0.22.0, but:
     //   * With DOM, .tagName is an uppercase string.
@@ -395,7 +396,7 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
           cc.startNewLine(state);
         }
       }
-    } else {
+    } else if (dom.isElementNode(node)) {
       const tname = dom.tagName(node) || '';
 
       if (tname === 'img') {

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -496,16 +496,8 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             // lists do not need to have a type, so before we make a wrong guess
             // check if we find a better hint within the node's children
             if (!rr && !type) {
-              // If `node` is from the DOM (not cheerio) then it implements the ParentNode interface
-              // and `node.children` is a HTMLCollection. The DOM + Web IDL specs guarantee that
-              // HTMLCollection implements the iterable protocol, so for..of iteration should always
-              // work. See: https://stackoverflow.com/a/41759532. Cheerio behaves the same with
-              // regard to iteration.
-              //
-              // TODO: The set of Nodes included in node.children differs between the DOM and
-              // cheerio 0.22.0: cheerio includes all child Nodes (including non-Element Nodes)
-              // whereas the DOM only includes Nodes that are Elements.
-              for (const child of node.children) {
+              for (let i = 0; i < dom.numChildNodes(node); i++) {
+                const child = dom.childNode(node, i);
                 if (child && child.name === 'ul') {
                   type = dom.getAttribute(child, 'class');
                   if (type) {

--- a/tests/backend/specs/api/characterEncoding.js
+++ b/tests/backend/specs/api/characterEncoding.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
  * This file is copied & modified from <basedir>/tests/backend/specs/api/pad.js
  *

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -31,7 +31,6 @@ const testImports = {
     input: '<html><body><ul> <li>FOO</li></ul></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body><ul class="bullet"><li>FOO</ul><br></body></html>',
     expectedText: '\t* FOO\n\n',
-    disabled: true,
   },
   'prefixcorrectlinenumber': {
     input: '<html><body><ol><li>should be 1</li><li>should be 2</li></ol></body></html>',

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -227,15 +227,15 @@ const testImports = {
 
 describe(__filename, function () {
   Object.keys(testImports).forEach((testName) => {
-    const testPadId = makeid();
-    const test = testImports[testName];
-    if (test.disabled) {
-      return xit(`DISABLED: ${testName}`, function (done) {
-        done();
-      });
-    }
-    describe(`createPad ${testName}`, function () {
-      it('creates a new Pad', function (done) {
+    describe(testName, function () {
+      const testPadId = makeid();
+      const test = testImports[testName];
+      if (test.disabled) {
+        return xit(`DISABLED: ${testName}`, function (done) {
+          done();
+        });
+      }
+      it('createPad', function (done) {
         api.get(`${endPoint('createPad')}&padID=${testPadId}`)
             .expect((res) => {
               if (res.body.code !== 0) throw new Error('Unable to create new Pad');
@@ -243,10 +243,8 @@ describe(__filename, function () {
             .expect('Content-Type', /json/)
             .expect(200, done);
       });
-    });
 
-    describe(`setHTML ${testName}`, function () {
-      it('Sets the HTML', function (done) {
+      it('setHTML', function (done) {
         api.get(`${endPoint('setHTML')}&padID=${testPadId}&html=${encodeURIComponent(test.input)}`)
             .expect((res) => {
               if (res.body.code !== 0) throw new Error(`Error:${testName}`);
@@ -254,10 +252,8 @@ describe(__filename, function () {
             .expect('Content-Type', /json/)
             .expect(200, done);
       });
-    });
 
-    describe(`getHTML ${testName}`, function () {
-      it('Gets back the HTML of a Pad', function (done) {
+      it('getHTML', function (done) {
         api.get(`${endPoint('getHTML')}&padID=${testPadId}`)
             .expect((res) => {
               const receivedHtml = res.body.data.html;
@@ -279,10 +275,8 @@ describe(__filename, function () {
             .expect('Content-Type', /json/)
             .expect(200, done);
       });
-    });
 
-    describe(`getText ${testName}`, function () {
-      it('Gets back the Text of a Pad', function (done) {
+      it('getText', function (done) {
         api.get(`${endPoint('getText')}&padID=${testPadId}`)
             .expect((res) => {
               const receivedText = res.body.data.text;

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -6,13 +6,11 @@
  * TODO: unify those two files, and merge in a single one.
  */
 
-/* eslint-disable max-len */
-
 const common = require('../../common');
-const supertest = require(`${__dirname}/../../../../src/node_modules/supertest`);
-const settings = require(`${__dirname}/../../../../tests/container/loadSettings.js`).loadSettings();
-const api = supertest(`http://${settings.ip}:${settings.port}`);
+const settings = require('../../../container/loadSettings.js').loadSettings();
+const supertest = require('ep_etherpad-lite/node_modules/supertest');
 
+const api = supertest(`http://${settings.ip}:${settings.port}`);
 const apiKey = common.apiKey;
 const apiVersion = 1;
 
@@ -47,16 +45,16 @@ const testImports = {
   },
 
   /*
-  "prefixcorrectlinenumber when introduced none list item - currently not supported see #3450":{
+  "prefixcorrectlinenumber when introduced none list item - currently not supported see #3450": {
     input: '<html><body><ol><li>should be 1</li>test<li>should be 2</li></ol></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1</li>test<li>should be 2</li></ol><br></body></html>',
-    expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n'
+    expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n',
   }
   ,
-  "newlinesshouldntresetlinenumber #2194":{
+  "newlinesshouldntresetlinenumber #2194": {
     input: '<html><body><ol><li>should be 1</li>test<li>should be 2</li></ol></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body><ol class="number"><li>should be 1</li>test<li>should be 2</li></ol><br></body></html>',
-    expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n'
+    expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n',
   }
   */
   'ignoreAnyTagsOutsideBody': {
@@ -69,88 +67,88 @@ const testImports = {
     description: 'Indented lists are represented with tabs and without bullets',
     input: '<html><body><ul class="indent"><li>indent</li><li>indent</ul></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body><ul class="indent"><li>indent</li><li>indent</ul><br></body></html>',
-    expectedText: '\tindent\n\tindent\n\n'
+    expectedText: '\tindent\n\tindent\n\n',
   },
-  lineWithMultipleSpaces: {
+  'lineWithMultipleSpaces': {
     description: 'Multiple spaces should be collapsed',
     input: '<html><body>Text with  more   than    one space.<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Text with more than one space.<br><br></body></html>',
-    expectedText: 'Text with more than one space.\n\n'
+    expectedText: 'Text with more than one space.\n\n',
   },
-  lineWithMultipleNonBreakingAndNormalSpaces: {
+  'lineWithMultipleNonBreakingAndNormalSpaces': {
     // XXX the HTML between "than" and "one" looks strange
     description: 'non-breaking space should be preserved, but can be replaced when it',
     input: '<html><body>Text&nbsp;with&nbsp; more&nbsp;&nbsp;&nbsp;than   &nbsp;one space.<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Text with&nbsp; more&nbsp;&nbsp; than&nbsp; one space.<br><br></body></html>',
-    expectedText: 'Text with  more   than  one space.\n\n'
+    expectedText: 'Text with  more   than  one space.\n\n',
   },
-  multiplenbsp: {
+  'multiplenbsp': {
     description: 'Multiple non-breaking space should be preserved',
     input: '<html><body>&nbsp;&nbsp;<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp;&nbsp;<br><br></body></html>',
-    expectedText: '  \n\n'
+    expectedText: '  \n\n',
   },
-  multipleNonBreakingSpaceBetweenWords: {
+  'multipleNonBreakingSpaceBetweenWords': {
     description: 'A normal space is always inserted before a word',
     input: '<html><body>&nbsp;&nbsp;word1&nbsp;&nbsp;word2&nbsp;&nbsp;&nbsp;word3<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp; word1&nbsp; word2&nbsp;&nbsp; word3<br><br></body></html>',
-    expectedText: '  word1  word2   word3\n\n'
+    expectedText: '  word1  word2   word3\n\n',
   },
-  nonBreakingSpacePreceededBySpaceBetweenWords: {
+  'nonBreakingSpacePreceededBySpaceBetweenWords': {
     description: 'A non-breaking space preceeded by a normal space',
     input: '<html><body> &nbsp;word1 &nbsp;word2 &nbsp;word3<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp;word1&nbsp; word2&nbsp; word3<br><br></body></html>',
-    expectedText: ' word1  word2  word3\n\n'
+    expectedText: ' word1  word2  word3\n\n',
   },
-  nonBreakingSpaceFollowededBySpaceBetweenWords: {
+  'nonBreakingSpaceFollowededBySpaceBetweenWords': {
     description: 'A non-breaking space followed by a normal space',
     input: '<html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br><br></body></html>',
-    expectedText: '  word1  word2  word3\n\n'
+    expectedText: '  word1  word2  word3\n\n',
   },
-  spacesAfterNewline: {
+  'spacesAfterNewline': {
     description: 'Collapse spaces that follow a newline',
-    input:'<!doctype html><html><body>something<br>             something<br></body></html>',
+    input: '<!doctype html><html><body>something<br>             something<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>something<br>something<br><br></body></html>',
-    expectedText: 'something\nsomething\n\n'
+    expectedText: 'something\nsomething\n\n',
   },
-  spacesAfterNewlineP: {
+  'spacesAfterNewlineP': {
     description: 'Collapse spaces that follow a paragraph',
-    input:'<!doctype html><html><body>something<p></p>             something<br></body></html>',
+    input: '<!doctype html><html><body>something<p></p>             something<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>something<br><br>something<br><br></body></html>',
-    expectedText: 'something\n\nsomething\n\n'
+    expectedText: 'something\n\nsomething\n\n',
   },
-  spacesAtEndOfLine: {
+  'spacesAtEndOfLine': {
     description: 'Collapse spaces that preceed/follow a newline',
-    input:'<html><body>something            <br>             something<br></body></html>',
+    input: '<html><body>something            <br>             something<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>something<br>something<br><br></body></html>',
-    expectedText: 'something\nsomething\n\n'
+    expectedText: 'something\nsomething\n\n',
   },
-  spacesAtEndOfLineP: {
+  'spacesAtEndOfLineP': {
     description: 'Collapse spaces that preceed/follow a paragraph',
-    input:'<html><body>something            <p></p>             something<br></body></html>',
+    input: '<html><body>something            <p></p>             something<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>something<br><br>something<br><br></body></html>',
-    expectedText: 'something\n\nsomething\n\n'
+    expectedText: 'something\n\nsomething\n\n',
   },
-  nonBreakingSpacesAfterNewlines: {
+  'nonBreakingSpacesAfterNewlines': {
     description: 'Don\'t collapse non-breaking spaces that follow a newline',
-    input:'<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
+    input: '<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>something<br>&nbsp;&nbsp; something<br><br></body></html>',
-    expectedText: 'something\n   something\n\n'
+    expectedText: 'something\n   something\n\n',
   },
-  nonBreakingSpacesAfterNewlinesP: {
+  'nonBreakingSpacesAfterNewlinesP': {
     description: 'Don\'t collapse non-breaking spaces that follow a paragraph',
-    input:'<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
+    input: '<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>something<br><br>&nbsp;&nbsp; something<br><br></body></html>',
-    expectedText: 'something\n\n   something\n\n'
+    expectedText: 'something\n\n   something\n\n',
   },
-  collapseSpacesInsideElements: {
+  'collapseSpacesInsideElements': {
     description: 'Preserve only one space when multiple are present',
     input: '<html><body>Need <span> more </span> space<i>  s </i> !<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n'
+    expectedText: 'Need more space s !\n\n',
   },
-  collapseSpacesAcrossNewlines: {
+  'collapseSpacesAcrossNewlines': {
     description: 'Newlines and multiple spaces across newlines should be collapsed',
     input: `
       <html><body>Need
@@ -159,29 +157,29 @@ const testImports = {
           <i>  s </i>
           !<br></body></html>`,
     expectedHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n'
+    expectedText: 'Need more space s !\n\n',
   },
-  multipleNewLinesAtBeginning: {
+  'multipleNewLinesAtBeginning': {
     description: 'Multiple new lines and paragraphs at the beginning should be preserved',
     input: '<html><body><br><br><p></p><p></p>first line<br><br>second line<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body><br><br><br><br>first line<br><br>second line<br><br></body></html>',
-    expectedText: '\n\n\n\nfirst line\n\nsecond line\n\n'
+    expectedText: '\n\n\n\nfirst line\n\nsecond line\n\n',
   },
-  multiLineParagraph:{
-    description: "A paragraph with multiple lines should not loose spaces when lines are combined",
-    input:`<html><body>
+  'multiLineParagraph': {
+    description: 'A paragraph with multiple lines should not loose spaces when lines are combined',
+    input: `<html><body>
     <p>
       а б в г ґ д е є ж з и і ї й к л м н о
       п р с т у ф х ц ч ш щ ю я ь
     </p>
 </body></html>`,
     expectedHTML: '<!DOCTYPE HTML><html><body>&#1072; &#1073; &#1074; &#1075; &#1169; &#1076; &#1077; &#1108; &#1078; &#1079; &#1080; &#1110; &#1111; &#1081; &#1082; &#1083; &#1084; &#1085; &#1086; &#1087; &#1088; &#1089; &#1090; &#1091; &#1092; &#1093; &#1094; &#1095; &#1096; &#1097; &#1102; &#1103; &#1100;<br><br></body></html>',
-    expectedText: 'а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь\n\n'
+    expectedText: 'а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь\n\n',
   },
-  multiLineParagraphWithPre:{
-    //XXX why is there &nbsp; before "in"?
-    description: "lines in preformatted text should be kept intact",
-    input:`<html><body>
+  'multiLineParagraphWithPre': {
+    // XXX why is there &nbsp; before "in"?
+    description: 'lines in preformatted text should be kept intact',
+    input: `<html><body>
     <p>
         а б в г ґ д е є ж з и і ї й к л м н о<pre>multiple
    lines
@@ -191,40 +189,40 @@ const testImports = {
 ь</p>
 </body></html>`,
     expectedHTML: '<!DOCTYPE HTML><html><body>&#1072; &#1073; &#1074; &#1075; &#1169; &#1076; &#1077; &#1108; &#1078; &#1079; &#1080; &#1110; &#1111; &#1081; &#1082; &#1083; &#1084; &#1085; &#1086;<br>multiple<br>&nbsp;&nbsp; lines<br>&nbsp;in<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; pre<br><br>&#1087; &#1088; &#1089; &#1090; &#1091; &#1092; &#1093; &#1094; &#1095; &#1096; &#1097; &#1102; &#1103; &#1100;<br><br></body></html>',
-    expectedText: 'а б в г ґ д е є ж з и і ї й к л м н о\nmultiple\n   lines\n in\n      pre\n\nп р с т у ф х ц ч ш щ ю я ь\n\n'
+    expectedText: 'а б в г ґ д е є ж з и і ї й к л м н о\nmultiple\n   lines\n in\n      pre\n\nп р с т у ф х ц ч ш щ ю я ь\n\n',
   },
-  preIntroducesASpace: {
-    description: "pre should be on a new line not preceeded by a space",
-    input:`<html><body><p>
+  'preIntroducesASpace': {
+    description: 'pre should be on a new line not preceeded by a space',
+    input: `<html><body><p>
     1
 <pre>preline
 </pre></p></body></html>`,
     expectedHTML: '<!DOCTYPE HTML><html><body>1<br>preline<br><br><br></body></html>',
-    expectedText: '1\npreline\n\n\n'
+    expectedText: '1\npreline\n\n\n',
   },
-  dontDeleteSpaceInsideElements: {
+  'dontDeleteSpaceInsideElements': {
     description: 'Preserve spaces inside elements',
     input: '<html><body>Need<span> more </span>space<i> s </i>!<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n'
+    expectedText: 'Need more space s !\n\n',
   },
-  dontDeleteSpaceOutsideElements: {
+  'dontDeleteSpaceOutsideElements': {
     description: 'Preserve spaces outside elements',
     input: '<html><body>Need <span>more</span> space <i>s</i> !<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s</em> !<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n'
+    expectedText: 'Need more space s !\n\n',
   },
-  dontDeleteSpaceAtEndOfElement: {
+  'dontDeleteSpaceAtEndOfElement': {
     description: 'Preserve spaces at the end of an element',
     input: '<html><body>Need <span>more </span>space <i>s </i>!<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n'
+    expectedText: 'Need more space s !\n\n',
   },
-  dontDeleteSpaceAtBeginOfElements: {
+  'dontDeleteSpaceAtBeginOfElements': {
     description: 'Preserve spaces at the start of an element',
     input: '<html><body>Need<span> more</span> space<i> s</i> !<br></body></html>',
     expectedHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s</em> !<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n'
+    expectedText: 'Need more space s !\n\n',
   },
 };
 
@@ -315,7 +313,7 @@ describe(__filename, function () {
 function endPoint(point, version) {
   version = version || apiVersion;
   return `/api/${version}/${point}?apikey=${apiKey}`;
-};
+}
 
 function makeid() {
   let text = '';

--- a/tests/backend/specs/api/importexport.js
+++ b/tests/backend/specs/api/importexport.js
@@ -17,135 +17,135 @@ const apiVersion = 1;
 const testImports = {
   'malformed': {
     input: '<html><body><li>wtf</ul></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>wtf<br><br></body></html>',
-    expectedText: 'wtf\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>wtf<br><br></body></html>',
+    wantText: 'wtf\n\n',
     disabled: true,
   },
   'nonelistiteminlist #3620': {
     input: '<html><body><ul>test<li>FOO</li></ul></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ul class="bullet">test<li>FOO</ul><br></body></html>',
-    expectedText: '\ttest\n\t* FOO\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ul class="bullet">test<li>FOO</ul><br></body></html>',
+    wantText: '\ttest\n\t* FOO\n\n',
     disabled: true,
   },
   'whitespaceinlist #3620': {
     input: '<html><body><ul> <li>FOO</li></ul></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ul class="bullet"><li>FOO</ul><br></body></html>',
-    expectedText: '\t* FOO\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ul class="bullet"><li>FOO</ul><br></body></html>',
+    wantText: '\t* FOO\n\n',
   },
   'prefixcorrectlinenumber': {
     input: '<html><body><ol><li>should be 1</li><li>should be 2</li></ol></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1</li><li>should be 2</ol><br></body></html>',
-    expectedText: '\t1. should be 1\n\t2. should be 2\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1</li><li>should be 2</ol><br></body></html>',
+    wantText: '\t1. should be 1\n\t2. should be 2\n\n',
   },
   'prefixcorrectlinenumbernested': {
     input: '<html><body><ol><li>should be 1</li><ol><li>foo</li></ol><li>should be 2</li></ol></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1<ol start="2" class="number"><li>foo</ol><li>should be 2</ol><br></body></html>',
-    expectedText: '\t1. should be 1\n\t\t1.1. foo\n\t2. should be 2\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1<ol start="2" class="number"><li>foo</ol><li>should be 2</ol><br></body></html>',
+    wantText: '\t1. should be 1\n\t\t1.1. foo\n\t2. should be 2\n\n',
   },
 
   /*
   "prefixcorrectlinenumber when introduced none list item - currently not supported see #3450": {
     input: '<html><body><ol><li>should be 1</li>test<li>should be 2</li></ol></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1</li>test<li>should be 2</li></ol><br></body></html>',
-    expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ol start="1" class="number"><li>should be 1</li>test<li>should be 2</li></ol><br></body></html>',
+    wantText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n',
   }
   ,
   "newlinesshouldntresetlinenumber #2194": {
     input: '<html><body><ol><li>should be 1</li>test<li>should be 2</li></ol></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ol class="number"><li>should be 1</li>test<li>should be 2</li></ol><br></body></html>',
-    expectedText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ol class="number"><li>should be 1</li>test<li>should be 2</li></ol><br></body></html>',
+    wantText: '\t1. should be 1\n\ttest\n\t2. should be 2\n\n',
   }
   */
   'ignoreAnyTagsOutsideBody': {
     description: 'Content outside body should be ignored',
     input: '<html><head><title>title</title><style></style></head><body>empty<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>empty<br><br></body></html>',
-    expectedText: 'empty\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>empty<br><br></body></html>',
+    wantText: 'empty\n\n',
   },
   'indentedListsAreNotBullets': {
     description: 'Indented lists are represented with tabs and without bullets',
     input: '<html><body><ul class="indent"><li>indent</li><li>indent</ul></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><ul class="indent"><li>indent</li><li>indent</ul><br></body></html>',
-    expectedText: '\tindent\n\tindent\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><ul class="indent"><li>indent</li><li>indent</ul><br></body></html>',
+    wantText: '\tindent\n\tindent\n\n',
   },
   'lineWithMultipleSpaces': {
     description: 'Multiple spaces should be collapsed',
     input: '<html><body>Text with  more   than    one space.<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Text with more than one space.<br><br></body></html>',
-    expectedText: 'Text with more than one space.\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Text with more than one space.<br><br></body></html>',
+    wantText: 'Text with more than one space.\n\n',
   },
   'lineWithMultipleNonBreakingAndNormalSpaces': {
     // XXX the HTML between "than" and "one" looks strange
     description: 'non-breaking space should be preserved, but can be replaced when it',
     input: '<html><body>Text&nbsp;with&nbsp; more&nbsp;&nbsp;&nbsp;than   &nbsp;one space.<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Text with&nbsp; more&nbsp;&nbsp; than&nbsp; one space.<br><br></body></html>',
-    expectedText: 'Text with  more   than  one space.\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Text with&nbsp; more&nbsp;&nbsp; than&nbsp; one space.<br><br></body></html>',
+    wantText: 'Text with  more   than  one space.\n\n',
   },
   'multiplenbsp': {
     description: 'Multiple non-breaking space should be preserved',
     input: '<html><body>&nbsp;&nbsp;<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp;&nbsp;<br><br></body></html>',
-    expectedText: '  \n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>&nbsp;&nbsp;<br><br></body></html>',
+    wantText: '  \n\n',
   },
   'multipleNonBreakingSpaceBetweenWords': {
     description: 'A normal space is always inserted before a word',
     input: '<html><body>&nbsp;&nbsp;word1&nbsp;&nbsp;word2&nbsp;&nbsp;&nbsp;word3<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp; word1&nbsp; word2&nbsp;&nbsp; word3<br><br></body></html>',
-    expectedText: '  word1  word2   word3\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>&nbsp; word1&nbsp; word2&nbsp;&nbsp; word3<br><br></body></html>',
+    wantText: '  word1  word2   word3\n\n',
   },
   'nonBreakingSpacePreceededBySpaceBetweenWords': {
     description: 'A non-breaking space preceeded by a normal space',
     input: '<html><body> &nbsp;word1 &nbsp;word2 &nbsp;word3<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp;word1&nbsp; word2&nbsp; word3<br><br></body></html>',
-    expectedText: ' word1  word2  word3\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>&nbsp;word1&nbsp; word2&nbsp; word3<br><br></body></html>',
+    wantText: ' word1  word2  word3\n\n',
   },
   'nonBreakingSpaceFollowededBySpaceBetweenWords': {
     description: 'A non-breaking space followed by a normal space',
     input: '<html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br><br></body></html>',
-    expectedText: '  word1  word2  word3\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br><br></body></html>',
+    wantText: '  word1  word2  word3\n\n',
   },
   'spacesAfterNewline': {
     description: 'Collapse spaces that follow a newline',
     input: '<!doctype html><html><body>something<br>             something<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>something<br>something<br><br></body></html>',
-    expectedText: 'something\nsomething\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>something<br>something<br><br></body></html>',
+    wantText: 'something\nsomething\n\n',
   },
   'spacesAfterNewlineP': {
     description: 'Collapse spaces that follow a paragraph',
     input: '<!doctype html><html><body>something<p></p>             something<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>something<br><br>something<br><br></body></html>',
-    expectedText: 'something\n\nsomething\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>something<br><br>something<br><br></body></html>',
+    wantText: 'something\n\nsomething\n\n',
   },
   'spacesAtEndOfLine': {
     description: 'Collapse spaces that preceed/follow a newline',
     input: '<html><body>something            <br>             something<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>something<br>something<br><br></body></html>',
-    expectedText: 'something\nsomething\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>something<br>something<br><br></body></html>',
+    wantText: 'something\nsomething\n\n',
   },
   'spacesAtEndOfLineP': {
     description: 'Collapse spaces that preceed/follow a paragraph',
     input: '<html><body>something            <p></p>             something<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>something<br><br>something<br><br></body></html>',
-    expectedText: 'something\n\nsomething\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>something<br><br>something<br><br></body></html>',
+    wantText: 'something\n\nsomething\n\n',
   },
   'nonBreakingSpacesAfterNewlines': {
     description: 'Don\'t collapse non-breaking spaces that follow a newline',
     input: '<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>something<br>&nbsp;&nbsp; something<br><br></body></html>',
-    expectedText: 'something\n   something\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>something<br>&nbsp;&nbsp; something<br><br></body></html>',
+    wantText: 'something\n   something\n\n',
   },
   'nonBreakingSpacesAfterNewlinesP': {
     description: 'Don\'t collapse non-breaking spaces that follow a paragraph',
     input: '<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>something<br><br>&nbsp;&nbsp; something<br><br></body></html>',
-    expectedText: 'something\n\n   something\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>something<br><br>&nbsp;&nbsp; something<br><br></body></html>',
+    wantText: 'something\n\n   something\n\n',
   },
   'collapseSpacesInsideElements': {
     description: 'Preserve only one space when multiple are present',
     input: '<html><body>Need <span> more </span> space<i>  s </i> !<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s </em>!<br><br></body></html>',
+    wantText: 'Need more space s !\n\n',
   },
   'collapseSpacesAcrossNewlines': {
     description: 'Newlines and multiple spaces across newlines should be collapsed',
@@ -155,14 +155,14 @@ const testImports = {
           space
           <i>  s </i>
           !<br></body></html>`,
-    expectedHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s </em>!<br><br></body></html>',
+    wantText: 'Need more space s !\n\n',
   },
   'multipleNewLinesAtBeginning': {
     description: 'Multiple new lines and paragraphs at the beginning should be preserved',
     input: '<html><body><br><br><p></p><p></p>first line<br><br>second line<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body><br><br><br><br>first line<br><br>second line<br><br></body></html>',
-    expectedText: '\n\n\n\nfirst line\n\nsecond line\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body><br><br><br><br>first line<br><br>second line<br><br></body></html>',
+    wantText: '\n\n\n\nfirst line\n\nsecond line\n\n',
   },
   'multiLineParagraph': {
     description: 'A paragraph with multiple lines should not loose spaces when lines are combined',
@@ -172,8 +172,8 @@ const testImports = {
       п р с т у ф х ц ч ш щ ю я ь
     </p>
 </body></html>`,
-    expectedHTML: '<!DOCTYPE HTML><html><body>&#1072; &#1073; &#1074; &#1075; &#1169; &#1076; &#1077; &#1108; &#1078; &#1079; &#1080; &#1110; &#1111; &#1081; &#1082; &#1083; &#1084; &#1085; &#1086; &#1087; &#1088; &#1089; &#1090; &#1091; &#1092; &#1093; &#1094; &#1095; &#1096; &#1097; &#1102; &#1103; &#1100;<br><br></body></html>',
-    expectedText: 'а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>&#1072; &#1073; &#1074; &#1075; &#1169; &#1076; &#1077; &#1108; &#1078; &#1079; &#1080; &#1110; &#1111; &#1081; &#1082; &#1083; &#1084; &#1085; &#1086; &#1087; &#1088; &#1089; &#1090; &#1091; &#1092; &#1093; &#1094; &#1095; &#1096; &#1097; &#1102; &#1103; &#1100;<br><br></body></html>',
+    wantText: 'а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь\n\n',
   },
   'multiLineParagraphWithPre': {
     // XXX why is there &nbsp; before "in"?
@@ -187,8 +187,8 @@ const testImports = {
 </pre></p><p>п р с т у ф х ц ч ш щ ю я
 ь</p>
 </body></html>`,
-    expectedHTML: '<!DOCTYPE HTML><html><body>&#1072; &#1073; &#1074; &#1075; &#1169; &#1076; &#1077; &#1108; &#1078; &#1079; &#1080; &#1110; &#1111; &#1081; &#1082; &#1083; &#1084; &#1085; &#1086;<br>multiple<br>&nbsp;&nbsp; lines<br>&nbsp;in<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; pre<br><br>&#1087; &#1088; &#1089; &#1090; &#1091; &#1092; &#1093; &#1094; &#1095; &#1096; &#1097; &#1102; &#1103; &#1100;<br><br></body></html>',
-    expectedText: 'а б в г ґ д е є ж з и і ї й к л м н о\nmultiple\n   lines\n in\n      pre\n\nп р с т у ф х ц ч ш щ ю я ь\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>&#1072; &#1073; &#1074; &#1075; &#1169; &#1076; &#1077; &#1108; &#1078; &#1079; &#1080; &#1110; &#1111; &#1081; &#1082; &#1083; &#1084; &#1085; &#1086;<br>multiple<br>&nbsp;&nbsp; lines<br>&nbsp;in<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; pre<br><br>&#1087; &#1088; &#1089; &#1090; &#1091; &#1092; &#1093; &#1094; &#1095; &#1096; &#1097; &#1102; &#1103; &#1100;<br><br></body></html>',
+    wantText: 'а б в г ґ д е є ж з и і ї й к л м н о\nmultiple\n   lines\n in\n      pre\n\nп р с т у ф х ц ч ш щ ю я ь\n\n',
   },
   'preIntroducesASpace': {
     description: 'pre should be on a new line not preceeded by a space',
@@ -196,32 +196,32 @@ const testImports = {
     1
 <pre>preline
 </pre></p></body></html>`,
-    expectedHTML: '<!DOCTYPE HTML><html><body>1<br>preline<br><br><br></body></html>',
-    expectedText: '1\npreline\n\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>1<br>preline<br><br><br></body></html>',
+    wantText: '1\npreline\n\n\n',
   },
   'dontDeleteSpaceInsideElements': {
     description: 'Preserve spaces inside elements',
     input: '<html><body>Need<span> more </span>space<i> s </i>!<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s </em>!<br><br></body></html>',
+    wantText: 'Need more space s !\n\n',
   },
   'dontDeleteSpaceOutsideElements': {
     description: 'Preserve spaces outside elements',
     input: '<html><body>Need <span>more</span> space <i>s</i> !<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s</em> !<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s</em> !<br><br></body></html>',
+    wantText: 'Need more space s !\n\n',
   },
   'dontDeleteSpaceAtEndOfElement': {
     description: 'Preserve spaces at the end of an element',
     input: '<html><body>Need <span>more </span>space <i>s </i>!<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s </em>!<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Need more space <em>s </em>!<br><br></body></html>',
+    wantText: 'Need more space s !\n\n',
   },
   'dontDeleteSpaceAtBeginOfElements': {
     description: 'Preserve spaces at the start of an element',
     input: '<html><body>Need<span> more</span> space<i> s</i> !<br></body></html>',
-    expectedHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s</em> !<br><br></body></html>',
-    expectedText: 'Need more space s !\n\n',
+    wantHTML: '<!DOCTYPE HTML><html><body>Need more space<em> s</em> !<br><br></body></html>',
+    wantText: 'Need more space s !\n\n',
   },
 };
 
@@ -256,17 +256,17 @@ describe(__filename, function () {
       it('getHTML', function (done) {
         api.get(`${endPoint('getHTML')}&padID=${testPadId}`)
             .expect((res) => {
-              const receivedHtml = res.body.data.html;
-              if (receivedHtml !== test.expectedHTML) {
+              const gotHtml = res.body.data.html;
+              if (gotHtml !== test.wantHTML) {
                 throw new Error(`HTML received from export is not the one we were expecting.
              Test Name:
              ${testName}
 
-             Received:
-             ${JSON.stringify(receivedHtml)}
+             Got:
+             ${JSON.stringify(gotHtml)}
 
-             Expected:
-             ${JSON.stringify(test.expectedHTML)}
+             Want:
+             ${JSON.stringify(test.wantHTML)}
 
              Which is a different version of the originally imported one:
              ${test.input}`);
@@ -279,17 +279,17 @@ describe(__filename, function () {
       it('getText', function (done) {
         api.get(`${endPoint('getText')}&padID=${testPadId}`)
             .expect((res) => {
-              const receivedText = res.body.data.text;
-              if (receivedText !== test.expectedText) {
+              const gotText = res.body.data.text;
+              if (gotText !== test.wantText) {
                 throw new Error(`Text received from export is not the one we were expecting.
              Test Name:
              ${testName}
 
-             Received:
-             ${JSON.stringify(receivedText)}
+             Got:
+             ${JSON.stringify(gotText)}
 
-             Expected:
-             ${JSON.stringify(test.expectedText)}
+             Want:
+             ${JSON.stringify(test.wantText)}
 
              Which is a different version of the originally imported one:
              ${test.input}`);

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -18,17 +18,17 @@ const tests = {
   nestedLi: {
     description: 'Complex nested Li',
     html: '<!doctype html><html><body><ol><li>one</li><li><ol><li>1.1</li></ol></li><li>two</li></ol></body></html>',
-    expectedLineAttribs: [
+    wantLineAttribs: [
       '*0*1*2*3+1+3', '*0*4*2*5+1+3', '*0*1*2*5+1+3',
     ],
-    expectedText: [
+    wantText: [
       '*one', '*1.1', '*two',
     ],
   },
   complexNest: {
     description: 'Complex list of different types',
     html: '<!doctype html><html><body><ul class="bullet"><li>one</li><li>two</li><li>0</li><li>1</li><li>2<ul class="bullet"><li>3</li><li>4</li></ul></li></ul><ol class="number"><li>item<ol class="number"><li>item1</li><li>item2</li></ol></li></ol></body></html>',
-    expectedLineAttribs: [
+    wantLineAttribs: [
       '*0*1*2+1+3',
       '*0*1*2+1+3',
       '*0*1*2+1+1',
@@ -40,7 +40,7 @@ const tests = {
       '*0*6*2*7+1+5',
       '*0*6*2*7+1+5',
     ],
-    expectedText: [
+    wantText: [
       '*one',
       '*two',
       '*0',
@@ -56,142 +56,142 @@ const tests = {
   ul: {
     description: 'Tests if uls properly get attributes',
     html: '<html><body><ul><li>a</li><li>b</li></ul><div>div</div><p>foo</p></body></html>',
-    expectedLineAttribs: ['*0*1*2+1+1', '*0*1*2+1+1', '+3', '+3'],
-    expectedText: ['*a', '*b', 'div', 'foo'],
+    wantLineAttribs: ['*0*1*2+1+1', '*0*1*2+1+1', '+3', '+3'],
+    wantText: ['*a', '*b', 'div', 'foo'],
   },
   ulIndented: {
     description: 'Tests if indented uls properly get attributes',
     html: '<html><body><ul><li>a</li><ul><li>b</li></ul><li>a</li></ul><p>foo</p></body></html>',
-    expectedLineAttribs: ['*0*1*2+1+1', '*0*3*2+1+1', '*0*1*2+1+1', '+3'],
-    expectedText: ['*a', '*b', '*a', 'foo'],
+    wantLineAttribs: ['*0*1*2+1+1', '*0*3*2+1+1', '*0*1*2+1+1', '+3'],
+    wantText: ['*a', '*b', '*a', 'foo'],
   },
   ol: {
     description: 'Tests if ols properly get line numbers when in a normal OL',
     html: '<html><body><ol><li>a</li><li>b</li><li>c</li></ol><p>test</p></body></html>',
-    expectedLineAttribs: ['*0*1*2*3+1+1', '*0*1*2*3+1+1', '*0*1*2*3+1+1', '+4'],
-    expectedText: ['*a', '*b', '*c', 'test'],
+    wantLineAttribs: ['*0*1*2*3+1+1', '*0*1*2*3+1+1', '*0*1*2*3+1+1', '+4'],
+    wantText: ['*a', '*b', '*c', 'test'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
   },
   lineDoBreakInOl: {
     description: 'A single completely empty line break within an ol should reset count if OL is closed off..',
     html: '<html><body><ol><li>should be 1</li></ol><p>hello</p><ol><li>should be 1</li><li>should be 2</li></ol><p></p></body></html>',
-    expectedLineAttribs: ['*0*1*2*3+1+b', '+5', '*0*1*2*4+1+b', '*0*1*2*4+1+b', ''],
-    expectedText: ['*should be 1', 'hello', '*should be 1', '*should be 2', ''],
+    wantLineAttribs: ['*0*1*2*3+1+b', '+5', '*0*1*2*4+1+b', '*0*1*2*4+1+b', ''],
+    wantText: ['*should be 1', 'hello', '*should be 1', '*should be 2', ''],
     noteToSelf: "Shouldn't include attribute marker in the <p> line",
   },
   testP: {
     description: 'A single <p></p> should create a new line',
     html: '<html><body><p></p><p></p></body></html>',
-    expectedLineAttribs: ['', ''],
-    expectedText: ['', ''],
+    wantLineAttribs: ['', ''],
+    wantText: ['', ''],
     noteToSelf: '<p></p>should create a line break but not break numbering',
   },
   nestedOl: {
     description: 'Tests if ols properly get line numbers when in a normal OL',
     html: '<html><body>a<ol><li>b<ol><li>c</li></ol></ol>notlist<p>foo</p></body></html>',
-    expectedLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1', '+7', '+3'],
-    expectedText: ['a', '*b', '*c', 'notlist', 'foo'],
+    wantLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1', '+7', '+3'],
+    wantText: ['a', '*b', '*c', 'notlist', 'foo'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
   },
   nestedOl2: {
     description: 'First item being an UL then subsequent being OL will fail',
     html: '<html><body><ul><li>a<ol><li>b</li><li>c</li></ol></li></ul></body></html>',
-    expectedLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1'],
-    expectedText: ['a', '*b', '*c'],
+    wantLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1'],
+    wantText: ['a', '*b', '*c'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
     disabled: true,
   },
   lineDontBreakOL: {
     description: 'A single completely empty line break within an ol should NOT reset count',
     html: '<html><body><ol><li>should be 1</li><p></p><li>should be 2</li><li>should be 3</li></ol><p></p></body></html>',
-    expectedLineAttribs: [],
-    expectedText: ['*should be 1', '*should be 2', '*should be 3'],
+    wantLineAttribs: [],
+    wantText: ['*should be 1', '*should be 2', '*should be 3'],
     noteToSelf: "<p></p>should create a line break but not break numbering -- This is what I can't get working!",
     disabled: true,
   },
   ignoreAnyTagsOutsideBody: {
     description: 'Content outside body should be ignored',
     html: '<html><head><title>title</title><style></style></head><body>empty<br></body></html>',
-    expectedLineAttribs: ['+5'],
-    expectedText: ['empty'],
+    wantLineAttribs: ['+5'],
+    wantText: ['empty'],
   },
   lineWithMultipleSpaces: {
     description: 'Multiple spaces should be preserved',
     html: '<html><body>Text with  more   than    one space.<br></body></html>',
-    expectedLineAttribs: ['+10'],
-    expectedText: ['Text with  more   than    one space.'],
+    wantLineAttribs: ['+10'],
+    wantText: ['Text with  more   than    one space.'],
   },
   lineWithMultipleNonBreakingAndNormalSpaces: {
     description: 'non-breaking and normal space should be preserved',
     html: '<html><body>Text&nbsp;with&nbsp; more&nbsp;&nbsp;&nbsp;than   &nbsp;one space.<br></body></html>',
-    expectedLineAttribs: ['+10'],
-    expectedText: ['Text with  more   than    one space.'],
+    wantLineAttribs: ['+10'],
+    wantText: ['Text with  more   than    one space.'],
   },
   multiplenbsp: {
     description: 'Multiple nbsp should be preserved',
     html: '<html><body>&nbsp;&nbsp;<br></body></html>',
-    expectedLineAttribs: ['+2'],
-    expectedText: ['  '],
+    wantLineAttribs: ['+2'],
+    wantText: ['  '],
   },
   multipleNonBreakingSpaceBetweenWords: {
     description: 'Multiple nbsp between words ',
     html: '<html><body>&nbsp;&nbsp;word1&nbsp;&nbsp;word2&nbsp;&nbsp;&nbsp;word3<br></body></html>',
-    expectedLineAttribs: ['+m'],
-    expectedText: ['  word1  word2   word3'],
+    wantLineAttribs: ['+m'],
+    wantText: ['  word1  word2   word3'],
   },
   nonBreakingSpacePreceededBySpaceBetweenWords: {
     description: 'A non-breaking space preceeded by a normal space',
     html: '<html><body> &nbsp;word1 &nbsp;word2 &nbsp;word3<br></body></html>',
-    expectedLineAttribs: ['+l'],
-    expectedText: ['  word1  word2  word3'],
+    wantLineAttribs: ['+l'],
+    wantText: ['  word1  word2  word3'],
   },
   nonBreakingSpaceFollowededBySpaceBetweenWords: {
     description: 'A non-breaking space followed by a normal space',
     html: '<html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br></body></html>',
-    expectedLineAttribs: ['+l'],
-    expectedText: ['  word1  word2  word3'],
+    wantLineAttribs: ['+l'],
+    wantText: ['  word1  word2  word3'],
   },
   spacesAfterNewline: {
     description: 'Don\'t collapse spaces that follow a newline',
     html: '<!doctype html><html><body>something<br>             something<br></body></html>',
-    expectedLineAttribs: ['+9', '+m'],
-    expectedText: ['something', '             something'],
+    wantLineAttribs: ['+9', '+m'],
+    wantText: ['something', '             something'],
   },
   spacesAfterNewlineP: {
     description: 'Don\'t collapse spaces that follow a empty paragraph',
     html: '<!doctype html><html><body>something<p></p>             something<br></body></html>',
-    expectedLineAttribs: ['+9', '', '+m'],
-    expectedText: ['something', '', '             something'],
+    wantLineAttribs: ['+9', '', '+m'],
+    wantText: ['something', '', '             something'],
   },
   spacesAtEndOfLine: {
     description: 'Don\'t collapse spaces that preceed/follow a newline',
     html: '<html><body>something            <br>             something<br></body></html>',
-    expectedLineAttribs: ['+l', '+m'],
-    expectedText: ['something            ', '             something'],
+    wantLineAttribs: ['+l', '+m'],
+    wantText: ['something            ', '             something'],
   },
   spacesAtEndOfLineP: {
     description: 'Don\'t collapse spaces that preceed/follow a empty paragraph',
     html: '<html><body>something            <p></p>             something<br></body></html>',
-    expectedLineAttribs: ['+l', '', '+m'],
-    expectedText: ['something            ', '', '             something'],
+    wantLineAttribs: ['+l', '', '+m'],
+    wantText: ['something            ', '', '             something'],
   },
   nonBreakingSpacesAfterNewlines: {
     description: 'Don\'t collapse non-breaking spaces that follow a newline',
     html: '<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
-    expectedLineAttribs: ['+9', '+c'],
-    expectedText: ['something', '   something'],
+    wantLineAttribs: ['+9', '+c'],
+    wantText: ['something', '   something'],
   },
   nonBreakingSpacesAfterNewlinesP: {
     description: 'Don\'t collapse non-breaking spaces that follow a paragraph',
     html: '<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
-    expectedLineAttribs: ['+9', '', '+c'],
-    expectedText: ['something', '', '   something'],
+    wantLineAttribs: ['+9', '', '+c'],
+    wantText: ['something', '', '   something'],
   },
   preserveSpacesInsideElements: {
     description: 'Preserve all spaces when multiple are present',
     html: '<html><body>Need <span> more </span> space<i>  s </i> !<br></body></html>',
-    expectedLineAttribs: ['+h*0+4+2'],
-    expectedText: ['Need  more  space  s  !'],
+    wantLineAttribs: ['+h*0+4+2'],
+    wantText: ['Need  more  space  s  !'],
   },
   preserveSpacesAcrossNewlines: {
     description: 'Newlines and multiple spaces across newlines should be preserved',
@@ -201,14 +201,14 @@ const tests = {
           space
           <i>  s </i>
           !<br></body></html>`,
-    expectedLineAttribs: ['+19*0+4+b'],
-    expectedText: ['Need           more           space            s           !'],
+    wantLineAttribs: ['+19*0+4+b'],
+    wantText: ['Need           more           space            s           !'],
   },
   multipleNewLinesAtBeginning: {
     description: 'Multiple new lines at the beginning should be preserved',
     html: '<html><body><br><br><p></p><p></p>first line<br><br>second line<br></body></html>',
-    expectedLineAttribs: ['', '', '', '', '+a', '', '+b'],
-    expectedText: ['', '', '', '', 'first line', '', 'second line'],
+    wantLineAttribs: ['', '', '', '', '+a', '', '+b'],
+    wantText: ['', '', '', '', 'first line', '', 'second line'],
   },
   multiLineParagraph: {
     description: 'A paragraph with multiple lines should not loose spaces when lines are combined',
@@ -216,8 +216,8 @@ const tests = {
 а б в г ґ д е є ж з и і ї й к л м н о
 п р с т у ф х ц ч ш щ ю я ь</p>
 </body></html>`,
-    expectedLineAttribs: ['+1t'],
-    expectedText: ['а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь'],
+    wantLineAttribs: ['+1t'],
+    wantText: ['а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь'],
   },
   multiLineParagraphWithPre: {
     description: 'lines in preformatted text should be kept intact',
@@ -229,8 +229,8 @@ pre
 </pre><p>п р с т у ф х ц ч ш щ ю я
 ь</p>
 </body></html>`,
-    expectedLineAttribs: ['+11', '+8', '+5', '+2', '+3', '+r'],
-    expectedText: [
+    wantLineAttribs: ['+11', '+8', '+5', '+2', '+3', '+r'],
+    wantText: [
       'а б в г ґ д е є ж з и і ї й к л м н о',
       'multiple',
       'lines',
@@ -245,32 +245,32 @@ pre
     1
 </p><pre>preline
 </pre></body></html>`,
-    expectedLineAttribs: ['+6', '+7'],
-    expectedText: ['    1 ', 'preline'],
+    wantLineAttribs: ['+6', '+7'],
+    wantText: ['    1 ', 'preline'],
   },
   dontDeleteSpaceInsideElements: {
     description: 'Preserve spaces on the beginning and end of a element',
     html: '<html><body>Need<span> more </span>space<i> s </i>!<br></body></html>',
-    expectedLineAttribs: ['+f*0+3+1'],
-    expectedText: ['Need more space s !'],
+    wantLineAttribs: ['+f*0+3+1'],
+    wantText: ['Need more space s !'],
   },
   dontDeleteSpaceOutsideElements: {
     description: 'Preserve spaces outside elements',
     html: '<html><body>Need <span>more</span> space <i>s</i> !<br></body></html>',
-    expectedLineAttribs: ['+g*0+1+2'],
-    expectedText: ['Need more space s !'],
+    wantLineAttribs: ['+g*0+1+2'],
+    wantText: ['Need more space s !'],
   },
   dontDeleteSpaceAtEndOfElement: {
     description: 'Preserve spaces at the end of an element',
     html: '<html><body>Need <span>more </span>space <i>s </i>!<br></body></html>',
-    expectedLineAttribs: ['+g*0+2+1'],
-    expectedText: ['Need more space s !'],
+    wantLineAttribs: ['+g*0+2+1'],
+    wantText: ['Need more space s !'],
   },
   dontDeleteSpaceAtBeginOfElements: {
     description: 'Preserve spaces at the start of an element',
     html: '<html><body>Need<span> more</span> space<i> s</i> !<br></body></html>',
-    expectedLineAttribs: ['+f*0+2+2'],
-    expectedText: ['Need more space s !'],
+    wantLineAttribs: ['+f*0+2+2'],
+    wantText: ['Need more space s !'],
   },
 };
 
@@ -294,13 +294,13 @@ describe(__filename, function () {
         const cc = contentcollector.makeContentCollector(true, null, apool);
         cc.collectContent(doc);
         const result = cc.finish();
-        const recievedAttributes = result.lineAttribs;
-        const expectedAttributes = testObj.expectedLineAttribs;
-        const recievedText = new Array(result.lines);
-        const expectedText = testObj.expectedText;
+        const gotAttributes = result.lineAttribs;
+        const wantAttributes = testObj.wantLineAttribs;
+        const gotText = new Array(result.lines);
+        const wantText = testObj.wantText;
 
-        assert.deepEqual(recievedText[0], expectedText);
-        assert.deepEqual(recievedAttributes, expectedAttributes);
+        assert.deepEqual(gotText[0], wantText);
+        assert.deepEqual(gotAttributes, wantAttributes);
       });
     });
   }

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -78,12 +78,6 @@ const tests = {
     expectedText: ['*should be 1', 'hello', '*should be 1', '*should be 2', ''],
     noteToSelf: "Shouldn't include attribute marker in the <p> line",
   },
-  bulletListInOL: {
-    description: 'A bullet within an OL should not change numbering..',
-    html: '<html><body><ol><li>should be 1</li><ul><li>should be a bullet</li></ul><li>should be 2</li></ol><p></p></body></html>',
-    expectedLineAttribs: ['*0*1*2*3+1+b', '*0*4*2*3+1+i', '*0*1*2*5+1+b', ''],
-    expectedText: ['*should be 1', '*should be a bullet', '*should be 2', ''],
-  },
   testP: {
     description: 'A single <p></p> should create a new line',
     html: '<html><body><p></p><p></p></body></html>',

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -10,6 +10,7 @@
  */
 
 const AttributePool = require('ep_etherpad-lite/static/js/AttributePool');
+const assert = require('assert').strict;
 const cheerio = require('ep_etherpad-lite/node_modules/cheerio');
 const contentcollector = require('ep_etherpad-lite/static/js/contentcollector');
 
@@ -298,24 +299,8 @@ describe(__filename, function () {
         const recievedText = new Array(result.lines);
         const expectedText = testObj.expectedText;
 
-        // Check recieved text matches the expected text
-        if (arraysEqual(recievedText[0], expectedText)) {
-          // console.log("PASS: Recieved Text did match Expected Text\nRecieved:", recievedText[0], "\nExpected:", testObj.expectedText)
-        } else {
-          console.error('FAIL: Recieved Text did not match Expected Text\nRecieved:', recievedText[0], '\nExpected:', testObj.expectedText);
-          throw new Error();
-        }
-
-        // Check recieved attributes matches the expected attributes
-        if (arraysEqual(recievedAttributes, expectedAttributes)) {
-          // console.log("PASS: Recieved Attributes matched Expected Attributes");
-          done();
-        } else {
-          console.error('FAIL', test, testObj.description);
-          console.error('FAIL: Recieved Attributes did not match Expected Attributes\nRecieved: ', recievedAttributes, '\nExpected: ', expectedAttributes);
-          console.error('FAILING HTML', testObj.html);
-          throw new Error();
-        }
+        assert.deepEqual(recievedText[0], expectedText);
+        assert.deepEqual(recievedAttributes, expectedAttributes);
       });
     });
   }

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -284,7 +284,7 @@ describe(__filename, function () {
         });
       }
 
-      it(testObj.description, function (done) {
+      it(testObj.description, async function () {
         const $ = cheerio.load(testObj.html); // Load HTML into Cheerio
         const doc = $('body')[0]; // Creates a dom-like representation of HTML
         // Create an empty attribute pool

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -221,11 +221,11 @@ const tests = {
   multiLineParagraphWithPre: {
     description: 'lines in preformatted text should be kept intact',
     html: `<html><body><p>
-а б в г ґ д е є ж з и і ї й к л м н о<pre>multiple
+а б в г ґ д е є ж з и і ї й к л м н о</p><pre>multiple
 lines
 in
 pre
-</pre></p><p>п р с т у ф х ц ч ш щ ю я
+</pre><p>п р с т у ф х ц ч ш щ ю я
 ь</p>
 </body></html>`,
     expectedLineAttribs: ['+11', '+8', '+5', '+2', '+3', '+r'],
@@ -242,8 +242,8 @@ pre
     description: 'pre should be on a new line not preceeded by a space',
     html: `<html><body><p>
     1
-<pre>preline
-</pre></p></body></html>`,
+</p><pre>preline
+</pre></body></html>`,
     expectedLineAttribs: ['+6', '+7'],
     expectedText: ['    1 ', 'preline'],
   },

--- a/tests/backend/specs/contentcollector.js
+++ b/tests/backend/specs/contentcollector.js
@@ -1,18 +1,17 @@
 'use strict';
 
-/* eslint-disable max-len */
 /*
- * While importexport tests target the `setHTML` API endpoint, which is nearly identical to what happens
- * when a user manually imports a document via the UI, the contentcollector tests here don't use rehype to process
- * the document. Rehype removes spaces and newĺines were applicable, so the expected results here can
- * differ from importexport.js.
+ * While importexport tests target the `setHTML` API endpoint, which is nearly identical to what
+ * happens when a user manually imports a document via the UI, the contentcollector tests here don't
+ * use rehype to process the document. Rehype removes spaces and newĺines were applicable, so the
+ * expected results here can differ from importexport.js.
  *
  * If you add tests here, please also add them to importexport.js
  */
 
-const contentcollector = require('../../../src/static/js/contentcollector');
-const AttributePool = require('../../../src/static/js/AttributePool');
-const cheerio = require('../../../src/node_modules/cheerio');
+const AttributePool = require('ep_etherpad-lite/static/js/AttributePool');
+const cheerio = require('ep_etherpad-lite/node_modules/cheerio');
+const contentcollector = require('ep_etherpad-lite/static/js/contentcollector');
 
 const tests = {
   nestedLi: {
@@ -124,74 +123,74 @@ const tests = {
   lineWithMultipleSpaces: {
     description: 'Multiple spaces should be preserved',
     html: '<html><body>Text with  more   than    one space.<br></body></html>',
-    expectedLineAttribs: [ '+10' ],
-    expectedText: ['Text with  more   than    one space.']
+    expectedLineAttribs: ['+10'],
+    expectedText: ['Text with  more   than    one space.'],
   },
   lineWithMultipleNonBreakingAndNormalSpaces: {
     description: 'non-breaking and normal space should be preserved',
     html: '<html><body>Text&nbsp;with&nbsp; more&nbsp;&nbsp;&nbsp;than   &nbsp;one space.<br></body></html>',
-    expectedLineAttribs: [ '+10' ],
-    expectedText: ['Text with  more   than    one space.']
+    expectedLineAttribs: ['+10'],
+    expectedText: ['Text with  more   than    one space.'],
   },
   multiplenbsp: {
     description: 'Multiple nbsp should be preserved',
     html: '<html><body>&nbsp;&nbsp;<br></body></html>',
-    expectedLineAttribs: [ '+2' ],
-    expectedText: ['  ']
+    expectedLineAttribs: ['+2'],
+    expectedText: ['  '],
   },
   multipleNonBreakingSpaceBetweenWords: {
     description: 'Multiple nbsp between words ',
     html: '<html><body>&nbsp;&nbsp;word1&nbsp;&nbsp;word2&nbsp;&nbsp;&nbsp;word3<br></body></html>',
-    expectedLineAttribs: [ '+m' ],
-    expectedText: ['  word1  word2   word3']
+    expectedLineAttribs: ['+m'],
+    expectedText: ['  word1  word2   word3'],
   },
   nonBreakingSpacePreceededBySpaceBetweenWords: {
     description: 'A non-breaking space preceeded by a normal space',
     html: '<html><body> &nbsp;word1 &nbsp;word2 &nbsp;word3<br></body></html>',
-    expectedLineAttribs: [ '+l' ],
-    expectedText: ['  word1  word2  word3']
+    expectedLineAttribs: ['+l'],
+    expectedText: ['  word1  word2  word3'],
   },
   nonBreakingSpaceFollowededBySpaceBetweenWords: {
     description: 'A non-breaking space followed by a normal space',
     html: '<html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br></body></html>',
-    expectedLineAttribs: [ '+l' ],
-    expectedText: ['  word1  word2  word3']
+    expectedLineAttribs: ['+l'],
+    expectedText: ['  word1  word2  word3'],
   },
   spacesAfterNewline: {
     description: 'Don\'t collapse spaces that follow a newline',
-    html:'<!doctype html><html><body>something<br>             something<br></body></html>',
+    html: '<!doctype html><html><body>something<br>             something<br></body></html>',
     expectedLineAttribs: ['+9', '+m'],
-    expectedText: ['something', '             something']
+    expectedText: ['something', '             something'],
   },
   spacesAfterNewlineP: {
     description: 'Don\'t collapse spaces that follow a empty paragraph',
-    html:'<!doctype html><html><body>something<p></p>             something<br></body></html>',
+    html: '<!doctype html><html><body>something<p></p>             something<br></body></html>',
     expectedLineAttribs: ['+9', '', '+m'],
-    expectedText: ['something', '', '             something']
+    expectedText: ['something', '', '             something'],
   },
   spacesAtEndOfLine: {
     description: 'Don\'t collapse spaces that preceed/follow a newline',
-    html:'<html><body>something            <br>             something<br></body></html>',
+    html: '<html><body>something            <br>             something<br></body></html>',
     expectedLineAttribs: ['+l', '+m'],
-    expectedText: ['something            ', '             something']
+    expectedText: ['something            ', '             something'],
   },
   spacesAtEndOfLineP: {
     description: 'Don\'t collapse spaces that preceed/follow a empty paragraph',
-    html:'<html><body>something            <p></p>             something<br></body></html>',
+    html: '<html><body>something            <p></p>             something<br></body></html>',
     expectedLineAttribs: ['+l', '', '+m'],
-    expectedText: ['something            ', '', '             something']
+    expectedText: ['something            ', '', '             something'],
   },
   nonBreakingSpacesAfterNewlines: {
     description: 'Don\'t collapse non-breaking spaces that follow a newline',
-    html:'<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
+    html: '<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
     expectedLineAttribs: ['+9', '+c'],
-    expectedText: ['something', '   something']
+    expectedText: ['something', '   something'],
   },
   nonBreakingSpacesAfterNewlinesP: {
     description: 'Don\'t collapse non-breaking spaces that follow a paragraph',
-    html:'<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
+    html: '<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
     expectedLineAttribs: ['+9', '', '+c'],
-    expectedText: ['something', '', '   something']
+    expectedText: ['something', '', '   something'],
   },
   preserveSpacesInsideElements: {
     description: 'Preserve all spaces when multiple are present',
@@ -207,27 +206,27 @@ const tests = {
           space
           <i>  s </i>
           !<br></body></html>`,
-    expectedLineAttribs: [ '+19*0+4+b' ],
-    expectedText: [ 'Need           more           space            s           !' ]
+    expectedLineAttribs: ['+19*0+4+b'],
+    expectedText: ['Need           more           space            s           !'],
   },
   multipleNewLinesAtBeginning: {
     description: 'Multiple new lines at the beginning should be preserved',
     html: '<html><body><br><br><p></p><p></p>first line<br><br>second line<br></body></html>',
     expectedLineAttribs: ['', '', '', '', '+a', '', '+b'],
-    expectedText: [ '', '', '', '', 'first line', '', 'second line']
+    expectedText: ['', '', '', '', 'first line', '', 'second line'],
   },
-  multiLineParagraph:{
-    description: "A paragraph with multiple lines should not loose spaces when lines are combined",
-    html:`<html><body><p>
+  multiLineParagraph: {
+    description: 'A paragraph with multiple lines should not loose spaces when lines are combined',
+    html: `<html><body><p>
 а б в г ґ д е є ж з и і ї й к л м н о
 п р с т у ф х ц ч ш щ ю я ь</p>
 </body></html>`,
-    expectedLineAttribs: [ '+1t' ],
-    expectedText: ["а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь"]
+    expectedLineAttribs: ['+1t'],
+    expectedText: ['а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь'],
   },
-  multiLineParagraphWithPre:{
-    description: "lines in preformatted text should be kept intact",
-    html:`<html><body><p>
+  multiLineParagraphWithPre: {
+    description: 'lines in preformatted text should be kept intact',
+    html: `<html><body><p>
 а б в г ґ д е є ж з и і ї й к л м н о<pre>multiple
 lines
 in
@@ -235,41 +234,48 @@ pre
 </pre></p><p>п р с т у ф х ц ч ш щ ю я
 ь</p>
 </body></html>`,
-    expectedLineAttribs: [ '+11', '+8', '+5', '+2', '+3', '+r' ],
-    expectedText: ['а б в г ґ д е є ж з и і ї й к л м н о', 'multiple', 'lines', 'in', 'pre', 'п р с т у ф х ц ч ш щ ю я ь']
+    expectedLineAttribs: ['+11', '+8', '+5', '+2', '+3', '+r'],
+    expectedText: [
+      'а б в г ґ д е є ж з и і ї й к л м н о',
+      'multiple',
+      'lines',
+      'in',
+      'pre',
+      'п р с т у ф х ц ч ш щ ю я ь',
+    ],
   },
   preIntroducesASpace: {
-    description: "pre should be on a new line not preceeded by a space",
-    html:`<html><body><p>
+    description: 'pre should be on a new line not preceeded by a space',
+    html: `<html><body><p>
     1
 <pre>preline
 </pre></p></body></html>`,
-    expectedLineAttribs: [ '+6', '+7' ],
-    expectedText: ['    1 ', 'preline']
+    expectedLineAttribs: ['+6', '+7'],
+    expectedText: ['    1 ', 'preline'],
   },
   dontDeleteSpaceInsideElements: {
     description: 'Preserve spaces on the beginning and end of a element',
     html: '<html><body>Need<span> more </span>space<i> s </i>!<br></body></html>',
     expectedLineAttribs: ['+f*0+3+1'],
-    expectedText: ['Need more space s !']
+    expectedText: ['Need more space s !'],
   },
   dontDeleteSpaceOutsideElements: {
     description: 'Preserve spaces outside elements',
     html: '<html><body>Need <span>more</span> space <i>s</i> !<br></body></html>',
     expectedLineAttribs: ['+g*0+1+2'],
-    expectedText: ['Need more space s !']
+    expectedText: ['Need more space s !'],
   },
   dontDeleteSpaceAtEndOfElement: {
     description: 'Preserve spaces at the end of an element',
     html: '<html><body>Need <span>more </span>space <i>s </i>!<br></body></html>',
     expectedLineAttribs: ['+g*0+2+1'],
-    expectedText: ['Need more space s !']
+    expectedText: ['Need more space s !'],
   },
   dontDeleteSpaceAtBeginOfElements: {
     description: 'Preserve spaces at the start of an element',
     html: '<html><body>Need<span> more</span> space<i> s</i> !<br></body></html>',
     expectedLineAttribs: ['+f*0+2+2'],
-    expectedText: ['Need more space s !']
+    expectedText: ['Need more space s !'],
   },
 };
 
@@ -325,7 +331,7 @@ describe(__filename, function () {
 function arraysEqual(a, b) {
   if (a === b) return true;
   if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
+  if (a.length !== b.length) return false;
 
   // If you don't care about the order of the elements inside
   // the array, you should sort both arrays here.


### PR DESCRIPTION
Multiple commits:
* lint: Fix some straightforward ESLint errors
* tests: Re-enable import/export test that is now working
* tests: Delete invalid contentcollector test
* tests: Fix invalid HTML in contentcollector tests
* tests: Delete erroneous `describe()` calls
* tests: Use `assert.deepEqual()` to simplify equality checks
* tests: Replace "expected" with "want", "received" with "got"
* tests: Fix missing call to `done` callback
* openapi: Fix error logging
* contentcollector: Delete unused `domInterface` parameter
* contentcollector: Document the `dom` object
* contentcollector: Factor out call to `.toLowerCase()`
* contentcollector: Fix Element attribute accesses
* contentcollector: Rename `dom` functions for consistency with DOM spec
* contentcollector: Avoid `for..in` iteration of object properties
* contentcollector: Fix iteration over child Nodes
* contentcollector: Delete unnecessary truthiness check
* contentcollector: Invert logic to improve readability
* contentcollector: Use destructuring to improve readability
* contentcollector: Fix collectContentLineText hook
* contentcollector: Delete unnecessary parentheses
* contentcollector: Fix parent node access
* contentcollector: Fix Element tag name fetch
* contentcollector: Skip over non-Text, non-Element Nodes
* contentcollector: Simplify child node access
* contentcollector: Delete unnecessary `dom` functions

cc @webzwo0i