### PR TITLE
tests: Allow time for minification to complete

### DIFF
--- a/src/tests/frontend/cypress/integration/test.js
+++ b/src/tests/frontend/cypress/integration/test.js
@@ -10,6 +10,7 @@ Cypress.Commands.add('iframe', {prevSubject: 'element'},
 describe(__filename, () => {
   it('Pad content exists', () => {
     cy.visit('http://127.0.0.1:9001/p/test');
+    cy.wait(10000); // wait for Minified JS to be built...
     cy.get('iframe[name="ace_outer"]', {timeout: 10000}).iframe()
         .find('.line-number:first')
         .should('have.text', '1');


### PR DESCRIPTION
Minification happens after the initial visit and request to pages.

It could be that I can use timeout on the iframe elements but I'd rather just have a known static wait here for test stability temporarily.