### PR TITLE
Minifiy: Pathname calculation refinements

### DIFF
--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -113,6 +113,13 @@ const minify = async (req, res) => {
     return;
   }
 
+  // Backward compatibility for plugins that were written when jQuery lived at
+  // src/static/js/jquery.js.
+  if (['js/jquery.js', 'plugins/ep_etherpad-lite/static/js/jquery.js'].indexOf(filename) !== -1) {
+    logger.warn(`request for deprecated jQuery path: ${filename}`);
+    filename = 'js/vendors/jquery.js';
+  }
+
   /* Handle static files for plugins/libraries:
      paths like "plugins/ep_myplugin/static/js/test.js"
      are rewritten into ROOT_PATH_OF_MYPLUGIN/static/js/test.js,

--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -82,4 +82,5 @@
   , "pluginfw/shared.js"
   , "pluginfw/hooks.js"
   ]
+, "jquery.js": ["jquery.js"]
 }

--- a/src/static/tests.html
+++ b/src/static/tests.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>API Test and Examples Page</title>
-  <script type="text/javascript" src="js/jquery.js"></script>
+  <script type="text/javascript" src="js/vendors/jquery.js"></script>
   <style type="text/css">
     body {
       font-size:9pt;


### PR DESCRIPTION
Multiple commits:
* /static/tests.html: Fix `jquery.js` path
* Minify: Also serve `jquery.js` from old path for compatibility
* Minify: Improve pathname sanitization
* Minify: Consistently use `path.join()` to build pathnames

I'm hoping this will help with #4800.