### PR TITLE
Minify: asyncify, plus some fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
   * `callFirst()` and `aCallFirst()` now support the same wide range of hook
     function behaviors that `callAll()`, `aCallAll()`, and `callAllSerial()`
     support. Also, they now warn when a hook function misbehaves.
-  * The `padCopy` and `padRemove` hooks now support asynchronous hook functions.
+  * The following server-side hooks now support asynchronous hook functions:
+    `expressConfigure`, `expressCreateServer`, `padCopy`, `padRemove`
   * Backend tests for plugins can now use the
     [`ep_etherpad-lite/tests/backend/common`](src/tests/backend/common.js)
     module to start the server and simplify API access.

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -182,9 +182,10 @@ exports.restartServer = async () => {
 
   app.use(cookieParser(settings.sessionKey, {}));
 
-  hooks.callAll('expressConfigure', {app});
-  hooks.callAll('expressCreateServer', {app, server: exports.server});
-
+  await Promise.all([
+    hooks.aCallAll('expressConfigure', {app}),
+    hooks.aCallAll('expressCreateServer', {app, server: exports.server}),
+  ]);
   await util.promisify(exports.server.listen).bind(exports.server)(settings.port, settings.ip);
 };
 

--- a/src/node/hooks/express/static.js
+++ b/src/node/hooks/express/static.js
@@ -26,8 +26,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
   });
 
   const StaticAssociator = Yajsml.associators.StaticAssociator;
-  const associations =
-    Yajsml.associators.associationsForSimpleMapping(minify.tar);
+  const associations = Yajsml.associators.associationsForSimpleMapping(minify.getTar());
   const associator = new StaticAssociator(associations);
   jsServer.setAssociator(associator);
 

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -22,7 +22,7 @@
  */
 
 const settings = require('./Settings');
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const plugins = require('../../static/js/pluginfw/plugin_defs');
 const RequireKernel = require('etherpad-require-kernel');
@@ -30,7 +30,6 @@ const urlutil = require('url');
 const mime = require('mime-types');
 const Threads = require('threads');
 const log4js = require('log4js');
-const util = require('util');
 
 const logger = log4js.getLogger('Minify');
 
@@ -195,7 +194,7 @@ const minify = async (req, res) => {
 
 // find all includes in ace.js and embed them.
 const getAceFile = async () => {
-  let data = await util.promisify(fs.readFile)(`${ROOT_DIR}js/ace.js`, 'utf8');
+  let data = await fs.readFile(`${ROOT_DIR}js/ace.js`, 'utf8');
 
   // Find all includes in ace.js and embed them
   const filenames = [];
@@ -255,7 +254,7 @@ const statFile = async (filename, dirStatLimit) => {
   } else {
     let stats;
     try {
-      stats = await util.promisify(fs.stat)(ROOT_DIR + filename);
+      stats = await fs.stat(ROOT_DIR + filename);
     } catch (err) {
       if (err.code === 'ENOENT') {
         // Stat the directory instead.
@@ -274,7 +273,7 @@ const lastModifiedDateOfEverything = async () => {
   // go through this two folders
   await Promise.all(folders2check.map(async (path) => {
     // read the files in the folder
-    const files = await util.promisify(fs.readdir)(path);
+    const files = await fs.readdir(path);
 
     // we wanna check the directory itself for changes too
     files.push('.');
@@ -282,7 +281,7 @@ const lastModifiedDateOfEverything = async () => {
     // go through all files in this folder
     await Promise.all(files.map(async (filename) => {
       // get the stat data of this file
-      const stats = await util.promisify(fs.stat)(`${path}/${filename}`);
+      const stats = await fs.stat(`${path}/${filename}`);
 
       // get the modification time
       const modificationTime = stats.mtime.getTime();
@@ -348,7 +347,7 @@ const getFileCompressed = async (filename, contentType) => {
 const getFile = async (filename) => {
   if (filename === 'js/ace.js') return await getAceFile();
   if (filename === 'js/require-kernel.js') return requireDefinition();
-  return await util.promisify(fs.readFile)(ROOT_DIR + filename);
+  return await fs.readFile(ROOT_DIR + filename);
 };
 
 exports.minify = (req, res, next) => minify(req, res).catch((err) => next(err || new Error(err)));

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -91,26 +91,12 @@ const requestURI = async (url, method, headers) => {
 };
 
 const requestURIs = (locations, method, headers, callback) => {
-  let pendingRequests = locations.length;
-  const responses = [];
-
-  const completed = () => {
+  Promise.all(locations.map((loc) => requestURI(loc, method, headers))).then((responses) => {
     const statuss = responses.map((x) => x[0]);
     const headerss = responses.map((x) => x[1]);
     const contentss = responses.map((x) => x[2]);
     callback(statuss, headerss, contentss);
-  };
-
-  const respondFor = (i) => (response) => {
-    responses[i] = response;
-    if (--pendingRequests === 0) {
-      completed();
-    }
-  };
-
-  for (let i = 0, ii = locations.length; i < ii; i++) {
-    requestURI(locations[i], method, headers).then(respondFor(i));
-  }
+  });
 };
 
 /**

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -48,26 +48,6 @@ const LIBRARY_WHITELIST = [
   'unorm',
 ];
 
-// Rewrite tar to include modules with no extensions and proper rooted paths.
-exports.getTar = () => {
-  const prefixLocalLibraryPath = (path) => {
-    if (path.charAt(0) === '$') {
-      return path.slice(1);
-    } else {
-      return `ep_etherpad-lite/static/js/${path}`;
-    }
-  };
-  const tarJson = fs.readFileSync(path.join(__dirname, 'tar.json'), 'utf8');
-  const tar = {};
-  for (const [key, relativeFiles] of Object.entries(JSON.parse(tarJson))) {
-    const files = relativeFiles.map(prefixLocalLibraryPath);
-    tar[prefixLocalLibraryPath(key)] = files
-        .concat(files.map((p) => p.replace(/\.js$/, '')))
-        .concat(files.map((p) => `${p.replace(/\.js$/, '')}/index.js`));
-  }
-  return tar;
-};
-
 // What follows is a terrible hack to avoid loop-back within the server.
 // TODO: Serve files from another service, or directly from the file system.
 const requestURI = (url, method, headers, callback) => {

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -245,9 +245,9 @@ const statFile = (filename, callback, dirStatLimit) => {
   } else if (filename === 'js/ace.js') {
     // Sometimes static assets are inlined into this file, so we have to stat
     // everything.
-    lastModifiedDateOfEverything((error, date) => {
-      callback(error, date, !error);
-    });
+    lastModifiedDateOfEverything().then(
+        (date) => callback(null, date, true),
+        (err) => callback(err || new Error(err)));
   } else if (filename === 'js/require-kernel.js') {
     callback(null, requireLastModified(), true);
   } else {
@@ -270,11 +270,11 @@ const statFile = (filename, callback, dirStatLimit) => {
   }
 };
 
-const lastModifiedDateOfEverything = (callback) => {
+const lastModifiedDateOfEverything = async () => {
   const folders2check = [`${ROOT_DIR}js/`, `${ROOT_DIR}css/`];
   let latestModification = 0;
   // go through this two folders
-  Promise.all(folders2check.map(async (path) => {
+  await Promise.all(folders2check.map(async (path) => {
     // read the files in the folder
     const files = await util.promisify(fs.readdir)(path);
 
@@ -294,7 +294,8 @@ const lastModifiedDateOfEverything = (callback) => {
         latestModification = modificationTime;
       }
     }));
-  })).then(() => callback(null, latestModification), (err) => callback(err || new Error(err)));
+  }));
+  return latestModification;
 };
 
 // This should be provided by the module, but until then, just use startup

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -305,7 +305,7 @@ const requireLastModified = () => _requireLastModified.toUTCString();
 const requireDefinition = () => `var require = ${RequireKernel.kernelSource};\n`;
 
 const getFileCompressed = (filename, contentType, callback) => {
-  getFile(filename, (error, content) => {
+  util.callbackify(getFile)(filename, (error, content) => {
     if (error || !content || !settings.minify) {
       callback(error, content);
     } else if (contentType === 'application/javascript') {
@@ -346,14 +346,10 @@ const getFileCompressed = (filename, contentType, callback) => {
   });
 };
 
-const getFile = (filename, callback) => {
-  if (filename === 'js/ace.js') {
-    util.callbackify(getAceFile)(callback);
-  } else if (filename === 'js/require-kernel.js') {
-    callback(undefined, requireDefinition());
-  } else {
-    fs.readFile(ROOT_DIR + filename, callback);
-  }
+const getFile = async (filename) => {
+  if (filename === 'js/ace.js') return await getAceFile();
+  if (filename === 'js/require-kernel.js') return requireDefinition();
+  return await util.promisify(fs.readFile)(ROOT_DIR + filename);
 };
 
 exports.minify = minify;

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -50,44 +50,44 @@ const LIBRARY_WHITELIST = [
 
 // What follows is a terrible hack to avoid loop-back within the server.
 // TODO: Serve files from another service, or directly from the file system.
-const requestURI = (url, method, headers, callback) => {
-  const parsedURL = urlutil.parse(url);
-
-  let status = 500;
+const requestURI = async (url, method, headers) => {
   var headers = {};
-  const content = [];
 
-  const mockRequest = {
-    url,
-    method,
-    params: {filename: parsedURL.path.replace(/^\/static\//, '')},
-    headers,
-  };
-  const mockResponse = {
-    writeHead: (_status, _headers) => {
-      status = _status;
-      for (const header in _headers) {
-        if (Object.prototype.hasOwnProperty.call(_headers, header)) {
-          headers[header] = _headers[header];
+  return await new Promise((resolve) => {
+    const parsedURL = urlutil.parse(url);
+    let status = 500;
+    const content = [];
+    const mockRequest = {
+      url,
+      method,
+      params: {filename: parsedURL.path.replace(/^\/static\//, '')},
+      headers,
+    };
+    const mockResponse = {
+      writeHead: (_status, _headers) => {
+        status = _status;
+        for (const header in _headers) {
+          if (Object.prototype.hasOwnProperty.call(_headers, header)) {
+            headers[header] = _headers[header];
+          }
         }
-      }
-    },
-    setHeader: (header, value) => {
-      headers[header.toLowerCase()] = value.toString();
-    },
-    header: (header, value) => {
-      headers[header.toLowerCase()] = value.toString();
-    },
-    write: (_content) => {
-      _content && content.push(_content);
-    },
-    end: (_content) => {
-      _content && content.push(_content);
-      callback(status, headers, content.join(''));
-    },
-  };
-
-  minify(mockRequest, mockResponse);
+      },
+      setHeader: (header, value) => {
+        headers[header.toLowerCase()] = value.toString();
+      },
+      header: (header, value) => {
+        headers[header.toLowerCase()] = value.toString();
+      },
+      write: (_content) => {
+        _content && content.push(_content);
+      },
+      end: (_content) => {
+        _content && content.push(_content);
+        resolve([status, headers, content.join('')]);
+      },
+    };
+    minify(mockRequest, mockResponse);
+  });
 };
 
 const requestURIs = (locations, method, headers, callback) => {
@@ -101,15 +101,15 @@ const requestURIs = (locations, method, headers, callback) => {
     callback(statuss, headerss, contentss);
   };
 
-  const respondFor = (i) => (status, headers, content) => {
-    responses[i] = [status, headers, content];
+  const respondFor = (i) => (response) => {
+    responses[i] = response;
     if (--pendingRequests === 0) {
       completed();
     }
   };
 
   for (let i = 0, ii = locations.length; i < ii; i++) {
-    requestURI(locations[i], method, headers, respondFor(i));
+    requestURI(locations[i], method, headers).then(respondFor(i));
   }
 };
 
@@ -233,7 +233,7 @@ const getAceFile = (callback) => {
       let resourceURI = baseURI + path.normalize(path.join('/static/', filename));
       resourceURI = resourceURI.replace(/\\/g, '/'); // Windows (safe generally?)
 
-      requestURI(resourceURI, 'GET', {}, (status, headers, body) => {
+      requestURI(resourceURI, 'GET', {}).then(([status, headers, body]) => {
         const error = !(status === 200 || status === 404);
         if (!error) {
           data += `Ace2Editor.EMBEDED[${JSON.stringify(filename)}] = ${

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -143,14 +143,7 @@ const minify = async (req, res) => {
 
   const contentType = mime.lookup(filename);
 
-  let date, exists;
-  try {
-    [date, exists] = await statFile(filename, 3);
-  } catch (err) {
-    res.writeHead(500, {});
-    res.end();
-    return;
-  }
+  const [date, exists] = await statFile(filename, 3);
   if (date) {
     date.setMilliseconds(0);
     res.setHeader('last-modified', date.toUTCString());
@@ -173,14 +166,7 @@ const minify = async (req, res) => {
     res.writeHead(200, {});
     res.end();
   } else if (req.method === 'GET') {
-    let content;
-    try {
-      content = await getFileCompressed(filename, contentType);
-    } catch (err) {
-      res.writeHead(500, {});
-      res.end();
-      return;
-    }
+    const content = await getFileCompressed(filename, contentType);
     res.header('Content-Type', contentType);
     res.writeHead(200, {});
     res.write(content);

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -26,7 +26,6 @@ const fs = require('fs').promises;
 const path = require('path');
 const plugins = require('../../static/js/pluginfw/plugin_defs');
 const RequireKernel = require('etherpad-require-kernel');
-const urlutil = require('url');
 const mime = require('mime-types');
 const Threads = require('threads');
 const log4js = require('log4js');
@@ -49,13 +48,13 @@ const LIBRARY_WHITELIST = [
 // What follows is a terrible hack to avoid loop-back within the server.
 // TODO: Serve files from another service, or directly from the file system.
 const requestURI = async (url, method, headers) => await new Promise((resolve, reject) => {
-  const parsedURL = urlutil.parse(url);
+  const parsedUrl = new URL(url);
   let status = 500;
   const content = [];
   const mockRequest = {
     url,
     method,
-    params: {filename: parsedURL.path.replace(/^\/static\//, '')},
+    params: {filename: (parsedUrl.pathname + parsedUrl.search).replace(/^\/static\//, '')},
     headers,
   };
   const mockResponse = {

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -146,6 +146,11 @@ const minify = (req, res) => {
   const contentType = mime.lookup(filename);
 
   util.callbackify(statFile)(filename, 3, (error, [date, exists]) => {
+    if (error) {
+      res.writeHead(500, {});
+      res.end();
+      return;
+    }
     if (date) {
       date = new Date(date);
       date.setMilliseconds(0);
@@ -158,10 +163,7 @@ const minify = (req, res) => {
       }
     }
 
-    if (error) {
-      res.writeHead(500, {});
-      res.end();
-    } else if (!exists) {
+    if (!exists) {
       res.writeHead(404, {});
       res.end();
     } else if (new Date(req.headers['if-modified-since']) >= date) {

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -384,7 +384,6 @@ const getFile = (filename, callback) => {
 
 exports.minify = minify;
 
-exports.requestURI = requestURI;
 exports.requestURIs = requestURIs;
 
 exports.shutdown = async (hookName, context) => {

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -197,7 +197,7 @@ const Ace2Editor = function () {
 
       pushStyleTagsFor(iframeHTML, includedCSS);
 
-      if (!Ace2Editor.EMBEDED && Ace2Editor.EMBEDED[KERNEL_SOURCE]) {
+      if (!Ace2Editor.EMBEDED || !Ace2Editor.EMBEDED[KERNEL_SOURCE]) {
         // Remotely src'd script tag will not work in IE; it must be embedded, so
         // throw an error if it is not.
         throw new Error('Require kernel could not be found.');


### PR DESCRIPTION
Multiple commits:
* lint: Replace use of underscore.js with plain ECMAScript
* express: Call expressConfigure, expressCreateServer hooks asynchronously
* ace: Fix EMBEDDED check
* Minify: Move tar processing into a function
* Minify: Move `getTar()` to `static.js`
* static: Asyncify
* Minify: Un-export `requestURI()`
* Minify: Asyncify `requestURI()`
* Minify: Use `Promise.all()` to simplify `requestURIs()`
* Minify: Replace `async.forEach()` with `Promise.all()`
* Minify: Asyncify `getAceFile()`
* Minify: Asyncify `lastModifiedDateOfEverything()`
* Minify: Asyncify `getFile()`
* Minify: Asyncify `statFile()`
* Minify: Asyncify `getFileCompressed()`
* Minify: Don't set cache headers if `statFile()` causes 500
* Minify: Asyncify `minify()`
* Minify: Use `fs.promises`
* Minify: Return `Date` objects from `statFile()`
* Minify: Let Express render the 500 error page
* Minify: Don't ignore request headers in `requestURI()`
* Minify: Replace deprecated `url.parse()` with `new URL()`
