### PR TITLE
Various CSS fixes

### DIFF
--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -4,7 +4,7 @@
 
 @import url('./lists_and_indents.css');
 
-html.inner-editor {
+html.outer-editor, html.inner-editor {
   height: auto !important;
   background-color: transparent !important;
 }

--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -5,7 +5,6 @@
 @import url('./lists_and_indents.css');
 
 html.outer-editor, html.inner-editor {
-  height: auto !important;
   background-color: transparent !important;
 }
 #outerdocbody {

--- a/src/static/css/pad/layout.css
+++ b/src/static/css/pad/layout.css
@@ -4,7 +4,7 @@ html, body {
   margin: 0;
   padding: 0;
 }
-html:not(.inner-editor), html:not(.inner-editor) body {
+html.pad, html.pad body {
   overflow: hidden;
 }
 body {

--- a/src/static/css/pad/layout.css
+++ b/src/static/css/pad/layout.css
@@ -1,11 +1,12 @@
 html, body {
   width: 100%;
-  height: 100%;
+  height: auto;
   margin: 0;
   padding: 0;
 }
 html.pad, html.pad body {
   overflow: hidden;
+  height: 100%;
 }
 body {
   display: flex;

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -215,7 +215,6 @@ const Ace2Editor = function () {
     const pluginNames = pluginUtils.clientPluginNames();
     outerHTML.push(
         '<style type="text/css" title="dynamicsyntax"></style>',
-        '<link rel="stylesheet" type="text/css" href="data:text/css,"/>',
         scriptTag(outerScript),
         '</head>',
         '<body id="outerdocbody" class="outerdocbody ', pluginNames.join(' '), '">',

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -207,7 +207,7 @@ const Ace2Editor = function () {
     })();`;
 
     const outerHTML =
-        [doctype, `<html class="inner-editor outerdoc ${clientVars.skinVariants}"><head>`];
+        [doctype, `<html class="outer-editor outerdoc ${clientVars.skinVariants}"><head>`];
     pushStyleTagsFor(outerHTML, includedCSS);
 
     // bizarrely, in FF2, a file with no "external" dependencies won't finish loading properly

--- a/src/static/skins/no-skin/pad.css
+++ b/src/static/skins/no-skin/pad.css
@@ -1,0 +1,1 @@
+/* intentionally empty */

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -7,7 +7,7 @@
 <!doctype html>
 
 <% e.begin_block("htmlHead"); %>
-<html class="<%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
+<html class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
 <% e.end_block(); %>
 
   <title><%=settings.title%></title>


### PR DESCRIPTION
Multiple commits:
* CSS: Fix class name for outer iframe `<html>` tag
* CSS: Use `auto` for iframe body height
* CSS: Delete bogus `<link>` tag
* CSS: Add comment to `no-skin/pad.css` to silence warning
