### PR TITLE
socketio: include image upload frontend test coverage and increase socketio limit to something workable

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -66,6 +66,7 @@ jobs:
         ep_font_size
         ep_hash_auth
         ep_headings2
+        ep_image_upload
         ep_markdown
         ep_readonly_guest
         ep_set_title_on_pad

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -72,6 +72,7 @@ jobs:
         ep_font_size
         ep_hash_auth
         ep_headings2
+        ep_image_upload
         ep_markdown
         ep_readonly_guest
         ep_set_title_on_pad

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -56,7 +56,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
      *   https://github.com/socketio/socket.io/issues/2276#issuecomment-147184662 (not totally true, actually, see above)
      */
     cookie: false,
-    maxHttpBufferSize: 10E3,
+    maxHttpBufferSize: 1 << 20, // 1MiB
   });
 
   io.use((socket, next) => {


### PR DESCRIPTION
The initial value was 10k, @Exploder98 rightly pointed out this value is far too low.

@webzwo0i I hope this is still inline with your testing on this issue?