### PR TITLE
Instead of remove JSONP API this might serve as temp patch

### DIFF
--- a/src/node/hooks/express/isValidJSONPName.js
+++ b/src/node/hooks/express/isValidJSONPName.js
@@ -67,7 +67,7 @@ const RESERVED_WORDS = [
   'yield',
 ];
 
-const regex = /^[a-zA-Z_$][0-9a-zA-Z_$]*(?:\[(?:".+"|'.+'|\d+)\])*?$/;
+const regex = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
 
 module.exports.check = (inputStr) => {
   let isValid = true;

--- a/src/node/hooks/express/isValidJSONPName.js
+++ b/src/node/hooks/express/isValidJSONPName.js
@@ -67,7 +67,7 @@ const RESERVED_WORDS = [
   'yield',
 ];
 
-const regex = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
+const regex = /^[a-zA-Z_$][0-9a-zA-Z_$\[\]"'.-]*$/;
 
 module.exports.check = (inputStr) => {
   let isValid = true;


### PR DESCRIPTION
Fix the LGTM security issue:

> This part of the regular expression may cause exponential backtracking on strings starting with '$["' and containing many repetitions of 'a"]["'.
> This part of the regular expression may cause exponential backtracking on strings starting with '$['' and containing many repetitions of 'a'][''.

https://lgtm.com/projects/g/ether/etherpad-lite/snapshot/a6141937b719967b0fc6c16925cd91e6d39002f2/files/src/node/hooks/express/isValidJSONPName.js?sort=name&dir=ASC&mode=heatmap

A further consideration is to drop JSONP entirely.