### PR TITLE
Fix OL list items not increasing

### DIFF
--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -101,7 +101,7 @@ domline.createDomLine = (nonEmpty, doesWrap, optBrowser, optDocument) => {
             postHtml = `</li></ul>${postHtml}`;
           } else {
             if (start) { // is it a start of a list with more than one item in?
-              if (parseInt(start[1]) === 1) { // if its the first one at this level?
+              if (Number.parseInt(start[1]) === 1) { // if its the first one at this level?
                 // Add start class to DIV node
                 lineClass = `${lineClass} ` + `list-start-${listType}`;
               }

--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -101,7 +101,7 @@ domline.createDomLine = (nonEmpty, doesWrap, optBrowser, optDocument) => {
             postHtml = `</li></ul>${postHtml}`;
           } else {
             if (start) { // is it a start of a list with more than one item in?
-              if (start[1] === 1) { // if its the first one at this level?
+              if (parseInt(start[1]) === 1) { // if its the first one at this level?
                 // Add start class to DIV node
                 lineClass = `${lineClass} ` + `list-start-${listType}`;
               }

--- a/src/tests/frontend/specs/ordered_list.js
+++ b/src/tests/frontend/specs/ordered_list.js
@@ -108,6 +108,21 @@ describe('ordered_list.js', function () {
       });
     });
 
+    it('issue #4748 keeps numbers increment on OL', function (done) {
+      this.timeout(5000);
+      const inner$ = helper.padInner$;
+      const chrome$ = helper.padChrome$;
+      const $insertorderedlistButton = chrome$('.buttonicon-insertorderedlist');
+      const $firstLine = inner$('div').first();
+      $firstLine.sendkeys('{selectall}');
+      $insertorderedlistButton.click();
+      const $secondLine = inner$('div').first().next();
+      $secondLine.sendkeys('{selectall}');
+      $insertorderedlistButton.click();
+      expect($secondLine.hasClass('list-number2')).to.be(true);
+      done();
+    });
+
     xit('issue #1125 keeps the numbered list on enter for the new line', function (done) {
       // EMULATES PASTING INTO A PAD
       const inner$ = helper.padInner$;

--- a/src/tests/frontend/specs/ordered_list.js
+++ b/src/tests/frontend/specs/ordered_list.js
@@ -119,7 +119,7 @@ describe('ordered_list.js', function () {
       const $secondLine = inner$('div').first().next();
       $secondLine.sendkeys('{selectall}');
       $insertorderedlistButton.click();
-      expect($secondLine.hasClass('list-number2')).to.be(true);
+      expect($secondLine.find('ol').attr('start') === 2);
       done();
     });
 


### PR DESCRIPTION
#4748 is a bug report where ordered list items were not properly formatted due to a lazy check.  The lazy check was ``x == 1`` and when we linted we changed it to ``x === 1``, the ``1`` was coming from a string check so it was typeOf string which meant when we did a more strict check it never returned true causing line number snot to incremented.

This PR.

* Fixes bug by parsing the string to an integer
* Fixes test by adding a new test which covers this edge case, although I'm not sure why it wasn't failing before on other tests..   we can investigate why once this is merged and we have order restored so can release.