### PR TITLE
caretPosition: Simplify `getPosition()`

### DIFF
--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -6,17 +6,13 @@
 exports.getPosition = () => {
   const range = getSelectionRange();
   if (!range || $(range.endContainer).closest('body')[0].id !== 'innerdocbody') return null;
-
-  // when there's a <br> or any element that has no height, we can't get
-  // the dimension of the element where the caret is
+  // When there's a <br> or any element that has no height, we can't get the dimension of the
+  // element where the caret is. As we can't get the element height, we create a text node to get
+  // the dimensions on the position.
   const clonedRange = createSelectionRange(range);
-
-  // as we can't get the element height, we create a text node to get the dimensions
-  // on the position
   const shadowCaret = $(document.createTextNode('|'));
   clonedRange.insertNode(shadowCaret[0]);
   clonedRange.selectNode(shadowCaret[0]);
-
   const line = getPositionOfElementOrSelection(clonedRange);
   shadowCaret.remove();
   return line;

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -14,7 +14,6 @@ exports.getPosition = () => {
   if (selectionIsInTheBeginningOfLine) {
     const clonedRange = createSelectionRange(range);
     line = getPositionOfElementOrSelection(clonedRange);
-    clonedRange.detach();
   }
 
   // when there's a <br> or any element that has no height, we can't get
@@ -28,7 +27,6 @@ exports.getPosition = () => {
   clonedRange.selectNode(shadowCaret[0]);
 
   line = getPositionOfElementOrSelection(clonedRange);
-  clonedRange.detach();
   shadowCaret.remove();
   return line;
 };

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -6,7 +6,7 @@
 exports.getPosition = () => {
   const range = getSelectionRange();
   if (!range || $(range.endContainer).closest('body')[0].id !== 'innerdocbody') return null;
-  let rect, line;
+  let line;
 
   // when we have the caret in an empty line, e.g. a line with only a <br>,
   // getBoundingClientRect() returns all dimensions value as 0
@@ -19,19 +19,17 @@ exports.getPosition = () => {
 
   // when there's a <br> or any element that has no height, we can't get
   // the dimension of the element where the caret is
-  if (!rect || rect.height === 0) {
-    const clonedRange = createSelectionRange(range);
+  const clonedRange = createSelectionRange(range);
 
-    // as we can't get the element height, we create a text node to get the dimensions
-    // on the position
-    const shadowCaret = $(document.createTextNode('|'));
-    clonedRange.insertNode(shadowCaret[0]);
-    clonedRange.selectNode(shadowCaret[0]);
+  // as we can't get the element height, we create a text node to get the dimensions
+  // on the position
+  const shadowCaret = $(document.createTextNode('|'));
+  clonedRange.insertNode(shadowCaret[0]);
+  clonedRange.selectNode(shadowCaret[0]);
 
-    line = getPositionOfElementOrSelection(clonedRange);
-    clonedRange.detach();
-    shadowCaret.remove();
-  }
+  line = getPositionOfElementOrSelection(clonedRange);
+  clonedRange.detach();
+  shadowCaret.remove();
   return line;
 };
 

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -4,36 +4,33 @@
 // This function is useful to get the caret position of the line as
 // is represented by the browser
 exports.getPosition = () => {
-  let rect, line;
   const range = getSelectionRange();
-  const isSelectionInsideTheEditor = range &&
-      $(range.endContainer).closest('body')[0].id === 'innerdocbody';
+  if (!range || $(range.endContainer).closest('body')[0].id !== 'innerdocbody') return null;
+  let rect, line;
 
-  if (isSelectionInsideTheEditor) {
-    // when we have the caret in an empty line, e.g. a line with only a <br>,
-    // getBoundingClientRect() returns all dimensions value as 0
-    const selectionIsInTheBeginningOfLine = range.endOffset > 0;
-    if (selectionIsInTheBeginningOfLine) {
-      const clonedRange = createSelectionRange(range);
-      line = getPositionOfElementOrSelection(clonedRange);
-      clonedRange.detach();
-    }
+  // when we have the caret in an empty line, e.g. a line with only a <br>,
+  // getBoundingClientRect() returns all dimensions value as 0
+  const selectionIsInTheBeginningOfLine = range.endOffset > 0;
+  if (selectionIsInTheBeginningOfLine) {
+    const clonedRange = createSelectionRange(range);
+    line = getPositionOfElementOrSelection(clonedRange);
+    clonedRange.detach();
+  }
 
-    // when there's a <br> or any element that has no height, we can't get
-    // the dimension of the element where the caret is
-    if (!rect || rect.height === 0) {
-      const clonedRange = createSelectionRange(range);
+  // when there's a <br> or any element that has no height, we can't get
+  // the dimension of the element where the caret is
+  if (!rect || rect.height === 0) {
+    const clonedRange = createSelectionRange(range);
 
-      // as we can't get the element height, we create a text node to get the dimensions
-      // on the position
-      const shadowCaret = $(document.createTextNode('|'));
-      clonedRange.insertNode(shadowCaret[0]);
-      clonedRange.selectNode(shadowCaret[0]);
+    // as we can't get the element height, we create a text node to get the dimensions
+    // on the position
+    const shadowCaret = $(document.createTextNode('|'));
+    clonedRange.insertNode(shadowCaret[0]);
+    clonedRange.selectNode(shadowCaret[0]);
 
-      line = getPositionOfElementOrSelection(clonedRange);
-      clonedRange.detach();
-      shadowCaret.remove();
-    }
+    line = getPositionOfElementOrSelection(clonedRange);
+    clonedRange.detach();
+    shadowCaret.remove();
   }
   return line;
 };

--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -6,15 +6,6 @@
 exports.getPosition = () => {
   const range = getSelectionRange();
   if (!range || $(range.endContainer).closest('body')[0].id !== 'innerdocbody') return null;
-  let line;
-
-  // when we have the caret in an empty line, e.g. a line with only a <br>,
-  // getBoundingClientRect() returns all dimensions value as 0
-  const selectionIsInTheBeginningOfLine = range.endOffset > 0;
-  if (selectionIsInTheBeginningOfLine) {
-    const clonedRange = createSelectionRange(range);
-    line = getPositionOfElementOrSelection(clonedRange);
-  }
 
   // when there's a <br> or any element that has no height, we can't get
   // the dimension of the element where the caret is
@@ -26,7 +17,7 @@ exports.getPosition = () => {
   clonedRange.insertNode(shadowCaret[0]);
   clonedRange.selectNode(shadowCaret[0]);
 
-  line = getPositionOfElementOrSelection(clonedRange);
+  const line = getPositionOfElementOrSelection(clonedRange);
   shadowCaret.remove();
   return line;
 };


### PR DESCRIPTION
Multiple commits:
* caretPosition: Invert condition in `getPosition()` for readability
* caretPosition: Delete unused var in `getPosition()`
* caretPosition: Delete no-op `Range.detach()` call
* caretPosition: Delete pointless logic in `getPosition()`
* caretPosition: Clarify comment in `getPosition()`
