### PR TITLE
editor: update lines with zero height on sidediv

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3858,7 +3858,7 @@ function Ace2Inner() {
     // Apply height to existing sidediv lines
     currentLine = 0;
     while (sidebarLine && currentLine <= lineNumbersShown) {
-      if (lineHeights[currentLine]) {
+      if (lineHeights[currentLine] !== undefined) {
         sidebarLine.style.height = `${lineHeights[currentLine]}px`;
       }
       sidebarLine = sidebarLine.nextSibling;


### PR DESCRIPTION
Our proposal is to simply modify the `if` condition, allowing us to update lines with zero height.
This change does not have any side effects for the current cases of updating the `#sidediv`.

Closes #4764