### PR TITLE
express: Change `httpUptime` to `httpStartTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Database performance is significantly improved.
 * Admin UI now has test coverage in CI. (The tests are not enabled by default;
   see `settings.json`.)
-* New stats/metrics: `activePads`, `httpUptime`, `lastDisconnected`,
+* New stats/metrics: `activePads`, `httpStartTime`, `lastDisconnected`,
   `memoryUsageHeap`.
 * For plugin authors:
   * New `callAllSerial()` function that invokes hook functions like `callAll()`

--- a/src/node/hooks/express.js
+++ b/src/node/hooks/express.js
@@ -17,7 +17,7 @@ const logger = log4js.getLogger('http');
 let serverName;
 const sockets = new Set();
 const socketsEvents = new events.EventEmitter();
-let startTime = null;
+const startTime = stats.settableGauge('httpStartTime');
 
 exports.server = null;
 
@@ -46,11 +46,11 @@ const closeServer = async () => {
   await p;
   clearTimeout(timeout);
   exports.server = null;
+  startTime.setValue(0);
   logger.info('HTTP server closed');
 };
 
 exports.createServer = async () => {
-  stats.gauge('httpUptime', () => startTime == null ? 0 : new Date() - startTime);
   console.log('Report bugs at https://github.com/ether/etherpad-lite/issues');
 
   serverName = `Etherpad ${settings.getGitCommit()} (https://etherpad.org)`;
@@ -217,7 +217,7 @@ exports.restartServer = async () => {
     });
   });
   await util.promisify(exports.server.listen).bind(exports.server)(settings.port, settings.ip);
-  startTime = new Date();
+  startTime.setValue(Date.now());
   logger.info('HTTP server listening for connections');
 };
 

--- a/src/tests/frontend/specs/adminsettings.js
+++ b/src/tests/frontend/specs/adminsettings.js
@@ -56,28 +56,28 @@ describe('Admin > Settings', function () {
 
   it('restart works', async function () {
     this.timeout(60000);
-    const getUptime = async () => {
+    const getStartTime = async () => {
       try {
-        const {httpUptime} = await $.ajax({
+        const {httpStartTime} = await $.ajax({
           url: new URL('/stats', window.location.href),
           method: 'GET',
           dataType: 'json',
           timeout: 450, // Slightly less than the waitForPromise() interval.
         });
-        return httpUptime;
+        return httpStartTime;
       } catch (err) {
         return null;
       }
     };
     await helper.waitForPromise(async () => {
-      const uptime = await getUptime();
-      return uptime != null && uptime > 0;
+      const startTime = await getStartTime();
+      return startTime != null && startTime > 0 && Date.now() > startTime;
     }, 1000, 500);
     const clickTime = Date.now();
     helper.admin$('#restartEtherpad').click();
     await helper.waitForPromise(async () => {
-      const uptime = await getUptime();
-      return uptime != null && Date.now() - uptime >= clickTime;
+      const startTime = await getStartTime();
+      return startTime != null && startTime >= clickTime;
     }, 60000, 500);
   });
 });


### PR DESCRIPTION
It's better to provide a primitive value and let the consumer of the metric do math if desired.
