### PR TITLE
Windows CI Installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -10,12 +10,16 @@ jobs:
     if: |
          (github.event_name != 'pull_request')
          || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
-    name: Building Windows Zip and Executable Installer on Linux without plugins
-    runs-on: ubuntu-latest
+
+    name: Build Zip & Exe
+    runs-on: windows-latest
 
     steps:
-    - name: 'Install makensis (apt)'
-      run: sudo apt update && sudo apt install -y nsis nsis-pluginapi
+    - uses: msys2/setup-msys2@v2
+      with:
+        path-type: inherit
+        install: >-
+          zip
 
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -25,16 +29,19 @@ jobs:
         node-version: 12
 
     - name: Install all dependencies and symlink for ep_etherpad-lite
+      shell: msys2 {0}
       run: src/bin/installDeps.sh
 
     - name: Run the backend tests
+      shell: msys2 {0}
       run: cd src && npm test
 
     - name: Build the .zip
+      shell: msys2 {0}
       run: src/bin/buildForWindows.sh
 
     - name: Extract the .zip into folder
-      run: unzip etherpad-lite-win.zip -d etherpad-lite-new
+      run: 7z x etherpad-lite-win.zip -oetherpad-lite-new
 
     - name: Grab nsis config
       run: git clone https://github.com/ether/etherpad_nsis.git

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -1,0 +1,54 @@
+name: "Windows Installer"
+
+# any branch is useful for testing before a PR is submitted
+on: [push, pull_request]
+
+jobs:
+  build:
+    # run on pushes to any branch
+    # run on PRs from external forks
+    if: |
+         (github.event_name != 'pull_request')
+         || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
+    name: Building Windows Zip and Executable Installer on Linux without plugins
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: 'Install makensis (apt)'
+      run: sudo apt update && sudo apt install -y nsis nsis-pluginapi
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+
+    - name: Install all dependencies and symlink for ep_etherpad-lite
+      run: src/bin/installDeps.sh
+
+    - name: Run the backend tests
+      run: cd src && npm test
+
+    - name: Build the .zip
+      run: src/bin/buildForWindows.sh
+
+    - name: Extract the .zip into folder
+      run: unzip etherpad-lite-win.zip -d etherpad-lite-new
+
+    - name: Grab nsis config
+      run: git clone https://github.com/ether/etherpad_nsis.git
+
+    - name: Create installer
+      uses: joncloud/makensis-action@v3.4
+      with:
+        script-file: 'etherpad_nsis/etherpad.nsi'
+
+    - name: Check something..
+      run: ls etherpad_nsis
+
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: etherpad-server-windows.exe
+        path: etherpad_nsis/etherpad-server-windows.exe


### PR DESCRIPTION
This PR introduces CI builds of a windows installer(using NSIS) .

It builds an executable that installs Etherpad and runs it.

There are obvious steps to make once this has been merged. But I'd suggest on each release we include both the .zip and the .exe and allow users to have a portable zip or an installed executable.

https://github.com/ether/etherpad_nsis

This was a relatively rushed project (4 hours) and I didn't want to spend any more time on it so it will need a foster parent to maintain it :)

props to @joncloud for https://github.com/joncloud/makensis-action-test and the nsis team that while have a horrible UX make relatively easy to use and rapid tools.

Note for review: I'm using linux to build the windows executable, this may need to be reviewed and we might want to switch to Windows if we can confirm building on linux causes a problem.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
