### PR TITLE
ace: Refactor to avoid `document.write()`, remove EMBEDED logic

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -168,12 +168,9 @@ const Ace2Editor = function () {
     const $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
     $$INCLUDE_CSS('../static/css/iframe_editor.css');
     $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
-    includedCSS.push(...hooks.callAll('aceEditorCSS').map((path) => {
-      if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
-        return path;
-      }
-      return `../static/plugins/${path}`;
-    }));
+    includedCSS.push(...hooks.callAll('aceEditorCSS').map(
+        // Allow urls to external CSS - http(s):// and //some/path.css
+        (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`));
     $$INCLUDE_CSS(
         `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
 

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -222,7 +222,7 @@ plugins.ensure(function () {\n\
       });
 
       iframeHTML.push('</head><body id="innerdocbody" class="innerdocbody" role="application" ' +
-                      'class="syntax" spellcheck="false">&nbsp;</body></html>');
+                      'spellcheck="false">&nbsp;</body></html>');
 
       // eslint-disable-next-line node/no-unsupported-features/es-builtins
       const gt = typeof globalThis === 'object' ? globalThis : window;

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -160,145 +160,143 @@ const Ace2Editor = function () {
       doneFunc();
     };
 
-    (() => {
-      const doctype = '<!doctype html>';
+    const doctype = '<!doctype html>';
 
-      const iframeHTML = [];
+    const iframeHTML = [];
 
-      iframeHTML.push(doctype);
-      iframeHTML.push(`<html class='inner-editor ${clientVars.skinVariants}'><head>`);
+    iframeHTML.push(doctype);
+    iframeHTML.push(`<html class='inner-editor ${clientVars.skinVariants}'><head>`);
 
-      // calls to these functions ($$INCLUDE_...)  are replaced when this file is processed
-      // and compressed, putting the compressed code from the named file directly into the
-      // source here.
-      // these lines must conform to a specific format because they are passed by the build script:
-      let includedCSS = [];
-      let $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
-      $$INCLUDE_CSS('../static/css/iframe_editor.css');
+    // calls to these functions ($$INCLUDE_...)  are replaced when this file is processed
+    // and compressed, putting the compressed code from the named file directly into the
+    // source here.
+    // these lines must conform to a specific format because they are passed by the build script:
+    let includedCSS = [];
+    let $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
+    $$INCLUDE_CSS('../static/css/iframe_editor.css');
 
-      // disableCustomScriptsAndStyles can be used to disable loading of custom scripts
-      if (!clientVars.disableCustomScriptsAndStyles) {
-        $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
-      }
-
-      let additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
-        if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
-          return path;
-        }
-        return `../static/plugins/${path}`;
-      });
-      includedCSS = includedCSS.concat(additionalCSS);
-      $$INCLUDE_CSS(
-          `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
-
-      pushStyleTagsFor(iframeHTML, includedCSS);
-      iframeHTML.push(`<script type="text/javascript" src="../static/js/require-kernel.js?v=${clientVars.randomVersionString}"></script>`);
-      // fill the cache
-      iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
-      iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
-
-      iframeHTML.push(scriptTag(`(() => {
-        const require = window.require;
-        require.setRootURI('../javascripts/src');
-        require.setLibraryURI('../javascripts/lib');
-        require.setGlobalKeyPath('require');
-
-        // intentially moved before requiring client_plugins to save a 307
-        window.Ace2Inner = require('ep_etherpad-lite/static/js/ace2_inner');
-        window.plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
-        window.plugins.adoptPluginsFromAncestorsOf(window);
-
-        window.$ = window.jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery;
-
-        window.plugins.ensure(() => { window.Ace2Inner.init(); });
-      })();`));
-
-      iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');
-
-      hooks.callAll('aceInitInnerdocbodyHead', {
-        iframeHTML,
-      });
-
-      iframeHTML.push('</head><body id="innerdocbody" class="innerdocbody" role="application" ' +
-                      'spellcheck="false">&nbsp;</body></html>');
-
-      // eslint-disable-next-line node/no-unsupported-features/es-builtins
-      const gt = typeof globalThis === 'object' ? globalThis : window;
-      gt.ChildAccessibleAce2Editor = Ace2Editor;
-
-      const outerScript = `(() => {
-        window.editorInfo = parent.ChildAccessibleAce2Editor.registry[${JSON.stringify(info.id)}];
-        window.onload = () => {
-          window.onload = null;
-          setTimeout(() => {
-            const iframe = document.createElement('iframe');
-            iframe.name = 'ace_inner';
-            iframe.title = 'pad';
-            iframe.scrolling = 'no';
-            iframe.frameBorder = 0;
-            iframe.allowTransparency = true; // for IE
-            iframe.ace_outerWin = window;
-            document.body.insertBefore(iframe, document.body.firstChild);
-            window.readyFunc = () => {
-              delete window.readyFunc;
-              window.editorInfo.onEditorReady();
-              delete window.editorInfo;
-            };
-            const doc = iframe.contentWindow.document;
-            doc.open();
-            doc.write(${JSON.stringify(iframeHTML.join('\n'))});
-            doc.close();
-          }, 0);
-        }
-      })();`;
-
-      const outerHTML =
-          [doctype, `<html class="inner-editor outerdoc ${clientVars.skinVariants}"><head>`];
-
-      includedCSS = [];
-      $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
-      $$INCLUDE_CSS('../static/css/iframe_editor.css');
+    // disableCustomScriptsAndStyles can be used to disable loading of custom scripts
+    if (!clientVars.disableCustomScriptsAndStyles) {
       $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
+    }
+
+    let additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
+      if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
+        return path;
+      }
+      return `../static/plugins/${path}`;
+    });
+    includedCSS = includedCSS.concat(additionalCSS);
+    $$INCLUDE_CSS(
+        `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
+
+    pushStyleTagsFor(iframeHTML, includedCSS);
+    iframeHTML.push(`<script type="text/javascript" src="../static/js/require-kernel.js?v=${clientVars.randomVersionString}"></script>`);
+    // fill the cache
+    iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
+    iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
+
+    iframeHTML.push(scriptTag(`(() => {
+      const require = window.require;
+      require.setRootURI('../javascripts/src');
+      require.setLibraryURI('../javascripts/lib');
+      require.setGlobalKeyPath('require');
+
+      // intentially moved before requiring client_plugins to save a 307
+      window.Ace2Inner = require('ep_etherpad-lite/static/js/ace2_inner');
+      window.plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
+      window.plugins.adoptPluginsFromAncestorsOf(window);
+
+      window.$ = window.jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery;
+
+      window.plugins.ensure(() => { window.Ace2Inner.init(); });
+    })();`));
+
+    iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');
+
+    hooks.callAll('aceInitInnerdocbodyHead', {
+      iframeHTML,
+    });
+
+    iframeHTML.push('</head><body id="innerdocbody" class="innerdocbody" role="application" ' +
+                    'spellcheck="false">&nbsp;</body></html>');
+
+    // eslint-disable-next-line node/no-unsupported-features/es-builtins
+    const gt = typeof globalThis === 'object' ? globalThis : window;
+    gt.ChildAccessibleAce2Editor = Ace2Editor;
+
+    const outerScript = `(() => {
+      window.editorInfo = parent.ChildAccessibleAce2Editor.registry[${JSON.stringify(info.id)}];
+      window.onload = () => {
+        window.onload = null;
+        setTimeout(() => {
+          const iframe = document.createElement('iframe');
+          iframe.name = 'ace_inner';
+          iframe.title = 'pad';
+          iframe.scrolling = 'no';
+          iframe.frameBorder = 0;
+          iframe.allowTransparency = true; // for IE
+          iframe.ace_outerWin = window;
+          document.body.insertBefore(iframe, document.body.firstChild);
+          window.readyFunc = () => {
+            delete window.readyFunc;
+            window.editorInfo.onEditorReady();
+            delete window.editorInfo;
+          };
+          const doc = iframe.contentWindow.document;
+          doc.open();
+          doc.write(${JSON.stringify(iframeHTML.join('\n'))});
+          doc.close();
+        }, 0);
+      }
+    })();`;
+
+    const outerHTML =
+        [doctype, `<html class="inner-editor outerdoc ${clientVars.skinVariants}"><head>`];
+
+    includedCSS = [];
+    $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
+    $$INCLUDE_CSS('../static/css/iframe_editor.css');
+    $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
 
 
-      additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
-        if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
-          return path;
-        }
-        return `../static/plugins/${path}`;
-      });
-      includedCSS = includedCSS.concat(additionalCSS);
-      $$INCLUDE_CSS(
-          `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
+    additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
+      if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
+        return path;
+      }
+      return `../static/plugins/${path}`;
+    });
+    includedCSS = includedCSS.concat(additionalCSS);
+    $$INCLUDE_CSS(
+        `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
 
-      pushStyleTagsFor(outerHTML, includedCSS);
+    pushStyleTagsFor(outerHTML, includedCSS);
 
-      // bizarrely, in FF2, a file with no "external" dependencies won't finish loading properly
-      // (throbs busy while typing)
-      const pluginNames = pluginUtils.clientPluginNames();
-      outerHTML.push(
-          '<style type="text/css" title="dynamicsyntax"></style>',
-          '<link rel="stylesheet" type="text/css" href="data:text/css,"/>',
-          scriptTag(outerScript),
-          '</head>',
-          '<body id="outerdocbody" class="outerdocbody ', pluginNames.join(' '), '">',
-          '<div id="sidediv" class="sidediv"><!-- --></div>',
-          '<div id="linemetricsdiv">x</div>',
-          '</body></html>');
+    // bizarrely, in FF2, a file with no "external" dependencies won't finish loading properly
+    // (throbs busy while typing)
+    const pluginNames = pluginUtils.clientPluginNames();
+    outerHTML.push(
+        '<style type="text/css" title="dynamicsyntax"></style>',
+        '<link rel="stylesheet" type="text/css" href="data:text/css,"/>',
+        scriptTag(outerScript),
+        '</head>',
+        '<body id="outerdocbody" class="outerdocbody ', pluginNames.join(' '), '">',
+        '<div id="sidediv" class="sidediv"><!-- --></div>',
+        '<div id="linemetricsdiv">x</div>',
+        '</body></html>');
 
-      const outerFrame = document.createElement('IFRAME');
-      outerFrame.name = 'ace_outer';
-      outerFrame.frameBorder = 0; // for IE
-      outerFrame.title = 'Ether';
-      info.frame = outerFrame;
-      document.getElementById(containerId).appendChild(outerFrame);
+    const outerFrame = document.createElement('IFRAME');
+    outerFrame.name = 'ace_outer';
+    outerFrame.frameBorder = 0; // for IE
+    outerFrame.title = 'Ether';
+    info.frame = outerFrame;
+    document.getElementById(containerId).appendChild(outerFrame);
 
-      const editorDocument = outerFrame.contentWindow.document;
+    const editorDocument = outerFrame.contentWindow.document;
 
-      editorDocument.open();
-      editorDocument.write(outerHTML.join(''));
-      editorDocument.close();
-    })();
+    editorDocument.open();
+    editorDocument.write(outerHTML.join(''));
+    editorDocument.close();
   };
 };
 

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -174,12 +174,7 @@ const Ace2Editor = function () {
     let includedCSS = [];
     let $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
     $$INCLUDE_CSS('../static/css/iframe_editor.css');
-
-    // disableCustomScriptsAndStyles can be used to disable loading of custom scripts
-    if (!clientVars.disableCustomScriptsAndStyles) {
-      $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
-    }
-
+    $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
     let additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
       if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
         return path;

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -178,39 +178,8 @@ const Ace2Editor = function () {
   // returns array of {error: <browser Error object>, time: +new Date()}
   this.getUnhandledErrors = () => loaded ? info.ace_getUnhandledErrors() : [];
 
-  const sortFilesByEmbeded = (files) => {
-    const embededFiles = [];
-    let remoteFiles = [];
-
-    if (Ace2Editor.EMBEDED) {
-      for (let i = 0, ii = files.length; i < ii; i++) {
-        const file = files[i];
-        if (Object.prototype.hasOwnProperty.call(Ace2Editor.EMBEDED, file)) {
-          embededFiles.push(file);
-        } else {
-          remoteFiles.push(file);
-        }
-      }
-    } else {
-      remoteFiles = files;
-    }
-
-    return {embeded: embededFiles, remote: remoteFiles};
-  };
-
   const addStyleTagsFor = (doc, files) => {
-    const sorted = sortFilesByEmbeded(files);
-    const embededFiles = sorted.embeded;
-    const remoteFiles = sorted.remote;
-
-    if (embededFiles.length > 0) {
-      const css = embededFiles.map((f) => Ace2Editor.EMBEDED[f]).join('\n');
-      const style = doc.createElement('style');
-      style.type = 'text/css';
-      style.appendChild(doc.createTextNode(css));
-      doc.head.appendChild(style);
-    }
-    for (const file of remoteFiles) {
+    for (const file of files) {
       const link = doc.createElement('link');
       link.rel = 'stylesheet';
       link.type = 'text/css';
@@ -229,19 +198,14 @@ const Ace2Editor = function () {
     debugLog('Ace2Editor.init()');
     this.importText(initialCode);
 
-    // calls to these functions ($$INCLUDE_...)  are replaced when this file is processed
-    // and compressed, putting the compressed code from the named file directly into the
-    // source here.
-    // these lines must conform to a specific format because they are passed by the build script:
-    const includedCSS = [];
-    const $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
-    $$INCLUDE_CSS('../static/css/iframe_editor.css');
-    $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
-    includedCSS.push(...hooks.callAll('aceEditorCSS').map(
-        // Allow urls to external CSS - http(s):// and //some/path.css
-        (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`));
-    $$INCLUDE_CSS(
-        `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
+    const includedCSS = [
+      '../static/css/iframe_editor.css',
+      `../static/css/pad.css?v=${clientVars.randomVersionString}`,
+      ...hooks.callAll('aceEditorCSS').map(
+          // Allow urls to external CSS - http(s):// and //some/path.css
+          (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
+      `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`,
+    ];
 
     const skinVariants = clientVars.skinVariants.split(' ').filter((x) => x !== '');
 

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -89,8 +89,6 @@ const Ace2Editor = function () {
 
   this.exportText = () => loaded ? info.ace_exportText() : '(awaiting init)\n';
 
-  this.getFrame = () => info.frame || null;
-
   this.getDebugProperty = (prop) => info.ace_getDebugProperty(prop);
 
   this.getInInternationalComposition =

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -209,7 +209,7 @@ const Ace2Editor = function () {
 
       window.$ = window.jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery;
 
-      window.plugins.ensure(() => { window.Ace2Inner.init(); });
+      window.plugins.ensure(() => { window.Ace2Inner.init(parent.editorInfo, parent.readyFunc); });
     })();`));
 
     iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -197,23 +197,22 @@ const Ace2Editor = function () {
       iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
       iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
 
-      iframeHTML.push(scriptTag(
-          `\n\
-require.setRootURI("../javascripts/src");\n\
-require.setLibraryURI("../javascripts/lib");\n\
-require.setGlobalKeyPath("require");\n\
-\n\
-// intentially moved before requiring client_plugins to save a 307
-var Ace2Inner = require("ep_etherpad-lite/static/js/ace2_inner");\n\
-var plugins = require("ep_etherpad-lite/static/js/pluginfw/client_plugins");\n\
-plugins.adoptPluginsFromAncestorsOf(window);\n\
-\n\
-$ = jQuery = require("ep_etherpad-lite/static/js/rjquery").jQuery; // Expose jQuery #HACK\n\
-\n\
-plugins.ensure(function () {\n\
-  Ace2Inner.init();\n\
-});\n\
-`));
+      iframeHTML.push(scriptTag(`
+        require.setRootURI("../javascripts/src");
+        require.setLibraryURI("../javascripts/lib");
+        require.setGlobalKeyPath("require");
+
+        // intentially moved before requiring client_plugins to save a 307
+        var Ace2Inner = require("ep_etherpad-lite/static/js/ace2_inner");
+        var plugins = require("ep_etherpad-lite/static/js/pluginfw/client_plugins");
+        plugins.adoptPluginsFromAncestorsOf(window);
+
+        $ = jQuery = require("ep_etherpad-lite/static/js/rjquery").jQuery; // Expose jQuery #HACK
+
+        plugins.ensure(function () {
+          Ace2Inner.init();
+        });
+      `));
 
       iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');
 
@@ -228,33 +227,34 @@ plugins.ensure(function () {\n\
       const gt = typeof globalThis === 'object' ? globalThis : window;
       gt.ChildAccessibleAce2Editor = Ace2Editor;
 
-      const outerScript = `\
-editorId = ${JSON.stringify(info.id)};\n\
-editorInfo = parent.ChildAccessibleAce2Editor.registry[editorId];\n\
-window.onload = function () {\n\
-  window.onload = null;\n\
-  setTimeout(function () {\n\
-    var iframe = document.createElement("IFRAME");\n\
-    iframe.name = "ace_inner";\n\
-    iframe.title = "pad";\n\
-    iframe.scrolling = "no";\n\
-    var outerdocbody = document.getElementById("outerdocbody");\n\
-    iframe.frameBorder = 0;\n\
-    iframe.allowTransparency = true; // for IE\n\
-    outerdocbody.insertBefore(iframe, outerdocbody.firstChild);\n\
-    iframe.ace_outerWin = window;\n\
-    readyFunc = function () {\n\
-      editorInfo.onEditorReady();\n\
-      readyFunc = null;\n\
-      editorInfo = null;\n\
-    };\n\
-    var doc = iframe.contentWindow.document;\n\
-    doc.open();\n\
-    var text = (${JSON.stringify(iframeHTML.join('\n'))});\n\
-    doc.write(text);\n\
-    doc.close();\n\
-  }, 0);\n\
-}`;
+      const outerScript = `
+        editorId = ${JSON.stringify(info.id)};
+        editorInfo = parent.ChildAccessibleAce2Editor.registry[editorId];
+        window.onload = function () {
+          window.onload = null;
+          setTimeout(function () {
+            var iframe = document.createElement("IFRAME");
+            iframe.name = "ace_inner";
+            iframe.title = "pad";
+            iframe.scrolling = "no";
+            var outerdocbody = document.getElementById("outerdocbody");
+            iframe.frameBorder = 0;
+            iframe.allowTransparency = true; // for IE
+            outerdocbody.insertBefore(iframe, outerdocbody.firstChild);
+            iframe.ace_outerWin = window;
+            readyFunc = function () {
+              editorInfo.onEditorReady();
+              readyFunc = null;
+              editorInfo = null;
+            };
+            var doc = iframe.contentWindow.document;
+            doc.open();
+            var text = (${JSON.stringify(iframeHTML.join('\n'))});
+            doc.write(text);
+            doc.close();
+          }, 0);
+        }
+      `;
 
       const outerHTML =
           [doctype, `<html class="inner-editor outerdoc ${clientVars.skinVariants}"><head>`];

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -32,12 +32,78 @@ const pluginUtils = require('./pluginfw/shared');
 // errors out unless given an absolute URL for a JavaScript-created element.
 const absUrl = (url) => new URL(url, window.location.href).href;
 
-const scriptTag =
-    (source) => `<script type="text/javascript">\n${source.replace(/<\//g, '<\\/')}</script>`;
+const eventFired = async (obj, event, cleanups = [], predicate = () => true) => {
+  if (typeof cleanups === 'function') {
+    predicate = cleanups;
+    cleanups = [];
+  }
+  await new Promise((resolve, reject) => {
+    let cleanup;
+    const successCb = () => {
+      if (!predicate()) return;
+      cleanup();
+      resolve();
+    };
+    const errorCb = () => {
+      const err = new Error(`Ace2Editor.init() error event while waiting for ${event} event`);
+      cleanup();
+      reject(err);
+    };
+    cleanup = () => {
+      cleanup = () => {};
+      obj.removeEventListener(event, successCb);
+      obj.removeEventListener('error', errorCb);
+    };
+    cleanups.push(cleanup);
+    obj.addEventListener(event, successCb);
+    obj.addEventListener('error', errorCb);
+  });
+};
+
+const pollCondition = async (predicate, cleanups, pollPeriod, timeout) => {
+  let done = false;
+  cleanups.push(() => { done = true; });
+  // Pause a tick to give the predicate a chance to become true before adding latency.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const start = Date.now();
+  while (!done && !predicate()) {
+    if (Date.now() - start > timeout) throw new Error('timeout');
+    await new Promise((resolve) => setTimeout(resolve, pollPeriod));
+  }
+};
+
+// Resolves when the frame's document is ready to be mutated:
+//   - Firefox seems to replace the frame's contentWindow.document object with a different object
+//     after the frame is created so we need to wait for the window's load event before continuing.
+//   - Chrome doesn't need any waiting (not even next tick), but on Windows it never seems to fire
+//     any events. Eventually the document's readyState becomes 'complete' (even though it never
+//     fires a readystatechange event), so this function waits for that to happen to avoid returning
+//     too soon on Firefox.
+//   - Safari behaves like Chrome.
+// I'm not sure how other browsers behave, so this function throws the kitchen sink at the problem.
+// Maybe one day we'll find a concise general solution.
+const frameReady = async (frame) => {
+  // Can't do `const doc = frame.contentDocument;` because Firefox seems to asynchronously replace
+  // the document object after the frame is first created for some reason. ¯\_(ツ)_/¯
+  const doc = () => frame.contentDocument;
+  const cleanups = [];
+  try {
+    await Promise.race([
+      eventFired(frame, 'load', cleanups),
+      eventFired(frame.contentWindow, 'load', cleanups),
+      eventFired(doc(), 'load', cleanups),
+      eventFired(doc(), 'DOMContentLoaded', cleanups),
+      eventFired(doc(), 'readystatechange', cleanups, () => doc.readyState === 'complete'),
+      // If all else fails, poll.
+      pollCondition(() => doc().readyState === 'complete', cleanups, 10, 5000),
+    ]);
+  } finally {
+    for (const cleanup of cleanups) cleanup();
+  }
+};
 
 const Ace2Editor = function () {
   let info = {editor: this};
-  window.ace2EditorInfo = info; // Make it accessible to iframes.
   let loaded = false;
 
   let actionsPendingInit = [];
@@ -126,27 +192,30 @@ const Ace2Editor = function () {
     return {embeded: embededFiles, remote: remoteFiles};
   };
 
-  const pushStyleTagsFor = (buffer, files) => {
+  const addStyleTagsFor = (doc, files) => {
     const sorted = sortFilesByEmbeded(files);
     const embededFiles = sorted.embeded;
     const remoteFiles = sorted.remote;
 
     if (embededFiles.length > 0) {
-      buffer.push('<style type="text/css">');
-      for (const file of embededFiles) {
-        buffer.push((Ace2Editor.EMBEDED[file] || '').replace(/<\//g, '<\\/'));
-      }
-      buffer.push('</style>');
+      const css = embededFiles.map((f) => Ace2Editor.EMBEDED[f]).join('\n');
+      const style = doc.createElement('style');
+      style.type = 'text/css';
+      style.appendChild(doc.createTextNode(css));
+      doc.head.appendChild(style);
     }
     for (const file of remoteFiles) {
-      buffer.push(`<link rel="stylesheet" type="text/css" href="${absUrl(encodeURI(file))}"/>`);
+      const link = doc.createElement('link');
+      link.rel = 'stylesheet';
+      link.type = 'text/css';
+      link.href = absUrl(encodeURI(file));
+      doc.head.appendChild(link);
     }
   };
 
   this.destroy = pendingInit(() => {
     info.ace_dispose();
     info.frame.parentNode.removeChild(info.frame);
-    delete window.ace2EditorInfo;
     info = null; // prevent IE 6 closure memory leaks
   });
 
@@ -167,103 +236,119 @@ const Ace2Editor = function () {
     $$INCLUDE_CSS(
         `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
 
-    const doctype = '<!doctype html>';
+    const skinVariants = clientVars.skinVariants.split(' ').filter((x) => x !== '');
 
-    const iframeHTML = [];
-
-    iframeHTML.push(doctype);
-    iframeHTML.push(`<html class='inner-editor ${clientVars.skinVariants}'><head>`);
-    pushStyleTagsFor(iframeHTML, includedCSS);
-    const requireKernelUrl =
-        absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
-    iframeHTML.push(`<script type="text/javascript" src="${requireKernelUrl}"></script>`);
-    // Pre-fetch modules to improve load performance.
-    for (const module of ['ace2_inner', 'ace2_common']) {
-      const url = absUrl(`../javascripts/lib/ep_etherpad-lite/static/js/${module}.js` +
-                         `?callback=require.define&v=${clientVars.randomVersionString}`);
-      iframeHTML.push(`<script type="text/javascript" src="${url}"></script>`);
-    }
-
-    iframeHTML.push(scriptTag(`(async () => {
-      const require = window.require;
-      require.setRootURI(${JSON.stringify(absUrl('../javascripts/src'))});
-      require.setLibraryURI(${JSON.stringify(absUrl('../javascripts/lib'))});
-      require.setGlobalKeyPath('require');
-
-      // intentially moved before requiring client_plugins to save a 307
-      window.Ace2Inner = require('ep_etherpad-lite/static/js/ace2_inner');
-      window.plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
-      window.plugins.adoptPluginsFromAncestorsOf(window);
-
-      window.$ = window.jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery;
-
-      await new Promise((resolve, reject) => window.plugins.ensure(
-          (err) => err != null ? reject(err) : resolve()));
-      const editorInfo = parent.parent.ace2EditorInfo;
-      await new Promise((resolve, reject) => window.Ace2Inner.init(
-          editorInfo, (err) => err != null ? reject(err) : resolve()));
-      editorInfo.onEditorReady();
-    })();`));
-
-    iframeHTML.push('<style type="text/css" title="dynamicsyntax"></style>');
-
-    hooks.callAll('aceInitInnerdocbodyHead', {
-      iframeHTML,
-    });
-
-    iframeHTML.push('</head><body id="innerdocbody" class="innerdocbody" role="application" ' +
-                    'spellcheck="false">&nbsp;</body></html>');
-
-    const outerScript = `(async () => {
-      await new Promise((resolve) => { window.onload = () => resolve(); });
-      window.onload = null;
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      const iframe = document.createElement('iframe');
-      iframe.name = 'ace_inner';
-      iframe.title = 'pad';
-      iframe.scrolling = 'no';
-      iframe.frameBorder = 0;
-      iframe.allowTransparency = true; // for IE
-      iframe.ace_outerWin = window;
-      document.body.insertBefore(iframe, document.body.firstChild);
-      const doc = iframe.contentWindow.document;
-      doc.open();
-      doc.write(${JSON.stringify(iframeHTML.join('\n'))});
-      doc.close();
-    })();`;
-
-    const outerHTML =
-        [doctype, `<html class="inner-editor outerdoc ${clientVars.skinVariants}"><head>`];
-    pushStyleTagsFor(outerHTML, includedCSS);
-
-    // bizarrely, in FF2, a file with no "external" dependencies won't finish loading properly
-    // (throbs busy while typing)
-    const pluginNames = pluginUtils.clientPluginNames();
-    outerHTML.push(
-        '<style type="text/css" title="dynamicsyntax"></style>',
-        '<link rel="stylesheet" type="text/css" href="data:text/css,"/>',
-        scriptTag(outerScript),
-        '</head>',
-        '<body id="outerdocbody" class="outerdocbody ', pluginNames.join(' '), '">',
-        '<div id="sidediv" class="sidediv"><!-- --></div>',
-        '<div id="linemetricsdiv">x</div>',
-        '</body></html>');
-
-    const outerFrame = document.createElement('IFRAME');
+    const outerFrame = document.createElement('iframe');
     outerFrame.name = 'ace_outer';
     outerFrame.frameBorder = 0; // for IE
     outerFrame.title = 'Ether';
     info.frame = outerFrame;
     document.getElementById(containerId).appendChild(outerFrame);
+    const outerWindow = outerFrame.contentWindow;
 
-    const editorDocument = outerFrame.contentWindow.document;
+    // For some unknown reason Firefox replaces outerWindow.document with a new Document object some
+    // time between running the above code and firing the outerWindow load event. Work around it by
+    // waiting until the load event fires before mutating the Document object.
+    await frameReady(outerFrame);
 
-    await new Promise((resolve, reject) => {
-      info.onEditorReady = (err) => err != null ? reject(err) : resolve();
-      editorDocument.open();
-      editorDocument.write(outerHTML.join(''));
-      editorDocument.close();
-    });
+    // This must be done after the Window's load event. See above comment.
+    const outerDocument = outerWindow.document;
+
+    // <html> tag
+    outerDocument.documentElement.classList.add('inner-editor', 'outerdoc', ...skinVariants);
+
+    // <head> tag
+    addStyleTagsFor(outerDocument, includedCSS);
+    const outerStyle = outerDocument.createElement('style');
+    outerStyle.type = 'text/css';
+    outerStyle.title = 'dynamicsyntax';
+    outerDocument.head.appendChild(outerStyle);
+    const link = outerDocument.createElement('link');
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    link.href = 'data:text/css,';
+    outerDocument.head.appendChild(link);
+
+    // <body> tag
+    outerDocument.body.id = 'outerdocbody';
+    outerDocument.body.classList.add('outerdocbody', ...pluginUtils.clientPluginNames());
+    const sideDiv = outerDocument.createElement('div');
+    sideDiv.id = 'sidediv';
+    sideDiv.classList.add('sidediv');
+    outerDocument.body.appendChild(sideDiv);
+    const lineMetricsDiv = outerDocument.createElement('div');
+    lineMetricsDiv.id = 'linemetricsdiv';
+    lineMetricsDiv.appendChild(outerDocument.createTextNode('x'));
+    outerDocument.body.appendChild(lineMetricsDiv);
+
+    const innerFrame = outerDocument.createElement('iframe');
+    innerFrame.name = 'ace_inner';
+    innerFrame.title = 'pad';
+    innerFrame.scrolling = 'no';
+    innerFrame.frameBorder = 0;
+    innerFrame.allowTransparency = true; // for IE
+    innerFrame.ace_outerWin = outerWindow;
+    outerDocument.body.insertBefore(innerFrame, outerDocument.body.firstChild);
+    const innerWindow = innerFrame.contentWindow;
+
+    // Wait before mutating the inner document. See above comment recarding outerWindow load.
+    await frameReady(innerFrame);
+
+    // This must be done after the Window's load event. See above comment.
+    const innerDocument = innerWindow.document;
+
+    // <html> tag
+    innerDocument.documentElement.classList.add('inner-editor', ...skinVariants);
+
+    // <head> tag
+    addStyleTagsFor(innerDocument, includedCSS);
+    const requireKernel = innerDocument.createElement('script');
+    requireKernel.type = 'text/javascript';
+    requireKernel.src =
+        absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
+    innerDocument.head.appendChild(requireKernel);
+    // Pre-fetch modules to improve load performance.
+    for (const module of ['ace2_inner', 'ace2_common']) {
+      const script = innerDocument.createElement('script');
+      script.type = 'text/javascript';
+      script.src = absUrl(`../javascripts/lib/ep_etherpad-lite/static/js/${module}.js` +
+                          `?callback=require.define&v=${clientVars.randomVersionString}`);
+      innerDocument.head.appendChild(script);
+    }
+    const innerStyle = innerDocument.createElement('style');
+    innerStyle.type = 'text/css';
+    innerStyle.title = 'dynamicsyntax';
+    innerDocument.head.appendChild(innerStyle);
+    const headLines = [];
+    hooks.callAll('aceInitInnerdocbodyHead', {iframeHTML: headLines});
+    const tmp = innerDocument.createElement('div');
+    tmp.innerHTML = headLines.join('\n');
+    while (tmp.firstChild) innerDocument.head.appendChild(tmp.firstChild);
+
+    // <body> tag
+    innerDocument.body.id = 'innerdocbody';
+    innerDocument.body.classList.add('innerdocbody');
+    innerDocument.body.setAttribute('role', 'application');
+    innerDocument.body.setAttribute('spellcheck', 'false');
+    innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
+
+    await eventFired(requireKernel, 'load');
+    const require = innerWindow.require;
+    require.setRootURI(absUrl('../javascripts/src'));
+    require.setLibraryURI(absUrl('../javascripts/lib'));
+    require.setGlobalKeyPath('require');
+
+    // intentially moved before requiring client_plugins to save a 307
+    innerWindow.Ace2Inner = require('ep_etherpad-lite/static/js/ace2_inner');
+    innerWindow.plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
+    innerWindow.plugins.adoptPluginsFromAncestorsOf(innerWindow);
+
+    innerWindow.$ = innerWindow.jQuery = require('ep_etherpad-lite/static/js/rjquery').jQuery;
+
+    await new Promise((resolve, reject) => innerWindow.plugins.ensure(
+        (err) => err != null ? reject(err) : resolve()));
+    await new Promise((resolve, reject) => innerWindow.Ace2Inner.init(
+        info, (err) => err != null ? reject(err) : resolve()));
     loaded = true;
     doActionsPendingInit();
   };

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -160,31 +160,29 @@ const Ace2Editor = function () {
       doneFunc();
     };
 
+    // calls to these functions ($$INCLUDE_...)  are replaced when this file is processed
+    // and compressed, putting the compressed code from the named file directly into the
+    // source here.
+    // these lines must conform to a specific format because they are passed by the build script:
+    const includedCSS = [];
+    const $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
+    $$INCLUDE_CSS('../static/css/iframe_editor.css');
+    $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
+    includedCSS.push(...hooks.callAll('aceEditorCSS').map((path) => {
+      if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
+        return path;
+      }
+      return `../static/plugins/${path}`;
+    }));
+    $$INCLUDE_CSS(
+        `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
+
     const doctype = '<!doctype html>';
 
     const iframeHTML = [];
 
     iframeHTML.push(doctype);
     iframeHTML.push(`<html class='inner-editor ${clientVars.skinVariants}'><head>`);
-
-    // calls to these functions ($$INCLUDE_...)  are replaced when this file is processed
-    // and compressed, putting the compressed code from the named file directly into the
-    // source here.
-    // these lines must conform to a specific format because they are passed by the build script:
-    let includedCSS = [];
-    let $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
-    $$INCLUDE_CSS('../static/css/iframe_editor.css');
-    $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
-    let additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
-      if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
-        return path;
-      }
-      return `../static/plugins/${path}`;
-    });
-    includedCSS = includedCSS.concat(additionalCSS);
-    $$INCLUDE_CSS(
-        `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
-
     pushStyleTagsFor(iframeHTML, includedCSS);
     iframeHTML.push(`<script type="text/javascript" src="../static/js/require-kernel.js?v=${clientVars.randomVersionString}"></script>`);
     // fill the cache
@@ -248,23 +246,6 @@ const Ace2Editor = function () {
 
     const outerHTML =
         [doctype, `<html class="inner-editor outerdoc ${clientVars.skinVariants}"><head>`];
-
-    includedCSS = [];
-    $$INCLUDE_CSS = (filename) => { includedCSS.push(filename); };
-    $$INCLUDE_CSS('../static/css/iframe_editor.css');
-    $$INCLUDE_CSS(`../static/css/pad.css?v=${clientVars.randomVersionString}`);
-
-
-    additionalCSS = hooks.callAll('aceEditorCSS').map((path) => {
-      if (path.match(/\/\//)) { // Allow urls to external CSS - http(s):// and //some/path.css
-        return path;
-      }
-      return `../static/plugins/${path}`;
-    });
-    includedCSS = includedCSS.concat(additionalCSS);
-    $$INCLUDE_CSS(
-        `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`);
-
     pushStyleTagsFor(outerHTML, includedCSS);
 
     // bizarrely, in FF2, a file with no "external" dependencies won't finish loading properly

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -30,7 +30,7 @@ const htmlPrettyEscape = Ace2Common.htmlPrettyEscape;
 const noop = Ace2Common.noop;
 const hooks = require('./pluginfw/hooks');
 
-function Ace2Inner() {
+function Ace2Inner(editorInfo) {
   const makeChangesetTracker = require('./changesettracker').makeChangesetTracker;
   const colorutils = require('./colorutils').colorutils;
   const makeContentCollector = require('./contentcollector').makeContentCollector;
@@ -57,7 +57,6 @@ function Ace2Inner() {
   let thisAuthor = '';
 
   let disposed = false;
-  const editorInfo = parent.editorInfo;
 
   const focus = () => {
     window.focus();
@@ -3896,7 +3895,7 @@ function Ace2Inner() {
   editorInfo.ace_performDocumentApplyAttributesToRange =
       (...args) => documentAttributeManager.setAttributesOnRange(...args);
 
-  this.init = () => {
+  this.init = (cb) => {
     $(document).ready(() => {
       doc = document; // defined as a var in scope outside
       inCallStack('setup', () => {
@@ -3928,14 +3927,12 @@ function Ace2Inner() {
         documentAttributeManager,
       });
 
-      scheduler.setTimeout(() => {
-        parent.readyFunc(); // defined in code that sets up the inner iframe
-      }, 0);
+      scheduler.setTimeout(cb, 0);
     });
   };
 }
 
-exports.init = () => {
-  const editor = new Ace2Inner();
-  editor.init();
+exports.init = (editorInfo, cb) => {
+  const editor = new Ace2Inner(editorInfo);
+  editor.init(cb);
 };

--- a/src/static/js/pad_editor.js
+++ b/src/static/js/pad_editor.js
@@ -56,7 +56,8 @@ const padeditor = (() => {
       };
 
       self.ace = new Ace2Editor();
-      self.ace.init('editorcontainer', '', aceReady);
+      self.ace.init('editorcontainer', '').then(
+          () => aceReady(), (err) => { throw err || new Error(err); });
       self.ace.setProperty('wraps', true);
       if (pad.getIsDebugEnabled()) {
         self.ace.setProperty('dmesg', pad.dmesg);


### PR DESCRIPTION
Multiple commits:
* ace: Delete unused `Ace2Editor.getFrame()` method
* ace: Delete ignored class attribute
* ace: Format script strings for readability
* ace: Lint and simplify script strings
* ace: Delete unnecessary IIFE
* ace: Delete unused `clientVars.disableCustomScriptsAndStyles`
* ace: Factor out duplicated `$$INCLUDE_CSS` code
* ace: Simplify the `aceEditorCSS` hook map function
* ace: Use absolute URLs when building iframes
* ace: Pass objects to Ace2Inner via function args
* ace: Simplify passing of `editorInfo`
* ace: Asyncify `Ace2Editor.init()`
* ace: Build the outer and inner iframes programmatically
* ace: Debug logging
* ace: Delete all `$$INCLUDE_CSS` logic

cc @webzwo0i 