### PR TITLE
tests: export correct HTML when ul or ol is indented

### DIFF
--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -311,6 +311,11 @@ const getHTMLFromAtext = async (pad, atext, authorColors) => {
       if (i < textLines.length) {
         nextLine = _analyzeLine(textLines[i + 1], attribLines[i + 1], apool);
       }
+      // lineBulletLevel is used to ensure that the bullet is only drawn on
+      // the <ul> item that needs to display a bullet, this is to stop multiple
+      // bullets being drawn in an indented list.
+      // https://github.com/ether/etherpad-lite/issues/4426 for details.
+      let lineBulletLevel = 1;
       await hooks.aCallAll('getLineHTMLForExport', context);
       // To create list parent elements
       if ((!prevLine || prevLine.listLevel !== line.listLevel) ||
@@ -386,7 +391,13 @@ const getHTMLFromAtext = async (pad, atext, authorColors) => {
                 pieces.push(`<ol class="${line.listTypeName}">`);
               }
             } else {
-              pieces.push(`<ul class="${line.listTypeName}">`);
+              // listLevel is when we want to include bullet
+              if (lineBulletLevel === line.listLevel) {
+                pieces.push(`<ul class="${line.listTypeName}">`);
+              } else {
+                pieces.push('<ul class="indent">');
+                lineBulletLevel++;
+              }
             }
           }
         }

--- a/src/tests/frontend/specs/unordered_list.js
+++ b/src/tests/frontend/specs/unordered_list.js
@@ -1,6 +1,39 @@
 'use strict';
 
 describe('unordered_list.js', function () {
+  describe('exports correct HTML', function () {
+    // create a new pad before each test run
+    beforeEach(function (cb) {
+      helper.newPad(cb);
+      this.timeout(60000);
+    });
+    it('Creates indented content and ensures HTML looks right', async function () {
+      helper.padInner$('#innerdocbody').text('Hello world');
+      // Coverage for https://github.com/ether/etherpad-lite/issues/4426
+      helper.padChrome$('.buttonicon-indent').click();
+      helper.padChrome$('.buttonicon-indent').click();
+      await helper.waitForPromise(
+          () => helper.padInner$('div').first().find('ul').length !== 0);
+      helper.padChrome$('.buttonicon-insertunorderedlist').click();
+      await helper.waitForPromise(
+          () => helper.padInner$('div').first().find('.list-bullet2').length !== 0);
+
+      let gotHtml;
+      await helper.waitForPromise(async () => {
+        // export this.
+        const link = helper.padChrome$('#exporthtmla').attr('href');
+        const url = new URL(link, helper.padChrome$.window.location.href).href;
+        gotHtml = await $.ajax({url, dataType: 'html'});
+        return gotHtml.indexOf('bullet') !== -1;
+      }, 5000, 1000);
+      const expectedHtml =
+          '<ul class="indent"><li><ul class="bullet"><li>Hello world</ul></li></ul>';
+      if (gotHtml.indexOf(expectedHtml) === -1) {
+        throw new Error(`Expected <body> to contain ${expectedHtml}, got ${gotHtml}`);
+      }
+    });
+  });
+
   describe('assign unordered list', function () {
     // create a new pad before each test run
     beforeEach(function (cb) {


### PR DESCRIPTION
- [x] Test coverage for https://github.com/ether/etherpad-lite/issues/4426
- [ ] Fix for https://github.com/ether/etherpad-lite/issues/4426