### PR TITLE
tests: run a long test

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -28,7 +28,7 @@ jobs:
       run: sudo npm install -g etherpad-load-test
 
     - name: Run load test
-      run: src/tests/frontend/travis/runnerLoadTest.sh
+      run: src/tests/frontend/travis/runnerLoadTest.sh 25
 
   withplugins:
     # run on pushes to any branch
@@ -80,4 +80,30 @@ jobs:
 
     # configures some settings and runs npm run test
     - name: Run load test
-      run: src/tests/frontend/travis/runnerLoadTest.sh
+      run: src/tests/frontend/travis/runnerLoadTest.sh 25
+
+  long:
+    # run on pushes to any branch
+    # run on PRs from external forks
+    if: |
+         (github.event_name != 'pull_request')
+         || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
+    name: long running
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
+
+    - name: Install all dependencies and symlink for ep_etherpad-lite
+      run: src/bin/installDeps.sh
+
+    - name: Install etherpad-load-test
+      run: sudo npm install -g etherpad-load-test
+
+    - name: Run load test
+      run: src/tests/frontend/travis/runnerLoadTest.sh 5000

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install all dependencies and symlink for ep_etherpad-lite
       run: src/bin/installDeps.sh
 
-    # configures some settings and runs npm run test
+    # configures some settings and runs npm run test for 25 seconds with 50 authors
     - name: Run load test
       run: src/tests/frontend/travis/runnerLoadTest.sh 25 50
 
@@ -105,5 +105,7 @@ jobs:
     - name: Install etherpad-load-test
       run: sudo npm install -g etherpad-load-test
 
+
+    # configures some settings and runs npm run test for 5000 seconds(50 mins) with 5 authors
     - name: Run load test
       run: src/tests/frontend/travis/runnerLoadTest.sh 5000 5

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -28,7 +28,7 @@ jobs:
       run: sudo npm install -g etherpad-load-test
 
     - name: Run load test
-      run: src/tests/frontend/travis/runnerLoadTest.sh 25
+      run: src/tests/frontend/travis/runnerLoadTest.sh 25 50
 
   withplugins:
     # run on pushes to any branch
@@ -80,7 +80,7 @@ jobs:
 
     # configures some settings and runs npm run test
     - name: Run load test
-      run: src/tests/frontend/travis/runnerLoadTest.sh 25
+      run: src/tests/frontend/travis/runnerLoadTest.sh 25 50
 
   long:
     # run on pushes to any branch
@@ -106,4 +106,4 @@ jobs:
       run: sudo npm install -g etherpad-load-test
 
     - name: Run load test
-      run: src/tests/frontend/travis/runnerLoadTest.sh 5000
+      run: src/tests/frontend/travis/runnerLoadTest.sh 5000 5

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Install all dependencies and symlink for ep_etherpad-lite
       run: src/bin/installDeps.sh
 
-    # configures some settings and runs npm run test for 25 seconds with 50 authors
+    # configures some settings and runs npm run test
     - name: Run load test
       run: src/tests/frontend/travis/runnerLoadTest.sh 25 50
 

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -106,6 +106,6 @@ jobs:
       run: sudo npm install -g etherpad-load-test
 
 
-    # configures some settings and runs npm run test for 5000 seconds(50 mins) with 5 authors
+    # configures some settings and runs npm run test
     - name: Run load test
       run: src/tests/frontend/travis/runnerLoadTest.sh 5000 5

--- a/src/tests/frontend/travis/runnerLoadTest.sh
+++ b/src/tests/frontend/travis/runnerLoadTest.sh
@@ -42,6 +42,8 @@ try curl http://localhost:9001/p/minifyme -f -s >/dev/null
 sleep 10
 
 log "Running the load tests..."
+# -d is duration of test, -a is number of authors to test with
+# by specifying the number of authors we set the overall rate of messages
 etherpad-loadtest -d $1 -a $2
 exit_code=$?
 

--- a/src/tests/frontend/travis/runnerLoadTest.sh
+++ b/src/tests/frontend/travis/runnerLoadTest.sh
@@ -42,7 +42,7 @@ try curl http://localhost:9001/p/minifyme -f -s >/dev/null
 sleep 10
 
 log "Running the load tests..."
-etherpad-loadtest -d 25
+etherpad-loadtest -d $1
 exit_code=$?
 
 kill "$ep_pid" && wait "$ep_pid"

--- a/src/tests/frontend/travis/runnerLoadTest.sh
+++ b/src/tests/frontend/travis/runnerLoadTest.sh
@@ -42,7 +42,7 @@ try curl http://localhost:9001/p/minifyme -f -s >/dev/null
 sleep 10
 
 log "Running the load tests..."
-etherpad-loadtest -d $1
+etherpad-loadtest -d $1 -a $2
 exit_code=$?
 
 kill "$ep_pid" && wait "$ep_pid"


### PR DESCRIPTION
Designed to catch issues that only appear X duration.

We might want to introduce some "chaos" into the load test tool or do we think this will be sufficient?