### PR TITLE
pluginfw: Improve rendering of hook list

### DIFF
--- a/src/node/hooks/express/adminplugins.js
+++ b/src/node/hooks/express/adminplugins.js
@@ -26,8 +26,8 @@ exports.expressCreateServer = (hookName, args, cb) => {
       epVersion,
       installedPlugins: `<pre>${plugins.formatPlugins().replace(/, /g, '\n')}</pre>`,
       installedParts: `<pre>${plugins.formatParts()}</pre>`,
-      installedServerHooks: `<div>${plugins.formatHooks()}</div>`,
-      installedClientHooks: `<div>${plugins.formatHooks('client_hooks')}</div>`,
+      installedServerHooks: `<div>${plugins.formatHooks('hooks', true)}</div>`,
+      installedClientHooks: `<div>${plugins.formatHooks('client_hooks', true)}</div>`,
       latestVersion: UpdateCheck.getLatestVersion(),
       req,
     }));

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -144,7 +144,7 @@ exports.start = async () => {
         .join(', ');
     logger.info(`Installed plugins: ${installedPlugins}`);
     logger.debug(`Installed parts:\n${plugins.formatParts()}`);
-    logger.debug(`Installed hooks:\n${plugins.formatHooks()}`);
+    logger.debug(`Installed server-side hooks:\n${plugins.formatHooks('hooks', false)}`);
     await hooks.aCallAll('loadSettings', {settings});
     await hooks.aCallAll('createServer');
   } catch (err) {

--- a/src/static/js/pluginfw/shared.js
+++ b/src/static/js/pluginfw/shared.js
@@ -55,9 +55,10 @@ const extractHooks = (parts, hookSetName, normalizer) => {
       try {
         hookFn = loadFn(hookFnName, hookName);
         if (!hookFn) throw new Error('Not a function');
-      } catch (exc) {
-        console.error(`Failed to load '${hookFnName}' for ` +
-                      `'${part.full_name}/${hookSetName}/${hookName}': ${exc.toString()}`);
+      } catch (err) {
+        console.error(`Failed to load hook function "${hookFnName}" for plugin "${part.plugin}" ` +
+                      `part "${part.name}" hook set "${hookSetName}" hook "${hookName}": ` +
+                      `${err.stack || err}`);
       }
       if (hookFn) {
         if (hooks[hookName] == null) hooks[hookName] = [];


### PR DESCRIPTION
There are two main benefits:
* HTML is no longer printed in the startup debug logs.
* `require()` is no longer called on client-side files. This eliminates "Failed to load \<file\> for \<plugin\>: ReferenceError: window is not defined" errors when users visit `/admin/plugins/info`.

Fixes #3245.