### PR TITLE
Various pluginfw fixes and cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -862,7 +862,6 @@
         "resolve": "1.1.7",
         "security": "1.0.0",
         "semver": "5.6.0",
-        "slide": "1.1.6",
         "socket.io": "^2.4.1",
         "terser": "^4.7.0",
         "threads": "^1.4.0",
@@ -10544,6 +10543,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
       "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
+    "wtfnode": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.4.tgz",
+      "integrity": "sha512-64GEKtMt/MUBuAm+8kHqP74ojjafzu00aT0JKsmkIwYmjRQ/odO0yhbzKLm+Z9v1gMla+8dwITRKzTAlHsB+Og=="
+    },
     "xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
@@ -10577,11 +10581,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "wtfnode": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/wtfnode/-/wtfnode-0.8.4.tgz",
-      "integrity": "sha512-64GEKtMt/MUBuAm+8kHqP74ojjafzu00aT0JKsmkIwYmjRQ/odO0yhbzKLm+Z9v1gMla+8dwITRKzTAlHsB+Og=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -44,6 +44,7 @@ const db = require('./db/DB');
 const express = require('./hooks/express');
 const hooks = require('../static/js/pluginfw/hooks');
 const npm = require('npm/lib/npm.js');
+const pluginDefs = require('../static/js/pluginfw/plugin_defs');
 const plugins = require('../static/js/pluginfw/plugins');
 const settings = require('./utils/Settings');
 const util = require('util');
@@ -120,7 +121,11 @@ exports.start = async () => {
   await util.promisify(npm.load)();
   await db.init();
   await plugins.update();
-  console.info(`Installed plugins: ${plugins.formatPluginsWithVersion()}`);
+  const installedPlugins = Object.values(pluginDefs.plugins)
+      .filter((plugin) => plugin.package.name !== 'ep_etherpad-lite')
+      .map((plugin) => `${plugin.package.name}@${plugin.package.version}`)
+      .join(', ');
+  console.info(`Installed plugins: ${installedPlugins}`);
   console.debug(`Installed parts:\n${plugins.formatParts()}`);
   console.debug(`Installed hooks:\n${plugins.formatHooks()}`);
   await hooks.aCallAll('loadSettings', {settings});

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -7680,11 +7680,6 @@
         }
       }
     },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-    },
     "socket.io": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -64,7 +64,6 @@
     "resolve": "1.1.7",
     "security": "1.0.0",
     "semver": "5.6.0",
-    "slide": "1.1.6",
     "socket.io": "^2.4.1",
     "terser": "^4.7.0",
     "threads": "^1.4.0",

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -97,9 +97,6 @@ exports.getPackages = async () => {
         delete packages[name].dependencies;
         delete packages[name].parent;
       }
-
-      // I don't think we need recursion
-      // if (deps[name].dependencies !== undefined) flatten(deps[name].dependencies);
     });
   };
 

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -15,11 +15,6 @@ exports.prefix = 'ep_';
 
 exports.formatPlugins = () => Object.keys(defs.plugins).join(', ');
 
-exports.formatPluginsWithVersion = () => Object.values(defs.plugins)
-    .filter((plugin) => plugin.package.name !== 'ep_etherpad-lite')
-    .map((plugin) => `${plugin.package.name}@${plugin.package.version}`)
-    .join(', ');
-
 exports.formatParts = () => defs.parts.map((part) => part.full_name).join('\n');
 
 exports.formatHooks = (hookSetName) => {

--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -131,8 +131,6 @@ function readInstalled(folder, cb) {
 
 var rpSeen = {};
 function readInstalled_(folder, parent, name, reqver, depth, maxDepth, cb) {
-  // console.error(folder, name)
-
   let installed,
     obj,
     real,
@@ -161,7 +159,6 @@ function readInstalled_(folder, parent, name, reqver, depth, maxDepth, cb) {
       return next(er);
     }
     fs.realpath(folder, (er, rp) => {
-      // console.error("realpath(%j) = %j", folder, rp)
       real = rp;
       if (st.isSymbolicLink()) link = rp;
       next(er);
@@ -176,7 +173,6 @@ function readInstalled_(folder, parent, name, reqver, depth, maxDepth, cb) {
       errState = er;
       return cb(null, []);
     }
-    // console.error('next', installed, obj && typeof obj, name, real)
     if (!installed || !obj || !real || called) return;
     called = true;
     if (rpSeen[real]) return cb(null, rpSeen[real]);
@@ -256,13 +252,10 @@ const fuSeen = [];
 function findUnmet(obj) {
   if (fuSeen.indexOf(obj) !== -1) return;
   fuSeen.push(obj);
-  // console.error("find unmet", obj.name, obj.parent && obj.parent.name)
   const deps = obj.dependencies = obj.dependencies || {};
-  // console.error(deps)
   Object.keys(deps)
       .filter((d) => typeof deps[d] === 'string')
       .forEach((d) => {
-      // console.error("find unmet", obj.name, d, deps[d])
         let r = obj.parent;
         let found = null;
         while (r && !found && typeof deps[d] === 'string') {
@@ -328,9 +321,7 @@ if (module === require.main) {
       }
     }
     const dep = map.dependencies;
-    //    delete map.dependencies
     if (dep) {
-      //      map.dependencies = dep
       for (var i in dep) {
         if (typeof dep[i] === 'object') {
           cleanup(dep[i]);

--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -279,7 +279,6 @@ const findUnmet = (obj) => {
       deps[d] = found;
     }
   }
-  return obj;
 };
 
 const copy = (obj) => {

--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -303,11 +303,14 @@ if (module === require.main) {
   console.error('testing');
 
   let called = 0;
-  readInstalled(process.cwd(), (er, map) => {
-    console.error(called++);
-    if (er) return console.error(er.stack || er.message);
-    cleanup(map);
-    console.error(util.inspect(map, true, 10, true));
+  npm.load({}, (err) => {
+    if (err != null) throw err;
+    readInstalled(process.cwd(), (er, map) => {
+      console.error(called++);
+      if (er) return console.error(er.stack || er.message);
+      cleanup(map);
+      console.error(util.inspect(map, true, 10, true));
+    });
   });
 
   const seen = [];

--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -250,6 +250,7 @@ function resolveInheritance(obj) {
 // No I/O
 const fuSeen = [];
 function findUnmet(obj) {
+  if (typeof obj !== 'object') return;
   if (fuSeen.indexOf(obj) !== -1) return;
   fuSeen.push(obj);
   const deps = obj.dependencies = obj.dependencies || {};

--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -96,6 +96,8 @@ const asyncMap = require('slide').asyncMap;
 const semver = require('semver');
 const log = require('log4js').getLogger('pluginfw');
 
+let fuSeen = [];
+
 function readJson(file, callback) {
   fs.readFile(file, (er, buf) => {
     if (er) {
@@ -115,9 +117,9 @@ module.exports = readInstalled;
 function readInstalled(folder, cb) {
   /* This is where we clear the cache, these three lines are all the
    * new code there is */
+  fuSeen = [];
   rpSeen = {};
   riSeen = [];
-  const fuSeen = [];
 
   const d = npm.config.get('depth');
   readInstalled_(folder, null, null, null, 0, d, (er, obj) => {
@@ -248,7 +250,6 @@ function resolveInheritance(obj) {
 
 // find unmet deps by walking up the tree object.
 // No I/O
-const fuSeen = [];
 function findUnmet(obj) {
   if (typeof obj !== 'object') return;
   if (fuSeen.indexOf(obj) !== -1) return;

--- a/src/static/js/pluginfw/read-installed.js
+++ b/src/static/js/pluginfw/read-installed.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // A copy of npm/lib/utils/read-installed.js
 // that is hacked to not cache everything :)
 
@@ -88,7 +90,6 @@ as far as the left-most node_modules folder.
 
 */
 
-
 const npm = require('npm/lib/npm.js');
 const fs = require('graceful-fs');
 const path = require('path');
@@ -97,8 +98,10 @@ const semver = require('semver');
 const log = require('log4js').getLogger('pluginfw');
 
 let fuSeen = [];
+let riSeen = [];
+let rpSeen = {};
 
-function readJson(file, callback) {
+const readJson = (file, callback) => {
   fs.readFile(file, (er, buf) => {
     if (er) {
       callback(er);
@@ -110,11 +113,9 @@ function readJson(file, callback) {
       callback(er);
     }
   });
-}
+};
 
-module.exports = readInstalled;
-
-function readInstalled(folder, cb) {
+const readInstalled = (folder, cb) => {
   /* This is where we clear the cache, these three lines are all the
    * new code there is */
   fuSeen = [];
@@ -129,10 +130,11 @@ function readInstalled(folder, cb) {
     resolveInheritance(obj);
     cb(null, obj);
   });
-}
+};
 
-var rpSeen = {};
-function readInstalled_(folder, parent, name, reqver, depth, maxDepth, cb) {
+module.exports = readInstalled;
+
+const readInstalled_ = (folder, parent, name, reqver, depth, maxDepth, cb) => {
   let installed,
     obj,
     real,
@@ -229,11 +231,10 @@ function readInstalled_(folder, parent, name, reqver, depth, maxDepth, cb) {
       return cb(null, obj);
     });
   }
-}
+};
 
 // starting from a root object, call findUnmet on each layer of children
-var riSeen = [];
-function resolveInheritance(obj) {
+const resolveInheritance = (obj) => {
   if (typeof obj !== 'object') return;
   if (riSeen.indexOf(obj) !== -1) return;
   riSeen.push(obj);
@@ -246,11 +247,11 @@ function resolveInheritance(obj) {
   Object.keys(obj.dependencies).forEach((dep) => {
     resolveInheritance(obj.dependencies[dep]);
   });
-}
+};
 
 // find unmet deps by walking up the tree object.
 // No I/O
-function findUnmet(obj) {
+const findUnmet = (obj) => {
   if (typeof obj !== 'object') return;
   if (fuSeen.indexOf(obj) !== -1) return;
   fuSeen.push(obj);
@@ -282,16 +283,16 @@ function findUnmet(obj) {
         }
       });
   return obj;
-}
+};
 
-function copy(obj) {
+const copy = (obj) => {
   if (!obj || typeof obj !== 'object') return obj;
   if (Array.isArray(obj)) return obj.map(copy);
 
   const o = {};
-  for (const i in obj) o[i] = copy(obj[i]);
+  for (const [i, v] of Object.entries(obj)) o[i] = copy(v);
   return o;
-}
+};
 
 if (module === require.main) {
   const util = require('util');
@@ -312,7 +313,7 @@ if (module === require.main) {
   function cleanup(map) {
     if (seen.indexOf(map) !== -1) return;
     seen.push(map);
-    for (var i in map) {
+    for (const i of Object.keys(map)) {
       switch (i) {
         case '_id':
         case 'path':
@@ -322,12 +323,9 @@ if (module === require.main) {
         default: delete map[i];
       }
     }
-    const dep = map.dependencies;
-    if (dep) {
-      for (var i in dep) {
-        if (typeof dep[i] === 'object') {
-          cleanup(dep[i]);
-        }
+    for (const dep of Object.values(map.dependencies || {})) {
+      if (typeof dep === 'object') {
+        cleanup(dep);
       }
     }
     return map;

--- a/src/static/js/pluginfw/shared.js
+++ b/src/static/js/pluginfw/shared.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('underscore');
+
 const defs = require('./plugin_defs');
 
 const disabledHookReasons = {
@@ -27,54 +27,49 @@ const loadFn = (path, hookName) => {
   let fn = require(path);
   functionName = functionName ? functionName : hookName;
 
-  _.each(functionName.split('.'), (name) => {
+  for (const name of functionName.split('.')) {
     fn = fn[name];
-  });
+  }
   return fn;
 };
 
-const extractHooks = (parts, hook_set_name, normalizer) => {
+const extractHooks = (parts, hookSetName, normalizer) => {
   const hooks = {};
-  _.each(parts, (part) => {
-    _.chain(part[hook_set_name] || {})
-        .keys()
-        .each((hook_name) => {
-          let hook_fn_name = part[hook_set_name][hook_name];
-
-          /* On the server side, you can't just
+  for (const part of parts) {
+    for (const [hookName, regHookFnName] of Object.entries(part[hookSetName] || {})) {
+      /* On the server side, you can't just
        * require("pluginname/whatever") if the plugin is installed as
        * a dependency of another plugin! Bah, pesky little details of
        * npm... */
-          if (normalizer) {
-            hook_fn_name = normalizer(part, hook_fn_name, hook_name);
-          }
+      const hookFnName = normalizer ? normalizer(part, regHookFnName, hookName) : regHookFnName;
 
-          const disabledReason = (disabledHookReasons[hook_set_name] || {})[hook_name];
-          if (disabledReason) {
-            console.error(
-                `Hook ${hook_set_name}/${hook_name} is disabled. Reason: ${disabledReason}`);
-            console.error(`The hook function ${hook_fn_name} from plugin ${part.plugin} ` +
-                          'will never be called, which may cause the plugin to fail');
-            console.error(
-                `Please update the ${part.plugin} plugin to not use the ${hook_name} hook`);
-            return;
-          }
-          let hook_fn;
-          try {
-            hook_fn = loadFn(hook_fn_name, hook_name);
-            if (!hook_fn) {
-              throw new Error('Not a function');
-            }
-          } catch (exc) {
-            console.error(`Failed to load '${hook_fn_name}' for ` +
-                          `'${part.full_name}/${hook_set_name}/${hook_name}': ${exc.toString()}`);
-          }
-          if (hook_fn) {
-            if (hooks[hook_name] == null) hooks[hook_name] = [];
-            hooks[hook_name].push({hook_name, hook_fn, hook_fn_name, part});
-          }
+      const disabledReason = (disabledHookReasons[hookSetName] || {})[hookName];
+      if (disabledReason) {
+        console.error(`Hook ${hookSetName}/${hookName} is disabled. Reason: ${disabledReason}`);
+        console.error(`The hook function ${hookFnName} from plugin ${part.plugin} ` +
+                      'will never be called, which may cause the plugin to fail');
+        console.error(`Please update the ${part.plugin} plugin to not use the ${hookName} hook`);
+        return;
+      }
+      let hookFn;
+      try {
+        hookFn = loadFn(hookFnName, hookName);
+        if (!hookFn) throw new Error('Not a function');
+      } catch (exc) {
+        console.error(`Failed to load '${hookFnName}' for ` +
+                      `'${part.full_name}/${hookSetName}/${hookName}': ${exc.toString()}`);
+      }
+      if (hookFn) {
+        if (hooks[hookName] == null) hooks[hookName] = [];
+        hooks[hookName].push({
+          hook_name: hookName,
+          hook_fn: hookFn,
+          hook_fn_name: hookFnName,
+          part,
         });
-  });
+      }
+    }
+  }
   return hooks;
 };
 
@@ -93,11 +88,8 @@ exports.extractHooks = extractHooks;
  *   Some plugins: [ 'ep_adminpads', 'ep_add_buttons', 'ep_activepads' ]
  */
 exports.clientPluginNames = () => {
-  const client_plugin_names = _.uniq(
-      defs.parts
-          .filter((part) => Object.prototype.hasOwnProperty.call(part, 'client_hooks'))
-          .map((part) => `plugin-${part.plugin}`)
-  );
-
-  return client_plugin_names;
+  const clientPluginNames = defs.parts
+      .filter((part) => Object.prototype.hasOwnProperty.call(part, 'client_hooks'))
+      .map((part) => `plugin-${part.plugin}`);
+  return [...new Set(clientPluginNames)];
 };

--- a/src/templates/admin/plugins-info.html
+++ b/src/templates/admin/plugins-info.html
@@ -1,6 +1,3 @@
-<%
-  var plugins = require("ep_etherpad-lite/static/js/pluginfw/plugins");
-%>
 <!doctype html>
 <html>
   <head>
@@ -31,17 +28,17 @@
         <p>Git sha: <a href='https://github.com/ether/etherpad-lite/commit/<%= gitCommit %>'><%= gitCommit %></a></p>
 
         <h2 data-l10n-id="admin_plugins_info.plugins">Installed plugins</h2>
-        <pre><%- plugins.formatPlugins().replace(/, /g,"\n") %></pre>
+        <%- installedPlugins %>
 
         <h2 data-l10n-id="admin_plugins_info.parts">Installed parts</h2>
-        <pre><%= plugins.formatParts() %></pre>
+        <%- installedParts %>
 
         <h2 data-l10n-id="admin_plugins_info.hooks">Installed hooks</h2>
         <h3 data-l10n-id="admin_plugins_info.hooks_server">Server-side hooks</h3>
-        <div><%- plugins.formatHooks() %></div>
+        <%- installedServerHooks %>
 
         <h3 data-l10n-id="admin_plugins_info.hooks_client">Client-side hooks</h3>
-        <div><%- plugins.formatHooks("client_hooks") %></div>
+        <%- installedClientHooks %>
 
       </div>
     </div>


### PR DESCRIPTION
Multiple commits:
* pluginfw: Call `npm.load()` before using `npm`
* pluginfw: Delete commented-out code
* pluginfw: Return from `findUnmet()` early if not given an object
* pluginfw: Fix state reset logic
* lint: src/static/js/pluginfw/plugins.js
* lint: src/static/js/pluginfw/read-installed.js
* lint: src/static/js/pluginfw/shared.js
* lint: Move functions up to fix more lint errors
* /admin/plugins/info: Move logic to `.js` file
* pluginfw: In-line `formatPluginsWithVersion()`
* pluginfw: Replace `slide.asyncMap()` with `Promise.all()`
* pluginfw: Use `for` loops to improve readability
* pluginfw: Delete unused return value

These changes are to prepare for migrating from `require('npm')` to running the `npm` CLI tool directly.