### PR TITLE
Fix editor height issue

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2051,9 +2051,9 @@
       }
     },
     "etherpad-require-kernel": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/etherpad-require-kernel/-/etherpad-require-kernel-1.0.9.tgz",
-      "integrity": "sha1-7Y8E6f0szsOgBVu20t/p2ZkS5+I="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/etherpad-require-kernel/-/etherpad-require-kernel-1.0.10.tgz",
+      "integrity": "sha512-3njsTgZrTG/Z6M849dJGRzF9YZ8hp1BynGdX290WB6JK+rKz5jZt8rDGYyu8n/PDXJPf1dGWps9soxreHRDzpA=="
     },
     "etherpad-yajsml": {
       "version": "0.0.4",

--- a/src/package.json
+++ b/src/package.json
@@ -38,7 +38,7 @@
     "cookie-parser": "1.4.5",
     "cross-spawn": "^7.0.3",
     "ejs": "^3.1.6",
-    "etherpad-require-kernel": "1.0.9",
+    "etherpad-require-kernel": "1.0.10",
     "etherpad-yajsml": "0.0.4",
     "express": "4.17.1",
     "express-rate-limit": "5.2.5",

--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -5,6 +5,7 @@
 @import url('./lists_and_indents.css');
 
 html.outer-editor, html.inner-editor {
+  height: auto !important;
   background-color: transparent !important;
 }
 #outerdocbody {

--- a/src/static/css/pad/layout.css
+++ b/src/static/css/pad/layout.css
@@ -1,6 +1,6 @@
 html, body {
   width: 100%;
-  height: auto;
+  height: 100%;
   margin: 0;
   padding: 0;
 }
@@ -8,7 +8,6 @@ html, body {
 /* used in pad and timeslider */
 html.pad, html.pad body {
   overflow: hidden;
-  height: 100%;
 }
 body {
   display: flex;

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -263,14 +263,6 @@ const Ace2Editor = function () {
     requireKernel.src =
         absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
     innerDocument.head.appendChild(requireKernel);
-    // Pre-fetch modules to improve load performance.
-    for (const module of ['ace2_inner', 'ace2_common']) {
-      const script = innerDocument.createElement('script');
-      script.type = 'text/javascript';
-      script.src = absUrl(`../javascripts/lib/ep_etherpad-lite/static/js/${module}.js` +
-                          `?callback=require.define&v=${clientVars.randomVersionString}`);
-      innerDocument.head.appendChild(script);
-    }
     const innerStyle = innerDocument.createElement('style');
     innerStyle.type = 'text/css';
     innerStyle.title = 'dynamicsyntax';

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -176,7 +176,7 @@ const Ace2Editor = function () {
     this.importText(initialCode);
 
     const includedCSS = [
-      '../static/css/iframe_editor.css',
+      `../static/css/iframe_editor.css?v=${clientVars.randomVersionString}`,
       `../static/css/pad.css?v=${clientVars.randomVersionString}`,
       ...hooks.callAll('aceEditorCSS').map(
           // Allow urls to external CSS - http(s):// and //some/path.css

--- a/src/tests/frontend/specs/inner_height.js
+++ b/src/tests/frontend/specs/inner_height.js
@@ -1,0 +1,31 @@
+'use strict';
+
+describe('height regression after ace.js refactoring', function () {
+  before(function (cb) {
+    helper.newPad(cb);
+  });
+
+  // everything fits inside the viewport
+  it('clientHeight should equal scrollHeight with few lines', function() {
+    const aceOuter = helper.padChrome$('iframe')[0].contentDocument;
+    const clientHeight = aceOuter.documentElement.clientHeight;
+    const scrollHeight = aceOuter.documentElement.scrollHeight;
+    expect(clientHeight).to.be(scrollHeight);
+  });
+
+  it('client height should be less than scrollHeight with many lines', async function () {
+    await helper.clearPad();
+    await helper.edit('Test line\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n');
+    const aceOuter = helper.padChrome$('iframe')[0].contentDocument;
+    const clientHeight = aceOuter.documentElement.clientHeight;
+    const scrollHeight = aceOuter.documentElement.scrollHeight;
+    expect(clientHeight).to.be.lessThan(scrollHeight);
+  });
+});


### PR DESCRIPTION
This fixes the problem of the clientHeight in ace_inner iframe being as large as the whole document instead of only the visible viewport. Please don't squash as it also fixes some other things.

@rhansen 
I deleted the poll condition as it was the source of loading problems in ~20% with chromium. The debug output was:
```
["Ace2Editor.init()"]
["Ace2Editor.init() waiting for outer frame"]
(2) ["Ace2Editor.init() load event on", Window]
["Ace2Editor.init() outer frame ready"]
["Ace2Editor.init() waiting for inner frame"]
["Ace2Editor.init() polling"]
["Ace2Editor.init() poll condition became true"]
["Ace2Editor.init() inner frame ready"]
["Ace2Editor.init() waiting for require kernel load"]
```

In the other 80% "poll condition became true" never happened. Do you know which browsers needed that, as our frontend tests are passing?