### PR TITLE
tests: Various improvements

### DIFF
--- a/src/tests/backend/common.js
+++ b/src/tests/backend/common.js
@@ -23,6 +23,11 @@ const logLevel = exports.logger.level;
 // https://github.com/mochajs/mocha/issues/2640
 process.on('unhandledRejection', (reason, promise) => { throw reason; });
 
+before(async function () {
+  this.timeout(60000);
+  await exports.init();
+});
+
 exports.init = async function () {
   if (agentPromise != null) return await agentPromise;
   let agentResolve;

--- a/src/tests/backend/common.js
+++ b/src/tests/backend/common.js
@@ -9,7 +9,7 @@ const supertest = require('supertest');
 const webaccess = require('../../node/hooks/express/webaccess');
 
 const backups = {};
-let inited = false;
+let agentPromise = null;
 
 exports.apiKey = apiHandler.exportedForTestingOnly.apiKey;
 exports.agent = null;
@@ -24,8 +24,9 @@ const logLevel = exports.logger.level;
 process.on('unhandledRejection', (reason, promise) => { throw reason; });
 
 exports.init = async function () {
-  if (inited) return exports.agent;
-  inited = true;
+  if (agentPromise != null) return await agentPromise;
+  let agentResolve;
+  agentPromise = new Promise((resolve) => { agentResolve = resolve; });
 
   if (!logLevel.isLessThanOrEqualTo(log4js.levels.DEBUG)) {
     exports.logger.warn('Disabling non-test logging for the duration of the test. ' +
@@ -56,5 +57,6 @@ exports.init = async function () {
     await server.exit();
   });
 
+  agentResolve(exports.agent);
   return exports.agent;
 };

--- a/src/tests/backend/specs/api/api.js
+++ b/src/tests/backend/specs/api/api.js
@@ -32,20 +32,19 @@ const endPoint = (point) => `/api/${apiVersion}/${point}?apikey=${apiKey}`;
 describe(__filename, function () {
   before(async function () { agent = await common.init(); });
 
-  it('can obtain API version', function (done) {
-    agent
-        .get('/api/')
+  it('can obtain API version', async function () {
+    await agent.get('/api/')
+        .expect(200)
         .expect((res) => {
           apiVersion = res.body.currentVersion;
           if (!res.body.currentVersion) throw new Error('No version set in API');
           return;
-        })
-        .expect(200, done);
+        });
   });
 
-  it('can obtain valid openapi definition document', function (done) {
-    agent
-        .get('/api/openapi.json')
+  it('can obtain valid openapi definition document', async function () {
+    await agent.get('/api/openapi.json')
+        .expect(200)
         .expect((res) => {
           const {valid, errors} = validateOpenAPI(res.body, 3);
           if (!valid) {
@@ -53,18 +52,15 @@ describe(__filename, function () {
             throw new Error(`Document is not valid OpenAPI. ${errors.length} ` +
                             `validation errors:\n${prettyErrors}`);
           }
-          return;
-        })
-        .expect(200, done);
+        });
   });
 
-  it('supports jsonp calls', function (done) {
-    agent
-        .get(`${endPoint('createPad')}&jsonp=jsonp_1&padID=${testPadId}`)
+  it('supports jsonp calls', async function () {
+    await agent.get(`${endPoint('createPad')}&jsonp=jsonp_1&padID=${testPadId}`)
+        .expect(200)
+        .expect('Content-Type', /javascript/)
         .expect((res) => {
           if (!res.text.match('jsonp_1')) throw new Error('no jsonp call seen');
-        })
-        .expect('Content-Type', /javascript/)
-        .expect(200, done);
+        });
   });
 });

--- a/src/tests/backend/specs/api/api.js
+++ b/src/tests/backend/specs/api/api.js
@@ -32,45 +32,39 @@ const testPadId = makeid();
 const endPoint = (point) => `/api/${apiVersion}/${point}?apikey=${apiKey}`;
 
 describe(__filename, function () {
-  describe('API Versioning', function () {
-    it('errors if can not connect', function (done) {
-      api
-          .get('/api/')
-          .expect((res) => {
-            apiVersion = res.body.currentVersion;
-            if (!res.body.currentVersion) throw new Error('No version set in API');
-            return;
-          })
-          .expect(200, done);
-    });
+  it('can obtain API version', function (done) {
+    api
+        .get('/api/')
+        .expect((res) => {
+          apiVersion = res.body.currentVersion;
+          if (!res.body.currentVersion) throw new Error('No version set in API');
+          return;
+        })
+        .expect(200, done);
   });
 
-  describe('OpenAPI definition', function () {
-    it('generates valid openapi definition document', function (done) {
-      api
-          .get('/api/openapi.json')
-          .expect((res) => {
-            const {valid, errors} = validateOpenAPI(res.body, 3);
-            if (!valid) {
-              const prettyErrors = JSON.stringify(errors, null, 2);
-              throw new Error(`Document is not valid OpenAPI. ${errors.length} ` +
-                              `validation errors:\n${prettyErrors}`);
-            }
-            return;
-          })
-          .expect(200, done);
-    });
+  it('can obtain valid openapi definition document', function (done) {
+    api
+        .get('/api/openapi.json')
+        .expect((res) => {
+          const {valid, errors} = validateOpenAPI(res.body, 3);
+          if (!valid) {
+            const prettyErrors = JSON.stringify(errors, null, 2);
+            throw new Error(`Document is not valid OpenAPI. ${errors.length} ` +
+                            `validation errors:\n${prettyErrors}`);
+          }
+          return;
+        })
+        .expect(200, done);
   });
 
-  describe('jsonp support', function () {
-    it('supports jsonp calls', function (done) {
-      api
-          .get(`${endPoint('createPad')}&jsonp=jsonp_1&padID=${testPadId}`)
-          .expect((res) => {
-            if (!res.text.match('jsonp_1')) throw new Error('no jsonp call seen');
-          })
-          .expect('Content-Type', /javascript/)
-          .expect(200, done);
-    });
+  it('supports jsonp calls', function (done) {
+    api
+        .get(`${endPoint('createPad')}&jsonp=jsonp_1&padID=${testPadId}`)
+        .expect((res) => {
+          if (!res.text.match('jsonp_1')) throw new Error('no jsonp call seen');
+        })
+        .expect('Content-Type', /javascript/)
+        .expect(200, done);
   });
 });

--- a/src/tests/backend/specs/api/api.js
+++ b/src/tests/backend/specs/api/api.js
@@ -9,11 +9,9 @@
  */
 
 const common = require('../../common');
-const settings = require('../../../../node/utils/Settings');
-const supertest = require('supertest');
 const validateOpenAPI = require('openapi-schema-validation').validate;
 
-const api = supertest(`http://${settings.ip}:${settings.port}`);
+let agent;
 const apiKey = common.apiKey;
 let apiVersion = 1;
 
@@ -32,8 +30,10 @@ const testPadId = makeid();
 const endPoint = (point) => `/api/${apiVersion}/${point}?apikey=${apiKey}`;
 
 describe(__filename, function () {
+  before(async function () { agent = await common.init(); });
+
   it('can obtain API version', function (done) {
-    api
+    agent
         .get('/api/')
         .expect((res) => {
           apiVersion = res.body.currentVersion;
@@ -44,7 +44,7 @@ describe(__filename, function () {
   });
 
   it('can obtain valid openapi definition document', function (done) {
-    api
+    agent
         .get('/api/openapi.json')
         .expect((res) => {
           const {valid, errors} = validateOpenAPI(res.body, 3);
@@ -59,7 +59,7 @@ describe(__filename, function () {
   });
 
   it('supports jsonp calls', function (done) {
-    api
+    agent
         .get(`${endPoint('createPad')}&jsonp=jsonp_1&padID=${testPadId}`)
         .expect((res) => {
           if (!res.text.match('jsonp_1')) throw new Error('no jsonp call seen');

--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const helper = {}; // eslint-disable-line no-redeclare
+const helper = {};
 
 (() => {
   let $iframe;

--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -198,6 +198,10 @@ const helper = {};
   };
 
   helper.waitFor = (conditionFunc, timeoutTime = 1900, intervalTime = 10) => {
+    // Create an Error object to use if the condition is never satisfied. This is created here so
+    // that the Error has a useful stack trace associated with it.
+    const timeoutError =
+        new Error(`waitFor condition never became true ${conditionFunc.toString()}`);
     const deferred = new $.Deferred();
 
     const _fail = deferred.fail.bind(deferred);
@@ -222,11 +226,10 @@ const helper = {};
 
     const timeout = setTimeout(() => {
       clearInterval(intervalCheck);
-      const error = new Error(`wait for condition never became true ${conditionFunc.toString()}`);
-      deferred.reject(error);
+      deferred.reject(timeoutError);
 
       if (!listenForFail) {
-        throw error;
+        throw timeoutError;
       }
     }, timeoutTime);
 

--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -211,9 +211,9 @@ const helper = {};
       return _fail(...args);
     };
 
-    const check = () => {
+    const check = async () => {
       try {
-        if (!conditionFunc()) return;
+        if (!await conditionFunc()) return;
         deferred.resolve();
       } catch (err) {
         deferred.reject(err);

--- a/src/tests/frontend/specs/helper.js
+++ b/src/tests/frontend/specs/helper.js
@@ -210,6 +210,19 @@ describe('the test helper', function () {
         await helper.waitFor(() => true, 0);
       });
     });
+
+    it('accepts async functions', async function () {
+      await helper.waitFor(async () => true).fail(() => {});
+      // Make sure it checks the truthiness of the Promise's resolved value, not the truthiness of
+      // the Promise itself (a Promise is always truthy).
+      let ok = false;
+      try {
+        await helper.waitFor(async () => false, 0).fail(() => {});
+      } catch (err) {
+        ok = true;
+      }
+      expect(ok).to.be(true);
+    });
   });
 
   describe('the waitForPromise method', function () {


### PR DESCRIPTION
Multiple commits:
* lint: Delete unnecessary `eslint-disable-line` comment
* tests: Wait for `common.init()` to complete before returning
* tests: Always call backend `common.init()` at startup
* tests: Delete unnecessary `describe()` calls in `api.js`
* tests: Use the supertest agent from `common.js` for `api.js`
* tests: Asyncify tests in `api.js`
* tests: Give `helper.waitFor()` timeout errors a useful stack trace
* tests: Accept async condition functions for `helper.waitFor()`
