### PR TITLE
performance: Page load improvements by way of removal of unnecessary 307 redirections

### DIFF
--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -2,6 +2,9 @@
   "pad.js": [
     "pad.js"
   , "pad_utils.js"
+  , "$js-cookie/src/js.cookie.js"
+  , "security.js"
+  , "$security.js"
   , "vendors/browser.js"
   , "pad_cookie.js"
   , "pad_editor.js"
@@ -22,12 +25,14 @@
   , "vendors/farbtastic.js"
   , "skin_variants.js"
   , "socketio.js"
+  , "colorutils.js"
   ]
 , "timeslider.js": [
     "timeslider.js"
   , "colorutils.js"
   , "draggable.js"
   , "pad_utils.js"
+  , "$js-cookie/src/js.cookie.js"
   , "vendors/browser.js"
   , "pad_cookie.js"
   , "pad_editor.js"
@@ -46,6 +51,8 @@
   , "broadcast_slider.js"
   , "broadcast_revisions.js"
   , "socketio.js"
+  , "AttributeManager.js"
+  , "ChangesetUtils.js"
   ]
 , "ace2_inner.js": [
     "ace2_inner.js"
@@ -65,6 +72,10 @@
   , "AttributeManager.js"
   , "scroll.js"
   , "caretPosition.js"
+  , "pad_utils.js"
+  , "$js-cookie/src/js.cookie.js"
+  , "security.js"
+  , "$security.js"
   ]
 , "ace2_common.js": [
     "ace2_common.js"

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -202,11 +202,12 @@ require.setRootURI("../javascripts/src");\n\
 require.setLibraryURI("../javascripts/lib");\n\
 require.setGlobalKeyPath("require");\n\
 \n\
+// intentially moved before requiring client_plugins to save a 307
+var Ace2Inner = require("ep_etherpad-lite/static/js/ace2_inner");\n\
 var plugins = require("ep_etherpad-lite/static/js/pluginfw/client_plugins");\n\
 plugins.adoptPluginsFromAncestorsOf(window);\n\
 \n\
 $ = jQuery = require("ep_etherpad-lite/static/js/rjquery").jQuery; // Expose jQuery #HACK\n\
-var Ace2Inner = require("ep_etherpad-lite/static/js/ace2_inner");\n\
 \n\
 plugins.ensure(function () {\n\
   Ace2Inner.init();\n\

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -195,6 +195,9 @@ const Ace2Editor = function () {
 
       pushStyleTagsFor(iframeHTML, includedCSS);
       iframeHTML.push(`<script type="text/javascript" src="../static/js/require-kernel.js?v=${clientVars.randomVersionString}"></script>`);
+      // fill the cache
+      iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_inner.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
+      iframeHTML.push(`<script type="text/javascript" src="../javascripts/lib/ep_etherpad-lite/static/js/ace2_common.js?callback=require.define&v=${clientVars.randomVersionString}"></script>`);
 
       iframeHTML.push(scriptTag(
           `\n\


### PR DESCRIPTION
removes 4 307s redirections.

It also ensures that there is no request without a `versionString` made from the inner iframe, because it explicitly downloads the needed files via script tag now. (Before the change, the files were loaded on demand via require-kernel which did not append the `versionString` which could have resulted in problems during upgrades.)