### PR TITLE
Ace2Inner: Fix missing spread operator on `args`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixed a bug in the `dirty` database driver that sometimes caused Node.js to
   crash during shutdown and lose buffered database writes.
+* Fixed a regression in v1.8.8 that caused "Uncaught TypeError: Cannot read
+  property '0' of undefined" with some plugins (#4885)
 
 # 1.8.11
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3894,7 +3894,7 @@ function Ace2Inner() {
   documentAttributeManager = new AttributeManager(rep, performDocumentApplyChangeset);
 
   editorInfo.ace_performDocumentApplyAttributesToRange =
-      (...args) => documentAttributeManager.setAttributesOnRange(args);
+      (...args) => documentAttributeManager.setAttributesOnRange(...args);
 
   this.init = () => {
     $(document).ready(() => {


### PR DESCRIPTION
This fixes a bug that was introduced in commit c38c34bef47a74467394797b34165641a87ac620.

Fixes #4885.