### PR TITLE
maxHttpBufferSize as a setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 * Dependencies are now installed with the `--no-optional` flag to speed
   installation. Optional dependencies such as `sqlite3` must now be manually
   installed (e.g., `(cd src && npm i sqlite3)`).
-* Socket.IO messages are now limited to 1MiB to make denial of service attacks
-  more difficult. This may cause issues with plugins that send large messages,
-  e.g., `ep_image_upload`.
+* Socket.IO messages are now limited to 10K bytes to make denial of service
+  attacks more difficult. This may cause issues when pasting large amounts of
+  text or with plugins that send large messages (e.g., `ep_image_upload`). You
+  can change the limit via `settings.json`; see `socketIo.maxHttpBufferSize`.
 * The top-level `package.json` file, added in v1.8.7, has been removed due to
   problematic npm behavior. Whenever you install a plugin you will see the
   following benign warnings that can be safely ignored:

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -445,6 +445,17 @@
    */
   "socketTransportProtocols" : ["xhr-polling", "jsonp-polling", "htmlfile"],
 
+  "socketIo": {
+    /*
+     * Maximum permitted client message size (in bytes). All messages from
+     * clients that are larger than this will be rejected. Large values make it
+     * possible to paste large amounts of text, and plugins may require a larger
+     * value to work properly, but increasing the value increases susceptibility
+     * to denial of service attacks (malicious clients can exhaust memory).
+     */
+    "maxHttpBufferSize": 10000
+  },
+
   /*
    * Allow Load Testing tools to hit the Etherpad Instance.
    *
@@ -594,12 +605,5 @@
     }, // logconfig
 
   /* Override any strings found in locale directories */
-  "customLocaleStrings": {},
-
-  /* SocketIO security / functionality.
-   *
-   * Change maximum socket packet length(in bytes) allowed to be sent from a client
-   * to Etherpad, useful for copy/pasting large pads but at the cost of stability
-   */
-  "maxHttpBufferSize": 10000,
+  "customLocaleStrings": {}
 }

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -594,5 +594,12 @@
     }, // logconfig
 
   /* Override any strings found in locale directories */
-  "customLocaleStrings": {}
+  "customLocaleStrings": {},
+
+  /* SocketIO security / functionality.
+   *
+   * Change maximum socket packet length(in bytes) allowed to be sent from a client
+   * to Etherpad, useful for copy/pasting large pads but at the cost of stability
+   */
+  "maxHttpBufferSize": 10000,
 }

--- a/settings.json.template
+++ b/settings.json.template
@@ -450,6 +450,17 @@
    */
   "socketTransportProtocols" : ["xhr-polling", "jsonp-polling", "htmlfile"],
 
+  "socketIo": {
+    /*
+     * Maximum permitted client message size (in bytes). All messages from
+     * clients that are larger than this will be rejected. Large values make it
+     * possible to paste large amounts of text, and plugins may require a larger
+     * value to work properly, but increasing the value increases susceptibility
+     * to denial of service attacks (malicious clients can exhaust memory).
+     */
+    "maxHttpBufferSize": 10000
+  },
+
   /*
    * Allow Load Testing tools to hit the Etherpad Instance.
    *
@@ -603,12 +614,5 @@
   "customLocaleStrings": {},
 
   /* Disable Admin UI tests */
-  "enableAdminUITests": false,
-
-  /* SocketIO security / functionality.
-   *
-   * Change maximum socket packet length(in bytes) allowed to be sent from a client
-   * to Etherpad, useful for copy/pasting large pads but at the cost of stability
-   */
-  "maxHttpBufferSize": 10000,
+  "enableAdminUITests": false
 }

--- a/settings.json.template
+++ b/settings.json.template
@@ -603,5 +603,12 @@
   "customLocaleStrings": {},
 
   /* Disable Admin UI tests */
-  "enableAdminUITests": false
+  "enableAdminUITests": false,
+
+  /* SocketIO security / functionality.
+   *
+   * Change maximum socket packet length(in bytes) allowed to be sent from a client
+   * to Etherpad, useful for copy/pasting large pads but at the cost of stability
+   */
+  "maxHttpBufferSize": 10000,
 }

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -74,7 +74,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
      *   https://github.com/socketio/socket.io/issues/2276#issuecomment-147184662 (not totally true, actually, see above)
      */
     cookie: false,
-    maxHttpBufferSize: 10E3,
+    maxHttpBufferSize: settings.maxHttpBufferSize,
   });
 
   io.on('connect', (socket) => {

--- a/src/node/hooks/express/socketio.js
+++ b/src/node/hooks/express/socketio.js
@@ -74,7 +74,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
      *   https://github.com/socketio/socket.io/issues/2276#issuecomment-147184662 (not totally true, actually, see above)
      */
     cookie: false,
-    maxHttpBufferSize: settings.maxHttpBufferSize,
+    maxHttpBufferSize: settings.socketIo.maxHttpBufferSize,
   });
 
   io.on('connect', (socket) => {

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -104,6 +104,18 @@ exports.ssl = false;
  **/
 exports.socketTransportProtocols = ['xhr-polling', 'jsonp-polling', 'htmlfile'];
 
+exports.socketIo = {
+  /**
+   * Maximum permitted client message size (in bytes).
+   *
+   * All messages from clients that are larger than this will be rejected. Large values make it
+   * possible to paste large amounts of text, and plugins may require a larger value to work
+   * properly, but increasing the value increases susceptibility to denial of service attacks
+   * (malicious clients can exhaust memory).
+   */
+  maxHttpBufferSize: 10000,
+};
+
 /*
  * The Type of the database
  */
@@ -385,12 +397,6 @@ exports.importMaxFileSize = 50 * 1024 * 1024;
  */
 exports.enableAdminUITests = false;
 
-/* SocketIO security / functionality.
- *
- * Change maximum socket packet length(in bytes) allowed to be sent from a client
- * to Etherpad, useful for copy/pasting large pads but at the cost of stability
- */
-exports.maxHttpBufferSize = 10000;
 
 // checks if abiword is avaiable
 exports.abiwordAvailable = () => {

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -385,6 +385,12 @@ exports.importMaxFileSize = 50 * 1024 * 1024;
  */
 exports.enableAdminUITests = false;
 
+/* SocketIO security / functionality.
+ *
+ * Change maximum socket packet length(in bytes) allowed to be sent from a client
+ * to Etherpad, useful for copy/pasting large pads but at the cost of stability
+ */
+exports.maxHttpBufferSize = 10000;
 
 // checks if abiword is avaiable
 exports.abiwordAvailable = () => {


### PR DESCRIPTION
By default we limit insertion size to ~10k.

ep_image_upload modifies this value in https://github.com/citizenos/ep_image_upload/commit/aac99c998780f1fd45554e3956e8213dcfee8f94 to a much larger number.

This is a stop gap solution until we chop socket messages up instead of allowing large ones to be sent.

