### PR TITLE
tests: Try all supported node versions during backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -135,7 +135,7 @@ jobs:
 
     - name: Install Etherpad plugins
       run: >
-        npm install
+        npm install --no-save
         ep_align
         ep_author_hover
         ep_cursortrace

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -13,13 +13,18 @@ jobs:
     name: Linux without plugins
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [10, 12, 14, 15]
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
     - uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: ${{ matrix.node }}
 
     - name: Install libreoffice
       run: |
@@ -42,13 +47,18 @@ jobs:
     name: Linux with Plugins
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [10, 12, 14, 15]
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 
     - uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: ${{ matrix.node }}
 
     - name: Install libreoffice
       run: |

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -57,8 +57,10 @@ jobs:
         sudo apt install -y --no-install-recommends libreoffice libreoffice-pdfimport
 
     - name: Install Etherpad plugins
+      # The --legacy-peer-deps flag is required to work around a bug in npm v7:
+      # https://github.com/npm/cli/issues/2199
       run: >
-        npm install --no-save
+        npm install --no-save --legacy-peer-deps
         ep_align
         ep_author_hover
         ep_cursortrace
@@ -134,8 +136,10 @@ jobs:
         node-version: 12
 
     - name: Install Etherpad plugins
+      # The --legacy-peer-deps flag is required to work around a bug in npm v7:
+      # https://github.com/npm/cli/issues/2199
       run: >
-        npm install --no-save
+        npm install --no-save --legacy-peer-deps
         ep_align
         ep_author_hover
         ep_cursortrace

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -21,14 +21,21 @@ jobs:
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
         tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
 
+    - name: Install etherpad plugins
+      # We intentionally install an old ep_align version to test upgrades to the minor version number.
+      run: npm install --no-save ep_align@0.2.27
+
+    # This must be run after installing the plugins, otherwise npm will try to
+    # hoist common dependencies by removing them from src/node_modules and
+    # installing them in the top-level node_modules. As of v6.14.10, npm's hoist
+    # logic appears to be buggy, because it sometimes removes dependencies from
+    # src/node_modules but fails to add them to the top-level node_modules. Even
+    # if npm correctly hoists the dependencies, the hoisting seems to confuse
+    # tools such as `npm outdated`, `npm update`, and some ESLint rules.
     - name: Install all dependencies and symlink for ep_etherpad-lite
       run: src/bin/installDeps.sh
 
-      # We intentionally install a much old ep_align version to test update minor versions
-    - name: Install etherpad plugins
-      run: npm install --no-save ep_align@0.2.27
-
-      # Nuke plugin tests
+    # Nuke plugin tests
     - name: Install etherpad plugins
       run: rm -Rf node_modules/ep_align/static/tests/*
 

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -7,13 +7,23 @@ jobs:
     name: with plugins
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [10, 12, 14, 15]
+
     steps:
+    - name: Generate Sauce Labs strings
+      id: sauce_strings
+      run: |
+        printf %s\\n '::set-output name=tunnel_id::${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}-node${{ matrix.node }}'
+
     - name: Checkout repository
       uses: actions/checkout@v2
 
     - uses: actions/setup-node@v2
       with:
-        node-version: 12
+        node-version: ${{ matrix.node }}
 
     - name: Install etherpad plugins
       # We intentionally install an old ep_align version to test upgrades to the minor version number.
@@ -52,14 +62,14 @@ jobs:
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
+        tunnelIdentifier: ${{ steps.sauce_strings.outputs.tunnel_id }}
 
     - name: Run the frontend admin tests
       shell: bash
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        TRAVIS_JOB_NUMBER: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
+        TRAVIS_JOB_NUMBER: ${{ steps.sauce_strings.outputs.tunnel_id }}
         GIT_HASH: ${{ steps.environment.outputs.sha_short }}
       run: |
         src/tests/frontend/travis/adminrunner.sh

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -15,12 +15,6 @@ jobs:
       with:
         node-version: 12
 
-    - uses: saucelabs/sauce-connect-action@v1.1.2
-      with:
-        username: ${{ secrets.SAUCE_USERNAME }}
-        accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
-
     - name: Install etherpad plugins
       # We intentionally install an old ep_align version to test upgrades to the minor version number.
       # The --legacy-peer-deps flag is required to work around a bug in npm v7:
@@ -53,6 +47,12 @@ jobs:
 
     - name: Remove standard frontend test files, so only admin tests are run
       run: mv src/tests/frontend/specs/* /tmp && mv /tmp/admin*.js src/tests/frontend/specs
+
+    - uses: saucelabs/sauce-connect-action@v1.1.2
+      with:
+        username: ${{ secrets.SAUCE_USERNAME }}
+        accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
 
     - name: Run the frontend admin tests
       shell: bash

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -23,7 +23,9 @@ jobs:
 
     - name: Install etherpad plugins
       # We intentionally install an old ep_align version to test upgrades to the minor version number.
-      run: npm install --no-save ep_align@0.2.27
+      # The --legacy-peer-deps flag is required to work around a bug in npm v7:
+      # https://github.com/npm/cli/issues/2199
+      run: npm install --no-save --legacy-peer-deps ep_align@0.2.27
 
     # This must be run after installing the plugins, otherwise npm will try to
     # hoist common dependencies by removing them from src/node_modules and

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -16,6 +16,7 @@ jobs:
     - name: Generate Sauce Labs strings
       id: sauce_strings
       run: |
+        printf %s\\n '::set-output name=name::${{ github.workflow }} - ${{ github.job }} - Node ${{ matrix.node }}'
         printf %s\\n '::set-output name=tunnel_id::${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}-node${{ matrix.node }}'
 
     - name: Checkout repository
@@ -69,6 +70,7 @@ jobs:
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        SAUCE_NAME: ${{ steps.sauce_strings.outputs.name }}
         TRAVIS_JOB_NUMBER: ${{ steps.sauce_strings.outputs.tunnel_id }}
         GIT_HASH: ${{ steps.environment.outputs.sha_short }}
       run: |

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -15,12 +15,6 @@ jobs:
       with:
         node-version: 12
 
-    - uses: saucelabs/sauce-connect-action@v1.1.2
-      with:
-        username: ${{ secrets.SAUCE_USERNAME }}
-        accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
-
     - name: Install all dependencies and symlink for ep_etherpad-lite
       run: src/bin/installDeps.sh
 
@@ -30,6 +24,12 @@ jobs:
 
     - name: Write custom settings.json with loglevel WARN
       run: "sed 's/\"loglevel\": \"INFO\",/\"loglevel\": \"WARN\",/' < settings.json.template > settings.json"
+
+    - uses: saucelabs/sauce-connect-action@v1.1.2
+      with:
+        username: ${{ secrets.SAUCE_USERNAME }}
+        accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
 
     - name: Run the frontend tests
       shell: bash
@@ -52,14 +52,6 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: 12
-
-    - name: Run sauce-connect-action
-      shell: bash
-      env:
-        SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        TRAVIS_JOB_NUMBER: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
-      run: src/tests/frontend/travis/sauce_tunnel.sh
 
     - name: Install Etherpad plugins
       # The --legacy-peer-deps flag is required to work around a bug in npm v7:
@@ -103,6 +95,12 @@ jobs:
       # XXX we should probably run all tests, because plugins could effect their results
     - name: Remove standard frontend test files, so only plugin tests are run
       run: rm src/tests/frontend/specs/*
+
+    - uses: saucelabs/sauce-connect-action@v1.1.2
+      with:
+        username: ${{ secrets.SAUCE_USERNAME }}
+        accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
 
     - name: Run the frontend tests
       shell: bash

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -62,8 +62,10 @@ jobs:
       run: src/tests/frontend/travis/sauce_tunnel.sh
 
     - name: Install Etherpad plugins
+      # The --legacy-peer-deps flag is required to work around a bug in npm v7:
+      # https://github.com/npm/cli/issues/2199
       run: >
-        npm install --no-save
+        npm install --no-save --legacy-peer-deps
         ep_align
         ep_author_hover
         ep_cursortrace

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate Sauce Labs strings
+      id: sauce_strings
+      run: |
+        printf %s\\n '::set-output name=name::${{ github.workflow }} - ${{ github.job }}'
+        printf %s\\n '::set-output name=tunnel_id::${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}'
+
     - name: Checkout repository
       uses: actions/checkout@v2
 
@@ -29,14 +35,15 @@ jobs:
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
+        tunnelIdentifier: ${{ steps.sauce_strings.outputs.tunnel_id }}
 
     - name: Run the frontend tests
       shell: bash
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        TRAVIS_JOB_NUMBER: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
+        SAUCE_NAME: ${{ steps.sauce_strings.outputs.name }}
+        TRAVIS_JOB_NUMBER: ${{ steps.sauce_strings.outputs.tunnel_id }}
         GIT_HASH: ${{ steps.environment.outputs.sha_short }}
       run: |
         src/tests/frontend/travis/runner.sh
@@ -46,6 +53,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate Sauce Labs strings
+      id: sauce_strings
+      run: |
+        printf %s\\n '::set-output name=name::${{ github.workflow }} - ${{ github.job }}'
+        printf %s\\n '::set-output name=tunnel_id::${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}'
+
     - name: Checkout repository
       uses: actions/checkout@v2
 
@@ -100,14 +113,15 @@ jobs:
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
-        tunnelIdentifier: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
+        tunnelIdentifier: ${{ steps.sauce_strings.outputs.tunnel_id }}
 
     - name: Run the frontend tests
       shell: bash
       env:
         SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
         SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        TRAVIS_JOB_NUMBER: ${{ github.run_id }}-${{ github.run_number }}-${{ github.job }}
+        SAUCE_NAME: ${{ steps.sauce_strings.outputs.name }}
+        TRAVIS_JOB_NUMBER: ${{ steps.sauce_strings.outputs.tunnel_id }}
         GIT_HASH: ${{ steps.environment.outputs.sha_short }}
       run: |
         src/tests/frontend/travis/runner.sh

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -51,8 +51,10 @@ jobs:
       run: sudo npm install -g etherpad-load-test
 
     - name: Install etherpad plugins
+      # The --legacy-peer-deps flag is required to work around a bug in npm v7:
+      # https://github.com/npm/cli/issues/2199
       run: >
-        npm install --no-save
+        npm install --no-save --legacy-peer-deps
         ep_align
         ep_author_hover
         ep_cursortrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ _install_libreoffice: &install_libreoffice >-
   sudo apt-get update &&
   sudo apt-get -y install libreoffice libreoffice-pdfimport
 
+# The --legacy-peer-deps flag is required to work around a bug in npm v7:
+# https://github.com/npm/cli/issues/2199
 _install_plugins: &install_plugins >-
-  npm install --no-save
+  npm install --no-save --legacy-peer-deps
   ep_align
   ep_author_hover
   ep_cursortrace

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Etherpad is very customizable through plugins. Instructions for installing theme
 Run the following command in your Etherpad folder to get all of the features visible in the demo gif:
 
 ```
-npm install --no-save ep_headings2 ep_markdown ep_comments_page ep_align ep_font_color ep_webrtc ep_embedded_hyperlinks2
+npm install --no-save --legacy-peer-deps ep_headings2 ep_markdown ep_comments_page ep_align ep_font_color ep_webrtc ep_embedded_hyperlinks2
 ```
 
 ## Customize the style with skin variants

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -7,8 +7,8 @@ execute its own functionality based on these events.
 Publicly available plugins can be found in the npm registry (see
 <https://npmjs.org>). Etherpad's naming convention for plugins is to prefix your
 plugins with `ep_`. So, e.g. it's `ep_flubberworms`. Thus you can install
-plugins from npm, using `npm install --no-save ep_flubberworm` in Etherpad's
-root directory.
+plugins from npm, using `npm install --no-save --legacy-peer-deps
+ep_flubberworm` in Etherpad's root directory.
 
 You can also browse to `http://yourEtherpadInstan.ce/admin/plugins`, which will
 list all installed plugins and those available on npm. It even provides

--- a/src/bin/plugins/lib/README.md
+++ b/src/bin/plugins/lib/README.md
@@ -9,7 +9,7 @@ Explain what your plugin does and who it's useful for.
 ## Installing
 
 ```
-npm install --no-save [plugin_name]
+npm install --no-save --legacy-peer-deps [plugin_name]
 ```
 
 or Use the Etherpad ``/admin`` interface.

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -32,7 +32,9 @@ exports.uninstall = async (pluginName, cb = null) => {
   logger.info(`Uninstalling plugin ${pluginName}...`);
   try {
     // The --no-save flag prevents npm from creating package.json or package-lock.json.
-    await runCmd(['npm', 'uninstall', '--no-save', pluginName]);
+    // The --legacy-peer-deps flag is required to work around a bug in npm v7:
+    // https://github.com/npm/cli/issues/2199
+    await runCmd(['npm', 'uninstall', '--no-save', '--legacy-peer-deps', pluginName]);
   } catch (err) {
     logger.error(`Failed to uninstall plugin ${pluginName}`);
     cb(err || new Error(err));
@@ -49,7 +51,9 @@ exports.install = async (pluginName, cb = null) => {
   logger.info(`Installing plugin ${pluginName}...`);
   try {
     // The --no-save flag prevents npm from creating package.json or package-lock.json.
-    await runCmd(['npm', 'install', '--no-save', pluginName]);
+    // The --legacy-peer-deps flag is required to work around a bug in npm v7:
+    // https://github.com/npm/cli/issues/2199
+    await runCmd(['npm', 'install', '--no-save', '--legacy-peer-deps', pluginName]);
   } catch (err) {
     logger.error(`Failed to install plugin ${pluginName}`);
     cb(err || new Error(err));

--- a/src/tests/backend/assert-legacy.js
+++ b/src/tests/backend/assert-legacy.js
@@ -1,0 +1,48 @@
+'use strict';
+// support for older node versions (<12)
+const assert = require('assert');
+
+const internalMatch = (string, regexp, message, fn) => {
+  if (!regexp.test) {
+    throw new Error('regexp parameter is not a RegExp');
+  }
+  if (typeof string !== 'string') {
+    throw new Error('string parameter is not a string');
+  }
+  const match = fn.name === 'match';
+
+  const result = string.match(regexp);
+  if (match && !result) {
+    if (message) {
+      throw message;
+    } else {
+      throw new Error(`${string} does not match regex ${regexp}`);
+    }
+  }
+  if (!match && result) {
+    if (message) {
+      throw message;
+    } else {
+      throw new Error(`${string} does match regex ${regexp}`);
+    }
+  }
+};
+
+
+if (!assert.match) {
+  const match = (string, regexp, message) => {
+    internalMatch(string, regexp, message, match);
+  };
+  assert.match = match;
+}
+if (!assert.strict.match) assert.strict.match = assert.match;
+
+if (!assert.doesNotMatch) {
+  const doesNotMatch = (string, regexp, message) => {
+    internalMatch(string, regexp, message, doesNotMatch);
+  };
+  assert.doesNotMatch = doesNotMatch;
+}
+if (!assert.strict.doesNotMatch) assert.strict.doesNotMatch = assert.doesNotMatch;
+
+module.exports = assert;

--- a/src/tests/backend/specs/caching_middleware.js
+++ b/src/tests/backend/specs/caching_middleware.js
@@ -7,7 +7,7 @@
  */
 
 const common = require('../common');
-const assert = require('assert').strict;
+const assert = require('../assert-legacy').strict;
 const queryString = require('querystring');
 const settings = require('../../../node/utils/Settings');
 

--- a/src/tests/backend/specs/hooks.js
+++ b/src/tests/backend/specs/hooks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert').strict;
+const assert = require('../assert-legacy').strict;
 const hooks = require('../../../static/js/pluginfw/hooks');
 const plugins = require('../../../static/js/pluginfw/plugin_defs');
 const sinon = require('sinon');

--- a/src/tests/frontend/travis/remote_runner.js
+++ b/src/tests/frontend/travis/remote_runner.js
@@ -27,9 +27,9 @@ process.on('exit', (code) => {
 const sauceTestWorker = async.queue((testSettings, callback) => {
   const browser = wd.promiseChainRemote(
       config.host, config.port, config.username, config.accessKey);
-  const name =
-      `${process.env.GIT_HASH} - ${testSettings.browserName} ` +
-      `${testSettings.version}, ${testSettings.platform}`;
+  const name = [process.env.GIT_HASH].concat(process.env.SAUCE_NAME || []).concat([
+    `${testSettings.browserName} ${testSettings.version}, ${testSettings.platform}`,
+  ]).join(' - ');
   testSettings.name = name;
   testSettings.public = true;
   testSettings.build = process.env.GIT_HASH;


### PR DESCRIPTION
We should run our tests with all node versions that we currently support. This PR uses v10/12/14/15 for our backend tests. Maybe adding different versions to the admin tests would be clever too, as they use npm