### PR TITLE
pluginfw: Warn plugins on missing plugin

### DIFF
--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -89,7 +89,6 @@ exports.setPadRaw = (padId, r) => {
         if (prefix === oldPadId[0]) newKey = `${prefix}:${padId}`;
       }
     }
-    //
 
     // Write the value to the server
     await db.set(newKey, value);

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -22,6 +22,13 @@ const hooks = require('../../static/js/pluginfw/hooks');
 exports.setPadRaw = (padId, r) => {
   const records = JSON.parse(r);
 
+  const blockElems = ['div', 'br', 'p', 'pre', 'li', 'author', 'lmkr', 'insertorder'];
+
+  // get supported block Elements from plugins, we will use this later.
+  hooks.callAll('ccRegisterBlockElements').forEach((element) => {
+    blockElems.push(element);
+  });
+
   Object.keys(records).forEach(async (key) => {
     let value = records[key];
 
@@ -53,6 +60,17 @@ exports.setPadRaw = (padId, r) => {
     } else {
       // Not author data, probably pad data
       // we can split it to look to see if it's pad data
+
+      // is this an attribute we support or not?  If not, tell the admin
+      if (value.pool) {
+        for (const attrib of Object.keys(value.pool.numToAttrib)) {
+          const attribName = value.pool.numToAttrib[attrib][0];
+          if(blockElems.indexOf(attribName) === -1) {
+            console.warn('Plugin missing: ' +
+                `You might want to install a plugin to support this node name: ${attribName}`);
+          }
+        }
+      }
       const oldPadId = key.split(':');
 
       // we know it's pad data
@@ -71,6 +89,7 @@ exports.setPadRaw = (padId, r) => {
         if (prefix === oldPadId[0]) newKey = `${prefix}:${padId}`;
       }
     }
+    //
 
     // Write the value to the server
     await db.set(newKey, value);

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -315,6 +315,10 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     const localAttribs = state.localAttribs;
     state.localAttribs = null;
     const isBlock = isBlockElement(node);
+    if (!isBlock && node.name && (node.name !== 'body') && (node.name !== 'br')) {
+      console.warn('Plugin missing: ' +
+          `You might want to install a plugin to support this node name: ${node.name}`);
+    }
     const isEmpty = _isEmpty(node, state);
     if (isBlock) _ensureColumnZero(state);
     const startLine = lines.length() - 1;


### PR DESCRIPTION
Add functionality to console.warn when a plugin is missing.  This will help admins know when people are trying to use plugins that are missing.  Resolves https://github.com/ether/etherpad-lite/issues/4730

