### PR TITLE
lint: vast majority of the remaining frontend code. - READY FOR REVIEW

### DIFF
--- a/src/static/js/AttributeManager.js
+++ b/src/static/js/AttributeManager.js
@@ -406,7 +406,8 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
       hasAttrib = this.getAttributeOnSelection(attributeName);
     } else {
       const attributesOnCaretPosition = this.getAttributesOnCaret();
-      hasAttrib = _.contains(_.flatten(attributesOnCaretPosition), attributeName);
+      const allAttribs = [].concat(...attributesOnCaretPosition); // flatten
+      hasAttrib = allAttribs.includes(attributeName);
     }
     return hasAttrib;
   },

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -2016,21 +2016,19 @@ exports.follow = (cs1, cs2, reverseInsertOrder, pool) => {
           whichToDo = 1;
         } else if (insertFirst2 && !insertFirst1) {
           whichToDo = 2;
-        }
-        // insert string that doesn't start with a newline first so as not to break up lines
-        else if (firstChar1 == '\n' && firstChar2 != '\n') {
+        } else if (firstChar1 === '\n' && firstChar2 !== '\n') {
+          // insert string that doesn't start with a newline first so as not to break up lines
           whichToDo = 2;
-        } else if (firstChar1 != '\n' && firstChar2 == '\n') {
+        } else if (firstChar1 !== '\n' && firstChar2 === '\n') {
           whichToDo = 1;
-        }
-        // break symmetry:
-        else if (reverseInsertOrder) {
+        } else if (reverseInsertOrder) {
+          // break symmetry:
           whichToDo = 2;
         } else {
           whichToDo = 1;
         }
       }
-      if (whichToDo == 1) {
+      if (whichToDo === 1) {
         chars1.skip(op1.chars);
         opOut.opcode = '=';
         opOut.lines = op1.lines;

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -308,20 +308,20 @@ exports.smartOpAssembler = () => {
     if (!op.opcode) return;
     if (!op.chars) return;
 
-    if (op.opcode == '-') {
-      if (lastOpcode == '=') {
+    if (op.opcode === '-') {
+      if (lastOpcode === '=') {
         flushKeeps();
       }
       minusAssem.append(op);
       lengthChange -= op.chars;
-    } else if (op.opcode == '+') {
-      if (lastOpcode == '=') {
+    } else if (op.opcode === '+') {
+      if (lastOpcode === '=') {
         flushKeeps();
       }
       plusAssem.append(op);
       lengthChange += op.chars;
-    } else if (op.opcode == '=') {
-      if (lastOpcode != '=') {
+    } else if (op.opcode === '=') {
+      if (lastOpcode !== '=') {
         flushPlusMinus();
       }
       keepAssem.append(op);
@@ -394,7 +394,7 @@ exports.mergingOpAssembler = () => {
 
   const flush = (isEndDocument) => {
     if (bufOp.opcode) {
-      if (isEndDocument && bufOp.opcode == '=' && !bufOp.attribs) {
+      if (isEndDocument && bufOp.opcode === '=' && !bufOp.attribs) {
         // final merged keep, leave it implicit
       } else {
         assem.append(bufOp);
@@ -411,7 +411,7 @@ exports.mergingOpAssembler = () => {
 
   const append = (op) => {
     if (op.chars > 0) {
-      if (bufOp.opcode == op.opcode && bufOp.attribs == op.attribs) {
+      if (bufOp.opcode === op.opcode && bufOp.attribs === op.attribs) {
         if (op.lines > 0) {
           // bufOp and additional chars are all mergeable into a multi-line op
           bufOp.chars += bufOpAdditionalCharsAfterNewline + op.chars;
@@ -844,7 +844,7 @@ exports.unpack = (cs) => {
     exports.error(`Not a exports: ${cs}`);
   }
   const oldLen = exports.parseNum(headerMatch[1]);
-  const changeSign = (headerMatch[2] == '>') ? 1 : -1;
+  const changeSign = (headerMatch[2] === '>') ? 1 : -1;
   const changeMag = exports.parseNum(headerMatch[3]);
   const newLen = oldLen + changeSign * changeMag;
   const opsStart = headerMatch[0].length;
@@ -1019,7 +1019,7 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
   // attribution string or the earlier of two exportss being composed.
   // pool can be null if definitely not needed.
   // print(csOp.toSource()+" "+attOp.toSource()+" "+opOut.toSource());
-  if (attOp.opcode == '-') {
+  if (attOp.opcode === '-') {
     exports.copyOp(attOp, opOut);
     attOp.opcode = '';
   } else if (!attOp.opcode) {
@@ -1045,7 +1045,7 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
           }
         } else {
           // delete and keep going
-          if (attOp.opcode == '=') {
+          if (attOp.opcode === '=') {
             opOut.opcode = '-';
             opOut.chars = attOp.chars;
             opOut.lines = attOp.lines;
@@ -1071,7 +1071,7 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = csOp.chars;
           opOut.lines = csOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode == '=', pool);
+          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           csOp.opcode = '';
           attOp.chars -= csOp.chars;
           attOp.lines -= csOp.lines;
@@ -1171,12 +1171,12 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
     // print("csOp: "+csOp.toSource());
     if ((!csOp.opcode) && (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
       break; // done
-    } else if (csOp.opcode == '=' && csOp.lines > 0 && (!csOp.attribs) && (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
+    } else if (csOp.opcode === '=' && csOp.lines > 0 && (!csOp.attribs) && (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
       // skip multiple lines; this is what makes small changes not order of the document size
       mut.skipLines(csOp.lines);
       // print("skipped: "+csOp.lines);
       csOp.opcode = '';
-    } else if (csOp.opcode == '+') {
+    } else if (csOp.opcode === '+') {
       if (csOp.lines > 1) {
         const firstLineLen = csBank.indexOf('\n', csBankIndex) + 1 - csBankIndex;
         exports.copyOp(csOp, opOut);
@@ -1296,12 +1296,12 @@ exports.compose = (cs1, cs2, pool) => {
     // debugBuilder.append(' / ');
     const op1code = op1.opcode;
     const op2code = op2.opcode;
-    if (op1code == '+' && op2code == '-') {
+    if (op1code === '+' && op2code === '-') {
       bankIter1.skip(Math.min(op1.chars, op2.chars));
     }
     exports._slicerZipperFunc(op1, op2, opOut, pool);
-    if (opOut.opcode == '+') {
-      if (op2code == '+') {
+    if (opOut.opcode === '+') {
+      if (op2code === '+') {
         bankAssem.append(bankIter2.take(opOut.chars));
       } else {
         bankAssem.append(bankIter1.take(opOut.chars));
@@ -1396,7 +1396,7 @@ exports.toSplices = (cs) => {
   let inSplice = false;
   while (iter.hasNext()) {
     const op = iter.next();
-    if (op.opcode == '=') {
+    if (op.opcode === '=') {
       oldPos += op.chars;
       inSplice = false;
     } else {
@@ -1404,10 +1404,10 @@ exports.toSplices = (cs) => {
         splices.push([oldPos, oldPos, '']);
         inSplice = true;
       }
-      if (op.opcode == '-') {
+      if (op.opcode === '-') {
         oldPos += op.chars;
         splices[splices.length - 1][1] += op.chars;
-      } else if (op.opcode == '+') {
+      } else if (op.opcode === '+') {
         splices[splices.length - 1][2] += charIter.take(op.chars);
       }
     }
@@ -1663,7 +1663,7 @@ exports.prepareForWire = (cs, pool) => {
  */
 exports.isIdentity = (cs) => {
   const unpacked = exports.unpack(cs);
-  return unpacked.ops == '' && unpacked.oldLen == unpacked.newLen;
+  return unpacked.ops === '' && unpacked.oldLen == unpacked.newLen;
 };
 
 /**
@@ -1755,7 +1755,7 @@ exports.makeAttribsString = (opcode, attribs, pool) => {
     const result = [];
     for (let i = 0; i < attribs.length; i++) {
       const pair = attribs[i];
-      if (opcode == '=' || (opcode == '+' && pair[1])) {
+      if (opcode === '=' || (opcode === '+' && pair[1])) {
         result.push(`*${exports.numToString(pool.putAttrib(pair))}`);
       }
     }
@@ -1927,7 +1927,7 @@ exports.inverse = (cs, lines, alines, pool) => {
   const attribValues = [];
   while (csIter.hasNext()) {
     const csOp = csIter.next();
-    if (csOp.opcode == '=') {
+    if (csOp.opcode === '=') {
       if (csOp.attribs) {
         attribKeys.length = 0;
         attribValues.length = 0;
@@ -1954,9 +1954,9 @@ exports.inverse = (cs, lines, alines, pool) => {
         skip(csOp.chars, csOp.lines);
         builder.keep(csOp.chars, csOp.lines);
       }
-    } else if (csOp.opcode == '+') {
+    } else if (csOp.opcode === '+') {
       builder.remove(csOp.chars, csOp.lines);
-    } else if (csOp.opcode == '-') {
+    } else if (csOp.opcode === '-') {
       var textBank = nextText(csOp.chars);
       var textBankIndex = 0;
       consumeAttribRuns(csOp.chars, (len, attribs, endsLine) => {
@@ -1986,11 +1986,11 @@ exports.follow = (cs1, cs2, reverseInsertOrder, pool) => {
   const hasInsertFirst = exports.attributeTester(['insertorder', 'first'], pool);
 
   const newOps = exports.applyZip(unpacked1.ops, 0, unpacked2.ops, 0, (op1, op2, opOut) => {
-    if (op1.opcode == '+' || op2.opcode == '+') {
+    if (op1.opcode === '+' || op2.opcode === '+') {
       let whichToDo;
-      if (op2.opcode != '+') {
+      if (op2.opcode !== '+') {
         whichToDo = 1;
-      } else if (op1.opcode != '+') {
+      } else if (op1.opcode !== '+') {
         whichToDo = 2;
       } else {
         // both +
@@ -2029,7 +2029,7 @@ exports.follow = (cs1, cs2, reverseInsertOrder, pool) => {
         exports.copyOp(op2, opOut);
         op2.opcode = '';
       }
-    } else if (op1.opcode == '-') {
+    } else if (op1.opcode === '-') {
       if (!op2.opcode) {
         op1.opcode = '';
       } else if (op1.chars <= op2.chars) {
@@ -2044,7 +2044,7 @@ exports.follow = (cs1, cs2, reverseInsertOrder, pool) => {
         op1.lines -= op2.lines;
         op2.opcode = '';
       }
-    } else if (op2.opcode == '-') {
+    } else if (op2.opcode === '-') {
       exports.copyOp(op2, opOut);
       if (!op1.opcode) {
         op2.opcode = '';
@@ -2162,12 +2162,12 @@ exports.composeWithDeletions = (cs1, cs2, pool) => {
   const newOps = exports.applyZip(unpacked1.ops, 0, unpacked2.ops, 0, (op1, op2, opOut) => {
     const op1code = op1.opcode;
     const op2code = op2.opcode;
-    if (op1code == '+' && op2code == '-') {
+    if (op1code === '+' && op2code === '-') {
       bankIter1.skip(Math.min(op1.chars, op2.chars));
     }
     exports._slicerZipperFuncWithDeletions(op1, op2, opOut, pool);
-    if (opOut.opcode == '+') {
-      if (op2code == '+') {
+    if (opOut.opcode === '+') {
+      if (op2code === '+') {
         bankAssem.append(bankIter2.take(opOut.chars));
       } else {
         bankAssem.append(bankIter1.take(opOut.chars));
@@ -2185,7 +2185,7 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
   // attribution string or the earlier of two exportss being composed.
   // pool can be null if definitely not needed.
   // print(csOp.toSource()+" "+attOp.toSource()+" "+opOut.toSource());
-  if (attOp.opcode == '-') {
+  if (attOp.opcode === '-') {
     exports.copyOp(attOp, opOut);
     attOp.opcode = '';
   } else if (!attOp.opcode) {
@@ -2197,7 +2197,7 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
       {
         if (csOp.chars <= attOp.chars) {
           // delete or delete part
-          if (attOp.opcode == '=') {
+          if (attOp.opcode === '=') {
             opOut.opcode = '-';
             opOut.chars = csOp.chars;
             opOut.lines = csOp.lines;
@@ -2211,7 +2211,7 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
           }
         } else {
           // delete and keep going
-          if (attOp.opcode == '=') {
+          if (attOp.opcode === '=') {
             opOut.opcode = '-';
             opOut.chars = attOp.chars;
             opOut.lines = attOp.lines;
@@ -2237,7 +2237,7 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = csOp.chars;
           opOut.lines = csOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode == '=', pool);
+          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           csOp.opcode = '';
           attOp.chars -= csOp.chars;
           attOp.lines -= csOp.lines;
@@ -2249,7 +2249,7 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = attOp.chars;
           opOut.lines = attOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode == '=', pool);
+          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           attOp.opcode = '';
           csOp.chars -= attOp.chars;
           csOp.lines -= attOp.lines;

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -541,7 +541,8 @@ exports.stringAssembler = () => {
 /**
  * This class allows to iterate and modify texts which have several lines
  * It is used for applying Changesets on arrays of lines
- * Note from prev docs: "lines" need not be an array as long as it supports certain calls (lines_foo inside).
+ * Note from prev docs: "lines" need not be an array as long as it supports
+ * certain calls (lines_foo inside).
  */
 exports.textLinesMutator = (lines) => {
   // Mutates lines, an array of strings, in place.
@@ -645,7 +646,8 @@ exports.textLinesMutator = (lines) => {
         curLine += L;
         curCol = 0;
       }
-      // print(inSplice+" / "+isCurLineInSplice()+" / "+curSplice[0]+" / "+curSplice[1]+" / "+lines.length);
+      // print(inSplice+" / "+isCurLineInSplice()+" / "+curSplice[0]+" /
+      // "+curSplice[1]+" / "+lines.length);
       /* if (inSplice && (! isCurLineInSplice()) && (curSplice[0] + curSplice[1] < lines.length)) {
   print("BLAH");
   putCurLineInSplice();
@@ -696,7 +698,8 @@ exports.textLinesMutator = (lines) => {
           curSplice[1] += L - 1;
           const sline = curSplice.length - 1;
           removed = curSplice[sline].substring(curCol) + removed;
-          curSplice[sline] = curSplice[sline].substring(0, curCol) + lines_get(curSplice[0] + curSplice[1]);
+          curSplice[sline] = curSplice[sline].substring(0, curCol) +
+              lines_get(curSplice[0] + curSplice[1]);
           curSplice[1] += 1;
         }
       } else {
@@ -719,7 +722,8 @@ exports.textLinesMutator = (lines) => {
         }
         const sline = putCurLineInSplice();
         removed = curSplice[sline].substring(curCol, curCol + N);
-        curSplice[sline] = curSplice[sline].substring(0, curCol) + curSplice[sline].substring(curCol + N);
+        curSplice[sline] = curSplice[sline].substring(0, curCol) +
+            curSplice[sline].substring(curCol + N);
         // debugPrint("remove");
       }
     }
@@ -761,7 +765,8 @@ exports.textLinesMutator = (lines) => {
         if (!curSplice[sline]) {
           console.error('curSplice[sline] not populated, actual curSplice contents is ', curSplice, '. Possibly related to https://github.com/ether/etherpad-lite/issues/2802');
         }
-        curSplice[sline] = curSplice[sline].substring(0, curCol) + text + curSplice[sline].substring(curCol);
+        curSplice[sline] = curSplice[sline].substring(0, curCol) + text +
+            curSplice[sline].substring(curCol);
         curCol += text.length;
       }
       // debugPrint("insert");
@@ -868,7 +873,8 @@ exports.unpack = (cs) => {
  */
 exports.pack = (oldLen, newLen, opsStr, bank) => {
   const lenDiff = newLen - oldLen;
-  const lenDiffStr = (lenDiff >= 0 ? `>${exports.numToString(lenDiff)}` : `<${exports.numToString(-lenDiff)}`);
+  const lenDiffStr = (lenDiff >= 0 ? `>${exports.numToString(lenDiff)}`
+    : `<${exports.numToString(-lenDiff)}`);
   const a = [];
   a.push('Z:', exports.numToString(oldLen), lenDiffStr, opsStr, '$', bank);
   return a.join('');
@@ -881,7 +887,8 @@ exports.pack = (oldLen, newLen, opsStr, bank) => {
  */
 exports.applyToText = (cs, str) => {
   const unpacked = exports.unpack(cs);
-  exports.assert(str.length == unpacked.oldLen, 'mismatched apply: ', str.length, ' / ', unpacked.oldLen);
+  exports.assert(str.length == unpacked.oldLen, 'mismatched apply: ', str.length,
+      ' / ', unpacked.oldLen);
   const csIter = exports.opIterator(unpacked.ops);
   const bankIter = exports.stringIterator(unpacked.charBank);
   const strIter = exports.stringIterator(str);
@@ -1071,7 +1078,8 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = csOp.chars;
           opOut.lines = csOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
+          opOut.attribs = exports.composeAttributes(
+              attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           csOp.opcode = '';
           attOp.chars -= csOp.chars;
           attOp.lines -= csOp.lines;
@@ -1083,7 +1091,8 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = attOp.chars;
           opOut.lines = attOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode == '=', pool);
+          opOut.attribs = exports.composeAttributes(
+              attOp.attribs, csOp.attribs, attOp.opcode == '=', pool);
           attOp.opcode = '';
           csOp.chars -= attOp.chars;
           csOp.lines -= attOp.lines;
@@ -1109,7 +1118,8 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
 exports.applyToAttribution = (cs, astr, pool) => {
   const unpacked = exports.unpack(cs);
 
-  return exports.applyZip(astr, 0, unpacked.ops, 0, (op1, op2, opOut) => exports._slicerZipperFunc(op1, op2, opOut, pool));
+  return exports.applyZip(astr, 0, unpacked.ops, 0,
+      (op1, op2, opOut) => exports._slicerZipperFunc(op1, op2, opOut, pool));
 };
 
 /* exports.oneInsertedLineAtATimeOpIterator = function(opsStr, optStartIndex, charBank) {
@@ -1167,11 +1177,13 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
       csIter.next(csOp);
     }
     // print(csOp.toSource()+" "+attOp.toSource()+" "+opOut.toSource());
-    // print(csOp.opcode+"/"+csOp.lines+"/"+csOp.attribs+"/"+lineAssem+"/"+lineIter+"/"+(lineIter?lineIter.hasNext():null));
+    // print(csOp.opcode+"/"+csOp.lines+"/"+csOp.attribs+"/"+lineAssem+
+    // "/"+lineIter+"/"+(lineIter?lineIter.hasNext():null));
     // print("csOp: "+csOp.toSource());
     if ((!csOp.opcode) && (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
       break; // done
-    } else if (csOp.opcode === '=' && csOp.lines > 0 && (!csOp.attribs) && (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
+    } else if (csOp.opcode === '=' && csOp.lines > 0 && (!csOp.attribs) &&
+        (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
       // skip multiple lines; this is what makes small changes not order of the document size
       mut.skipLines(csOp.lines);
       // print("skipped: "+csOp.lines);
@@ -1776,7 +1788,8 @@ exports.subattribution = (astr, start, optEnd) => {
       while (csOp.opcode && (attOp.opcode || iter.hasNext())) {
         if (!attOp.opcode) iter.next(attOp);
 
-        if (csOp.opcode && attOp.opcode && csOp.chars >= attOp.chars && attOp.lines > 0 && csOp.lines <= 0) {
+        if (csOp.opcode && attOp.opcode && csOp.chars >= attOp.chars &&
+              attOp.lines > 0 && csOp.lines <= 0) {
           csOp.lines++;
         }
 
@@ -1872,7 +1885,8 @@ exports.inverse = (cs, lines, alines, pool) => {
         curLineOpIter.next(curLineNextOp);
       }
       const charsToUse = Math.min(numChars, curLineNextOp.chars);
-      func(charsToUse, curLineNextOp.attribs, charsToUse == curLineNextOp.chars && curLineNextOp.lines > 0);
+      func(charsToUse, curLineNextOp.attribs, charsToUse == curLineNextOp.chars &&
+          curLineNextOp.lines > 0);
       numChars -= charsToUse;
       curLineNextOp.chars -= charsToUse;
       curChar += charsToUse;
@@ -2178,8 +2192,10 @@ exports.composeWithDeletions = (cs1, cs2, pool) => {
   return exports.pack(len1, len3, newOps, bankAssem.toString());
 };
 
-// This function is 95% like _slicerZipperFunc, we just changed two lines to ensure it merges the attribs of deletions properly.
-// This is necassary for correct paddiff. But to ensure these changes doesn't affect anything else, we've created a seperate function only used for paddiffs
+// This function is 95% like _slicerZipperFunc, we just changed two lines to
+// ensure it merges the attribs of deletions properly.
+// This is necassary for correct paddiff. But to ensure these changes doesn't
+// affect anything else, we've created a seperate function only used for paddiffs
 exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
   // attOp is the op from the sequence that is being operated on, either an
   // attribution string or the earlier of two exportss being composed.
@@ -2237,7 +2253,8 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = csOp.chars;
           opOut.lines = csOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
+          opOut.attribs = exports.composeAttributes(
+              attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           csOp.opcode = '';
           attOp.chars -= csOp.chars;
           attOp.lines -= csOp.lines;
@@ -2249,7 +2266,8 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
           opOut.opcode = attOp.opcode;
           opOut.chars = attOp.chars;
           opOut.lines = attOp.lines;
-          opOut.attribs = exports.composeAttributes(attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
+          opOut.attribs = exports.composeAttributes(
+              attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           attOp.opcode = '';
           csOp.chars -= attOp.chars;
           csOp.lines -= attOp.lines;

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -417,7 +417,7 @@ exports.mergingOpAssembler = () => {
           bufOp.chars += bufOpAdditionalCharsAfterNewline + op.chars;
           bufOp.lines += op.lines;
           bufOpAdditionalCharsAfterNewline = 0;
-        } else if (bufOp.lines == 0) {
+        } else if (bufOp.lines === 0) {
           // both bufOp and op are in-line
           bufOp.chars += op.chars;
         } else {
@@ -687,7 +687,7 @@ exports.textLinesMutator = (lines) => {
       };
       if (isCurLineInSplice()) {
         // print(curCol);
-        if (curCol == 0) {
+        if (curCol === 0) {
           removed = curSplice[curSplice.length - 1];
           // print("FOO"); // case foo
           curSplice.length--;
@@ -887,7 +887,7 @@ exports.pack = (oldLen, newLen, opsStr, bank) => {
  */
 exports.applyToText = (cs, str) => {
   const unpacked = exports.unpack(cs);
-  exports.assert(str.length == unpacked.oldLen, 'mismatched apply: ', str.length,
+  exports.assert(str.length === unpacked.oldLen, 'mismatched apply: ', str.length,
       ' / ', unpacked.oldLen);
   const csIter = exports.opIterator(unpacked.ops);
   const bankIter = exports.stringIterator(unpacked.charBank);
@@ -899,7 +899,7 @@ exports.applyToText = (cs, str) => {
       case '+':
       // op is + and op.lines 0: no newlines must be in op.chars
       // op is + and op.lines >0: op.chars must include op.lines newlines
-        if (op.lines != bankIter.peek(op.chars).split('\n').length - 1) {
+        if (op.lines !== bankIter.peek(op.chars).split('\n').length - 1) {
           throw new Error(`newline count is wrong in op +; cs:${cs} and text:${str}`);
         }
         assem.append(bankIter.take(op.chars));
@@ -907,7 +907,7 @@ exports.applyToText = (cs, str) => {
       case '-':
       // op is - and op.lines 0: no newlines must be in the deleted string
       // op is - and op.lines >0: op.lines newlines must be in the deleted string
-        if (op.lines != strIter.peek(op.chars).split('\n').length - 1) {
+        if (op.lines !== strIter.peek(op.chars).split('\n').length - 1) {
           throw new Error(`newline count is wrong in op -; cs:${cs} and text:${str}`);
         }
         strIter.skip(op.chars);
@@ -915,7 +915,7 @@ exports.applyToText = (cs, str) => {
       case '=':
       // op is = and op.lines 0: no newlines must be in the copied string
       // op is = and op.lines >0: op.lines newlines must be in the copied string
-        if (op.lines != strIter.peek(op.chars).split('\n').length - 1) {
+        if (op.lines !== strIter.peek(op.chars).split('\n').length - 1) {
           throw new Error(`newline count is wrong in op =; cs:${cs} and text:${str}`);
         }
         assem.append(strIter.take(op.chars));
@@ -992,7 +992,7 @@ exports.composeAttributes = (att1, att2, resultIsMutation, pool) => {
     let found = false;
     for (let i = 0; i < atts.length; i++) {
       const oldPair = atts[i];
-      if (oldPair[0] == pair[0]) {
+      if (oldPair[0] === pair[0]) {
         if (pair[1] || resultIsMutation) {
           oldPair[1] = pair[1];
         } else {
@@ -1038,7 +1038,7 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
       {
         if (csOp.chars <= attOp.chars) {
           // delete or delete part
-          if (attOp.opcode == '=') {
+          if (attOp.opcode === '=') {
             opOut.opcode = '-';
             opOut.chars = csOp.chars;
             opOut.lines = csOp.lines;
@@ -1092,7 +1092,7 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
           opOut.chars = attOp.chars;
           opOut.lines = attOp.lines;
           opOut.attribs = exports.composeAttributes(
-              attOp.attribs, csOp.attribs, attOp.opcode == '=', pool);
+              attOp.attribs, csOp.attribs, attOp.opcode === '=', pool);
           attOp.opcode = '';
           csOp.chars -= attOp.chars;
           csOp.lines -= attOp.lines;
@@ -1162,7 +1162,7 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
     }
     lineAssem.append(op);
     if (op.lines > 0) {
-      exports.assert(op.lines == 1, "Can't have op.lines of ", op.lines, ' in attribution lines');
+      exports.assert(op.lines === 1, "Can't have op.lines of ", op.lines, ' in attribution lines');
       // ship it to the mut
       mut.insert(lineAssem.toString(), 1);
       lineAssem = null;
@@ -1267,7 +1267,7 @@ exports.splitAttributionLines = (attrOps, text) => {
       numChars -= op.chars;
       numLines -= op.lines;
     }
-    if (numLines == 1) {
+    if (numLines === 1) {
       op.chars = numChars;
       op.lines = 1;
     }
@@ -1294,7 +1294,7 @@ exports.compose = (cs1, cs2, pool) => {
   const unpacked2 = exports.unpack(cs2);
   const len1 = unpacked1.oldLen;
   const len2 = unpacked1.newLen;
-  exports.assert(len2 == unpacked2.oldLen, 'mismatched composition of two changesets');
+  exports.assert(len2 === unpacked2.oldLen, 'mismatched composition of two changesets');
   const len3 = unpacked2.newLen;
   const bankIter1 = exports.stringIterator(unpacked1.charBank);
   const bankIter2 = exports.stringIterator(unpacked2.charBank);
@@ -1675,7 +1675,7 @@ exports.prepareForWire = (cs, pool) => {
  */
 exports.isIdentity = (cs) => {
   const unpacked = exports.unpack(cs);
-  return unpacked.ops === '' && unpacked.oldLen == unpacked.newLen;
+  return unpacked.ops === '' && unpacked.oldLen === unpacked.newLen;
 };
 
 /**
@@ -1698,7 +1698,7 @@ exports.attribsAttributeValue = (attribs, key, pool) => {
   let value = '';
   if (attribs) {
     exports.eachAttribNumber(attribs, (n) => {
-      if (pool.getAttribKey(n) == key) {
+      if (pool.getAttribKey(n) === key) {
         value = pool.getAttribValue(n);
       }
     });
@@ -1856,7 +1856,7 @@ exports.inverse = (cs, lines, alines, pool) => {
   const builder = exports.builder(unpacked.newLen);
 
   const consumeAttribRuns = (numChars, func /* (len, attribs, endsLine)*/) => {
-    if ((!curLineOpIter) || (curLineOpIterLine != curLine)) {
+    if ((!curLineOpIter) || (curLineOpIterLine !== curLine)) {
       // create curLineOpIter and advance it to curChar
       curLineOpIter = exports.opIterator(alines_get(curLine));
       curLineOpIterLine = curLine;
@@ -1885,7 +1885,7 @@ exports.inverse = (cs, lines, alines, pool) => {
         curLineOpIter.next(curLineNextOp);
       }
       const charsToUse = Math.min(numChars, curLineNextOp.chars);
-      func(charsToUse, curLineNextOp.attribs, charsToUse == curLineNextOp.chars &&
+      func(charsToUse, curLineNextOp.attribs, charsToUse === curLineNextOp.chars &&
           curLineNextOp.lines > 0);
       numChars -= charsToUse;
       curLineNextOp.chars -= charsToUse;
@@ -1902,7 +1902,7 @@ exports.inverse = (cs, lines, alines, pool) => {
     if (L) {
       curLine += L;
       curChar = 0;
-    } else if (curLineOpIter && curLineOpIterLine == curLine) {
+    } else if (curLineOpIter && curLineOpIterLine === curLine) {
       consumeAttribRuns(N, () => {});
     } else {
       curChar += N;
@@ -1955,7 +1955,7 @@ exports.inverse = (cs, lines, alines, pool) => {
             const appliedKey = attribKeys[i];
             const appliedValue = attribValues[i];
             const oldValue = exports.attribsAttributeValue(attribs, appliedKey, pool);
-            if (appliedValue != oldValue) {
+            if (appliedValue !== oldValue) {
               backAttribs.push([appliedKey, oldValue]);
             }
           }
@@ -1989,7 +1989,7 @@ exports.follow = (cs1, cs2, reverseInsertOrder, pool) => {
   const unpacked2 = exports.unpack(cs2);
   const len1 = unpacked1.oldLen;
   const len2 = unpacked2.oldLen;
-  exports.assert(len1 == len2, 'mismatched follow - cannot transform cs1 on top of cs2');
+  exports.assert(len1 === len2, 'mismatched follow - cannot transform cs1 on top of cs2');
   const chars1 = exports.stringIterator(unpacked1.charBank);
   const chars2 = exports.stringIterator(unpacked2.charBank);
 
@@ -2141,7 +2141,7 @@ exports.followAttributes = (att1, att2, pool) => {
     const pair1 = pool.getAttrib(exports.parseNum(a));
     for (let i = 0; i < atts.length; i++) {
       const pair2 = atts[i];
-      if (pair1[0] == pair2[0]) {
+      if (pair1[0] === pair2[0]) {
         if (pair1[1] <= pair2[1]) {
           // winner of merge is pair1, delete this attribute
           atts.splice(i, 1);
@@ -2165,7 +2165,7 @@ exports.composeWithDeletions = (cs1, cs2, pool) => {
   const unpacked2 = exports.unpack(cs2);
   const len1 = unpacked1.oldLen;
   const len2 = unpacked1.newLen;
-  exports.assert(len2 == unpacked2.oldLen, 'mismatched composition of two changesets');
+  exports.assert(len2 === unpacked2.oldLen, 'mismatched composition of two changesets');
   const len3 = unpacked2.newLen;
   const bankIter1 = exports.stringIterator(unpacked1.charBank);
   const bankIter2 = exports.stringIterator(unpacked2.charBank);

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -612,7 +612,7 @@ exports.textLinesMutator = (lines) => {
 
   const isCurLineInSplice = () => (curLine - curSplice[0] < (curSplice.length - 2));
 
-  const debugPrint = (typ) => {
+  const debugPrint = (typ) => { /* eslint-disable-line no-unused-vars */
     print(`${typ}: ${curSplice.toSource()} / ${curLine},${curCol} / ${lines_toSource()}`);
   };
 
@@ -745,7 +745,7 @@ exports.textLinesMutator = (lines) => {
           // curLine += newLines.length;
           // }
           // else {
-          var sline = curSplice.length - 1;
+          const sline = curSplice.length - 1;
           const theLine = curSplice[sline];
           const lineCol = curCol;
           curSplice[sline] = theLine.substring(0, lineCol) + newLines[0];
@@ -761,7 +761,7 @@ exports.textLinesMutator = (lines) => {
           curLine += newLines.length;
         }
       } else {
-        var sline = putCurLineInSplice();
+        const sline = putCurLineInSplice();
         if (!curSplice[sline]) {
           console.error('curSplice[sline] not populated, actual curSplice contents is ', curSplice, '. Possibly related to https://github.com/ether/etherpad-lite/issues/2802');
         }
@@ -1716,7 +1716,7 @@ exports.builder = (oldLen) => {
   const o = exports.newOp();
   const charBank = exports.stringAssembler();
 
-  var self = {
+  const self = {
     // attribs are [[key1,value1],[key2,value2],...] or '*0*1...' (no pool needed in latter case)
     keep: (N, L, attribs, pool) => {
       o.opcode = '=';
@@ -1949,7 +1949,7 @@ exports.inverse = (cs, lines, alines, pool) => {
           attribKeys.push(pool.getAttribKey(n));
           attribValues.push(pool.getAttribValue(n));
         });
-        var undoBackToAttribs = cachedStrFunc((attribs) => {
+        const undoBackToAttribs = cachedStrFunc((attribs) => {
           const backAttribs = [];
           for (let i = 0; i < attribKeys.length; i++) {
             const appliedKey = attribKeys[i];
@@ -1971,8 +1971,8 @@ exports.inverse = (cs, lines, alines, pool) => {
     } else if (csOp.opcode === '+') {
       builder.remove(csOp.chars, csOp.lines);
     } else if (csOp.opcode === '-') {
-      var textBank = nextText(csOp.chars);
-      var textBankIndex = 0;
+      const textBank = nextText(csOp.chars);
+      let textBankIndex = 0;
       consumeAttribRuns(csOp.chars, (len, attribs, endsLine) => {
         builder.insert(textBank.substr(textBankIndex, len), attribs);
         textBankIndex += len;

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1336,9 +1336,7 @@ exports.attributeTester = (attribPair, pool) => {
     return never;
   } else {
     const re = new RegExp(`\\*${exports.numToString(attribNum)}(?!\\w)`);
-    return function (attribs) {
-      return re.test(attribs);
-    };
+    return (attribs) => re.test(attribs);
   }
 };
 
@@ -1538,9 +1536,7 @@ exports.eachAttribNumber = (cs, func) => {
  * @param filter {function} fnc which returns true if an
  *        attribute X (int) should be kept in the Changeset
  */
-exports.filterAttribNumbers = (cs, filter) => {
-  return exports.mapAttribNumbers(cs, filter);
-};
+exports.filterAttribNumbers = (cs, filter) => exports.mapAttribNumbers(cs, filter);
 
 /**
  * does exactly the same as exports.filterAttribNumbers
@@ -1572,12 +1568,10 @@ exports.mapAttribNumbers = (cs, func) => {
  * @attribs attribs {string} optional, operations which insert
  *    the text and also puts the right attributes
  */
-exports.makeAText = (text, attribs) => {
-  return {
-    text,
-    attribs: (attribs || exports.makeAttribution(text)),
-  };
-};
+exports.makeAText = (text, attribs) => ({
+  text,
+  attribs: (attribs || exports.makeAttribution(text)),
+});
 
 /**
  * Apply a Changeset to a AText
@@ -1585,12 +1579,10 @@ exports.makeAText = (text, attribs) => {
  * @param atext {AText}
  * @param pool {AttribPool} Attribute Pool to add to
  */
-exports.applyToAText = (cs, atext, pool) => {
-  return {
-    text: exports.applyToText(cs, atext.text),
-    attribs: exports.applyToAttribution(cs, atext.attribs, pool),
-  };
-};
+exports.applyToAText = (cs, atext, pool) => ({
+  text: exports.applyToText(cs, atext.text),
+  attribs: exports.applyToAttribution(cs, atext.attribs, pool),
+});
 
 /**
  * Clones a AText structure
@@ -1714,7 +1706,7 @@ exports.builder = (oldLen) => {
 
   var self = {
     // attribs are [[key1,value1],[key2,value2],...] or '*0*1...' (no pool needed in latter case)
-    keep(N, L, attribs, pool) {
+    keep: (N, L, attribs, pool) => {
       o.opcode = '=';
       o.attribs = (attribs && exports.makeAttribsString('=', attribs, pool)) || '';
       o.chars = N;
@@ -1726,12 +1718,12 @@ exports.builder = (oldLen) => {
       assem.appendOpWithText('=', text, attribs, pool);
       return self;
     },
-    insert(text, attribs, pool) {
+    insert: (text, attribs, pool) => {
       assem.appendOpWithText('+', text, attribs, pool);
       charBank.append(text);
       return self;
     },
-    remove(N, L) {
+    remove: (N, L) => {
       o.opcode = '-';
       o.attribs = '';
       o.chars = N;
@@ -1739,7 +1731,7 @@ exports.builder = (oldLen) => {
       assem.append(o);
       return self;
     },
-    toString() {
+    toString: () => {
       assem.endDocument();
       const newLen = oldLen + assem.getLengthChange();
       return exports.pack(oldLen, newLen, assem.toString(), charBank.toString());
@@ -1795,7 +1787,7 @@ exports.subattribution = (astr, start, optEnd) => {
         }
       }
     }
-  }
+  };
 
   csOp.opcode = '-';
   csOp.chars = start;
@@ -1830,7 +1822,7 @@ exports.inverse = (cs, lines, alines, pool) => {
     } else {
       return lines[idx];
     }
-  }
+  };
 
   const alines_get = (idx) => {
     if (alines.get) {
@@ -1838,7 +1830,7 @@ exports.inverse = (cs, lines, alines, pool) => {
     } else {
       return alines[idx];
     }
-  }
+  };
 
   let curLine = 0;
   let curChar = 0;
@@ -1890,7 +1882,7 @@ exports.inverse = (cs, lines, alines, pool) => {
       curLine++;
       curChar = 0;
     }
-  }
+  };
 
   const skip = (N, L) => {
     if (L) {
@@ -1919,17 +1911,17 @@ exports.inverse = (cs, lines, alines, pool) => {
     }
 
     return assem.toString().substring(0, numChars);
-  }
+  };
 
   const cachedStrFunc = (func) => {
     const cache = {};
-    return function (s) {
+    return (s) => {
       if (!cache[s]) {
         cache[s] = func(s);
       }
       return cache[s];
     };
-  }
+  };
 
   const attribKeys = [];
   const attribValues = [];

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1,5 +1,8 @@
+'use strict';
+
 /*
- * This is the Changeset library copied from the old Etherpad with some modifications to use it in node.js
+ * This is the Changeset library copied from the old Etherpad with some modifications
+ * to use it in node.js
  * Can be found in https://github.com/ether/pad/blob/master/infrastructure/ace/www/easysync2.js
  */
 
@@ -35,7 +38,7 @@ const AttributePool = require('./AttributePool');
  * This method is called whenever there is an error in the sync process
  * @param msg {string} Just some message
  */
-exports.error = function error(msg) {
+exports.error = (msg) => {
   const e = new Error(msg);
   e.easysync = true;
   throw e;
@@ -47,7 +50,7 @@ exports.error = function error(msg) {
  * @param b {boolean} assertion condition
  * @param msgParts {string} error to be passed if it fails
  */
-exports.assert = function assert(b, msgParts) {
+exports.assert = (b, msgParts) => {
   if (!b) {
     const msg = Array.prototype.slice.call(arguments, 1).join('');
     exports.error(`Failed assertion: ${msg}`);
@@ -59,18 +62,14 @@ exports.assert = function assert(b, msgParts) {
  * @param str {string} string of the number in base 36
  * @returns {int} number
  */
-exports.parseNum = function (str) {
-  return parseInt(str, 36);
-};
+exports.parseNum = (str) => parseInt(str, 36);
 
 /**
  * Writes a number in base 36 and puts it in a string
  * @param num {int} number
  * @returns {string} string
  */
-exports.numToString = function (num) {
-  return num.toString(36).toLowerCase();
-};
+exports.numToString = (num) => num.toString(36).toLowerCase();
 
 /**
  * Converts stuff before $ to base 10
@@ -78,7 +77,7 @@ exports.numToString = function (num) {
  * @param cs {string} the string
  * @return integer
  */
-exports.toBaseTen = function (cs) {
+exports.toBaseTen = (cs) => {
   const dollarIndex = cs.indexOf('$');
   const beforeDollar = cs.substring(0, dollarIndex);
   const fromDollar = cs.substring(dollarIndex);
@@ -95,17 +94,13 @@ exports.toBaseTen = function (cs) {
  * can be applied
  * @param cs {string} String representation of the Changeset
  */
-exports.oldLen = function (cs) {
-  return exports.unpack(cs).oldLen;
-};
+exports.oldLen = (cs) => exports.unpack(cs).oldLen;
 
 /**
  * returns the length of the text after changeset is applied
  * @param cs {string} String representation of the Changeset
  */
-exports.newLen = function (cs) {
-  return exports.unpack(cs).newLen;
-};
+exports.newLen = (cs) => exports.unpack(cs).newLen;
 
 /**
  * this function creates an iterator which decodes string changeset operations
@@ -113,29 +108,28 @@ exports.newLen = function (cs) {
  * @param optStartIndex {int} from where in the string should the iterator start
  * @return {Op} type object iterator
  */
-exports.opIterator = function (opsStr, optStartIndex) {
+exports.opIterator = (opsStr, optStartIndex) => {
   // print(opsStr);
   const regex = /((?:\*[0-9a-z]+)*)(?:\|([0-9a-z]+))?([-+=])([0-9a-z]+)|\?|/g;
   const startIndex = (optStartIndex || 0);
   let curIndex = startIndex;
   let prevIndex = curIndex;
 
-  function nextRegexMatch() {
+  const nextRegexMatch = () => {
     prevIndex = curIndex;
-    let result;
     regex.lastIndex = curIndex;
-    result = regex.exec(opsStr);
+    const result = regex.exec(opsStr);
     curIndex = regex.lastIndex;
-    if (result[0] == '?') {
+    if (result[0] === '?') {
       exports.error('Hit error opcode in op stream');
     }
 
     return result;
-  }
+  };
   let regexResult = nextRegexMatch();
   const obj = exports.newOp();
 
-  function next(optObj) {
+  const next = (optObj) => {
     const op = (optObj || obj);
     if (regexResult[0]) {
       op.attribs = regexResult[1];
@@ -147,15 +141,12 @@ exports.opIterator = function (opsStr, optStartIndex) {
       exports.clearOp(op);
     }
     return op;
-  }
+  };
 
-  function hasNext() {
-    return !!(regexResult[0]);
-  }
+  const hasNext = () => !!(regexResult[0]);
 
-  function lastIndex() {
-    return prevIndex;
-  }
+  const lastIndex = () => prevIndex;
+
   return {
     next,
     hasNext,
@@ -167,7 +158,7 @@ exports.opIterator = function (opsStr, optStartIndex) {
  * Cleans an Op object
  * @param {Op} object to be cleared
  */
-exports.clearOp = function (op) {
+exports.clearOp = (op) => {
   op.opcode = '';
   op.chars = 0;
   op.lines = 0;
@@ -178,34 +169,30 @@ exports.clearOp = function (op) {
  * Creates a new Op object
  * @param optOpcode the type operation of the Op object
  */
-exports.newOp = function (optOpcode) {
-  return {
-    opcode: (optOpcode || ''),
-    chars: 0,
-    lines: 0,
-    attribs: '',
-  };
-};
+exports.newOp = (optOpcode) => ({
+  opcode: (optOpcode || ''),
+  chars: 0,
+  lines: 0,
+  attribs: '',
+});
 
 /**
  * Clones an Op
  * @param op Op to be cloned
  */
-exports.cloneOp = function (op) {
-  return {
-    opcode: op.opcode,
-    chars: op.chars,
-    lines: op.lines,
-    attribs: op.attribs,
-  };
-};
+exports.cloneOp = (op) => ({
+  opcode: op.opcode,
+  chars: op.chars,
+  lines: op.lines,
+  attribs: op.attribs,
+});
 
 /**
  * Copies op1 to op2
  * @param op1 src Op
  * @param op2 dest Op
  */
-exports.copyOp = function (op1, op2) {
+exports.copyOp = (op1, op2) => {
   op2.opcode = op1.opcode;
   op2.chars = op1.chars;
   op2.lines = op1.lines;
@@ -215,7 +202,7 @@ exports.copyOp = function (op1, op2) {
 /**
  * Writes the Op in a string the way that changesets need it
  */
-exports.opString = function (op) {
+exports.opString = (op) => {
   // just for debugging
   if (!op.opcode) return 'null';
   const assem = exports.opAssembler();
@@ -226,16 +213,13 @@ exports.opString = function (op) {
 /**
  * Used just for debugging
  */
-exports.stringOp = function (str) {
-  // just for debugging
-  return exports.opIterator(str).next();
-};
+exports.stringOp = (str) => exports.opIterator(str).next();
 
 /**
  * Used to check if a Changeset if valid
  * @param cs {Changeset} Changeset to be checked
  */
-exports.checkRep = function (cs) {
+exports.checkRep = (cs) => {
   // doesn't check things that require access to attrib pool (e.g. attribute order)
   // or original string (e.g. newline positions)
   const unpacked = exports.unpack(cs);
@@ -279,7 +263,7 @@ exports.checkRep = function (cs) {
 
   assem.endDocument();
   const normalized = exports.pack(oldLen, calcNewLen, assem.toString(), charBank);
-  exports.assert(normalized == cs, 'Invalid changeset (checkRep failed)');
+  exports.assert(normalized === cs, 'Invalid changeset (checkRep failed)');
 
   return cs;
 };
@@ -293,7 +277,7 @@ exports.checkRep = function (cs) {
  * creates an object that allows you to append operations (type Op) and also
  * compresses them if possible
  */
-exports.smartOpAssembler = function () {
+exports.smartOpAssembler = () => {
   // Like opAssembler but able to produce conforming exportss
   // from slightly looser input, at the cost of speed.
   // Specifically:
@@ -308,19 +292,19 @@ exports.smartOpAssembler = function () {
   let lastOpcode = '';
   let lengthChange = 0;
 
-  function flushKeeps() {
+  const flushKeeps = () => {
     assem.append(keepAssem.toString());
     keepAssem.clear();
-  }
+  };
 
-  function flushPlusMinus() {
+  const flushPlusMinus = () => {
     assem.append(minusAssem.toString());
     minusAssem.clear();
     assem.append(plusAssem.toString());
     plusAssem.clear();
-  }
+  };
 
-  function append(op) {
+  const append = (op) => {
     if (!op.opcode) return;
     if (!op.chars) return;
 
@@ -343,9 +327,9 @@ exports.smartOpAssembler = function () {
       keepAssem.append(op);
     }
     lastOpcode = op.opcode;
-  }
+  };
 
-  function appendOpWithText(opcode, text, attribs, pool) {
+  const appendOpWithText = (opcode, text, attribs, pool) => {
     const op = exports.newOp(opcode);
     op.attribs = exports.makeAttribsString(opcode, attribs, pool);
     const lastNewlinePos = text.lastIndexOf('\n');
@@ -361,29 +345,27 @@ exports.smartOpAssembler = function () {
       op.lines = 0;
       append(op);
     }
-  }
+  };
 
-  function toString() {
+  const toString = () => {
     flushPlusMinus();
     flushKeeps();
     return assem.toString();
-  }
+  };
 
-  function clear() {
+  const clear = () => {
     minusAssem.clear();
     plusAssem.clear();
     keepAssem.clear();
     assem.clear();
     lengthChange = 0;
-  }
+  };
 
-  function endDocument() {
+  const endDocument = () => {
     keepAssem.endDocument();
-  }
+  };
 
-  function getLengthChange() {
-    return lengthChange;
-  }
+  const getLengthChange = () => lengthChange;
 
   return {
     append,
@@ -396,7 +378,7 @@ exports.smartOpAssembler = function () {
 };
 
 
-exports.mergingOpAssembler = function () {
+exports.mergingOpAssembler = () => {
   // This assembler can be used in production; it efficiently
   // merges consecutive operations that are mergeable, ignores
   // no-ops, and drops final pure "keeps".  It does not re-order
@@ -410,7 +392,7 @@ exports.mergingOpAssembler = function () {
   // ops immediately after it.
   let bufOpAdditionalCharsAfterNewline = 0;
 
-  function flush(isEndDocument) {
+  const flush = (isEndDocument) => {
     if (bufOp.opcode) {
       if (isEndDocument && bufOp.opcode == '=' && !bufOp.attribs) {
         // final merged keep, leave it implicit
@@ -425,9 +407,9 @@ exports.mergingOpAssembler = function () {
       }
       bufOp.opcode = '';
     }
-  }
+  };
 
-  function append(op) {
+  const append = (op) => {
     if (op.chars > 0) {
       if (bufOp.opcode == op.opcode && bufOp.attribs == op.attribs) {
         if (op.lines > 0) {
@@ -447,21 +429,21 @@ exports.mergingOpAssembler = function () {
         exports.copyOp(op, bufOp);
       }
     }
-  }
+  };
 
-  function endDocument() {
+  const endDocument = () => {
     flush(true);
-  }
+  };
 
-  function toString() {
+  const toString = () => {
     flush();
     return assem.toString();
-  }
+  };
 
-  function clear() {
+  const clear = () => {
     assem.clear();
     exports.clearOp(bufOp);
-  }
+  };
   return {
     append,
     toString,
@@ -471,26 +453,24 @@ exports.mergingOpAssembler = function () {
 };
 
 
-exports.opAssembler = function () {
+exports.opAssembler = () => {
   const pieces = [];
   // this function allows op to be mutated later (doesn't keep a ref)
 
-  function append(op) {
+  const append = (op) => {
     pieces.push(op.attribs);
     if (op.lines) {
       pieces.push('|', exports.numToString(op.lines));
     }
     pieces.push(op.opcode);
     pieces.push(exports.numToString(op.chars));
-  }
+  };
 
-  function toString() {
-    return pieces.join('');
-  }
+  const toString = () => pieces.join('');
 
-  function clear() {
+  const clear = () => {
     pieces.length = 0;
-  }
+  };
   return {
     append,
     toString,
@@ -502,40 +482,36 @@ exports.opAssembler = function () {
  * A custom made String Iterator
  * @param str {string} String to be iterated over
  */
-exports.stringIterator = function (str) {
+exports.stringIterator = (str) => {
   let curIndex = 0;
   // newLines is the number of \n between curIndex and str.length
   let newLines = str.split('\n').length - 1;
-  function getnewLines() {
-    return newLines;
-  }
+  const getnewLines = () => newLines;
 
-  function assertRemaining(n) {
+  const assertRemaining = (n) => {
     exports.assert(n <= remaining(), '!(', n, ' <= ', remaining(), ')');
-  }
+  };
 
-  function take(n) {
+  const take = (n) => {
     assertRemaining(n);
     const s = str.substr(curIndex, n);
     newLines -= s.split('\n').length - 1;
     curIndex += n;
     return s;
-  }
+  };
 
-  function peek(n) {
+  const peek = (n) => {
     assertRemaining(n);
     const s = str.substr(curIndex, n);
     return s;
-  }
+  };
 
-  function skip(n) {
+  const skip = (n) => {
     assertRemaining(n);
     curIndex += n;
-  }
+  };
 
-  function remaining() {
-    return str.length - curIndex;
-  }
+  const remaining = () => str.length - curIndex;
   return {
     take,
     skip,
@@ -548,16 +524,14 @@ exports.stringIterator = function (str) {
 /**
  * A custom made StringBuffer
  */
-exports.stringAssembler = function () {
+exports.stringAssembler = () => {
   const pieces = [];
 
-  function append(x) {
+  const append = (x) => {
     pieces.push(String(x));
-  }
+  };
 
-  function toString() {
-    return pieces.join('');
-  }
+  const toString = () => pieces.join('');
   return {
     append,
     toString,
@@ -569,7 +543,7 @@ exports.stringAssembler = function () {
  * It is used for applying Changesets on arrays of lines
  * Note from prev docs: "lines" need not be an array as long as it supports certain calls (lines_foo inside).
  */
-exports.textLinesMutator = function (lines) {
+exports.textLinesMutator = (lines) => {
   // Mutates lines, an array of strings, in place.
   // Mutation operations have the same constraints as exports operations
   // with respect to newlines, but not the other additional constraints
@@ -588,72 +562,68 @@ exports.textLinesMutator = function (lines) {
   // invariant: if (inSplice && (curLine >= curSplice[0] + curSplice.length - 2)) then
   //            curCol == 0
 
-  function lines_applySplice(s) {
+  const lines_applySplice = (s) => {
     lines.splice.apply(lines, s);
-  }
+  };
 
-  function lines_toSource() {
-    return lines.toSource();
-  }
+  const lines_toSource = () => lines.toSource();
 
-  function lines_get(idx) {
+  const lines_get = (idx) => {
     if (lines.get) {
       return lines.get(idx);
     } else {
       return lines[idx];
     }
-  }
+  };
   // can be unimplemented if removeLines's return value not needed
 
-  function lines_slice(start, end) {
+  const lines_slice = (start, end) => {
     if (lines.slice) {
       return lines.slice(start, end);
     } else {
       return [];
     }
-  }
+  };
 
-  function lines_length() {
+  const lines_length = () => {
     if ((typeof lines.length) === 'number') {
       return lines.length;
     } else {
       return lines.length();
     }
-  }
+  };
 
-  function enterSplice() {
+  const enterSplice = () => {
     curSplice[0] = curLine;
     curSplice[1] = 0;
     if (curCol > 0) {
       putCurLineInSplice();
     }
     inSplice = true;
-  }
+  };
 
-  function leaveSplice() {
+  const leaveSplice = () => {
     lines_applySplice(curSplice);
     curSplice.length = 2;
     curSplice[0] = curSplice[1] = 0;
     inSplice = false;
-  }
+  };
 
-  function isCurLineInSplice() {
-    return (curLine - curSplice[0] < (curSplice.length - 2));
-  }
+  const isCurLineInSplice = () => (curLine - curSplice[0] < (curSplice.length - 2));
 
-  function debugPrint(typ) {
+  const debugPrint = (typ) => {
     print(`${typ}: ${curSplice.toSource()} / ${curLine},${curCol} / ${lines_toSource()}`);
-  }
+  };
 
-  function putCurLineInSplice() {
+  const putCurLineInSplice = () => {
     if (!isCurLineInSplice()) {
       curSplice.push(lines_get(curSplice[0] + curSplice[1]));
       curSplice[1]++;
     }
     return 2 + curLine - curSplice[0];
-  }
+  };
 
-  function skipLines(L, includeInSplice) {
+  const skipLines = (L, includeInSplice) => {
     if (L) {
       if (includeInSplice) {
         if (!inSplice) {
@@ -683,9 +653,9 @@ exports.textLinesMutator = function (lines) {
       // tests case foo in remove(), which isn't otherwise covered in current impl
     }
     // debugPrint("skip");
-  }
+  };
 
-  function skip(N, L, includeInSplice) {
+  const skip = (N, L, includeInSplice) => {
     if (N) {
       if (L) {
         skipLines(L, includeInSplice);
@@ -700,19 +670,19 @@ exports.textLinesMutator = function (lines) {
         // debugPrint("skip");
       }
     }
-  }
+  };
 
-  function removeLines(L) {
+  const removeLines = (L) => {
     let removed = '';
     if (L) {
       if (!inSplice) {
         enterSplice();
       }
 
-      function nextKLinesText(k) {
+      const nextKLinesText = (k) => {
         const m = curSplice[0] + curSplice[1];
         return lines_slice(m, m + k).join('');
-      }
+      };
       if (isCurLineInSplice()) {
         // print(curCol);
         if (curCol == 0) {
@@ -736,9 +706,9 @@ exports.textLinesMutator = function (lines) {
       // debugPrint("remove");
     }
     return removed;
-  }
+  };
 
-  function remove(N, L) {
+  const remove = (N, L) => {
     let removed = '';
     if (N) {
       if (L) {
@@ -754,9 +724,9 @@ exports.textLinesMutator = function (lines) {
       }
     }
     return removed;
-  }
+  };
 
-  function insert(text, L) {
+  const insert = (text, L) => {
     if (text) {
       if (!inSplice) {
         enterSplice();
@@ -796,23 +766,23 @@ exports.textLinesMutator = function (lines) {
       }
       // debugPrint("insert");
     }
-  }
+  };
 
-  function hasMore() {
+  const hasMore = () => {
     // print(lines.length+" / "+inSplice+" / "+(curSplice.length - 2)+" / "+curSplice[1]);
     let docLines = lines_length();
     if (inSplice) {
       docLines += curSplice.length - 2 - curSplice[1];
     }
     return curLine < docLines;
-  }
+  };
 
-  function close() {
+  const close = () => {
     if (inSplice) {
       leaveSplice();
     }
     // debugPrint("close");
-  }
+  };
 
   const self = {
     skip,
@@ -841,7 +811,7 @@ exports.textLinesMutator = function (lines) {
  *             opOut - result operator to be put into Changeset
  * @return {string} the integrated changeset
  */
-exports.applyZip = function (in1, idx1, in2, idx2, func) {
+exports.applyZip = (in1, idx1, in2, idx2, func) => {
   const iter1 = exports.opIterator(in1, idx1);
   const iter2 = exports.opIterator(in2, idx2);
   const assem = exports.smartOpAssembler();
@@ -867,7 +837,7 @@ exports.applyZip = function (in1, idx1, in2, idx2, func) {
  * @params cs {string} String encoded Changeset
  * @returns {Changeset} a Changeset class
  */
-exports.unpack = function (cs) {
+exports.unpack = (cs) => {
   const headerRegex = /Z:([0-9a-z]+)([><])([0-9a-z]+)|/;
   const headerMatch = headerRegex.exec(cs);
   if ((!headerMatch) || (!headerMatch[0])) {
@@ -896,7 +866,7 @@ exports.unpack = function (cs) {
  * @params bank {string} Charbank of the Changeset
  * @returns {Changeset} a Changeset class
  */
-exports.pack = function (oldLen, newLen, opsStr, bank) {
+exports.pack = (oldLen, newLen, opsStr, bank) => {
   const lenDiff = newLen - oldLen;
   const lenDiffStr = (lenDiff >= 0 ? `>${exports.numToString(lenDiff)}` : `<${exports.numToString(-lenDiff)}`);
   const a = [];
@@ -909,7 +879,7 @@ exports.pack = function (oldLen, newLen, opsStr, bank) {
  * @params cs {string} String encoded Changeset
  * @params str {string} String to which a Changeset should be applied
  */
-exports.applyToText = function (cs, str) {
+exports.applyToText = (cs, str) => {
   const unpacked = exports.unpack(cs);
   exports.assert(str.length == unpacked.oldLen, 'mismatched apply: ', str.length, ' / ', unpacked.oldLen);
   const csIter = exports.opIterator(unpacked.ops);
@@ -954,7 +924,7 @@ exports.applyToText = function (cs, str) {
  * @param CS {Changeset} the changeset to be applied
  * @param lines The lines to which the changeset needs to be applied
  */
-exports.mutateTextLines = function (cs, lines) {
+exports.mutateTextLines = (cs, lines) => {
   const unpacked = exports.unpack(cs);
   const csIter = exports.opIterator(unpacked.ops);
   const bankIter = exports.stringIterator(unpacked.charBank);
@@ -983,7 +953,7 @@ exports.mutateTextLines = function (cs, lines) {
  * @param resultIsMutaton {boolean}
  * @param pool {AttribPool} attribute pool
  */
-exports.composeAttributes = function (att1, att2, resultIsMutation, pool) {
+exports.composeAttributes = (att1, att2, resultIsMutation, pool) => {
   // att1 and att2 are strings like "*3*f*1c", asMutation is a boolean.
   // Sometimes attribute (key,value) pairs are treated as attribute presence
   // information, while other times they are treated as operations that
@@ -1044,7 +1014,7 @@ exports.composeAttributes = function (att1, att2, resultIsMutation, pool) {
  * Function used as parameter for applyZip to apply a Changeset to an
  * attribute
  */
-exports._slicerZipperFunc = function (attOp, csOp, opOut, pool) {
+exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
   // attOp is the op from the sequence that is being operated on, either an
   // attribution string or the earlier of two exportss being composed.
   // pool can be null if definitely not needed.
@@ -1136,7 +1106,7 @@ exports._slicerZipperFunc = function (attOp, csOp, opOut, pool) {
  * @param astr {string} the attribs string of a AText
  * @param pool {AttribsPool} the attibutes pool
  */
-exports.applyToAttribution = function (cs, astr, pool) {
+exports.applyToAttribution = (cs, astr, pool) => {
   const unpacked = exports.unpack(cs);
 
   return exports.applyZip(astr, 0, unpacked.ops, 0, (op1, op2, opOut) => exports._slicerZipperFunc(op1, op2, opOut, pool));
@@ -1148,7 +1118,7 @@ exports.applyToAttribution = function (cs, astr, pool) {
 
 };*/
 
-exports.mutateAttributionLines = function (cs, lines, pool) {
+exports.mutateAttributionLines = (cs, lines, pool) => {
   // dmesg(cs);
   // dmesg(lines.toSource()+" ->");
   const unpacked = exports.unpack(cs);
@@ -1160,11 +1130,9 @@ exports.mutateAttributionLines = function (cs, lines, pool) {
 
   let lineIter = null;
 
-  function isNextMutOp() {
-    return (lineIter && lineIter.hasNext()) || mut.hasMore();
-  }
+  const isNextMutOp = () => (lineIter && lineIter.hasNext()) || mut.hasMore();
 
-  function nextMutOp(destOp) {
+  const nextMutOp = (destOp) => {
     if ((!(lineIter && lineIter.hasNext())) && mut.hasMore()) {
       const line = mut.removeLines(1);
       lineIter = exports.opIterator(line);
@@ -1174,10 +1142,10 @@ exports.mutateAttributionLines = function (cs, lines, pool) {
     } else {
       destOp.opcode = '';
     }
-  }
+  };
   let lineAssem = null;
 
-  function outputMutOp(op) {
+  const outputMutOp = (op) => {
     // print("outputMutOp: "+op.toSource());
     if (!lineAssem) {
       lineAssem = exports.mergingOpAssembler();
@@ -1189,7 +1157,7 @@ exports.mutateAttributionLines = function (cs, lines, pool) {
       mut.insert(lineAssem.toString(), 1);
       lineAssem = null;
     }
-  }
+  };
 
   const csOp = exports.newOp();
   const attOp = exports.newOp();
@@ -1247,7 +1215,7 @@ exports.mutateAttributionLines = function (cs, lines, pool) {
  * @param theAlines collection of Attribution lines
  * @returns {string} joined Attribution lines
  */
-exports.joinAttributionLines = function (theAlines) {
+exports.joinAttributionLines = (theAlines) => {
   const assem = exports.mergingOpAssembler();
   for (let i = 0; i < theAlines.length; i++) {
     const aline = theAlines[i];
@@ -1259,20 +1227,20 @@ exports.joinAttributionLines = function (theAlines) {
   return assem.toString();
 };
 
-exports.splitAttributionLines = function (attrOps, text) {
+exports.splitAttributionLines = (attrOps, text) => {
   const iter = exports.opIterator(attrOps);
   const assem = exports.mergingOpAssembler();
   const lines = [];
   let pos = 0;
 
-  function appendOp(op) {
+  const appendOp = (op) => {
     assem.append(op);
     if (op.lines > 0) {
       lines.push(assem.toString());
       assem.clear();
     }
     pos += op.chars;
-  }
+  };
 
   while (iter.hasNext()) {
     const op = iter.next();
@@ -1301,9 +1269,7 @@ exports.splitAttributionLines = function (attrOps, text) {
  * splits text into lines
  * @param {string} text to be splitted
  */
-exports.splitTextLines = function (text) {
-  return text.match(/[^\n]*(?:\n|[^\n]$)/g);
-};
+exports.splitTextLines = (text) => text.match(/[^\n]*(?:\n|[^\n]$)/g);
 
 /**
  * compose two Changesets
@@ -1311,7 +1277,7 @@ exports.splitTextLines = function (text) {
  * @param cs2 {Changeset} second Changeset
  * @param pool {AtribsPool} Attribs pool
  */
-exports.compose = function (cs1, cs2, pool) {
+exports.compose = (cs1, cs2, pool) => {
   const unpacked1 = exports.unpack(cs1);
   const unpacked2 = exports.unpack(cs2);
   const len1 = unpacked1.oldLen;
@@ -1360,7 +1326,8 @@ exports.compose = function (cs1, cs2, pool) {
  * @param attribPair array [key,value] of the attribute
  * @param pool {AttribPool} Attribute pool
  */
-exports.attributeTester = function (attribPair, pool) {
+exports.attributeTester = (attribPair, pool) => {
+  const never = (attribs) => false;
   if (!pool) {
     return never;
   }
@@ -1373,19 +1340,13 @@ exports.attributeTester = function (attribPair, pool) {
       return re.test(attribs);
     };
   }
-
-  function never(attribs) {
-    return false;
-  }
 };
 
 /**
  * creates the identity Changeset of length N
  * @param N {int} length of the identity changeset
  */
-exports.identity = function (N) {
-  return exports.pack(N, N, '', '');
-};
+exports.identity = (N) => exports.pack(N, N, '', '');
 
 
 /**
@@ -1400,7 +1361,7 @@ exports.identity = function (N) {
  * @param optNewTextAPairs {string} new pairs to be inserted
  * @param pool {AttribPool} Attribution Pool
  */
-exports.makeSplice = function (oldFullText, spliceStart, numRemoved, newText, optNewTextAPairs, pool) {
+exports.makeSplice = (oldFullText, spliceStart, numRemoved, newText, optNewTextAPairs, pool) => {
   const oldLen = oldFullText.length;
 
   if (spliceStart >= oldLen) {
@@ -1426,7 +1387,7 @@ exports.makeSplice = function (oldFullText, spliceStart, numRemoved, newText, op
  * startChar to endChar with newText
  * @param cs Changeset
  */
-exports.toSplices = function (cs) {
+exports.toSplices = (cs) => {
   //
   const unpacked = exports.unpack(cs);
   const splices = [];
@@ -1460,7 +1421,7 @@ exports.toSplices = function (cs) {
 /**
  *
  */
-exports.characterRangeFollow = function (cs, startChar, endChar, insertionsAfter) {
+exports.characterRangeFollow = (cs, startChar, endChar, insertionsAfter) => {
   let newStartChar = startChar;
   let newEndChar = endChar;
   const splices = exports.toSplices(cs);
@@ -1512,7 +1473,7 @@ exports.characterRangeFollow = function (cs, startChar, endChar, insertionsAfter
  * @param newPool {AttribPool} new attributes pool
  * @return {string} the new Changeset
  */
-exports.moveOpsToNewPool = function (cs, oldPool, newPool) {
+exports.moveOpsToNewPool = (cs, oldPool, newPool) => {
   // works on exports or attribution string
   let dollarPos = cs.indexOf('$');
   if (dollarPos < 0) {
@@ -1544,7 +1505,7 @@ exports.moveOpsToNewPool = function (cs, oldPool, newPool) {
  * create an attribution inserting a text
  * @param text {string} text to be inserted
  */
-exports.makeAttribution = function (text) {
+exports.makeAttribution = (text) => {
   const assem = exports.smartOpAssembler();
   assem.appendOpWithText('+', text);
   return assem.toString();
@@ -1556,7 +1517,7 @@ exports.makeAttribution = function (text) {
  * @param cs {Changeset} changeset
  * @param func {function} function to be called
  */
-exports.eachAttribNumber = function (cs, func) {
+exports.eachAttribNumber = (cs, func) => {
   let dollarPos = cs.indexOf('$');
   if (dollarPos < 0) {
     dollarPos = cs.length;
@@ -1577,14 +1538,14 @@ exports.eachAttribNumber = function (cs, func) {
  * @param filter {function} fnc which returns true if an
  *        attribute X (int) should be kept in the Changeset
  */
-exports.filterAttribNumbers = function (cs, filter) {
+exports.filterAttribNumbers = (cs, filter) => {
   return exports.mapAttribNumbers(cs, filter);
 };
 
 /**
  * does exactly the same as exports.filterAttribNumbers
  */
-exports.mapAttribNumbers = function (cs, func) {
+exports.mapAttribNumbers = (cs, func) => {
   let dollarPos = cs.indexOf('$');
   if (dollarPos < 0) {
     dollarPos = cs.length;
@@ -1611,7 +1572,7 @@ exports.mapAttribNumbers = function (cs, func) {
  * @attribs attribs {string} optional, operations which insert
  *    the text and also puts the right attributes
  */
-exports.makeAText = function (text, attribs) {
+exports.makeAText = (text, attribs) => {
   return {
     text,
     attribs: (attribs || exports.makeAttribution(text)),
@@ -1624,7 +1585,7 @@ exports.makeAText = function (text, attribs) {
  * @param atext {AText}
  * @param pool {AttribPool} Attribute Pool to add to
  */
-exports.applyToAText = function (cs, atext, pool) {
+exports.applyToAText = (cs, atext, pool) => {
   return {
     text: exports.applyToText(cs, atext.text),
     attribs: exports.applyToAttribution(cs, atext.attribs, pool),
@@ -1635,7 +1596,7 @@ exports.applyToAText = function (cs, atext, pool) {
  * Clones a AText structure
  * @param atext {AText}
  */
-exports.cloneAText = function (atext) {
+exports.cloneAText = (atext) => {
   if (atext) {
     return {
       text: atext.text,
@@ -1648,7 +1609,7 @@ exports.cloneAText = function (atext) {
  * Copies a AText structure from atext1 to atext2
  * @param atext {AText}
  */
-exports.copyAText = function (atext1, atext2) {
+exports.copyAText = (atext1, atext2) => {
   atext2.text = atext1.text;
   atext2.attribs = atext1.attribs;
 };
@@ -1658,7 +1619,7 @@ exports.copyAText = function (atext1, atext2) {
  * @param atext {AText}
  * @param assem Assembler like smartOpAssembler
  */
-exports.appendATextToAssembler = function (atext, assem) {
+exports.appendATextToAssembler = (atext, assem) => {
   // intentionally skips last newline char of atext
   const iter = exports.opIterator(atext.attribs);
   const op = exports.newOp();
@@ -1696,7 +1657,7 @@ exports.appendATextToAssembler = function (atext, assem) {
  * @param cs {Changeset}
  * @param pool {AtributePool}
  */
-exports.prepareForWire = function (cs, pool) {
+exports.prepareForWire = (cs, pool) => {
   const newPool = new AttributePool();
   const newCs = exports.moveOpsToNewPool(cs, pool, newPool);
   return {
@@ -1708,7 +1669,7 @@ exports.prepareForWire = function (cs, pool) {
 /**
  * Checks if a changeset s the identity changeset
  */
-exports.isIdentity = function (cs) {
+exports.isIdentity = (cs) => {
   const unpacked = exports.unpack(cs);
   return unpacked.ops == '' && unpacked.oldLen == unpacked.newLen;
 };
@@ -1720,9 +1681,7 @@ exports.isIdentity = function (cs) {
  * @param key {string} string to be seached for
  * @param pool {AttribPool} attribute pool
  */
-exports.opAttributeValue = function (op, key, pool) {
-  return exports.attribsAttributeValue(op.attribs, key, pool);
-};
+exports.opAttributeValue = (op, key, pool) => exports.attribsAttributeValue(op.attribs, key, pool);
 
 /**
  * returns all the values of attributes with a certain key
@@ -1731,7 +1690,7 @@ exports.opAttributeValue = function (op, key, pool) {
  * @param key {string} string to be seached for
  * @param pool {AttribPool} attribute pool
  */
-exports.attribsAttributeValue = function (attribs, key, pool) {
+exports.attribsAttributeValue = (attribs, key, pool) => {
   let value = '';
   if (attribs) {
     exports.eachAttribNumber(attribs, (n) => {
@@ -1748,7 +1707,7 @@ exports.attribsAttributeValue = function (attribs, key, pool) {
  * length oldLen. Allows to add/remove parts of it
  * @param oldLen {int} Old length
  */
-exports.builder = function (oldLen) {
+exports.builder = (oldLen) => {
   const assem = exports.smartOpAssembler();
   const o = exports.newOp();
   const charBank = exports.stringAssembler();
@@ -1763,7 +1722,7 @@ exports.builder = function (oldLen) {
       assem.append(o);
       return self;
     },
-    keepText(text, attribs, pool) {
+    keepText: (text, attribs, pool) => {
       assem.appendOpWithText('=', text, attribs, pool);
       return self;
     },
@@ -1790,7 +1749,7 @@ exports.builder = function (oldLen) {
   return self;
 };
 
-exports.makeAttribsString = function (opcode, attribs, pool) {
+exports.makeAttribsString = (opcode, attribs, pool) => {
   // makeAttribsString(opcode, '*3') or makeAttribsString(opcode, [['foo','bar']], myPool) work
   if (!attribs) {
     return '';
@@ -1813,14 +1772,14 @@ exports.makeAttribsString = function (opcode, attribs, pool) {
 };
 
 // like "substring" but on a single-line attribution string
-exports.subattribution = function (astr, start, optEnd) {
+exports.subattribution = (astr, start, optEnd) => {
   const iter = exports.opIterator(astr, 0);
   const assem = exports.smartOpAssembler();
   const attOp = exports.newOp();
   const csOp = exports.newOp();
   const opOut = exports.newOp();
 
-  function doCsOp() {
+  const doCsOp = () => {
     if (csOp.chars) {
       while (csOp.opcode && (attOp.opcode || iter.hasNext())) {
         if (!attOp.opcode) iter.next(attOp);
@@ -1860,12 +1819,12 @@ exports.subattribution = function (astr, start, optEnd) {
   return assem.toString();
 };
 
-exports.inverse = function (cs, lines, alines, pool) {
+exports.inverse = (cs, lines, alines, pool) => {
   // lines and alines are what the exports is meant to apply to.
   // They may be arrays or objects with .get(i) and .length methods.
   // They include final newlines on lines.
 
-  function lines_get(idx) {
+  const lines_get = (idx) => {
     if (lines.get) {
       return lines.get(idx);
     } else {
@@ -1873,7 +1832,7 @@ exports.inverse = function (cs, lines, alines, pool) {
     }
   }
 
-  function alines_get(idx) {
+  const alines_get = (idx) => {
     if (alines.get) {
       return alines.get(idx);
     } else {
@@ -1891,7 +1850,7 @@ exports.inverse = function (cs, lines, alines, pool) {
   const csIter = exports.opIterator(unpacked.ops);
   const builder = exports.builder(unpacked.newLen);
 
-  function consumeAttribRuns(numChars, func /* (len, attribs, endsLine)*/) {
+  const consumeAttribRuns = (numChars, func /* (len, attribs, endsLine)*/) => {
     if ((!curLineOpIter) || (curLineOpIterLine != curLine)) {
       // create curLineOpIter and advance it to curChar
       curLineOpIter = exports.opIterator(alines_get(curLine));
@@ -1933,7 +1892,7 @@ exports.inverse = function (cs, lines, alines, pool) {
     }
   }
 
-  function skip(N, L) {
+  const skip = (N, L) => {
     if (L) {
       curLine += L;
       curChar = 0;
@@ -1942,9 +1901,9 @@ exports.inverse = function (cs, lines, alines, pool) {
     } else {
       curChar += N;
     }
-  }
+  };
 
-  function nextText(numChars) {
+  const nextText = (numChars) => {
     let len = 0;
     const assem = exports.stringAssembler();
     const firstString = lines_get(curLine).substring(curChar);
@@ -1962,7 +1921,7 @@ exports.inverse = function (cs, lines, alines, pool) {
     return assem.toString().substring(0, numChars);
   }
 
-  function cachedStrFunc(func) {
+  const cachedStrFunc = (func) => {
     const cache = {};
     return function (s) {
       if (!cache[s]) {
@@ -2019,7 +1978,7 @@ exports.inverse = function (cs, lines, alines, pool) {
 };
 
 // %CLIENT FILE ENDS HERE%
-exports.follow = function (cs1, cs2, reverseInsertOrder, pool) {
+exports.follow = (cs1, cs2, reverseInsertOrder, pool) => {
   const unpacked1 = exports.unpack(cs1);
   const unpacked2 = exports.unpack(cs2);
   const len1 = unpacked1.oldLen;
@@ -2160,7 +2119,7 @@ exports.follow = function (cs1, cs2, reverseInsertOrder, pool) {
   return exports.pack(oldLen, newLen, newOps, unpacked2.charBank);
 };
 
-exports.followAttributes = function (att1, att2, pool) {
+exports.followAttributes = (att1, att2, pool) => {
   // The merge of two sets of attribute changes to the same text
   // takes the lexically-earlier value if there are two values
   // for the same key.  Otherwise, all key/value changes from
@@ -2197,7 +2156,7 @@ exports.followAttributes = function (att1, att2, pool) {
   return buf.toString();
 };
 
-exports.composeWithDeletions = function (cs1, cs2, pool) {
+exports.composeWithDeletions = (cs1, cs2, pool) => {
   const unpacked1 = exports.unpack(cs1);
   const unpacked2 = exports.unpack(cs2);
   const len1 = unpacked1.oldLen;
@@ -2229,7 +2188,7 @@ exports.composeWithDeletions = function (cs1, cs2, pool) {
 
 // This function is 95% like _slicerZipperFunc, we just changed two lines to ensure it merges the attribs of deletions properly.
 // This is necassary for correct paddiff. But to ensure these changes doesn't affect anything else, we've created a seperate function only used for paddiffs
-exports._slicerZipperFuncWithDeletions = function (attOp, csOp, opOut, pool) {
+exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
   // attOp is the op from the sequence that is being operated on, either an
   // attribution string or the earlier of two exportss being composed.
   // pool can be null if definitely not needed.

--- a/src/static/js/ChangesetUtils.js
+++ b/src/static/js/ChangesetUtils.js
@@ -20,7 +20,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-exports.buildRemoveRange = function (rep, builder, start, end) {
+exports.buildRemoveRange = (rep, builder, start, end) => {
   const startLineOffset = rep.lines.offsetOfIndex(start[0]);
   const endLineOffset = rep.lines.offsetOfIndex(end[0]);
 
@@ -32,7 +32,7 @@ exports.buildRemoveRange = function (rep, builder, start, end) {
   }
 };
 
-exports.buildKeepRange = function (rep, builder, start, end, attribs, pool) {
+exports.buildKeepRange = (rep, builder, start, end, attribs, pool) => {
   const startLineOffset = rep.lines.offsetOfIndex(start[0]);
   const endLineOffset = rep.lines.offsetOfIndex(end[0]);
 
@@ -44,7 +44,7 @@ exports.buildKeepRange = function (rep, builder, start, end, attribs, pool) {
   }
 };
 
-exports.buildKeepToStartOfRange = function (rep, builder, start) {
+exports.buildKeepToStartOfRange = (rep, builder, start) => {
   const startLineOffset = rep.lines.offsetOfIndex(start[0]);
 
   builder.keep(startLineOffset, start[0]);

--- a/src/static/js/ChangesetUtils.js
+++ b/src/static/js/ChangesetUtils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * This module contains several helper Functions to build Changesets
  * based on a SkipList

--- a/src/static/js/broadcast.js
+++ b/src/static/js/broadcast.js
@@ -33,7 +33,7 @@ const hooks = require('./pluginfw/hooks');
 
 // These parameters were global, now they are injected. A reference to the
 // Timeslider controller would probably be more appropriate.
-function loadBroadcastJS(socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, BroadcastSlider) {
+const loadBroadcastJS = (socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, BroadcastSlider) => {
   let goToRevisionIfEnabledCount = 0;
   let changesetLoader = undefined;
 
@@ -488,6 +488,6 @@ function loadBroadcastJS(socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, Bro
   receiveAuthorData(clientVars.collab_client_vars.historicalAuthorData);
 
   return changesetLoader;
-}
+};
 
 exports.loadBroadcastJS = loadBroadcastJS;

--- a/src/static/js/changesettracker.js
+++ b/src/static/js/changesettracker.js
@@ -48,11 +48,13 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
     // can call this multiple times per call-stack, because
     // we only schedule a call to changeCallback if it exists
     // and if there isn't a timeout already scheduled.
-    if (changeCallback && changeCallbackTimeout === null) {
+    if (changeCallback && changeCallbackTimeout == null) {
       changeCallbackTimeout = scheduler.setTimeout(() => {
         try {
           changeCallback();
-        } catch (pseudoError) {} finally {
+        } catch (pseudoError) {
+          // as empty as my soul
+        } finally {
           changeCallbackTimeout = null;
         }
       }, 0);
@@ -150,28 +152,30 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         // We need to replace all author attribs with thisSession.author,
         // in case they copy/pasted or otherwise inserted other peoples changes
         if (apool.numToAttrib) {
+          let authorAttr;
           for (const attr in apool.numToAttrib) {
-            if (apool.numToAttrib[attr][0] == 'author' && apool.numToAttrib[attr][1] == authorId) {
-              var authorAttr = Number(attr).toString(36);
+            if (apool.numToAttrib[attr][0] === 'author' &&
+                apool.numToAttrib[attr][1] === authorId) {
+              authorAttr = Number(attr).toString(36);
             }
           }
 
           // Replace all added 'author' attribs with the value of the current user
-          var cs = Changeset.unpack(userChangeset);
+          const cs = Changeset.unpack(userChangeset);
           const iterator = Changeset.opIterator(cs.ops);
           let op;
           const assem = Changeset.mergingOpAssembler();
 
           while (iterator.hasNext()) {
             op = iterator.next();
-            if (op.opcode == '+') {
-              var newAttrs = '';
+            if (op.opcode === '+') {
+              let newAttrs = '';
 
               op.attribs.split('*').forEach((attrNum) => {
                 if (!attrNum) return;
                 const attr = apool.getAttrib(parseInt(attrNum, 36));
                 if (!attr) return;
-                if ('author' == attr[0]) {
+                if ('author' === attr[0]) {
                   // replace that author with the current one
                   newAttrs += `*${authorAttr}`;
                 } else { newAttrs += `*${attrNum}`; } // overtake all other attribs as is
@@ -188,7 +192,7 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         else toSubmit = userChangeset;
       }
 
-      var cs = null;
+      let cs = null;
       if (toSubmit) {
         submittedChangeset = toSubmit;
         userChangeset = Changeset.identity(Changeset.newLen(toSubmit));

--- a/src/static/js/changesettracker.js
+++ b/src/static/js/changesettracker.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * This code is mostly from the old Etherpad. Please help us to comment this code.
  * This helps other people to understand this code better and helps them to improve it.
@@ -23,7 +25,7 @@
 const AttributePool = require('./AttributePool');
 const Changeset = require('./Changeset');
 
-function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
+const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
   // latest official text from server
   let baseAText = Changeset.makeAText('\n');
   // changes applied to baseText that have been submitted
@@ -42,7 +44,7 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
 
   let changeCallbackTimeout = null;
 
-  function setChangeCallbackTimeout() {
+  const setChangeCallbackTimeout = () => {
     // can call this multiple times per call-stack, because
     // we only schedule a call to changeCallback if it exists
     // and if there isn't a timeout already scheduled.
@@ -55,17 +57,15 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
         }
       }, 0);
     }
-  }
+  };
 
   let self;
   return self = {
-    isTracking() {
-      return tracking;
-    },
-    setBaseText(text) {
+    isTracking: () => tracking,
+    setBaseText: (text) => {
       self.setBaseAttributedText(Changeset.makeAText(text), null);
     },
-    setBaseAttributedText(atext, apoolJsonObj) {
+    setBaseAttributedText: (atext, apoolJsonObj) => {
       aceCallbacksProvider.withCallbacks('setBaseText', (callbacks) => {
         tracking = true;
         baseAText = Changeset.cloneAText(atext);
@@ -83,7 +83,7 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
         }
       });
     },
-    composeUserChangeset(c) {
+    composeUserChangeset: (c) => {
       if (!tracking) return;
       if (applyingNonUserChanges) return;
       if (Changeset.isIdentity(c)) return;
@@ -91,7 +91,7 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
 
       setChangeCallbackTimeout();
     },
-    applyChangesToBase(c, optAuthor, apoolJsonObj) {
+    applyChangesToBase: (c, optAuthor, apoolJsonObj) => {
       if (!tracking) return;
 
       aceCallbacksProvider.withCallbacks('applyChangesToBase', (callbacks) => {
@@ -123,7 +123,7 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
         }
       });
     },
-    prepareUserChangeset() {
+    prepareUserChangeset: () => {
       // If there are user changes to submit, 'changeset' will be the
       // changeset, else it will be null.
       let toSubmit;
@@ -201,7 +201,7 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
       };
       return data;
     },
-    applyPreparedChangesetToBase() {
+    applyPreparedChangesetToBase: () => {
       if (!submittedChangeset) {
         // violation of protocol; use prepareUserChangeset first
         throw new Error('applySubmittedChangesToBase: no submitted changes to apply');
@@ -210,13 +210,11 @@ function makeChangesetTracker(scheduler, apool, aceCallbacksProvider) {
       baseAText = Changeset.applyToAText(submittedChangeset, baseAText, apool);
       submittedChangeset = null;
     },
-    setUserChangeNotificationCallback(callback) {
+    setUserChangeNotificationCallback: (callback) => {
       changeCallback = callback;
     },
-    hasUncommittedChanges() {
-      return !!(submittedChangeset || (!Changeset.isIdentity(userChangeset)));
-    },
+    hasUncommittedChanges: () => !!(submittedChangeset || (!Changeset.isIdentity(userChangeset))),
   };
-}
+};
 
 exports.makeChangesetTracker = makeChangesetTracker;

--- a/src/static/js/changesettracker.js
+++ b/src/static/js/changesettracker.js
@@ -111,8 +111,10 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
 
         const preferInsertingAfterUserChanges = true;
         const oldUserChangeset = userChangeset;
-        userChangeset = Changeset.follow(c2, oldUserChangeset, preferInsertingAfterUserChanges, apool);
-        const postChange = Changeset.follow(oldUserChangeset, c2, !preferInsertingAfterUserChanges, apool);
+        userChangeset = Changeset.follow(
+            c2, oldUserChangeset, preferInsertingAfterUserChanges, apool);
+        const postChange = Changeset.follow(
+            oldUserChangeset, c2, !preferInsertingAfterUserChanges, apool);
 
         const preferInsertionAfterCaret = true; // (optAuthor && optAuthor > thisAuthor);
         applyingNonUserChanges = true;
@@ -135,7 +137,9 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         // add forEach function to Array.prototype for IE8
         if (!('forEach' in Array.prototype)) {
           Array.prototype.forEach = function (action, that /* opt*/) {
-            for (let i = 0, n = this.length; i < n; i++) if (i in this) action.call(that, this[i], i, this);
+            for (let i = 0, n = this.length; i < n; i++) {
+              if (i in this) action.call(that, this[i], i, this);
+            }
           };
         }
 
@@ -143,10 +147,13 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         const authorId = parent.parent.pad.myUserInfo.userId;
 
         // Sanitize authorship
-        // We need to replace all author attribs with thisSession.author, in case they copy/pasted or otherwise inserted other peoples changes
+        // We need to replace all author attribs with thisSession.author,
+        // in case they copy/pasted or otherwise inserted other peoples changes
         if (apool.numToAttrib) {
           for (const attr in apool.numToAttrib) {
-            if (apool.numToAttrib[attr][0] == 'author' && apool.numToAttrib[attr][1] == authorId) var authorAttr = Number(attr).toString(36);
+            if (apool.numToAttrib[attr][0] == 'author' && apool.numToAttrib[attr][1] == authorId) {
+              var authorAttr = Number(attr).toString(36);
+            }
           }
 
           // Replace all added 'author' attribs with the value of the current user

--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -34,7 +34,7 @@ const getSocket = () => pad && pad.socket;
 /** Call this when the document is ready, and a new Ace2Editor() has been created and inited.
     ACE's ready callback does not need to have fired yet.
     "serverVars" are from calling doc.getCollabClientVars() on the server. */
-function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad) {
+const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad) => {
   const editor = ace2editor;
   pad = _pad; // Inject pad to avoid a circular dependency.
 
@@ -583,6 +583,6 @@ function getCollabClient(ace2editor, serverVars, initialUserInfo, options, _pad)
 
   setUpSocket();
   return self;
-}
+};
 
 exports.getCollabClient = getCollabClient;

--- a/src/static/js/index.js
+++ b/src/static/js/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0
 /**
  * Copyright 2011 Peter Martischka, Primary Technology.
@@ -15,8 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/* global $, customStart */
 
 function randomPadName() {
   // the number of distinct chars (64) is chosen to ensure that the selection will be uniform when

--- a/src/static/js/index.js
+++ b/src/static/js/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/* eslint-disable-next-line max-len */
 // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt Apache-2.0
 /**
  * Copyright 2011 Peter Martischka, Primary Technology.
@@ -18,26 +19,26 @@
  * limitations under the License.
  */
 
-function randomPadName() {
+const randomPadName = () => {
   // the number of distinct chars (64) is chosen to ensure that the selection will be uniform when
   // using the PRNG below
   const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_';
   // the length of the pad name is chosen to get 120-bit security: log2(64^20) = 120
-  const string_length = 20;
+  const stringLength = 20;
   // make room for 8-bit integer values that span from 0 to 255.
-  const randomarray = new Uint8Array(string_length);
+  const randomarray = new Uint8Array(stringLength);
   // use browser's PRNG to generate a "unique" sequence
   const cryptoObj = window.crypto || window.msCrypto; // for IE 11
   cryptoObj.getRandomValues(randomarray);
   let randomstring = '';
-  for (let i = 0; i < string_length; i++) {
+  for (let i = 0; i < stringLength; i++) {
     // instead of writing "Math.floor(randomarray[i]/256*64)"
     // we can save some cycles.
     const rnum = Math.floor(randomarray[i] / 4);
     randomstring += chars.substring(rnum, rnum + 1);
   }
   return randomstring;
-}
+};
 
 $(() => {
   $('#go2Name').submit(() => {
@@ -55,7 +56,7 @@ $(() => {
   });
 
   // start the custom js
-  if (typeof customStart === 'function') customStart();
+  if (typeof window.customStart === 'function') window.customStart();
 });
 
 // @license-end

--- a/src/static/js/l10n.js
+++ b/src/static/js/l10n.js
@@ -1,4 +1,6 @@
-(function (document) {
+'use strict';
+
+((document) => {
   // Set language for l10n
   let language = document.cookie.match(/language=((\w{2,3})(-\w+)?)/);
   if (language) language = language[1];

--- a/src/static/js/pad_userlist.js
+++ b/src/static/js/pad_userlist.js
@@ -18,7 +18,6 @@
 
 const padutils = require('./pad_utils').padutils;
 const hooks = require('./pluginfw/hooks');
-const browser = require('./browser');
 
 let myUserInfo = {};
 

--- a/src/static/js/pad_userlist.js
+++ b/src/static/js/pad_userlist.js
@@ -24,8 +24,8 @@ let myUserInfo = {};
 let colorPickerOpen = false;
 let colorPickerSetup = false;
 
-const paduserlist = (function () {
-  const rowManager = (function () {
+const paduserlist = (() => {
+  const rowManager = (() => {
     // The row manager handles rendering rows of the user list and animating
     // their insertion, removal, and reordering.  It manipulates TD height
     // and TD opacity.
@@ -290,7 +290,7 @@ const paduserlist = (function () {
       updateRow,
     };
     return self;
-  }()); // //////// rowManager
+  })(); // //////// rowManager
   const otherUsersInfo = [];
   const otherUsersData = [];
 
@@ -346,7 +346,7 @@ const paduserlist = (function () {
 
   let pad = undefined;
   const self = {
-    init(myInitialUserInfo, _pad) {
+    init: (myInitialUserInfo, _pad) => {
       pad = _pad;
 
       self.setMyUserInfo(myInitialUserInfo);
@@ -543,7 +543,7 @@ const paduserlist = (function () {
     },
   };
   return self;
-}());
+})();
 
 const getColorPickerSwatchIndex = (jnode) => $('#colorpickerswatches li').index(jnode);
 

--- a/src/static/js/security.js
+++ b/src/static/js/security.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Copyright 2009 Google Inc.
  *

--- a/src/static/js/underscore.js
+++ b/src/static/js/underscore.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = require('underscore');

--- a/src/static/skins/colibris/index.js
+++ b/src/static/skins/colibris/index.js
@@ -1,5 +1,7 @@
-function customStart() {
+'use strict';
+
+window.customStart = () => {
   // define your javascript here
   // jquery is available - except index.js
   // you can load extra scripts with $.getScript http://api.jquery.com/jQuery.getScript/
-}
+};

--- a/src/static/skins/colibris/pad.js
+++ b/src/static/skins/colibris/pad.js
@@ -1,5 +1,7 @@
-function customStart() {
+'use strict';
+
+window.customStart = () => {
   $('#pad_title').show();
   $('.buttonicon').mousedown(function () { $(this).parent().addClass('pressed'); });
   $('.buttonicon').mouseup(function () { $(this).parent().removeClass('pressed'); });
-}
+};

--- a/src/static/skins/colibris/timeslider.js
+++ b/src/static/skins/colibris/timeslider.js
@@ -1,2 +1,4 @@
-function customStart() {
-}
+'use strict';
+
+window.customStart = () => {
+};

--- a/src/static/skins/no-skin/index.js
+++ b/src/static/skins/no-skin/index.js
@@ -1,5 +1,7 @@
-function customStart() {
+'use strict';
+
+window.customStart = () => {
   // define your javascript here
   // jquery is available - except index.js
   // you can load extra scripts with $.getScript http://api.jquery.com/jQuery.getScript/
-}
+};

--- a/src/static/skins/no-skin/pad.js
+++ b/src/static/skins/no-skin/pad.js
@@ -1,5 +1,7 @@
-function customStart() {
+'use strict';
+
+window.customStart = () => {
   // define your javascript here
   // jquery is available - except index.js
   // you can load extra scripts with $.getScript http://api.jquery.com/jQuery.getScript/
-}
+};

--- a/src/static/skins/no-skin/timeslider.js
+++ b/src/static/skins/no-skin/timeslider.js
@@ -1,5 +1,7 @@
-function customStart() {
+'use strict';
+
+window.customStart = () => {
   // define your javascript here
   // jquery is available - except index.js
   // you can load extra scripts with $.getScript http://api.jquery.com/jQuery.getScript/
-}
+};


### PR DESCRIPTION
This PR just leaves two more things in the front-end code that I'm too much of a noob to fix.  It would be awesome to see them sent as commits but I also don't mind getting to them when I have time.

- [ ] ``src\static\js\Changeset.js 567:5  error  Use the spread operator instead of '.apply()'  prefer-spread``
- [ ] ``src\static\js\changesettracker.js 141:11  error  Array prototype is read only, properties should not be added  no-extend-native``

I tried to keep my commit history as clean as possible but I wont be offended if this is squashed.

There are a few places that ``self`` is used and I lacked the patience to resolve it at that point as I wanted the lions share of the linting done so we can come back at a future date and remove the ``self`` and lines I have been forced to add eslint disables for.

Tests are passing.