### PR TITLE
tests: CI of updating from master > this commit.

### DIFF
--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -70,7 +70,7 @@ jobs:
       run: git fetch
 
     - name: Checkout this branch over master
-      run: git checkout ${GITHUB_REF##*/}
+      run: git checkout "${GITHUB_SHA}"
 
     - name: Pull
       run: git pull

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -72,9 +72,6 @@ jobs:
     - name: Checkout this branch over master
       run: git checkout "${GITHUB_SHA}"
 
-    - name: Pull
-      run: git pull
-
     - name: Install all dependencies and symlink for ep_etherpad-lite
       run: src/bin/installDeps.sh
 

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -86,7 +86,6 @@ jobs:
 
     - name: Run Etherpad
       run: |
-            cd etherpad
             node src/node/server.js &
             curl --connect-timeout 10 --max-time 20 --retry 5 --retry-delay 10 --retry-max-time 60 --retry-connrefused http://127.0.0.1:9001/p/test
             cd src/tests/frontend

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -28,12 +28,6 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
-    - name: Install libreoffice
-      run: |
-        sudo add-apt-repository -y ppa:libreoffice/ppa
-        sudo apt update
-        sudo apt install -y --no-install-recommends libreoffice libreoffice-pdfimport
-
     - name: Install Etherpad plugins
       # The --legacy-peer-deps flag is required to work around a bug in npm v7:
       # https://github.com/npm/cli/issues/2199

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -66,6 +66,9 @@ jobs:
     - name: Run the backend tests
       run: cd src && npm test
 
+    - name: Git fetch
+      run: git fetch
+
     - name: Checkout this branch over master
       run: git checkout ${GITHUB_REF##*/}
 

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -1,4 +1,4 @@
-name: "Backend tests"
+name: "In-place git pull from master"
 
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install Cypress
       run: npm install cypress -g
 
-    - name: Run Etherpad
+    - name: Run Etherpad & Test Frontend
       run: |
             node src/node/server.js &
             curl --connect-timeout 10 --max-time 20 --retry 5 --retry-delay 10 --retry-max-time 60 --retry-connrefused http://127.0.0.1:9001/p/test

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -1,0 +1,76 @@
+name: "Backend tests"
+
+# any branch is useful for testing before a PR is submitted
+on: [push, pull_request]
+
+jobs:
+  withpluginsLinux:
+    # run on pushes to any branch
+    # run on PRs from external forks
+    if: |
+         (github.event_name != 'pull_request')
+         || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
+    name: Linux with Plugins
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [10, 12, 14, 15]
+
+    steps:
+    - name: Checkout master repository
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+
+    - name: Install libreoffice
+      run: |
+        sudo add-apt-repository -y ppa:libreoffice/ppa
+        sudo apt update
+        sudo apt install -y --no-install-recommends libreoffice libreoffice-pdfimport
+
+    - name: Install Etherpad plugins
+      # The --legacy-peer-deps flag is required to work around a bug in npm v7:
+      # https://github.com/npm/cli/issues/2199
+      run: >
+        npm install --no-save --legacy-peer-deps
+        ep_align
+        ep_author_hover
+        ep_cursortrace
+        ep_font_size
+        ep_hash_auth
+        ep_headings2
+        ep_image_upload
+        ep_markdown
+        ep_readonly_guest
+        ep_set_title_on_pad
+        ep_spellcheck
+        ep_subscript_and_superscript
+        ep_table_of_contents
+
+    # This must be run after installing the plugins, otherwise npm will try to
+    # hoist common dependencies by removing them from src/node_modules and
+    # installing them in the top-level node_modules. As of v6.14.10, npm's hoist
+    # logic appears to be buggy, because it sometimes removes dependencies from
+    # src/node_modules but fails to add them to the top-level node_modules. Even
+    # if npm correctly hoists the dependencies, the hoisting seems to confuse
+    # tools such as `npm outdated`, `npm update`, and some ESLint rules.
+    - name: Install all dependencies and symlink for ep_etherpad-lite
+      run: src/bin/installDeps.sh
+
+    - name: Run the backend tests
+      run: cd src && npm test
+
+    - name: Checkout this branch over master
+      run: git checkout ${GITHUB_REF##*/}
+
+    - name: Pull
+      run: git pull
+
+    - name: Run the backend tests
+      run: cd src && npm test

--- a/.github/workflows/major-version-git-pull-update.yml
+++ b/.github/workflows/major-version-git-pull-update.yml
@@ -75,5 +75,19 @@ jobs:
     - name: Pull
       run: git pull
 
+    - name: Install all dependencies and symlink for ep_etherpad-lite
+      run: src/bin/installDeps.sh
+
     - name: Run the backend tests
       run: cd src && npm test
+
+    - name: Install Cypress
+      run: npm install cypress -g
+
+    - name: Run Etherpad
+      run: |
+            cd etherpad
+            node src/node/server.js &
+            curl --connect-timeout 10 --max-time 20 --retry 5 --retry-delay 10 --retry-max-time 60 --retry-connrefused http://127.0.0.1:9001/p/test
+            cd src/tests/frontend
+            cypress run --spec cypress/integration/test.js --config-file cypress/cypress.json


### PR DESCRIPTION
In response to cypress-eslint breaking changes I thought I'd put some CI testing for if a PR might break automated upgrading.

Matrix usage is probably overkill.  Cypress might be too but gives us decent coverage.

Needs squashing.