### PR TITLE
feat(docker): Add build var for optionally installing abiword

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,8 @@ RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
 RUN [ -z "${INSTALL_ABIWORD}" ] || (apt update && apt -y install abiword && apt clean && rm -rf /var/lib/apt/lists/*)
 
 # install libreoffice for DOC/PDF/ODT export
-RUN [ -z "${INSTALL_SOFFICE}" ] || (apt update && apt -y install libreoffice-common && apt clean && rm -rf /var/lib/apt/lists/*)
+# the mkdir is needed for configuration of openjdk-11-jre-headless, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+RUN [ -z "${INSTALL_SOFFICE}" ] || (apt update && mkdir -p /usr/share/man/man1 && apt -y install libreoffice && apt clean && rm -rf /var/lib/apt/lists/*)
 
 USER etherpad
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN useradd --uid 5001 --create-home etherpad
 RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
 
 # install abiword for DOC/PDF/ODT export
-RUN if [ "${INSTALL_ABIWORD}" != "0" ]; then apt update && apt -y install abiword && rm -rf /var/lib/apt/lists/*; fi
+RUN [ -z "${INSTALL_ABIWORD}" ] || apt update && apt -y install abiword && rm -rf /var/lib/apt/lists/*
 
 USER etherpad
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,14 @@ LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 #   ETHERPAD_PLUGINS="ep_codepad ep_author_neat"
 ARG ETHERPAD_PLUGINS=
 
+# Control whether abiword will be installed, enabling exports to DOC/PDF/ODT formats.
+# By default, it is not installed.
+# If given any value except 0, abiword will be installed.
+#
+# EXAMPLE:
+#   INSTALL_ABIWORD=true
+ARG INSTALL_ABIWORD=0
+
 # By default, Etherpad container is built and run in "production" mode. This is
 # leaner (development dependencies are not installed) and runs faster (among
 # other things, assets are minified & compressed).
@@ -27,6 +35,9 @@ ENV NODE_ENV=production
 RUN useradd --uid 5001 --create-home etherpad
 
 RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
+
+# install abiword for DOC/PDF/ODT export
+RUN if [ "${INSTALL_ABIWORD}" != "0" ]; then apt update && apt -y install abiword && rm -rf /var/lib/apt/lists/*; fi
 
 USER etherpad
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,19 @@ ARG ETHERPAD_PLUGINS=
 
 # Control whether abiword will be installed, enabling exports to DOC/PDF/ODT formats.
 # By default, it is not installed.
-# If given any value except 0, abiword will be installed.
+# If given any value, abiword will be installed.
 #
 # EXAMPLE:
 #   INSTALL_ABIWORD=true
-ARG INSTALL_ABIWORD=0
+ARG INSTALL_ABIWORD=
+
+# Control whether libreoffice will be installed, enabling exports to DOC/PDF/ODT formats.
+# By default, it is not installed.
+# If given any value, libreoffice will be installed.
+#
+# EXAMPLE:
+#   INSTALL_LIBREOFFICE=true
+ARG INSTALL_SOFFICE=
 
 # By default, Etherpad container is built and run in "production" mode. This is
 # leaner (development dependencies are not installed) and runs faster (among
@@ -37,7 +45,10 @@ RUN useradd --uid 5001 --create-home etherpad
 RUN mkdir /opt/etherpad-lite && chown etherpad:0 /opt/etherpad-lite
 
 # install abiword for DOC/PDF/ODT export
-RUN [ -z "${INSTALL_ABIWORD}" ] || apt update && apt -y install abiword && rm -rf /var/lib/apt/lists/*
+RUN [ -z "${INSTALL_ABIWORD}" ] || (apt update && apt -y install abiword && apt clean && rm -rf /var/lib/apt/lists/*)
+
+# install libreoffice for DOC/PDF/ODT export
+RUN [ -z "${INSTALL_SOFFICE}" ] || (apt update && apt -y install libreoffice-common && apt clean && rm -rf /var/lib/apt/lists/*)
 
 USER etherpad
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -29,6 +29,11 @@ The variable value has to be a space separated, double quoted list of plugin nam
 
 Some plugins will need personalized settings. Just refer to the previous section, and include them in your custom `settings.json.docker`.
 
+### Rebuilding including export functionality for DOC/PDF/ODT
+If you want to be able to export your pads to DOC/PDF/ODT files, you can set the INSTALL_ABIWORD build variable to any value other than "0".
+
+Also, you will need to configure the path to the abiword executable (`/usr/bin/abiword`) via editing `<BASEDIR>/settings.json.docker` or via setting the environment variable `ABIWORD` to `/usr/bin/abiword`.
+
 ### Examples
 
 Build a Docker image from the currently checked-out code:

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -30,9 +30,13 @@ The variable value has to be a space separated, double quoted list of plugin nam
 Some plugins will need personalized settings. Just refer to the previous section, and include them in your custom `settings.json.docker`.
 
 ### Rebuilding including export functionality for DOC/PDF/ODT
-If you want to be able to export your pads to DOC/PDF/ODT files, you can set the INSTALL_ABIWORD build variable to any value other than "0".
 
-Also, you will need to configure the path to the abiword executable (`/usr/bin/abiword`) via editing `<BASEDIR>/settings.json.docker` or via setting the environment variable `ABIWORD` to `/usr/bin/abiword`.
+If you want to be able to export your pads to DOC/PDF/ODT files, you can set the
+INSTALL_ABIWORD build variable to any value other than "0".
+
+Also, you will need to configure the path to the abiword executable
+(`/usr/bin/abiword`) via editing `<BASEDIR>/settings.json.docker` or via setting
+the environment variable `ABIWORD` to `/usr/bin/abiword`.
 
 ### Examples
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -31,12 +31,27 @@ Some plugins will need personalized settings. Just refer to the previous section
 
 ### Rebuilding including export functionality for DOC/PDF/ODT
 
-If you want to be able to export your pads to DOC/PDF/ODT files, you can set the
-INSTALL_ABIWORD build variable to any value other than "0".
+If you want to be able to export your pads to DOC/PDF/ODT files, you can install
+either Abiword or Libreoffice via setting a build variable.
+
+#### Via Abiword
+
+For installing Abiword, set the `INSTALL_ABIWORD` build variable to any value.
 
 Also, you will need to configure the path to the abiword executable
-(`/usr/bin/abiword`) via editing `<BASEDIR>/settings.json.docker` or via setting
-the environment variable `ABIWORD` to `/usr/bin/abiword`.
+via setting the `abiword` property in `<BASEDIR>/settings.json.docker` to 
+`/usr/bin/abiword` or via setting the environment variable  `ABIWORD` to 
+`/usr/bin/abiword`.
+
+#### Via Libreoffice
+
+For installing Libreoffice instead, set the `INSTALL_SOFFICE` build variable
+to any value.
+
+Also, you will need to configure the path to the libreoffice executable
+via setting the `soffice` property in `<BASEDIR>/settings.json.docker` to 
+`/usr/bin/soffice` or via setting the environment variable  `SOFFICE` to 
+`/usr/bin/soffice`.
 
 ### Examples
 
@@ -177,8 +192,8 @@ For the editor container, you can also make it full width by adding `full-width-
 | `IMPORT_MAX_FILE_SIZE`            | maximum allowed file size when importing a pad, in bytes.                                                                                                                                              | `52428800` (50 MB) |
 | `IMPORT_EXPORT_MAX_REQ_PER_IP`    | maximum number of import/export calls per IP.                                                                                                                                                          | `10`               |
 | `IMPORT_EXPORT_RATE_LIMIT_WINDOW` | the call rate for import/export requests will be estimated in this time window (in milliseconds)                                                                                                       | `90000`            |
-| `COMMIT_RATE_LIMIT_DURATION`      | duration of the rate limit window for commits by individual users/IPs (in seconds)                                                                                                                         | `1`                |
-| `COMMIT_RATE_LIMIT_POINTS`        | maximum number of changes per IP to allow during the rate limit window                                                                                                                                | `10`               |
+| `COMMIT_RATE_LIMIT_DURATION`      | duration of the rate limit window for commits by individual users/IPs (in seconds)                                                                                                                     | `1`                |
+| `COMMIT_RATE_LIMIT_POINTS`        | maximum number of changes per IP to allow during the rate limit window                                                                                                                                 | `10`               |
 | `SUPPRESS_ERRORS_IN_PAD_TEXT`     | Should we suppress errors from being visible in the default Pad Text?                                                                                                                                  | `false`            |
 | `REQUIRE_SESSION`                 | If this option is enabled, a user must have a session to access pads. This effectively allows only group pads to be accessed.                                                                          | `false`            |
 | `EDIT_ONLY`                       | Users may edit pads but not create new ones. Pad creation is only via the API. This applies both to group pads and regular pads.                                                                       | `false`            |


### PR DESCRIPTION
This MR introduces a docker build variable `INSTALL_ABIWORD`. When set
to any value other than `0`, ABIWORD is installed in the resulting
docker container, enabling the possibility to configure ABIWORD in
settings.json.docker or via ENV VAR `ABIWORD` for exporting to
DOC/PDF/ODT.

Documentation is included inline and in the docker markdown file.