### PR TITLE
tests: Check Etherpad is providing correct number of files to the browser

### DIFF
--- a/src/tests/frontend/specs/performance.js
+++ b/src/tests/frontend/specs/performance.js
@@ -1,0 +1,12 @@
+'use strict';
+
+describe('performance', function () {
+  beforeEach(function (cb) {
+    helper.newPad(cb);
+  });
+
+  // Etherpad core should never provide more than 30 files.
+  it('correct number of files are provided to browser from Etherpad', async function () {
+    await helper.waitForPromise(() => performance.getEntriesByType('resource').length <= 30);
+  });
+});


### PR DESCRIPTION
Requires a patch.

For some reason Etherpad is providing multiple copes of the same file when ``minify`` is set to false