### PR TITLE
fix for caching plugin-definitions

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -42,20 +42,6 @@ const _ = require('underscore');
 exports.root = absolutePaths.findEtherpadRoot();
 console.log(`All relative paths will be interpreted relative to the identified Etherpad base dir: ${exports.root}`);
 
-/*
- * At each start, Etherpad generates a random string and appends it as query
- * parameter to the URLs of the static assets, in order to force their reload.
- * Subsequent requests will be cached, as long as the server is not reloaded.
- *
- * For the rationale behind this choice, see
- * https://github.com/ether/etherpad-lite/pull/3958
- *
- * ACHTUNG: this may prevent caching HTTP proxies to work
- * TODO: remove the "?v=randomstring" parameter, and replace with hashed filenames instead
- */
-exports.randomVersionString = randomString(4);
-console.log(`Random string used for versioning assets: ${exports.randomVersionString}`);
-
 /**
  * The app title, visible e.g. in the browser window
  */
@@ -796,6 +782,20 @@ exports.reloadSettings = () => {
     // using Unix socket for connectivity
     console.warn('The settings file contains an empty string ("") for the "ip" parameter. The "port" parameter will be interpreted as the path to a Unix socket to bind at.');
   }
+
+  /*
+   * At each start, Etherpad generates a random string and appends it as query
+   * parameter to the URLs of the static assets, in order to force their reload.
+   * Subsequent requests will be cached, as long as the server is not reloaded.
+   *
+   * For the rationale behind this choice, see
+   * https://github.com/ether/etherpad-lite/pull/3958
+   *
+   * ACHTUNG: this may prevent caching HTTP proxies to work
+   * TODO: remove the "?v=randomstring" parameter, and replace with hashed filenames instead
+   */
+  exports.randomVersionString = randomString(4);
+  console.log(`Random string used for versioning assets: ${exports.randomVersionString}`);
 };
 
 // initially load settings

--- a/src/static/js/pluginfw/client_plugins.js
+++ b/src/static/js/pluginfw/client_plugins.js
@@ -12,9 +12,10 @@ exports.update = (cb) => {
   // of execution on Firefox. This schedules the response in the run-loop,
   // which appears to fix the issue.
   const callback = () => setTimeout(cb, 0);
-  $.ajaxSetup({cache: false});
 
-  jQuery.getJSON(`${exports.baseURL}pluginfw/plugin-definitions.json`).done((data) => {
+  jQuery.getJSON(
+      `${exports.baseURL}pluginfw/plugin-definitions.json?v=${clientVars.randomVersionString}`
+  ).done((data) => {
     defs.plugins = data.plugins;
     defs.parts = data.parts;
     defs.hooks = pluginUtils.extractHooks(defs.parts, 'client_hooks');

--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -5,11 +5,14 @@ const plugins = require('./plugins');
 const hooks = require('./hooks');
 const request = require('request');
 const runCmd = require('../../../node/utils/run_cmd');
+const settings = require('../../../node/utils/Settings');
 
 const logger = log4js.getLogger('plugins');
 
-const onAllTasksFinished = () => {
-  hooks.aCallAll('restartServer', {}, () => {});
+const onAllTasksFinished = async () => {
+  settings.reloadSettings();
+  await hooks.aCallAll('loadSettings', {settings});
+  await hooks.aCallAll('restartServer');
 };
 
 let tasks = 0;

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -475,7 +475,11 @@
   <!-- Bootstrap page -->
   <script type="text/javascript">
       // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
-      var clientVars = {};
+      var clientVars = {
+        // This is needed to fetch /pluginfw/plugin-definitions.json, which happens before the
+        // server sends the CLIENT_VARS message.
+        randomVersionString: <%-JSON.stringify(settings.randomVersionString)%>,
+      };
       (function () {
         var pathComponents = location.pathname.split('/');
 

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -260,7 +260,11 @@
 <!-- Bootstrap -->
 <script type="text/javascript" >
   // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
-  var clientVars = {};
+  var clientVars = {
+    // This is needed to fetch /pluginfw/plugin-definitions.json, which happens before the
+    // server sends the CLIENT_VARS message.
+    randomVersionString: <%-JSON.stringify(settings.randomVersionString)%>,
+  };
   var BroadcastSlider;
   (function () {
     var pathComponents = location.pathname.split('/');


### PR DESCRIPTION
see https://github.com/ether/etherpad-lite/pull/4761#issuecomment-779016536

Sets the randomVersionString earlier when delivering pad.html/timeslider.html and prevents jquery from adding a query parameter to circumvent the cache.