### PR TITLE
bin scripts: Various fixes and cleanups

### DIFF
--- a/bin/checkAllPads.js
+++ b/bin/checkAllPads.js
@@ -30,7 +30,7 @@ npm.load({}, async () => {
       const pad = await padManager.getPad(padId);
 
       // check if the pad has a pool
-      if (pad.pool === undefined) {
+      if (pad.pool == null) {
         console.error(`[${pad.id}] Missing attribute pool`);
         continue;
       }
@@ -66,7 +66,7 @@ npm.load({}, async () => {
         }
 
         // check if there is a atext in the keyRevisions
-        if (revisions[keyRev].meta === undefined || revisions[keyRev].meta.atext === undefined) {
+        if (revisions[keyRev].meta == null || revisions[keyRev].meta.atext == null) {
           console.error(`[${pad.id}] Missing atext in revision ${keyRev}`);
           continue;
         }

--- a/bin/checkAllPads.js
+++ b/bin/checkAllPads.js
@@ -66,13 +66,13 @@ npm.load({}, async () => {
         }
 
         // check if there is a atext in the keyRevisions
-        if (revisions[keyRev].meta == null || revisions[keyRev].meta.atext == null) {
+        let {meta: {atext} = {}} = revisions[keyRev];
+        if (atext == null) {
           console.error(`[${pad.id}] Missing atext in revision ${keyRev}`);
           continue;
         }
 
         const apool = pad.pool;
-        let atext = revisions[keyRev].meta.atext;
         for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
           try {
             const cs = revisions[rev].changeset;

--- a/bin/checkAllPads.js
+++ b/bin/checkAllPads.js
@@ -15,84 +15,79 @@ if (process.argv.length !== 2) throw new Error('Use: node bin/checkAllPads.js');
 (async () => {
   await util.promisify(npm.load)({});
 
-  try {
-    // initialize the database
-    require('ep_etherpad-lite/node/utils/Settings');
-    const db = require('ep_etherpad-lite/node/db/DB');
-    await db.init();
+  // initialize the database
+  require('ep_etherpad-lite/node/utils/Settings');
+  const db = require('ep_etherpad-lite/node/db/DB');
+  await db.init();
 
-    // load modules
-    const Changeset = require('ep_etherpad-lite/static/js/Changeset');
-    const padManager = require('ep_etherpad-lite/node/db/PadManager');
+  // load modules
+  const Changeset = require('ep_etherpad-lite/static/js/Changeset');
+  const padManager = require('ep_etherpad-lite/node/db/PadManager');
 
-    let revTestedCount = 0;
+  let revTestedCount = 0;
 
-    // get all pads
-    const res = await padManager.listAllPads();
-    for (const padId of res.padIDs) {
-      const pad = await padManager.getPad(padId);
+  // get all pads
+  const res = await padManager.listAllPads();
+  for (const padId of res.padIDs) {
+    const pad = await padManager.getPad(padId);
 
-      // check if the pad has a pool
-      if (pad.pool == null) {
-        console.error(`[${pad.id}] Missing attribute pool`);
+    // check if the pad has a pool
+    if (pad.pool == null) {
+      console.error(`[${pad.id}] Missing attribute pool`);
+      continue;
+    }
+    // create an array with key kevisions
+    // key revisions always save the full pad atext
+    const head = pad.getHeadRevisionNumber();
+    const keyRevisions = [];
+    for (let rev = 0; rev < head; rev += 100) {
+      keyRevisions.push(rev);
+    }
+
+    // run through all key revisions
+    for (const keyRev of keyRevisions) {
+      // create an array of revisions we need till the next keyRevision or the End
+      const revisionsNeeded = [];
+      for (let rev = keyRev; rev <= keyRev + 100 && rev <= head; rev++) {
+        revisionsNeeded.push(rev);
+      }
+
+      // this array will hold all revision changesets
+      const revisions = [];
+
+      // run through all needed revisions and get them from the database
+      for (const revNum of revisionsNeeded) {
+        const revision = await db.get(`pad:${pad.id}:revs:${revNum}`);
+        revisions[revNum] = revision;
+      }
+
+      // check if the revision exists
+      if (revisions[keyRev] == null) {
+        console.error(`[${pad.id}] Missing revision ${keyRev}`);
         continue;
       }
-      // create an array with key kevisions
-      // key revisions always save the full pad atext
-      const head = pad.getHeadRevisionNumber();
-      const keyRevisions = [];
-      for (let rev = 0; rev < head; rev += 100) {
-        keyRevisions.push(rev);
+
+      // check if there is a atext in the keyRevisions
+      let {meta: {atext} = {}} = revisions[keyRev];
+      if (atext == null) {
+        console.error(`[${pad.id}] Missing atext in revision ${keyRev}`);
+        continue;
       }
 
-      // run through all key revisions
-      for (const keyRev of keyRevisions) {
-        // create an array of revisions we need till the next keyRevision or the End
-        const revisionsNeeded = [];
-        for (let rev = keyRev; rev <= keyRev + 100 && rev <= head; rev++) {
-          revisionsNeeded.push(rev);
-        }
-
-        // this array will hold all revision changesets
-        const revisions = [];
-
-        // run through all needed revisions and get them from the database
-        for (const revNum of revisionsNeeded) {
-          const revision = await db.get(`pad:${pad.id}:revs:${revNum}`);
-          revisions[revNum] = revision;
-        }
-
-        // check if the revision exists
-        if (revisions[keyRev] == null) {
-          console.error(`[${pad.id}] Missing revision ${keyRev}`);
-          continue;
-        }
-
-        // check if there is a atext in the keyRevisions
-        let {meta: {atext} = {}} = revisions[keyRev];
-        if (atext == null) {
-          console.error(`[${pad.id}] Missing atext in revision ${keyRev}`);
-          continue;
-        }
-
-        const apool = pad.pool;
-        for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
-          try {
-            const cs = revisions[rev].changeset;
-            atext = Changeset.applyToAText(cs, atext, apool);
-            revTestedCount++;
-          } catch (e) {
-            console.error(`[${pad.id}] Bad changeset at revision ${rev} - ${e.message}`);
-          }
+      const apool = pad.pool;
+      for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
+        try {
+          const cs = revisions[rev].changeset;
+          atext = Changeset.applyToAText(cs, atext, apool);
+          revTestedCount++;
+        } catch (e) {
+          console.error(`[${pad.id}] Bad changeset at revision ${rev} - ${e.message}`);
         }
       }
     }
-    if (revTestedCount === 0) {
-      throw new Error('No revisions tested');
-    }
-    console.log(`Finished: Tested ${revTestedCount} revisions`);
-  } catch (err) {
-    console.trace(err);
-    throw err;
   }
+  if (revTestedCount === 0) {
+    throw new Error('No revisions tested');
+  }
+  console.log(`Finished: Tested ${revTestedCount} revisions`);
 })();

--- a/bin/checkAllPads.js
+++ b/bin/checkAllPads.js
@@ -7,11 +7,14 @@
 // unhandled rejection into an uncaught exception, which does cause Node.js to exit.
 process.on('unhandledRejection', (err) => { throw err; });
 
+const npm = require('ep_etherpad-lite/node_modules/npm');
+const util = require('util');
+
 if (process.argv.length !== 2) throw new Error('Use: node bin/checkAllPads.js');
 
-// load and initialize NPM
-const npm = require('ep_etherpad-lite/node_modules/npm');
-npm.load({}, async () => {
+(async () => {
+  await util.promisify(npm.load)({});
+
   try {
     // initialize the database
     require('ep_etherpad-lite/node/utils/Settings');
@@ -92,4 +95,4 @@ npm.load({}, async () => {
     console.trace(err);
     throw err;
   }
-});
+})();

--- a/bin/checkPad.js
+++ b/bin/checkPad.js
@@ -62,15 +62,13 @@ npm.load({}, async () => {
       if (pad.pool == null) throw new Error('Attribute pool is missing');
 
       // check if there is an atext in the keyRevisions
-      if (revisions[keyRev] == null ||
-          revisions[keyRev].meta == null ||
-          revisions[keyRev].meta.atext == null) {
+      let {meta: {atext} = {}} = revisions[keyRev] || {};
+      if (atext == null) {
         console.error(`No atext in key revision ${keyRev}`);
         continue;
       }
 
       const apool = pad.pool;
-      let atext = revisions[keyRev].meta.atext;
 
       for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
         checkRevisionCount++;

--- a/bin/checkPad.js
+++ b/bin/checkPad.js
@@ -7,15 +7,18 @@
 // unhandled rejection into an uncaught exception, which does cause Node.js to exit.
 process.on('unhandledRejection', (err) => { throw err; });
 
+const npm = require('ep_etherpad-lite/node_modules/npm');
+const util = require('util');
+
 if (process.argv.length !== 3) throw new Error('Use: node bin/checkPad.js $PADID');
 
 // get the padID
 const padId = process.argv[2];
 let checkRevisionCount = 0;
 
-// load and initialize NPM;
-const npm = require('ep_etherpad-lite/node_modules/npm');
-npm.load({}, async () => {
+(async () => {
+  await util.promisify(npm.load)({});
+
   try {
     // initialize database
     require('ep_etherpad-lite/node/utils/Settings');
@@ -86,4 +89,4 @@ npm.load({}, async () => {
     console.trace(err);
     throw err;
   }
-});
+})();

--- a/bin/checkPad.js
+++ b/bin/checkPad.js
@@ -19,74 +19,69 @@ let checkRevisionCount = 0;
 (async () => {
   await util.promisify(npm.load)({});
 
-  try {
-    // initialize database
-    require('ep_etherpad-lite/node/utils/Settings');
-    const db = require('ep_etherpad-lite/node/db/DB');
-    await db.init();
+  // initialize database
+  require('ep_etherpad-lite/node/utils/Settings');
+  const db = require('ep_etherpad-lite/node/db/DB');
+  await db.init();
 
-    // load modules
-    const Changeset = require('ep_etherpad-lite/static/js/Changeset');
-    const padManager = require('ep_etherpad-lite/node/db/PadManager');
+  // load modules
+  const Changeset = require('ep_etherpad-lite/static/js/Changeset');
+  const padManager = require('ep_etherpad-lite/node/db/PadManager');
 
-    const exists = await padManager.doesPadExists(padId);
-    if (!exists) throw new Error('Pad does not exist');
+  const exists = await padManager.doesPadExists(padId);
+  if (!exists) throw new Error('Pad does not exist');
 
-    // get the pad
-    const pad = await padManager.getPad(padId);
+  // get the pad
+  const pad = await padManager.getPad(padId);
 
-    // create an array with key revisions
-    // key revisions always save the full pad atext
-    const head = pad.getHeadRevisionNumber();
-    const keyRevisions = [];
-    for (let rev = 0; rev < head; rev += 100) {
-      keyRevisions.push(rev);
+  // create an array with key revisions
+  // key revisions always save the full pad atext
+  const head = pad.getHeadRevisionNumber();
+  const keyRevisions = [];
+  for (let rev = 0; rev < head; rev += 100) {
+    keyRevisions.push(rev);
+  }
+
+  // run through all key revisions
+  for (let keyRev of keyRevisions) {
+    keyRev = parseInt(keyRev);
+    // create an array of revisions we need till the next keyRevision or the End
+    const revisionsNeeded = [];
+    for (let rev = keyRev; rev <= keyRev + 100 && rev <= head; rev++) {
+      revisionsNeeded.push(rev);
     }
 
-    // run through all key revisions
-    for (let keyRev of keyRevisions) {
-      keyRev = parseInt(keyRev);
-      // create an array of revisions we need till the next keyRevision or the End
-      const revisionsNeeded = [];
-      for (let rev = keyRev; rev <= keyRev + 100 && rev <= head; rev++) {
-        revisionsNeeded.push(rev);
-      }
+    // this array will hold all revision changesets
+    const revisions = [];
 
-      // this array will hold all revision changesets
-      const revisions = [];
+    // run through all needed revisions and get them from the database
+    for (const revNum of revisionsNeeded) {
+      const revision = await db.get(`pad:${padId}:revs:${revNum}`);
+      revisions[revNum] = revision;
+    }
 
-      // run through all needed revisions and get them from the database
-      for (const revNum of revisionsNeeded) {
-        const revision = await db.get(`pad:${padId}:revs:${revNum}`);
-        revisions[revNum] = revision;
-      }
+    // check if the pad has a pool
+    if (pad.pool == null) throw new Error('Attribute pool is missing');
 
-      // check if the pad has a pool
-      if (pad.pool == null) throw new Error('Attribute pool is missing');
+    // check if there is an atext in the keyRevisions
+    let {meta: {atext} = {}} = revisions[keyRev] || {};
+    if (atext == null) {
+      console.error(`No atext in key revision ${keyRev}`);
+      continue;
+    }
 
-      // check if there is an atext in the keyRevisions
-      let {meta: {atext} = {}} = revisions[keyRev] || {};
-      if (atext == null) {
-        console.error(`No atext in key revision ${keyRev}`);
+    const apool = pad.pool;
+
+    for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
+      checkRevisionCount++;
+      try {
+        const cs = revisions[rev].changeset;
+        atext = Changeset.applyToAText(cs, atext, apool);
+      } catch (e) {
+        console.error(`Bad changeset at revision ${rev} - ${e.message}`);
         continue;
       }
-
-      const apool = pad.pool;
-
-      for (let rev = keyRev + 1; rev <= keyRev + 100 && rev <= head; rev++) {
-        checkRevisionCount++;
-        try {
-          const cs = revisions[rev].changeset;
-          atext = Changeset.applyToAText(cs, atext, apool);
-        } catch (e) {
-          console.error(`Bad changeset at revision ${rev} - ${e.message}`);
-          continue;
-        }
-      }
-      console.log(`Finished: Checked ${checkRevisionCount} revisions`);
     }
-  } catch (err) {
-    console.trace(err);
-    throw err;
+    console.log(`Finished: Checked ${checkRevisionCount} revisions`);
   }
 })();

--- a/bin/checkPad.js
+++ b/bin/checkPad.js
@@ -59,12 +59,12 @@ npm.load({}, async () => {
       }
 
       // check if the pad has a pool
-      if (pad.pool === undefined) throw new Error('Attribute pool is missing');
+      if (pad.pool == null) throw new Error('Attribute pool is missing');
 
       // check if there is an atext in the keyRevisions
-      if (revisions[keyRev] === undefined ||
-          revisions[keyRev].meta === undefined ||
-          revisions[keyRev].meta.atext === undefined) {
+      if (revisions[keyRev] == null ||
+          revisions[keyRev].meta == null ||
+          revisions[keyRev].meta.atext == null) {
         console.error(`No atext in key revision ${keyRev}`);
         continue;
       }

--- a/bin/checkPadDeltas.js
+++ b/bin/checkPadDeltas.js
@@ -12,12 +12,14 @@ if (process.argv.length !== 3) throw new Error('Use: node bin/checkPadDeltas.js 
 // get the padID
 const padId = process.argv[2];
 
-// load and initialize NPM;
 const expect = require('../tests/frontend/lib/expect');
 const diff = require('ep_etherpad-lite/node_modules/diff');
 const npm = require('ep_etherpad-lite/node_modules/npm');
+const util = require('util');
 
-npm.load({}, async () => {
+(async () => {
+  await util.promisify(npm.load)({});
+
   // initialize database
   require('ep_etherpad-lite/node/utils/Settings');
   const db = require('ep_etherpad-lite/node/db/DB');
@@ -102,4 +104,4 @@ npm.load({}, async () => {
       }
     }));
   }
-});
+})();

--- a/bin/checkPadDeltas.js
+++ b/bin/checkPadDeltas.js
@@ -54,8 +54,8 @@ npm.load({}, async () => {
     // console.log('Fetching', revNum)
     const revision = await db.get(`pad:${padId}:revs:${revNum}`);
     // check if there is a atext in the keyRevisions
-    if (~keyRevisions.indexOf(revNum) &&
-        (revision == null || revision.meta == null || revision.meta.atext == null)) {
+    const {meta: {atext: revAtext} = {}} = revision || {};
+    if (~keyRevisions.indexOf(revNum) && revAtext == null) {
       console.error(`No atext in key revision ${revNum}`);
       continue;
     }

--- a/bin/checkPadDeltas.js
+++ b/bin/checkPadDeltas.js
@@ -55,9 +55,7 @@ npm.load({}, async () => {
     const revision = await db.get(`pad:${padId}:revs:${revNum}`);
     // check if there is a atext in the keyRevisions
     if (~keyRevisions.indexOf(revNum) &&
-        (revision === undefined ||
-         revision.meta === undefined ||
-         revision.meta.atext === undefined)) {
+        (revision == null || revision.meta == null || revision.meta.atext == null)) {
       console.error(`No atext in key revision ${revNum}`);
       continue;
     }

--- a/bin/extractPadData.js
+++ b/bin/extractPadData.js
@@ -16,9 +16,10 @@ if (process.argv.length !== 3) throw new Error('Use: node extractPadData.js $PAD
 const padId = process.argv[2];
 
 const npm = require('ep_etherpad-lite/node_modules/npm');
+const util = require('util');
 
-npm.load({}, async (err) => {
-  if (err) throw err;
+(async () => {
+  await util.promisify(npm.load)({});
 
   try {
     // initialize database
@@ -29,7 +30,6 @@ npm.load({}, async (err) => {
     // load extra modules
     const dirtyDB = require('ep_etherpad-lite/node_modules/dirty');
     const padManager = require('ep_etherpad-lite/node/db/PadManager');
-    const util = require('util');
 
     // initialize output database
     const dirty = dirtyDB(`${padId}.db`);
@@ -71,4 +71,4 @@ npm.load({}, async (err) => {
     console.error(err);
     throw err;
   }
-});
+})();

--- a/bin/extractPadData.js
+++ b/bin/extractPadData.js
@@ -21,54 +21,49 @@ const util = require('util');
 (async () => {
   await util.promisify(npm.load)({});
 
-  try {
-    // initialize database
-    require('ep_etherpad-lite/node/utils/Settings');
-    const db = require('ep_etherpad-lite/node/db/DB');
-    await db.init();
+  // initialize database
+  require('ep_etherpad-lite/node/utils/Settings');
+  const db = require('ep_etherpad-lite/node/db/DB');
+  await db.init();
 
-    // load extra modules
-    const dirtyDB = require('ep_etherpad-lite/node_modules/dirty');
-    const padManager = require('ep_etherpad-lite/node/db/PadManager');
+  // load extra modules
+  const dirtyDB = require('ep_etherpad-lite/node_modules/dirty');
+  const padManager = require('ep_etherpad-lite/node/db/PadManager');
 
-    // initialize output database
-    const dirty = dirtyDB(`${padId}.db`);
+  // initialize output database
+  const dirty = dirtyDB(`${padId}.db`);
 
-    // Promise wrapped get and set function
-    const wrapped = db.db.db.wrappedDB;
-    const get = util.promisify(wrapped.get.bind(wrapped));
-    const set = util.promisify(dirty.set.bind(dirty));
+  // Promise wrapped get and set function
+  const wrapped = db.db.db.wrappedDB;
+  const get = util.promisify(wrapped.get.bind(wrapped));
+  const set = util.promisify(dirty.set.bind(dirty));
 
-    // array in which required key values will be accumulated
-    const neededDBValues = [`pad:${padId}`];
+  // array in which required key values will be accumulated
+  const neededDBValues = [`pad:${padId}`];
 
-    // get the actual pad object
-    const pad = await padManager.getPad(padId);
+  // get the actual pad object
+  const pad = await padManager.getPad(padId);
 
-    // add all authors
-    neededDBValues.push(...pad.getAllAuthors().map((author) => `globalAuthor:${author}`));
+  // add all authors
+  neededDBValues.push(...pad.getAllAuthors().map((author) => `globalAuthor:${author}`));
 
-    // add all revisions
-    for (let rev = 0; rev <= pad.head; ++rev) {
-      neededDBValues.push(`pad:${padId}:revs:${rev}`);
-    }
-
-    // add all chat values
-    for (let chat = 0; chat <= pad.chatHead; ++chat) {
-      neededDBValues.push(`pad:${padId}:chat:${chat}`);
-    }
-
-    for (const dbkey of neededDBValues) {
-      let dbvalue = await get(dbkey);
-      if (dbvalue && typeof dbvalue !== 'object') {
-        dbvalue = JSON.parse(dbvalue);
-      }
-      await set(dbkey, dbvalue);
-    }
-
-    console.log('finished');
-  } catch (err) {
-    console.error(err);
-    throw err;
+  // add all revisions
+  for (let rev = 0; rev <= pad.head; ++rev) {
+    neededDBValues.push(`pad:${padId}:revs:${rev}`);
   }
+
+  // add all chat values
+  for (let chat = 0; chat <= pad.chatHead; ++chat) {
+    neededDBValues.push(`pad:${padId}:chat:${chat}`);
+  }
+
+  for (const dbkey of neededDBValues) {
+    let dbvalue = await get(dbkey);
+    if (dbvalue && typeof dbvalue !== 'object') {
+      dbvalue = JSON.parse(dbvalue);
+    }
+    await set(dbkey, dbvalue);
+  }
+
+  console.log('finished');
 })();

--- a/bin/importSqlFile.js
+++ b/bin/importSqlFile.js
@@ -71,42 +71,35 @@ const unescape = (val) => {
   if (!sqlFile) throw new Error('Use: node importSqlFile.js $SQLFILE');
 
   log('initializing db');
-  db.init((err) => {
-    // there was an error while initializing the database, output it and stop
-    if (err) {
-      throw err;
-    } else {
-      log('done');
+  await util.promisify(db.init.bind(db))();
+  log('done');
 
-      log('open output file...');
-      const lines = fs.readFileSync(sqlFile, 'utf8').split('\n');
+  log('open output file...');
+  const lines = fs.readFileSync(sqlFile, 'utf8').split('\n');
 
-      const count = lines.length;
-      let keyNo = 0;
+  const count = lines.length;
+  let keyNo = 0;
 
-      process.stdout.write(`Start importing ${count} keys...\n`);
-      lines.forEach((l) => {
-        if (l.substr(0, 27) === 'REPLACE INTO store VALUES (') {
-          const pos = l.indexOf("', '");
-          const key = l.substr(28, pos - 28);
-          let value = l.substr(pos + 3);
-          value = value.substr(0, value.length - 2);
-          console.log(`key: ${key} val: ${value}`);
-          console.log(`unval: ${unescape(value)}`);
-          db.set(key, unescape(value), null);
-          keyNo++;
-          if (keyNo % 1000 === 0) {
-            process.stdout.write(` ${keyNo}/${count}\n`);
-          }
-        }
-      });
-      process.stdout.write('\n');
-      process.stdout.write('done. waiting for db to finish transaction. ' +
-                           'depended on dbms this may take some time..\n');
-
-      db.close(() => {
-        log(`finished, imported ${keyNo} keys.`);
-      });
+  process.stdout.write(`Start importing ${count} keys...\n`);
+  lines.forEach((l) => {
+    if (l.substr(0, 27) === 'REPLACE INTO store VALUES (') {
+      const pos = l.indexOf("', '");
+      const key = l.substr(28, pos - 28);
+      let value = l.substr(pos + 3);
+      value = value.substr(0, value.length - 2);
+      console.log(`key: ${key} val: ${value}`);
+      console.log(`unval: ${unescape(value)}`);
+      db.set(key, unescape(value), null);
+      keyNo++;
+      if (keyNo % 1000 === 0) {
+        process.stdout.write(` ${keyNo}/${count}\n`);
+      }
     }
   });
+  process.stdout.write('\n');
+  process.stdout.write('done. waiting for db to finish transaction. ' +
+                       'depended on dbms this may take some time..\n');
+
+  await util.promisify(db.close.bind(db))();
+  log(`finished, imported ${keyNo} keys.`);
 })();

--- a/bin/importSqlFile.js
+++ b/bin/importSqlFile.js
@@ -4,6 +4,9 @@
 // unhandled rejection into an uncaught exception, which does cause Node.js to exit.
 process.on('unhandledRejection', (err) => { throw err; });
 
+const npm = require('ep_etherpad-lite/node_modules/npm');
+const util = require('util');
+
 const startTime = Date.now();
 
 const log = (str) => {
@@ -43,10 +46,10 @@ const unescape = (val) => {
   return val;
 };
 
+(async () => {
+  await util.promisify(npm.load)({});
 
-require('ep_etherpad-lite/node_modules/npm').load({}, (er, npm) => {
   const fs = require('fs');
-
   const ueberDB = require('ep_etherpad-lite/node_modules/ueberdb2');
   const settings = require('ep_etherpad-lite/node/utils/Settings');
   const log4js = require('ep_etherpad-lite/node_modules/log4js');
@@ -106,4 +109,4 @@ require('ep_etherpad-lite/node_modules/npm').load({}, (er, npm) => {
       });
     }
   });
-});
+})();

--- a/bin/migrateDirtyDBtoRealDB.js
+++ b/bin/migrateDirtyDBtoRealDB.js
@@ -4,9 +4,12 @@
 // unhandled rejection into an uncaught exception, which does cause Node.js to exit.
 process.on('unhandledRejection', (err) => { throw err; });
 
+const npm = require('ep_etherpad-lite/node_modules/npm');
 const util = require('util');
 
-require('ep_etherpad-lite/node_modules/npm').load({}, async (er, npm) => {
+(async () => {
+  await util.promisify(npm.load)({});
+
   process.chdir(`${npm.root}/..`);
 
   // This script requires that you have modified your settings.json file
@@ -56,4 +59,4 @@ require('ep_etherpad-lite/node_modules/npm').load({}, async (er, npm) => {
 
   await util.promisify(db.close.bind(db))();
   console.log('Finished.');
-});
+})();

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -56,9 +56,7 @@ const newPadId = process.argv[4] || `${padId}-rebuilt`;
   newPad.pool.numToAttrib = oldPad.pool.numToAttrib;
   for (let curRevNum = 0; curRevNum <= newRevHead; curRevNum++) {
     const rev = await db.get(`pad:${padId}:revs:${curRevNum}`);
-    if (rev.meta) {
-      throw new Error('The specified revision number could not be found.');
-    }
+    if (!rev || !rev.meta) throw new Error('The specified revision number could not be found.');
     const newRevNum = ++newPad.head;
     const newRevId = `pad:${newPad.id}:revs:${newRevNum}`;
     await Promise.all([

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -13,7 +13,6 @@ if (process.argv.length !== 4 && process.argv.length !== 5) {
   throw new Error('Use: node bin/repairPad.js $PADID $REV [$NEWPADID]');
 }
 
-const async = require('ep_etherpad-lite/node_modules/async');
 const npm = require('ep_etherpad-lite/node_modules/npm');
 const util = require('util');
 
@@ -21,99 +20,76 @@ const padId = process.argv[2];
 const newRevHead = process.argv[3];
 const newPadId = process.argv[4] || `${padId}-rebuilt`;
 
-let db, oldPad, newPad;
-let Pad, PadManager;
+(async () => {
+  await util.promisify(npm.load)({});
 
-async.series([
-  (callback) => npm.load({}, callback),
-  (callback) => {
-    // Get a handle into the database
-    db = require('ep_etherpad-lite/node/db/DB');
-    util.callbackify(db.init)(callback);
-  },
-  (callback) => {
-    Pad = require('ep_etherpad-lite/node/db/Pad').Pad;
-    PadManager = require('ep_etherpad-lite/node/db/PadManager');
-    // Get references to the original pad and to a newly created pad
-    // HACK: This is a standalone script, so we want to write everything
-    // out to the database immediately.  The only problem with this is
-    // that a driver (like the mysql driver) can hardcode these values.
-    db.db.db.settings = {cache: 0, writeInterval: 0, json: true};
-    // Validate the newPadId if specified and that a pad with that ID does
-    // not already exist to avoid overwriting it.
-    if (!PadManager.isValidPadId(newPadId)) {
-      throw new Error('Cannot create a pad with that id as it is invalid');
+  const db = require('ep_etherpad-lite/node/db/DB');
+  await db.init();
+
+  const Pad = require('ep_etherpad-lite/node/db/Pad').Pad;
+  const PadManager = require('ep_etherpad-lite/node/db/PadManager');
+  // Get references to the original pad and to a newly created pad
+  // HACK: This is a standalone script, so we want to write everything
+  // out to the database immediately.  The only problem with this is
+  // that a driver (like the mysql driver) can hardcode these values.
+  db.db.db.settings = {cache: 0, writeInterval: 0, json: true};
+  // Validate the newPadId if specified and that a pad with that ID does
+  // not already exist to avoid overwriting it.
+  if (!PadManager.isValidPadId(newPadId)) {
+    throw new Error('Cannot create a pad with that id as it is invalid');
+  }
+  const exists = await PadManager.doesPadExist(newPadId);
+  if (exists) throw new Error('Cannot create a pad with that id as it already exists');
+
+  const oldPad = await PadManager.getPad(padId);
+  const newPad = new Pad(newPadId);
+
+  // Clone all Chat revisions
+  const chatHead = oldPad.chatHead;
+  await Promise.all([...Array(chatHead + 1).keys()].map(async (i) => {
+    const chat = await db.get(`pad:${padId}:chat:${i}`);
+    await db.set(`pad:${newPadId}:chat:${i}`, chat);
+    console.log(`Created: Chat Revision: pad:${newPadId}:chat:${i}`);
+  }));
+
+  // Rebuild Pad from revisions up to and including the new revision head
+  const AuthorManager = require('ep_etherpad-lite/node/db/AuthorManager');
+  const Changeset = require('ep_etherpad-lite/static/js/Changeset');
+  // Author attributes are derived from changesets, but there can also be
+  // non-author attributes with specific mappings that changesets depend on
+  // and, AFAICT, cannot be recreated any other way
+  newPad.pool.numToAttrib = oldPad.pool.numToAttrib;
+  for (let curRevNum = 0; curRevNum <= newRevHead; curRevNum++) {
+    const rev = await db.get(`pad:${padId}:revs:${curRevNum}`);
+    if (rev.meta) {
+      throw new Error('The specified revision number could not be found.');
     }
-    util.callbackify(PadManager.doesPadExist)(newPadId, (err, exists) => {
-      if (err != null) return callback(err);
-      if (exists) throw new Error('Cannot create a pad with that id as it already exists');
-      callback();
-    });
-  },
-  (callback) => {
-    util.callbackify(PadManager.getPad)(padId, (err, pad) => {
-      if (err) return callback(err);
-      oldPad = pad;
-      newPad = new Pad(newPadId);
-      callback();
-    });
-  },
-  (callback) => {
-    // Clone all Chat revisions
-    const chatHead = oldPad.chatHead;
-    for (let i = 0, curHeadNum = 0; i <= chatHead; i++) {
-      db.db.get(`pad:${padId}:chat:${i}`, (err, chat) => {
-        db.db.set(`pad:${newPadId}:chat:${curHeadNum++}`, chat);
-        console.log(`Created: Chat Revision: pad:${newPadId}:chat:${curHeadNum}`);
-      });
+    const newRevNum = ++newPad.head;
+    const newRevId = `pad:${newPad.id}:revs:${newRevNum}`;
+    await Promise.all([
+      db.set(newRevId, rev),
+      AuthorManager.addPad(rev.meta.author, newPad.id),
+    ]);
+    newPad.atext = Changeset.applyToAText(rev.changeset, newPad.atext, newPad.pool);
+    console.log(`Created: Revision: pad:${newPad.id}:revs:${newRevNum}`);
+  }
+
+  // Add saved revisions up to the new revision head
+  console.log(newPad.head);
+  const newSavedRevisions = [];
+  for (const savedRev of oldPad.savedRevisions) {
+    if (savedRev.revNum <= newRevHead) {
+      newSavedRevisions.push(savedRev);
+      console.log(`Added: Saved Revision: ${savedRev.revNum}`);
     }
-    callback();
-  },
-  (callback) => {
-    // Rebuild Pad from revisions up to and including the new revision head
-    const AuthorManager = require('ep_etherpad-lite/node/db/AuthorManager');
-    const Changeset = require('ep_etherpad-lite/static/js/Changeset');
-    // Author attributes are derived from changesets, but there can also be
-    // non-author attributes with specific mappings that changesets depend on
-    // and, AFAICT, cannot be recreated any other way
-    newPad.pool.numToAttrib = oldPad.pool.numToAttrib;
-    for (let curRevNum = 0; curRevNum <= newRevHead; curRevNum++) {
-      db.db.get(`pad:${padId}:revs:${curRevNum}`, (err, rev) => {
-        if (rev.meta) {
-          throw new Error('The specified revision number could not be found.');
-        }
-        const newRevNum = ++newPad.head;
-        const newRevId = `pad:${newPad.id}:revs:${newRevNum}`;
-        db.db.set(newRevId, rev);
-        AuthorManager.addPad(rev.meta.author, newPad.id);
-        newPad.atext = Changeset.applyToAText(rev.changeset, newPad.atext, newPad.pool);
-        console.log(`Created: Revision: pad:${newPad.id}:revs:${newRevNum}`);
-        if (newRevNum === newRevHead) {
-          callback();
-        }
-      });
-    }
-  },
-  (callback) => {
-    // Add saved revisions up to the new revision head
-    console.log(newPad.head);
-    const newSavedRevisions = [];
-    for (const savedRev of oldPad.savedRevisions) {
-      if (savedRev.revNum <= newRevHead) {
-        newSavedRevisions.push(savedRev);
-        console.log(`Added: Saved Revision: ${savedRev.revNum}`);
-      }
-    }
-    newPad.savedRevisions = newSavedRevisions;
-    callback();
-  },
+  }
+  newPad.savedRevisions = newSavedRevisions;
+
   // Save the source pad
-  (callback) => db.db.set(`pad:${newPadId}`, newPad, callback),
-  (callback) => {
-    console.log(`Created: Source Pad: pad:${newPadId}`);
-    util.callbackify(newPad.saveToDatabase.bind(newPad))(callback);
-  },
-], (err) => {
-  if (err) throw err;
+  await db.set(`pad:${newPadId}`, newPad);
+
+  console.log(`Created: Source Pad: pad:${newPadId}`);
+  await newPad.saveToDatabase();
+
   console.info('finished');
-});
+})();

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -26,8 +26,8 @@ const newPadId = process.argv[4] || `${padId}-rebuilt`;
   const db = require('ep_etherpad-lite/node/db/DB');
   await db.init();
 
-  const Pad = require('ep_etherpad-lite/node/db/Pad').Pad;
   const PadManager = require('ep_etherpad-lite/node/db/PadManager');
+  const Pad = require('ep_etherpad-lite/node/db/Pad').Pad;
   // Get references to the original pad and to a newly created pad
   // HACK: This is a standalone script, so we want to write everything
   // out to the database immediately.  The only problem with this is

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -28,11 +28,6 @@ const newPadId = process.argv[4] || `${padId}-rebuilt`;
 
   const PadManager = require('ep_etherpad-lite/node/db/PadManager');
   const Pad = require('ep_etherpad-lite/node/db/Pad').Pad;
-  // Get references to the original pad and to a newly created pad
-  // HACK: This is a standalone script, so we want to write everything
-  // out to the database immediately.  The only problem with this is
-  // that a driver (like the mysql driver) can hardcode these values.
-  db.db.db.settings = {cache: 0, writeInterval: 0, json: true};
   // Validate the newPadId if specified and that a pad with that ID does
   // not already exist to avoid overwriting it.
   if (!PadManager.isValidPadId(newPadId)) {

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -45,9 +45,14 @@ async.series([
       throw new Error('Cannot create a pad with that id as it is invalid');
     }
     util.callbackify(PadManager.doesPadExist)(newPadId, (err, exists) => {
+      if (err != null) return callback(err);
       if (exists) throw new Error('Cannot create a pad with that id as it already exists');
+      callback();
     });
+  },
+  (callback) => {
     util.callbackify(PadManager.getPad)(padId, (err, pad) => {
+      if (err) return callback(err);
       oldPad = pad;
       newPad = new Pad(newPadId);
       callback();
@@ -102,12 +107,11 @@ async.series([
     newPad.savedRevisions = newSavedRevisions;
     callback();
   },
+  // Save the source pad
+  (callback) => db.db.set(`pad:${newPadId}`, newPad, callback),
   (callback) => {
-    // Save the source pad
-    db.db.set(`pad:${newPadId}`, newPad, (err) => {
-      console.log(`Created: Source Pad: pad:${newPadId}`);
-      util.callbackify(newPad.saveToDatabase.bind(newPad))(callback);
-    });
+    console.log(`Created: Source Pad: pad:${newPadId}`);
+    util.callbackify(newPad.saveToDatabase.bind(newPad))(callback);
   },
 ], (err) => {
   if (err) throw err;

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -29,7 +29,7 @@ async.series([
   (callback) => {
     // Get a handle into the database
     db = require('ep_etherpad-lite/node/db/DB');
-    db.init(callback);
+    util.callbackify(db.init)(callback);
   },
   (callback) => {
     Pad = require('ep_etherpad-lite/node/db/Pad').Pad;
@@ -44,10 +44,10 @@ async.series([
     if (!PadManager.isValidPadId(newPadId)) {
       throw new Error('Cannot create a pad with that id as it is invalid');
     }
-    PadManager.doesPadExists(newPadId, (err, exists) => {
+    util.callbackify(PadManager.doesPadExist)(newPadId, (err, exists) => {
       if (exists) throw new Error('Cannot create a pad with that id as it already exists');
     });
-    PadManager.getPad(padId, (err, pad) => {
+    util.callbackify(PadManager.getPad)(padId, (err, pad) => {
       oldPad = pad;
       newPad = new Pad(newPadId);
       callback();

--- a/bin/rebuildPad.js
+++ b/bin/rebuildPad.js
@@ -91,5 +91,6 @@ const newPadId = process.argv[4] || `${padId}-rebuilt`;
   console.log(`Created: Source Pad: pad:${newPadId}`);
   await newPad.saveToDatabase();
 
+  await db.shutdown();
   console.info('finished');
 })();

--- a/bin/repairPad.js
+++ b/bin/repairPad.js
@@ -18,8 +18,10 @@ const padId = process.argv[2];
 let valueCount = 0;
 
 const npm = require('ep_etherpad-lite/node_modules/npm');
-npm.load({}, async (err) => {
-  if (err) throw err;
+const util = require('util');
+
+(async () => {
+  await util.promisify(npm.load)({});
 
   // intialize database
   require('ep_etherpad-lite/node/utils/Settings');
@@ -56,4 +58,4 @@ npm.load({}, async (err) => {
   }
 
   console.info(`Finished: Replaced ${valueCount} values in the database`);
-});
+})();


### PR DESCRIPTION
Multiple commits:
* bin scripts: compare against null, not undefined
* bin scripts: Use destructuring instead of long condition checks
* bin scripts: Promisify npm.load
* bin scripts: Delete redundant exception log messages
* bin scripts: Promisify db.init and db.close
* bin/rebuildPad.js: Add missing calls to `util.callbackify`
* bin/rebuildPad.js: Fix sequencing of asynchronous functions
* bin/rebuildPad.js: Asyncify
* bin/rebuildPad.js: PadManager must be loaded before Pad
* bin/rebuildPad.js: Close the database when done
* bin/rebuildPad.js: Don't overwrite DB settings
* bin/rebuildPad.js: Fix check for existing rev
