### PR TITLE
hooks.js improvements

### DIFF
--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -93,11 +93,8 @@ linestylefilter.getLineStyleFilter = (lineLength, aline, textAndClassFunc, apool
             } else if (linestylefilter.ATTRIB_CLASSES[key]) {
               classes += ` ${linestylefilter.ATTRIB_CLASSES[key]}`;
             } else {
-              classes += hooks.callAllStr('aceAttribsToClasses', {
-                linestylefilter,
-                key,
-                value,
-              }, ' ', ' ', '');
+              const results = hooks.callAll('aceAttribsToClasses', {linestylefilter, key, value});
+              classes += ` ${results.join(' ')}`;
             }
           }
         }

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -344,6 +344,9 @@ exports.aCallAll = async (hookName, context, cb = null) => {
   return flatten1(results);
 };
 
+// DEPRECATED: Use `aCallFirst()` instead.
+//
+// Like `aCallFirst()`, but synchronous. Hook functions must provide their values synchronously.
 exports.callFirst = (hookName, context) => {
   if (context == null) context = {};
   const predicate = (val) => val.length;
@@ -355,6 +358,27 @@ exports.callFirst = (hookName, context) => {
   return [];
 };
 
+// Invokes the registered hook functions one at a time until one provides a value that meets a
+// customizable condition.
+//
+// Arguments:
+//   * hookName: Name of the hook to invoke.
+//   * context: Passed unmodified to the hook functions, except nullish becomes {}.
+//   * cb: Deprecated callback. The following:
+//         const p1 = hooks.aCallFirst('myHook', context, cb);
+//     is equivalent to:
+//         const p2 = hooks.aCallFirst('myHook', context).then(
+//             (val) => cb(null, val), (err) => cb(err || new Error(err)));
+//   * predicate: Optional predicate function that returns true if the hook function provided a
+//     value that satisfies a desired condition. If nullish, the predicate defaults to a non-empty
+//     array check. The predicate is invoked each time a hook function returns. It takes one
+//     argument: the normalized value provided by the hook function. If the predicate returns
+//     truthy, iteration over the hook functions stops (no more hook functions will be called).
+//
+// Return value:
+//   If cb is nullish, resolves to an array that is either the normalized value that satisfied the
+//   predicate or empty if the predicate was never satisfied. If cb is non-nullish, resolves to the
+//   value returned from cb().
 exports.aCallFirst = async (hookName, context, cb = null, predicate = null) => {
   if (cb != null) {
     return await attachCallback(exports.aCallFirst(hookName, context, null, predicate), cb);

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -362,7 +362,10 @@ exports.callFirst = (hookName, context) => {
   return [];
 };
 
-const aCallFirst = async (hookName, context, predicate = null) => {
+exports.aCallFirst = async (hookName, context, cb = null, predicate = null) => {
+  if (cb != null) {
+    return await attachCallback(exports.aCallFirst(hookName, context, null, predicate), cb);
+  }
   if (!context) context = {};
   if (predicate == null) predicate = (val) => val.length;
   const hooks = pluginDefs.hooks[hookName] || [];
@@ -371,12 +374,6 @@ const aCallFirst = async (hookName, context, predicate = null) => {
     if (predicate(val)) return val;
   }
   return [];
-};
-
-/* return a Promise if cb is not supplied */
-exports.aCallFirst = (hookName, context, cb, predicate) => {
-  if (cb == null) return aCallFirst(hookName, context, predicate);
-  util.callbackify(aCallFirst)(hookName, context, predicate, cb);
 };
 
 exports.exportedForTestingOnly = {

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -39,12 +39,11 @@ const hookCallWrapper = (hook, hookName, context, cb) => {
   return () => normalize(hook.hook_fn(hookName, context, (x) => cb(normalize(x))));
 };
 
-const syncMapFirst = (lst, fn) => {
-  let i;
-  let result;
-  for (i = 0; i < lst.length; i++) {
-    result = fn(lst[i]);
-    if (result.length) return result;
+const syncMapFirst = (hooks, fn) => {
+  const predicate = (val) => val.length;
+  for (const hook of hooks) {
+    const val = fn(hook);
+    if (predicate(val)) return val;
   }
   return [];
 };

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -386,18 +386,6 @@ exports.aCallFirst = (hook_name, args, cb, predicate) => {
   }
 };
 
-exports.callAllStr = (hook_name, args, sep, pre, post) => {
-  if (sep === undefined) sep = '';
-  if (pre === undefined) pre = '';
-  if (post === undefined) post = '';
-  const newCallhooks = [];
-  const callhooks = exports.callAll(hook_name, args);
-  for (let i = 0, ii = callhooks.length; i < ii; i++) {
-    newCallhooks[i] = pre + callhooks[i] + post;
-  }
-  return newCallhooks.join(sep || '');
-};
-
 exports.exportedForTestingOnly = {
   callHookFnAsync,
   callHookFnSync,

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -352,7 +352,7 @@ exports.aCallAll = async (hookName, context, cb = null) => {
 };
 
 exports.callFirst = (hookName, context) => {
-  if (!context) context = {};
+  if (context == null) context = {};
   const predicate = (val) => val.length;
   const hooks = pluginDefs.hooks[hookName] || [];
   for (const hook of hooks) {
@@ -366,7 +366,7 @@ exports.aCallFirst = async (hookName, context, cb = null, predicate = null) => {
   if (cb != null) {
     return await attachCallback(exports.aCallFirst(hookName, context, null, predicate), cb);
   }
-  if (!context) context = {};
+  if (context == null) context = {};
   if (predicate == null) predicate = (val) => val.length;
   const hooks = pluginDefs.hooks[hookName] || [];
   for (const hook of hooks) {

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -39,7 +39,7 @@ const hookCallWrapper = (hook, hookName, args, cb) => {
   return () => normalize(hook.hook_fn(hookName, args, (x) => cb(normalize(x))));
 };
 
-exports.syncMapFirst = (lst, fn) => {
+const syncMapFirst = (lst, fn) => {
   let i;
   let result;
   for (i = 0; i < lst.length; i++) {
@@ -49,7 +49,7 @@ exports.syncMapFirst = (lst, fn) => {
   return [];
 };
 
-exports.mapFirst = (lst, fn, cb, predicate) => {
+const mapFirst = (lst, fn, cb, predicate) => {
   if (predicate == null) predicate = (x) => (x != null && x.length > 0);
   let i = 0;
 
@@ -347,7 +347,7 @@ exports.aCallAll = async (hookName, context, cb) => {
 exports.callFirst = (hookName, args) => {
   if (!args) args = {};
   if (pluginDefs.hooks[hookName] === undefined) return [];
-  return exports.syncMapFirst(pluginDefs.hooks[hookName],
+  return syncMapFirst(pluginDefs.hooks[hookName],
       (hook) => hookCallWrapper(hook, hookName, args));
 };
 
@@ -355,7 +355,7 @@ const aCallFirst = (hookName, args, cb, predicate) => {
   if (!args) args = {};
   if (!cb) cb = () => {};
   if (pluginDefs.hooks[hookName] === undefined) return cb(null, []);
-  exports.mapFirst(
+  mapFirst(
       pluginDefs.hooks[hookName],
       (hook, cb) => {
         hookCallWrapper(hook, hookName, args, (res) => { cb(null, res); });

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -26,8 +26,6 @@ const checkDeprecation = (hook) => {
 // Flattens the array one level.
 const flatten1 = (array) => array.reduce((a, b) => a.concat(b), []);
 
-exports.bubbleExceptions = true;
-
 const hookCallWrapper = (hook, hookName, args, cb) => {
   if (cb === undefined) cb = (x) => x;
 
@@ -38,17 +36,7 @@ const hookCallWrapper = (hook, hookName, args, cb) => {
     if (x === undefined) return [];
     return x;
   };
-  const normalizedhook = () => normalize(hook.hook_fn(hookName, args, (x) => cb(normalize(x))));
-
-  if (exports.bubbleExceptions) {
-    return normalizedhook();
-  } else {
-    try {
-      return normalizedhook();
-    } catch (ex) {
-      console.error([hookName, hook.part.full_name, ex.stack || ex]);
-    }
-  }
+  return () => normalize(hook.hook_fn(hookName, args, (x) => cb(normalize(x))));
 };
 
 exports.syncMapFirst = (lst, fn) => {

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -40,15 +40,6 @@ const hookCallWrapper = (hook, hookName, context, cb) => {
   return () => normalize(hook.hook_fn(hookName, context, (x) => cb(normalize(x))));
 };
 
-const syncMapFirst = (hooks, fn) => {
-  const predicate = (val) => val.length;
-  for (const hook of hooks) {
-    const val = fn(hook);
-    if (predicate(val)) return val;
-  }
-  return [];
-};
-
 const mapFirst = async (hooks, fn, predicate = null) => {
   if (predicate == null) predicate = (val) => val.length;
   for (const hook of hooks) {
@@ -364,9 +355,13 @@ exports.aCallAll = async (hookName, context, cb) => {
 
 exports.callFirst = (hookName, context) => {
   if (!context) context = {};
-  if (pluginDefs.hooks[hookName] === undefined) return [];
-  return syncMapFirst(pluginDefs.hooks[hookName],
-      (hook) => hookCallWrapper(hook, hookName, context));
+  const predicate = (val) => val.length;
+  const hooks = pluginDefs.hooks[hookName] || [];
+  for (const hook of hooks) {
+    const val = hookCallWrapper(hook, hookName, context);
+    if (predicate(val)) return val;
+  }
+  return [];
 };
 
 const aCallFirst = (hookName, context, cb, predicate) => {

--- a/src/static/js/pluginfw/hooks.js
+++ b/src/static/js/pluginfw/hooks.js
@@ -26,7 +26,7 @@ const checkDeprecation = (hook) => {
 // Flattens the array one level.
 const flatten1 = (array) => array.reduce((a, b) => a.concat(b), []);
 
-const hookCallWrapper = (hook, hookName, args, cb) => {
+const hookCallWrapper = (hook, hookName, context, cb) => {
   if (cb === undefined) cb = (x) => x;
 
   checkDeprecation(hook);
@@ -36,7 +36,7 @@ const hookCallWrapper = (hook, hookName, args, cb) => {
     if (x === undefined) return [];
     return x;
   };
-  return () => normalize(hook.hook_fn(hookName, args, (x) => cb(normalize(x))));
+  return () => normalize(hook.hook_fn(hookName, context, (x) => cb(normalize(x))));
 };
 
 const syncMapFirst = (lst, fn) => {
@@ -344,21 +344,21 @@ exports.aCallAll = async (hookName, context, cb) => {
   return await resultsPromise;
 };
 
-exports.callFirst = (hookName, args) => {
-  if (!args) args = {};
+exports.callFirst = (hookName, context) => {
+  if (!context) context = {};
   if (pluginDefs.hooks[hookName] === undefined) return [];
   return syncMapFirst(pluginDefs.hooks[hookName],
-      (hook) => hookCallWrapper(hook, hookName, args));
+      (hook) => hookCallWrapper(hook, hookName, context));
 };
 
-const aCallFirst = (hookName, args, cb, predicate) => {
-  if (!args) args = {};
+const aCallFirst = (hookName, context, cb, predicate) => {
+  if (!context) context = {};
   if (!cb) cb = () => {};
   if (pluginDefs.hooks[hookName] === undefined) return cb(null, []);
   mapFirst(
       pluginDefs.hooks[hookName],
       (hook, cb) => {
-        hookCallWrapper(hook, hookName, args, (res) => { cb(null, res); });
+        hookCallWrapper(hook, hookName, context, (res) => { cb(null, res); });
       },
       cb,
       predicate
@@ -366,13 +366,13 @@ const aCallFirst = (hookName, args, cb, predicate) => {
 };
 
 /* return a Promise if cb is not supplied */
-exports.aCallFirst = (hookName, args, cb, predicate) => {
+exports.aCallFirst = (hookName, context, cb, predicate) => {
   if (cb === undefined) {
     return new Promise((resolve, reject) => {
-      aCallFirst(hookName, args, (err, res) => err ? reject(err) : resolve(res), predicate);
+      aCallFirst(hookName, context, (err, res) => err ? reject(err) : resolve(res), predicate);
     });
   } else {
-    return aCallFirst(hookName, args, cb, predicate);
+    return aCallFirst(hookName, context, cb, predicate);
   }
 };
 

--- a/tests/backend/specs/hooks.js
+++ b/tests/backend/specs/hooks.js
@@ -1,14 +1,9 @@
-/* global __dirname, __filename, afterEach, beforeEach, describe, it, process, require */
-
-function m(mod) { return `${__dirname}/../../../src/${mod}`; }
+'use strict';
 
 const assert = require('assert').strict;
-const common = require('../common');
-const hooks = require(m('static/js/pluginfw/hooks'));
-const plugins = require(m('static/js/pluginfw/plugin_defs'));
-const sinon = require(m('node_modules/sinon'));
-
-const logger = common.logger;
+const hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+const plugins = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
+const sinon = require('ep_etherpad-lite/node_modules/sinon');
 
 describe(__filename, function () {
   const hookName = 'testHook';
@@ -203,7 +198,7 @@ describe(__filename, function () {
     // Test various ways a hook might attempt to settle twice. (Examples: call the callback a second
     // time, or call the callback and then return a value.)
     describe('bad hook function behavior (double settle)', function () {
-      beforeEach(function () {
+      beforeEach(async function () {
         sinon.stub(console, 'error');
       });
 
@@ -558,7 +553,7 @@ describe(__filename, function () {
     // Test various ways a hook might attempt to settle twice. (Examples: call the callback a second
     // time, or call the callback and then return a value.)
     describe('bad hook function behavior (double settle)', function () {
-      beforeEach(function () {
+      beforeEach(async function () {
         sinon.stub(console, 'error');
       });
 

--- a/tests/backend/specs/hooks.js
+++ b/tests/backend/specs/hooks.js
@@ -389,6 +389,90 @@ describe(__filename, function () {
     });
   });
 
+  describe('hooks.callFirst', function () {
+    it('no registered hooks (undefined) -> []', async function () {
+      delete plugins.hooks.testHook;
+      assert.deepEqual(hooks.callFirst(hookName), []);
+    });
+
+    it('no registered hooks (empty list) -> []', async function () {
+      testHooks.length = 0;
+      assert.deepEqual(hooks.callFirst(hookName), []);
+    });
+
+    it('passes hook name => {}', async function () {
+      hook.hook_fn = (hn) => { assert.equal(hn, hookName); };
+      hooks.callFirst(hookName);
+    });
+
+    it('undefined context => {}', async function () {
+      hook.hook_fn = (hn, ctx) => { assert.deepEqual(ctx, {}); };
+      hooks.callFirst(hookName);
+    });
+
+    it('null context => {}', async function () {
+      hook.hook_fn = (hn, ctx) => { assert.deepEqual(ctx, {}); };
+      hooks.callFirst(hookName, null);
+    });
+
+    it('context unmodified', async function () {
+      const wantContext = {};
+      hook.hook_fn = (hn, ctx) => { assert.equal(ctx, wantContext); };
+      hooks.callFirst(hookName, wantContext);
+    });
+
+    it('predicate never satisfied -> calls all in order', async function () {
+      const gotCalls = [];
+      testHooks.length = 0;
+      for (let i = 0; i < 3; i++) {
+        const hook = makeHook();
+        hook.hook_fn = () => { gotCalls.push(i); };
+        testHooks.push(hook);
+      }
+      assert.deepEqual(hooks.callFirst(hookName), []);
+      assert.deepEqual(gotCalls, [0, 1, 2]);
+    });
+
+    it('stops when predicate is satisfied', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(), makeHook('val1'), makeHook('val2'));
+      assert.deepEqual(hooks.callFirst(hookName), ['val1']);
+    });
+
+    it('skips values that do not satisfy predicate (undefined)', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(), makeHook('val1'));
+      assert.deepEqual(hooks.callFirst(hookName), ['val1']);
+    });
+
+    it('skips values that do not satisfy predicate (empty list)', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook([]), makeHook('val1'));
+      assert.deepEqual(hooks.callFirst(hookName), ['val1']);
+    });
+
+    it('null satisifes the predicate', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(null), makeHook('val1'));
+      assert.deepEqual(hooks.callFirst(hookName), [null]);
+    });
+
+    it('non-empty arrays are returned unmodified', async function () {
+      const want = ['val1'];
+      testHooks.length = 0;
+      testHooks.push(makeHook(want), makeHook(['val2']));
+      assert.equal(hooks.callFirst(hookName), want); // Note: *NOT* deepEqual!
+    });
+
+    it('value can be passed via callback', async function () {
+      const want = {};
+      hook.hook_fn = (hn, ctx, cb) => { cb(want); };
+      const got = hooks.callFirst(hookName);
+      assert.deepEqual(got, [want]);
+      assert.equal(got[0], want); // Note: *NOT* deepEqual!
+    });
+  });
+
   describe('callHookFnAsync', function () {
     const callHookFnAsync = hooks.exportedForTestingOnly.callHookFnAsync; // Convenience shorthand.
 
@@ -881,6 +965,162 @@ describe(__filename, function () {
         testHooks.push(makeHook(), makeHook(Promise.resolve()));
         assert.deepEqual(await hooks.aCallAll(hookName), []);
       });
+    });
+  });
+
+  describe('hooks.aCallFirst', function () {
+    it('no registered hooks (undefined) -> []', async function () {
+      delete plugins.hooks.testHook;
+      assert.deepEqual(await hooks.aCallFirst(hookName), []);
+    });
+
+    it('no registered hooks (empty list) -> []', async function () {
+      testHooks.length = 0;
+      assert.deepEqual(await hooks.aCallFirst(hookName), []);
+    });
+
+    it('passes hook name => {}', async function () {
+      hook.hook_fn = (hn) => { assert.equal(hn, hookName); };
+      await hooks.aCallFirst(hookName);
+    });
+
+    it('undefined context => {}', async function () {
+      hook.hook_fn = (hn, ctx) => { assert.deepEqual(ctx, {}); };
+      await hooks.aCallFirst(hookName);
+    });
+
+    it('null context => {}', async function () {
+      hook.hook_fn = (hn, ctx) => { assert.deepEqual(ctx, {}); };
+      await hooks.aCallFirst(hookName, null);
+    });
+
+    it('context unmodified', async function () {
+      const wantContext = {};
+      hook.hook_fn = (hn, ctx) => { assert.equal(ctx, wantContext); };
+      await hooks.aCallFirst(hookName, wantContext);
+    });
+
+    it('default predicate: predicate never satisfied -> calls all in order', async function () {
+      const gotCalls = [];
+      testHooks.length = 0;
+      for (let i = 0; i < 3; i++) {
+        const hook = makeHook();
+        hook.hook_fn = () => { gotCalls.push(i); };
+        testHooks.push(hook);
+      }
+      assert.deepEqual(await hooks.aCallFirst(hookName), []);
+      assert.deepEqual(gotCalls, [0, 1, 2]);
+    });
+
+    it('calls hook functions serially', async function () {
+      const gotCalls = [];
+      testHooks.length = 0;
+      for (let i = 0; i < 3; i++) {
+        const hook = makeHook();
+        hook.hook_fn = async () => {
+          gotCalls.push(i);
+          // Check gotCalls asynchronously to ensure that the next hook function does not start
+          // executing before this hook function has resolved.
+          return await new Promise((resolve) => {
+            setImmediate(() => {
+              assert.deepEqual(gotCalls, [...Array(i + 1).keys()]);
+              resolve();
+            });
+          });
+        };
+        testHooks.push(hook);
+      }
+      assert.deepEqual(await hooks.aCallFirst(hookName), []);
+      assert.deepEqual(gotCalls, [0, 1, 2]);
+    });
+
+    it('default predicate: stops when satisfied', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(), makeHook('val1'), makeHook('val2'));
+      assert.deepEqual(await hooks.aCallFirst(hookName), ['val1']);
+    });
+
+    it('default predicate: skips values that do not satisfy (undefined)', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(), makeHook('val1'));
+      assert.deepEqual(await hooks.aCallFirst(hookName), ['val1']);
+    });
+
+    it('default predicate: skips values that do not satisfy (empty list)', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook([]), makeHook('val1'));
+      assert.deepEqual(await hooks.aCallFirst(hookName), ['val1']);
+    });
+
+    it('default predicate: null satisifes', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(null), makeHook('val1'));
+      assert.deepEqual(await hooks.aCallFirst(hookName), [null]);
+    });
+
+    it('custom predicate: called for each hook function', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(0), makeHook(1), makeHook(2));
+      let got = 0;
+      await hooks.aCallFirst(hookName, null, null, (val) => { ++got; return false; });
+      assert.equal(got, 3);
+    });
+
+    it('custom predicate: boolean false/true continues/stops iteration', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(1), makeHook(2), makeHook(3));
+      let nCall = 0;
+      const predicate = (val) => {
+        assert.deepEqual(val, [++nCall]);
+        return nCall === 2;
+      };
+      assert.deepEqual(await hooks.aCallFirst(hookName, null, null, predicate), [2]);
+      assert.equal(nCall, 2);
+    });
+
+    it('custom predicate: non-boolean falsy/truthy continues/stops iteration', async function () {
+      testHooks.length = 0;
+      testHooks.push(makeHook(1), makeHook(2), makeHook(3));
+      let nCall = 0;
+      const predicate = (val) => {
+        assert.deepEqual(val, [++nCall]);
+        return nCall === 2 ? {} : null;
+      };
+      assert.deepEqual(await hooks.aCallFirst(hookName, null, null, predicate), [2]);
+      assert.equal(nCall, 2);
+    });
+
+    it('custom predicate: array value passed unmodified to predicate', async function () {
+      const want = [0];
+      hook.hook_fn = () => want;
+      const predicate = (got) => { assert.equal(got, want); }; // Note: *NOT* deepEqual!
+      await hooks.aCallFirst(hookName, null, null, predicate);
+    });
+
+    it('custom predicate: normalized value passed to predicate (undefined)', async function () {
+      const predicate = (got) => { assert.deepEqual(got, []); };
+      await hooks.aCallFirst(hookName, null, null, predicate);
+    });
+
+    it('custom predicate: normalized value passed to predicate (null)', async function () {
+      hook.hook_fn = () => null;
+      const predicate = (got) => { assert.deepEqual(got, [null]); };
+      await hooks.aCallFirst(hookName, null, null, predicate);
+    });
+
+    it('non-empty arrays are returned unmodified', async function () {
+      const want = ['val1'];
+      testHooks.length = 0;
+      testHooks.push(makeHook(want), makeHook(['val2']));
+      assert.equal(await hooks.aCallFirst(hookName), want); // Note: *NOT* deepEqual!
+    });
+
+    it('value can be passed via callback', async function () {
+      const want = {};
+      hook.hook_fn = (hn, ctx, cb) => { cb(want); };
+      const got = await hooks.aCallFirst(hookName);
+      assert.deepEqual(got, [want]);
+      assert.equal(got[0], want); // Note: *NOT* deepEqual!
     });
   });
 });

--- a/tests/backend/specs/webaccess.js
+++ b/tests/backend/specs/webaccess.js
@@ -1,11 +1,9 @@
-/* global __dirname, __filename, Buffer, afterEach, before, beforeEach, describe, it, require */
-
-function m(mod) { return `${__dirname}/../../../src/${mod}`; }
+'use strict';
 
 const assert = require('assert').strict;
 const common = require('../common');
-const plugins = require(m('static/js/pluginfw/plugin_defs'));
-const settings = require(m('node/utils/Settings'));
+const plugins = require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 describe(__filename, function () {
   let agent;
@@ -402,7 +400,7 @@ describe(__filename, function () {
     };
     const handlers = {};
 
-    beforeEach(function () {
+    beforeEach(async function () {
       failHookNames.forEach((hookName) => {
         const handler = new Handler(hookName);
         handlers[hookName] = handler;

--- a/tests/backend/specs/webaccess.js
+++ b/tests/backend/specs/webaccess.js
@@ -10,6 +10,13 @@ describe(__filename, function () {
   const backups = {};
   const authHookNames = ['preAuthorize', 'authenticate', 'authorize'];
   const failHookNames = ['preAuthzFailure', 'authnFailure', 'authzFailure', 'authFailure'];
+  const makeHook = (hookName, hookFn) => ({
+    hook_fn: hookFn,
+    hook_fn_name: `fake_plugin/${hookName}`,
+    hook_name: hookName,
+    part: {plugin: 'fake_plugin'},
+  });
+
   before(async function () { agent = await common.init(); });
   beforeEach(async function () {
     backups.hooks = {};
@@ -139,7 +146,10 @@ describe(__filename, function () {
         const h0 = new Handler(hookName, '_0');
         const h1 = new Handler(hookName, '_1');
         handlers[hookName] = [h0, h1];
-        plugins.hooks[hookName] = [{hook_fn: h0.handle.bind(h0)}, {hook_fn: h1.handle.bind(h1)}];
+        plugins.hooks[hookName] = [
+          makeHook(hookName, h0.handle.bind(h0)),
+          makeHook(hookName, h1.handle.bind(h1)),
+        ];
       }
     });
 
@@ -195,7 +205,7 @@ describe(__filename, function () {
       it('runs preAuthzFailure hook when access is denied', async function () {
         handlers.preAuthorize[0].innerHandle = () => [false];
         let called = false;
-        plugins.hooks.preAuthzFailure = [{hook_fn: (hookName, {req, res}, cb) => {
+        plugins.hooks.preAuthzFailure = [makeHook('preAuthzFailure', (hookName, {req, res}, cb) => {
           assert.equal(hookName, 'preAuthzFailure');
           assert(req != null);
           assert(res != null);
@@ -203,7 +213,7 @@ describe(__filename, function () {
           called = true;
           res.status(200).send('injected');
           return cb([true]);
-        }}];
+        })];
         await agent.get('/admin/').auth('admin', 'admin-password').expect(200, 'injected');
         assert(called);
       });
@@ -404,7 +414,7 @@ describe(__filename, function () {
       failHookNames.forEach((hookName) => {
         const handler = new Handler(hookName);
         handlers[hookName] = handler;
-        plugins.hooks[hookName] = [{hook_fn: handler.handle.bind(handler)}];
+        plugins.hooks[hookName] = [makeHook(hookName, handler.handle.bind(handler))];
       });
       settings.requireAuthentication = true;
       settings.requireAuthorization = true;


### PR DESCRIPTION
Multiple commits:
* hooks: Remove unnecessary `callAllStr()` function
* lint: Fix more ESLint errors
* tests: Make the fake webaccess hook registrations look more real
* hooks: Delete unused `bubbleExceptions` setting
* hooks: Don't export `syncMapFirst` or `mapFirst`
* hooks: Rename `args` to `context` for consistency
* hooks: Refine caveat comments about function parameter count
* hooks: Simplify `syncMapFirst` iteration
* hooks: Asyncify `mapFirst`
* hooks: Inline `syncMapFirst()` into `callFirst()` for readability
* hooks: Inline `mapFirst()` into `aCallFirst()` for readability
* hooks: Factor out callback attachment
* hooks: Never pass a falsy error to a callback
* hooks: Factor out value normalization
* hooks: Asyncify `aCallFirst`
* hooks: Inline `aCallFirst()` into `exports.aCallFirst()`
* hooks: Check context nullness, not truthiness
* hooks: Use `callHookFn{Sync,Async}()` for `{call,aCall}First()`
* hooks: Add unit tests for `callFirst()`, `aCallFirst()`
* hooks: Document `callFirst()` and `aCallFirst()`
* hooks: New `callAllSerial()` function
