### PR TITLE
Rework server shutdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -870,7 +870,8 @@
         "tinycon": "0.0.1",
         "ueberdb2": "^1.2.5",
         "underscore": "1.8.3",
-        "unorm": "1.4.1"
+        "unorm": "1.4.1",
+        "wtfnode": "^0.8.4"
       },
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": {
@@ -10576,6 +10577,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "wtfnode": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.4.tgz",
+      "integrity": "sha512-64GEKtMt/MUBuAm+8kHqP74ojjafzu00aT0JKsmkIwYmjRQ/odO0yhbzKLm+Z9v1gMla+8dwITRKzTAlHsB+Og=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -77,6 +77,9 @@ exports.start = async () => {
   }
 
   process.on('uncaughtException', exports.exit);
+  // As of v14, Node.js does not exit when there is an unhandled Promise rejection. Convert an
+  // unhandled rejection into an uncaught exception, which does cause Node.js to exit.
+  process.on('unhandledRejection', (err) => { throw err; });
 
   /*
    * Connect graceful shutdown with sigint and uncaught exception

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -106,12 +106,15 @@ exports.stop = async () => {
   if (stopped) return;
   stopped = true;
   console.log('Stopping Etherpad...');
-  await new Promise(async (resolve, reject) => {
-    const id = setTimeout(() => reject(new Error('Timed out waiting for shutdown tasks')), 3000);
-    await hooks.aCallAll('shutdown');
-    clearTimeout(id);
-    resolve();
-  });
+  let timeout = null;
+  await Promise.race([
+    hooks.aCallAll('shutdown'),
+    new Promise((resolve, reject) => {
+      timeout = setTimeout(() => reject(new Error('Timed out waiting for shutdown tasks')), 3000);
+    }),
+  ]);
+  clearTimeout(timeout);
+  console.log('Etherpad stopped');
 };
 
 exports.exit = async (err) => {

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -27,6 +27,10 @@
 const log4js = require('log4js');
 log4js.replaceConsole();
 
+// wtfnode should be loaded after log4js.replaceConsole() so that it uses log4js for logging, and it
+// should be above everything else so that it can hook in before resources are used.
+const wtfnode = require('wtfnode');
+
 /*
  * early check for version compatibility before calling
  * any modules that require newer versions of NodeJS
@@ -211,6 +215,7 @@ exports.exit = async (err = null) => {
   setTimeout(() => {
     console.error('Something that should have been cleaned up during the shutdown hook (such as ' +
                   'a timer, worker thread, or open connection) is preventing Node.js from exiting');
+    wtfnode.dump();
     console.error('Forcing an unclean exit...');
     process.exit(1);
   }, 5000).unref();

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8659,6 +8659,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
       "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
+    "wtfnode": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.4.tgz",
+      "integrity": "sha512-64GEKtMt/MUBuAm+8kHqP74ojjafzu00aT0JKsmkIwYmjRQ/odO0yhbzKLm+Z9v1gMla+8dwITRKzTAlHsB+Og=="
+    },
     "xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -72,7 +72,8 @@
     "tinycon": "0.0.1",
     "ueberdb2": "^1.2.5",
     "underscore": "1.8.3",
-    "unorm": "1.4.1"
+    "unorm": "1.4.1",
+    "wtfnode": "^0.8.4"
   },
   "bin": {
     "etherpad-lite": "node/server.js"

--- a/tests/backend/common.js
+++ b/tests/backend/common.js
@@ -50,10 +50,10 @@ exports.init = async function () {
 
   after(async function () {
     webaccess.authnFailureDelayMs = backups.authnFailureDelayMs;
-    await server.stop();
     // Note: This does not unset settings that were added.
     Object.assign(settings, backups.settings);
     log4js.setGlobalLogLevel(logLevel);
+    await server.exit();
   });
 
   return exports.agent;


### PR DESCRIPTION
I'm dusting off some old commits I had in the works a while ago:
* server: Exit on unhandled Promise rejection
* server: Perform init after adding uncaught exception handler
* server: Refactor `stop()` to avoid no-async-promise-executor lint error
* server: Refine process lifetime management
* server: Remove all other signal listeners
* server: Use wtfnode to log reasons why node isn't exiting

I'm hoping this PR will avoid whatever is causing #4684.