### PR TITLE
avoid pad_utils in pad.html

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -444,20 +444,19 @@
 
   <script type="text/javascript" src="../static/js/require-kernel.js?v=<%=settings.randomVersionString%>"></script>
 
-  <!-- Include pad_utils manually -->
-  <script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/pad_utils.js?callback=require.define&v=<%=settings.randomVersionString%>"></script>
-
   <script type="text/javascript">
       // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
       (function() {
         // Display errors on page load to the user
         // (Gets overridden by padutils.setupGlobalExceptionHandler)
-        var originalHandler = window.onerror;
+        const originalHandler = window.onerror;
         window.onerror = function(msg, url, line) {
-          var box   = document.getElementById('editorloadingbox');
-          box.innerHTML = '<p><b>An error occurred while loading the pad</b></p>'
-                        + '<p><b>'+msg+'</b> '
-                        + '<small>in '+ padutils.escapeHTML(url) +' (line '+ line +')</small></p>';
+          const box   = document.getElementById('editorloadingbox');
+          const cleanMessage = msg.replace(/[^0-9a-zA-Z=\.?&:\/]+/,'');
+          const cleanSource = url.replace(/[^0-9a-zA-Z=\.?&:\/]+/,'');
+          const cleanLine = parseInt(line);
+          box.innerText = `An error occurred while loading the pad\n${cleanMessage} in
+            ${cleanSource} at line ${cleanLine}`
           // call original error handler
           if(typeof(originalHandler) == 'function') originalHandler.call(null, arguments);
         };


### PR DESCRIPTION
This was long due and also makes the crashes in https://github.com/ether/etherpad-lite/issues/4800 look strange (as no error is written, but instead padutils fails)
The padutils stuff in pad.html never actually worked, as there is no global variable padutils even after requiring padutils. Instead simply whitelist some characters and display the error message.