### PR TITLE
Import plugins less warny

### DIFF
--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -18,25 +18,10 @@
 
 const db = require('../db/DB');
 const hooks = require('../../static/js/pluginfw/hooks');
+const supportedElems = require('../../static/js/contentcollector').supportedElems;
 
 exports.setPadRaw = (padId, r) => {
   const records = JSON.parse(r);
-
-  // supportedElems are Supported natively within Etherpad and don't require a plugin
-  const supportedElems = ['div',
-    'br',
-    'p',
-    'pre',
-    'li',
-    'author',
-    'lmkr',
-    'insertorder',
-    'strong',
-    'ul',
-    'ol',
-    'span',
-    'font',
-    'i'];
 
   // get supported block Elements from plugins, we will use this later.
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -22,12 +22,13 @@ const hooks = require('../../static/js/pluginfw/hooks');
 exports.setPadRaw = (padId, r) => {
   const records = JSON.parse(r);
 
-  const blockElems = ['div', 'br', 'p', 'pre', 'li', 'author', 'lmkr', 'insertorder',
+  // supportedElems are Supported natively within Etherpad and don't require a plugin
+  const supportedElems = ['div', 'br', 'p', 'pre', 'li', 'author', 'lmkr', 'insertorder',
     'strong', 'ul', 'ol', 'span', 'font', 'i'];
 
   // get supported block Elements from plugins, we will use this later.
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {
-    blockElems.push(element);
+    supportedElems.push(element);
   });
 
   Object.keys(records).forEach(async (key) => {
@@ -66,7 +67,7 @@ exports.setPadRaw = (padId, r) => {
       if (value.pool) {
         for (const attrib of Object.keys(value.pool.numToAttrib)) {
           const attribName = value.pool.numToAttrib[attrib][0];
-          if (blockElems.indexOf(attribName) === -1) {
+          if (supportedElems.indexOf(attribName) === -1) {
             console.warn('Plugin missing: ' +
                 `You might want to install a plugin to support this node name: ${attribName}`);
           }

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -23,8 +23,20 @@ exports.setPadRaw = (padId, r) => {
   const records = JSON.parse(r);
 
   // supportedElems are Supported natively within Etherpad and don't require a plugin
-  const supportedElems = ['div', 'br', 'p', 'pre', 'li', 'author', 'lmkr', 'insertorder',
-    'strong', 'ul', 'ol', 'span', 'font', 'i'];
+  const supportedElems = ['div',
+    'br',
+    'p',
+    'pre',
+    'li',
+    'author',
+    'lmkr',
+    'insertorder',
+    'strong',
+    'ul',
+    'ol',
+    'span',
+    'font',
+    'i'];
 
   // get supported block Elements from plugins, we will use this later.
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {

--- a/src/node/utils/ImportEtherpad.js
+++ b/src/node/utils/ImportEtherpad.js
@@ -22,7 +22,8 @@ const hooks = require('../../static/js/pluginfw/hooks');
 exports.setPadRaw = (padId, r) => {
   const records = JSON.parse(r);
 
-  const blockElems = ['div', 'br', 'p', 'pre', 'li', 'author', 'lmkr', 'insertorder'];
+  const blockElems = ['div', 'br', 'p', 'pre', 'li', 'author', 'lmkr', 'insertorder',
+    'strong', 'ul', 'ol', 'span', 'font', 'i'];
 
   // get supported block Elements from plugins, we will use this later.
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -64,8 +64,25 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     li: 1,
   };
 
+  // supportedElems are Supported natively within Etherpad and don't require a plugin
+  const supportedElems = ['div',
+    'br',
+    'p',
+    'pre',
+    'li',
+    'author',
+    'lmkr',
+    'insertorder',
+    'strong',
+    'ul',
+    'ol',
+    'span',
+    'font',
+    'i'];
+
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {
     _blockElems[element] = 1;
+    supportedElems.push(element);
   });
 
   const isBlockElement = (n) => !!_blockElems[tagName(n) || ''];
@@ -315,9 +332,11 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     const localAttribs = state.localAttribs;
     state.localAttribs = null;
     const isBlock = isBlockElement(node);
-    if (!isBlock && node.name && (node.name !== 'body') && (node.name !== 'br')) {
-      console.warn('Plugin missing: ' +
+    if (!isBlock && node.name && (node.name !== 'body')) {
+      if (supportedElems.indexOf(node.name) === -1) {
+        console.warn('Plugin missing: ' +
           `You might want to install a plugin to support this node name: ${node.name}`);
+      }
     }
     const isEmpty = _isEmpty(node, state);
     if (isBlock) _ensureColumnZero(state);

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -79,7 +79,8 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     'ol',
     'span',
     'font',
-    'i'];
+    'i',
+  ];
 
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {
     _blockElems[element] = 1;

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -55,6 +55,25 @@ const getAttribute = (n, a) => {
   if (n.attribs != null) return n.attribs[a];
   return null;
 };
+// supportedElems are Supported natively within Etherpad and don't require a plugin
+const supportedElems = [
+  'div',
+  'br',
+  'p',
+  'pre',
+  'li',
+  'author',
+  'lmkr',
+  'insertorder',
+  'strong',
+  'ul',
+  'ol',
+  'span',
+  'font',
+  'i',
+  'bold',
+  'italic',
+];
 
 const makeContentCollector = (collectStyles, abrowser, apool, className2Author) => {
   const _blockElems = {
@@ -63,24 +82,6 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     pre: 1,
     li: 1,
   };
-
-  // supportedElems are Supported natively within Etherpad and don't require a plugin
-  const supportedElems = [
-    'div',
-    'br',
-    'p',
-    'pre',
-    'li',
-    'author',
-    'lmkr',
-    'insertorder',
-    'strong',
-    'ul',
-    'ol',
-    'span',
-    'font',
-    'i',
-  ];
 
   hooks.callAll('ccRegisterBlockElements').forEach((element) => {
     _blockElems[element] = 1;
@@ -722,3 +723,4 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
 
 exports.sanitizeUnicode = sanitizeUnicode;
 exports.makeContentCollector = makeContentCollector;
+exports.supportedElems = supportedElems;

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -57,22 +57,25 @@ const getAttribute = (n, a) => {
 };
 // supportedElems are Supported natively within Etherpad and don't require a plugin
 const supportedElems = [
-  'div',
-  'br',
-  'p',
-  'pre',
-  'li',
   'author',
-  'lmkr',
-  'insertorder',
-  'strong',
-  'ul',
-  'ol',
-  'span',
+  'b',
+  'bold',
+  'br',
+  'div',
   'font',
   'i',
-  'bold',
+  'insertorder',
   'italic',
+  'li',
+  'lmkr',
+  'ol',
+  'p',
+  'pre',
+  'strong',
+  's',
+  'span',
+  'u',
+  'ul',
 ];
 
 const makeContentCollector = (collectStyles, abrowser, apool, className2Author) => {

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -65,7 +65,8 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
   };
 
   // supportedElems are Supported natively within Etherpad and don't require a plugin
-  const supportedElems = ['div',
+  const supportedElems = [
+    'div',
     'br',
     'p',
     'pre',


### PR DESCRIPTION
Currently Etherpad warns about too many elements that are actually supported (spans, strong etc).

This PR puts the arrays separate from blockElems (I could use a ... to create but it's nice to have an array that can be copy/pasted between the two files without concern).

The outcome of this PR is that admins will have less warnings in their console and the only warnings they should see will be the ones for the plugins they actually need.

If anything todays bug report (of a lot of noise) is a good indicator that this functionality is working as expected