### PR TITLE
tests: Use more modern relevant Firefox version in Sauce Labs

### DIFF
--- a/src/tests/frontend/specs/bold.js
+++ b/src/tests/frontend/specs/bold.js
@@ -8,7 +8,7 @@ describe('bold button', function () {
   });
 
   it('makes text bold on click', function (done) {
-    this.timeout(100);
+    this.timeout(200);
     const inner$ = helper.padInner$;
     const chrome$ = helper.padChrome$;
 
@@ -37,7 +37,7 @@ describe('bold button', function () {
   });
 
   it('makes text bold on keypress', function (done) {
-    this.timeout(100);
+    this.timeout(200);
     const inner$ = helper.padInner$;
 
     // get the first text element out of the inner iframe

--- a/src/tests/frontend/specs/embed_value.js
+++ b/src/tests/frontend/specs/embed_value.js
@@ -57,7 +57,7 @@ describe('embed links', function () {
 
     describe('the share link', function () {
       it('is the actual pad url', function (done) {
-        this.timeout(50);
+        this.timeout(100);
         const chrome$ = helper.padChrome$;
 
         // open share dropdown

--- a/src/tests/frontend/travis/remote_runner.js
+++ b/src/tests/frontend/travis/remote_runner.js
@@ -131,9 +131,9 @@ const sauceTestWorker = async.queue((testSettings, callback) => {
 if (!isAdminRunner) {
   // 1) Firefox on Linux
   sauceTestWorker.push({
-    platform: 'Windows 7',
+    platform: 'Windows 10',
     browserName: 'firefox',
-    version: '52.0',
+    version: '84.0',
   });
 
   // 2) Chrome on Linux


### PR DESCRIPTION
Firefox 52 has issues with rendering SVG animations which caused random tests to fail.  Less than 2% of total Firefox users now use Firefox 52 so we're safe to drop testing for it.