### PR TITLE
import/export: Improve error handling, promisify

### DIFF
--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -98,8 +98,7 @@ exports.doExport = async (req, res, padId, readOnlyId, type) => {
           settings.soffice != null ? require('../utils/LibreOffice')
           : settings.abiword != null ? require('../utils/Abiword')
           : null;
-      // @TODO no Promise interface for converters (yet)
-      await util.promisify(converter.convertFile)(srcFile, destFile, type);
+      await converter.convertFile(srcFile, destFile, type);
     }
 
     // send the file

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -33,17 +33,10 @@ const util = require('util');
 const fsp_writeFile = util.promisify(fs.writeFile);
 const fsp_unlink = util.promisify(fs.unlink);
 
-let convertor = null;
-
-// load abiword only if it is enabled
-if (settings.abiword != null) {
-  convertor = require('../utils/Abiword');
-}
-
-// Use LibreOffice if an executable has been defined in the settings
-if (settings.soffice != null) {
-  convertor = require('../utils/LibreOffice');
-}
+const convertor =
+    settings.soffice != null ? require('../utils/LibreOffice')
+    : settings.abiword != null ? require('../utils/Abiword')
+    : null;
 
 const tempDirectory = os.tmpdir();
 

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -33,11 +33,6 @@ const util = require('util');
 const fsp_writeFile = util.promisify(fs.writeFile);
 const fsp_unlink = util.promisify(fs.unlink);
 
-const converter =
-    settings.soffice != null ? require('../utils/LibreOffice')
-    : settings.abiword != null ? require('../utils/Abiword')
-    : null;
-
 const tempDirectory = os.tmpdir();
 
 /**
@@ -99,6 +94,10 @@ exports.doExport = async (req, res, padId, readOnlyId, type) => {
     if (result.length > 0) {
       // console.log("export handled by plugin", destFile);
     } else {
+      const converter =
+          settings.soffice != null ? require('../utils/LibreOffice')
+          : settings.abiword != null ? require('../utils/Abiword')
+          : null;
       // @TODO no Promise interface for converters (yet)
       await util.promisify(converter.convertFile)(srcFile, destFile, type);
     }

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -33,7 +33,7 @@ const util = require('util');
 const fsp_writeFile = util.promisify(fs.writeFile);
 const fsp_unlink = util.promisify(fs.unlink);
 
-const convertor =
+const converter =
     settings.soffice != null ? require('../utils/LibreOffice')
     : settings.abiword != null ? require('../utils/Abiword')
     : null;
@@ -91,7 +91,7 @@ exports.doExport = async (req, res, padId, readOnlyId, type) => {
     html = null;
     await TidyHtml.tidy(srcFile);
 
-    // send the convert job to the convertor (abiword, libreoffice, ..)
+    // send the convert job to the converter (abiword, libreoffice, ..)
     const destFile = `${tempDirectory}/etherpad_export_${randNum}.${type}`;
 
     // Allow plugins to overwrite the convert in export process
@@ -99,8 +99,8 @@ exports.doExport = async (req, res, padId, readOnlyId, type) => {
     if (result.length > 0) {
       // console.log("export handled by plugin", destFile);
     } else {
-      // @TODO no Promise interface for convertors (yet)
-      await util.promisify(convertor.convertFile)(srcFile, destFile, type);
+      // @TODO no Promise interface for converters (yet)
+      await util.promisify(converter.convertFile)(srcFile, destFile, type);
     }
 
     // send the file

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -43,7 +43,7 @@ const tempDirectory = os.tmpdir();
 /**
  * do a requested export
  */
-const doExport = async (req, res, padId, readOnlyId, type) => {
+exports.doExport = async (req, res, padId, readOnlyId, type) => {
   // avoid naming the read-only file as the original pad's id
   let fileName = readOnlyId ? readOnlyId : padId;
 
@@ -78,7 +78,7 @@ const doExport = async (req, res, padId, readOnlyId, type) => {
       const newHTML = await hooks.aCallFirst('exportHTMLSend', html);
       if (newHTML.length) html = newHTML;
       res.send(html);
-      throw 'stop';
+      return;
     }
 
     // else write the html export to a file
@@ -120,12 +120,4 @@ const doExport = async (req, res, padId, readOnlyId, type) => {
 
     await fsp_unlink(destFile);
   }
-};
-
-exports.doExport = (req, res, padId, readOnlyId, type) => {
-  doExport(req, res, padId, readOnlyId, type).catch((err) => {
-    if (err !== 'stop') {
-      throw err;
-    }
-  });
 };

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -100,11 +100,7 @@ exports.doExport = async (req, res, padId, readOnlyId, type) => {
       // console.log("export handled by plugin", destFile);
     } else {
       // @TODO no Promise interface for convertors (yet)
-      await new Promise((resolve, reject) => {
-        convertor.convertFile(srcFile, destFile, type, (err) => {
-          err ? reject(new Error('convertFailed')) : resolve();
-        });
-      });
+      await util.promisify(convertor.convertFile)(srcFile, destFile, type);
     }
 
     // send the file

--- a/src/node/handler/ExportHandler.js
+++ b/src/node/handler/ExportHandler.js
@@ -102,7 +102,7 @@ exports.doExport = async (req, res, padId, readOnlyId, type) => {
       // @TODO no Promise interface for convertors (yet)
       await new Promise((resolve, reject) => {
         convertor.convertFile(srcFile, destFile, type, (err) => {
-          err ? reject('convertFailed') : resolve();
+          err ? reject(new Error('convertFailed')) : resolve();
         });
       });
     }

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -179,17 +179,12 @@ const doImport = async (req, res, padId) => {
       // if no converter only rename
       await fs.rename(srcFile, destFile);
     } else {
-      // @TODO - no Promise interface for converters (yet)
-      await new Promise((resolve, reject) => {
-        converter.convertFile(srcFile, destFile, exportExtension, (err) => {
-          // catch convert errors
-          if (err) {
-            logger.warn(`Converting Error: ${err.stack || err}`);
-            return reject(new ImportError('convertFailed'));
-          }
-          resolve();
-        });
-      });
+      try {
+        await converter.convertFile(srcFile, destFile, exportExtension);
+      } catch (err) {
+        logger.warn(`Converting Error: ${err.stack || err}`);
+        throw new ImportError('convertFailed');
+      }
     }
   }
 

--- a/src/node/handler/ImportHandler.js
+++ b/src/node/handler/ImportHandler.js
@@ -55,17 +55,17 @@ const rm = async (path) => {
   }
 };
 
-let convertor = null;
+let converter = null;
 let exportExtension = 'htm';
 
 // load abiword only if it is enabled and if soffice is disabled
 if (settings.abiword != null && settings.soffice == null) {
-  convertor = require('../utils/Abiword');
+  converter = require('../utils/Abiword');
 }
 
 // load soffice only if it is enabled
 if (settings.soffice != null) {
-  convertor = require('../utils/LibreOffice');
+  converter = require('../utils/LibreOffice');
   exportExtension = 'html';
 }
 
@@ -80,8 +80,8 @@ const doImport = async (req, res, padId) => {
   // set html in the pad
   const randNum = Math.floor(Math.random() * 0xFFFFFFFF);
 
-  // setting flag for whether to use convertor or not
-  let useConvertor = (convertor != null);
+  // setting flag for whether to use converter or not
+  let useConverter = (converter != null);
 
   const form = new formidable.IncomingForm();
   form.keepExtensions = true;
@@ -170,18 +170,18 @@ const doImport = async (req, res, padId) => {
   // convert file to html if necessary
   if (!importHandledByPlugin && !directDatabaseAccess) {
     if (fileIsTXT) {
-      // Don't use convertor for text files
-      useConvertor = false;
+      // Don't use converter for text files
+      useConverter = false;
     }
 
     // See https://github.com/ether/etherpad-lite/issues/2572
-    if (fileIsHTML || !useConvertor) {
-      // if no convertor only rename
+    if (fileIsHTML || !useConverter) {
+      // if no converter only rename
       await fs.rename(srcFile, destFile);
     } else {
-      // @TODO - no Promise interface for convertors (yet)
+      // @TODO - no Promise interface for converters (yet)
       await new Promise((resolve, reject) => {
-        convertor.convertFile(srcFile, destFile, exportExtension, (err) => {
+        converter.convertFile(srcFile, destFile, exportExtension, (err) => {
           // catch convert errors
           if (err) {
             logger.warn(`Converting Error: ${err.stack || err}`);
@@ -193,7 +193,7 @@ const doImport = async (req, res, padId) => {
     }
   }
 
-  if (!useConvertor && !directDatabaseAccess) {
+  if (!useConverter && !directDatabaseAccess) {
     // Read the file with no encoding for raw buffer access.
     const buf = await fs.readFile(destFile);
 
@@ -224,7 +224,7 @@ const doImport = async (req, res, padId) => {
 
   // change text of the pad and broadcast the changeset
   if (!directDatabaseAccess) {
-    if (importHandledByPlugin || useConvertor || fileIsHTML) {
+    if (importHandledByPlugin || useConverter || fileIsHTML) {
       try {
         await importHtml.setPadHTML(pad, text);
       } catch (err) {

--- a/src/node/hooks/express/importexport.js
+++ b/src/node/hooks/express/importexport.js
@@ -60,7 +60,7 @@ exports.expressCreateServer = (hookName, args, cb) => {
         }
 
         console.log(`Exporting pad "${req.params.pad}" in ${req.params.type} format`);
-        exportHandler.doExport(req, res, padId, readOnlyId, req.params.type);
+        await exportHandler.doExport(req, res, padId, readOnlyId, req.params.type);
       }
     })().catch((err) => next(err || new Error(err)));
   });

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -59,7 +59,7 @@ if (os.type().indexOf('Windows') > -1) {
     abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {
       spawnAbiword();
-      stdoutCallback(new Error(`Abiword died with exit code ${code}`));
+      if (stdoutCallback != null) stdoutCallback(new Error(`Abiword died with exit code ${code}`));
     });
     abiword.stdout.on('data', (data) => {
       stdoutBuffer += data.toString();

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -81,11 +81,8 @@ if (os.type().indexOf('Windows') > -1) {
     abiword.stdin.write(`convert ${task.srcFile} ${task.destFile} ${task.type}\n`);
     stdoutCallback = (err) => {
       callback();
-      try {
-        task.callback(err);
-      } catch (e) {
-        console.error('Abiword File failed to convert', e);
-      }
+      if (err != null) console.error('Abiword File failed to convert', err);
+      task.callback(err);
     };
   };
 

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -77,17 +77,15 @@ if (os.type().indexOf('Windows') > -1) {
   };
   spawnAbiword();
 
-  doConvertTask = (task, callback) => {
+  const queue = async.queue((task, callback) => {
     abiword.stdin.write(`convert ${task.srcFile} ${task.destFile} ${task.type}\n`);
     stdoutCallback = (err) => {
-      callback();
       if (err != null) console.error('Abiword File failed to convert', err);
-      task.callback(err);
+      callback(err);
     };
-  };
+  }, 1);
 
-  const queue = async.queue(doConvertTask, 1);
   exports.convertFile = (srcFile, destFile, type, callback) => {
-    queue.push({srcFile, destFile, type, callback});
+    queue.push({srcFile, destFile, type}, callback);
   };
 }

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -81,7 +81,6 @@ if (os.type().indexOf('Windows') > -1) {
     abiword.stdin.write(`convert ${task.srcFile} ${task.destFile} ${task.type}\n`);
     stdoutCallback = (err) => {
       callback();
-      console.log('queue continue');
       try {
         task.callback(err);
       } catch (e) {

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -32,30 +32,16 @@ if (os.type().indexOf('Windows') > -1) {
   let stdoutBuffer = '';
 
   doConvertTask = (task, callback) => {
-    // span an abiword process to perform the conversion
     const abiword = spawn(settings.abiword, [`--to=${task.destFile}`, task.srcFile]);
-
-    // delegate the processing of stdout to another function
-    abiword.stdout.on('data', (data) => {
-      // add data to buffer
-      stdoutBuffer += data.toString();
-    });
-
-    // append error messages to the buffer
-    abiword.stderr.on('data', (data) => {
-      stdoutBuffer += data.toString();
-    });
-
-    // throw exceptions if abiword is dieing
+    abiword.stdout.on('data', (data) => { stdoutBuffer += data.toString(); });
+    abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {
       if (code !== 0) {
         return callback(`Abiword died with exit code ${code}`);
       }
-
       if (stdoutBuffer !== '') {
         console.log(stdoutBuffer);
       }
-
       callback();
     });
   };
@@ -67,45 +53,27 @@ if (os.type().indexOf('Windows') > -1) {
   // communicate with it via stdin/stdout
   // thats much faster, about factor 10
 } else {
-  // spawn the abiword process
   let abiword;
   let stdoutCallback = null;
   const spawnAbiword = () => {
     abiword = spawn(settings.abiword, ['--plugin', 'AbiCommand']);
     let stdoutBuffer = '';
     let firstPrompt = true;
-
-    // append error messages to the buffer
-    abiword.stderr.on('data', (data) => {
-      stdoutBuffer += data.toString();
-    });
-
-    // abiword died, let's restart abiword and return an error with the callback
+    abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {
       spawnAbiword();
       stdoutCallback(`Abiword died with exit code ${code}`);
     });
-
-    // delegate the processing of stdout to a other function
     abiword.stdout.on('data', (data) => {
-      // add data to buffer
       stdoutBuffer += data.toString();
-
       // we're searching for the prompt, cause this means everything we need is in the buffer
       if (stdoutBuffer.search('AbiWord:>') !== -1) {
-        // filter the feedback message
         const err = stdoutBuffer.search('OK') !== -1 ? null : stdoutBuffer;
-
-        // reset the buffer
         stdoutBuffer = '';
-
-        // call the callback with the error message
-        // skip the first prompt
         if (stdoutCallback != null && !firstPrompt) {
           stdoutCallback(err);
           stdoutCallback = null;
         }
-
         firstPrompt = false;
       }
     });
@@ -114,7 +82,6 @@ if (os.type().indexOf('Windows') > -1) {
 
   doConvertTask = (task, callback) => {
     abiword.stdin.write(`convert ${task.srcFile} ${task.destFile} ${task.type}\n`);
-    // create a callback that calls the task callback and the caller callback
     stdoutCallback = (err) => {
       callback();
       console.log('queue continue');
@@ -126,7 +93,6 @@ if (os.type().indexOf('Windows') > -1) {
     };
   };
 
-  // Queue with the converts we have to do
   const queue = async.queue(doConvertTask, 1);
   exports.convertFile = (srcFile, destFile, type, callback) => {
     queue.push({srcFile, destFile, type, callback});

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -29,10 +29,9 @@ let doConvertTask;
 // on windows we have to spawn a process for each convertion,
 // cause the plugin abicommand doesn't exist on this platform
 if (os.type().indexOf('Windows') > -1) {
-  let stdoutBuffer = '';
-
   doConvertTask = (task, callback) => {
     const abiword = spawn(settings.abiword, [`--to=${task.destFile}`, task.srcFile]);
+    let stdoutBuffer = '';
     abiword.stdout.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {

--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -35,9 +35,7 @@ if (os.type().indexOf('Windows') > -1) {
     abiword.stdout.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {
-      if (code !== 0) {
-        return callback(`Abiword died with exit code ${code}`);
-      }
+      if (code !== 0) return callback(new Error(`Abiword died with exit code ${code}`));
       if (stdoutBuffer !== '') {
         console.log(stdoutBuffer);
       }
@@ -61,13 +59,13 @@ if (os.type().indexOf('Windows') > -1) {
     abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {
       spawnAbiword();
-      stdoutCallback(`Abiword died with exit code ${code}`);
+      stdoutCallback(new Error(`Abiword died with exit code ${code}`));
     });
     abiword.stdout.on('data', (data) => {
       stdoutBuffer += data.toString();
       // we're searching for the prompt, cause this means everything we need is in the buffer
       if (stdoutBuffer.search('AbiWord:>') !== -1) {
-        const err = stdoutBuffer.search('OK') !== -1 ? null : stdoutBuffer;
+        const err = stdoutBuffer.search('OK') !== -1 ? null : new Error(stdoutBuffer);
         stdoutBuffer = '';
         if (stdoutCallback != null && !firstPrompt) {
           stdoutCallback(err);

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -109,15 +109,16 @@ exports.convertFile = (srcFile, destFile, type, callback) => {
   // we need to convert to odt first, then to doc
   // to avoid `Error: no export filter for /tmp/xxxx.doc` error
   if (type === 'doc') {
+    const intermediateFile = destFile.replace(/\.doc$/, '.odt');
     queue.push({
       srcFile,
-      destFile: destFile.replace(/\.doc$/, '.odt'),
+      destFile: intermediateFile,
       type: 'odt',
       fileExtension: 'odt',
       callback: () => {
         queue.push(
             {
-              srcFile: srcFile.replace(/\.html$/, '.odt'),
+              srcFile: intermediateFile,
               destFile,
               type,
               callback,

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -73,10 +73,7 @@ const doConvertTask = (task, callback) => {
       libreOfficeLogger.debug(`Renaming ${sourcePath} to ${task.destFile}`);
       fs.rename(sourcePath, task.destFile, callback);
     },
-  ], (err) => {
-    callback();
-    task.callback(err);
-  });
+  ], callback);
 };
 
 // Conversion tasks will be queued up, so we don't overload the system
@@ -116,17 +113,15 @@ exports.convertFile = (srcFile, destFile, type, callback) => {
         destFile: intermediateFile,
         type: 'odt',
         fileExtension: 'odt',
-        callback,
-      }),
+      }, callback),
       (callback) => queue.push({
         srcFile: intermediateFile,
         destFile,
         type,
-        callback,
         fileExtension,
-      }),
+      }, callback),
     ], callback);
   } else {
-    queue.push({srcFile, destFile, type, callback, fileExtension});
+    queue.push({srcFile, destFile, type, fileExtension}, callback);
   }
 };

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -59,7 +59,8 @@ const doConvertTask = (task, callback) => {
       soffice.on('exit', (code) => {
         clearTimeout(hangTimeout);
         if (code !== 0) {
-          return callback(`LibreOffice died with exit code ${code} and message: ${stdoutBuffer}`);
+          return callback(
+              new Error(`LibreOffice died with exit code ${code} and message: ${stdoutBuffer}`));
         }
         callback();
       });

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -110,23 +110,22 @@ exports.convertFile = (srcFile, destFile, type, callback) => {
   // to avoid `Error: no export filter for /tmp/xxxx.doc` error
   if (type === 'doc') {
     const intermediateFile = destFile.replace(/\.doc$/, '.odt');
-    queue.push({
-      srcFile,
-      destFile: intermediateFile,
-      type: 'odt',
-      fileExtension: 'odt',
-      callback: () => {
-        queue.push(
-            {
-              srcFile: intermediateFile,
-              destFile,
-              type,
-              callback,
-              fileExtension,
-            }
-        );
-      },
-    });
+    async.series([
+      (callback) => queue.push({
+        srcFile,
+        destFile: intermediateFile,
+        type: 'odt',
+        fileExtension: 'odt',
+        callback,
+      }),
+      (callback) => queue.push({
+        srcFile: intermediateFile,
+        destFile,
+        type,
+        callback,
+        fileExtension,
+      }),
+    ], callback);
   } else {
     queue.push({srcFile, destFile, type, callback, fileExtension});
   }

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -113,6 +113,7 @@ exports.convertFile = (srcFile, destFile, type, callback) => {
       srcFile,
       destFile: destFile.replace(/\.doc$/, '.odt'),
       type: 'odt',
+      fileExtension: 'odt',
       callback: () => {
         queue.push(
             {

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -57,8 +57,10 @@ const doConvertTask = async (task) => {
     soffice.on('exit', (code) => {
       clearTimeout(hangTimeout);
       if (code !== 0) {
-        return reject(
-            new Error(`LibreOffice died with exit code ${code} and message: ${stdoutBuffer}`));
+        const err =
+            new Error(`LibreOffice died with exit code ${code} and message: ${stdoutBuffer}`);
+        libreOfficeLogger.error(err.stack);
+        return reject(err);
       }
       resolve();
     });

--- a/src/tests/backend/specs/api/importexport.js
+++ b/src/tests/backend/specs/api/importexport.js
@@ -6,6 +6,7 @@
  * TODO: unify those two files, and merge in a single one.
  */
 
+const assert = require('assert').strict;
 const common = require('../../common');
 
 let agent;
@@ -241,68 +242,32 @@ describe(__filename, function () {
       }
 
       it('createPad', async function () {
-        await agent.get(`${endPoint('createPad')}&padID=${testPadId}`)
+        const res = await agent.get(`${endPoint('createPad')}&padID=${testPadId}`)
             .expect(200)
-            .expect('Content-Type', /json/)
-            .expect((res) => {
-              if (res.body.code !== 0) throw new Error('Unable to create new Pad');
-            });
+            .expect('Content-Type', /json/);
+        assert.equal(res.body.code, 0);
       });
 
       it('setHTML', async function () {
-        await agent.get(`${endPoint('setHTML')}&padID=${testPadId}` +
+        const res = await agent.get(`${endPoint('setHTML')}&padID=${testPadId}` +
                         `&html=${encodeURIComponent(test.input)}`)
             .expect(200)
-            .expect('Content-Type', /json/)
-            .expect((res) => {
-              if (res.body.code !== 0) throw new Error(`Error:${testName}`);
-            });
+            .expect('Content-Type', /json/);
+        assert.equal(res.body.code, 0);
       });
 
       it('getHTML', async function () {
-        await agent.get(`${endPoint('getHTML')}&padID=${testPadId}`)
+        const res = await agent.get(`${endPoint('getHTML')}&padID=${testPadId}`)
             .expect(200)
-            .expect('Content-Type', /json/)
-            .expect((res) => {
-              const gotHtml = res.body.data.html;
-              if (gotHtml !== test.wantHTML) {
-                throw new Error(`HTML received from export is not the one we were expecting.
-             Test Name:
-             ${testName}
-
-             Got:
-             ${JSON.stringify(gotHtml)}
-
-             Want:
-             ${JSON.stringify(test.wantHTML)}
-
-             Which is a different version of the originally imported one:
-             ${test.input}`);
-              }
-            });
+            .expect('Content-Type', /json/);
+        assert.equal(res.body.data.html, test.wantHTML);
       });
 
       it('getText', async function () {
-        await agent.get(`${endPoint('getText')}&padID=${testPadId}`)
+        const res = await agent.get(`${endPoint('getText')}&padID=${testPadId}`)
             .expect(200)
-            .expect('Content-Type', /json/)
-            .expect((res) => {
-              const gotText = res.body.data.text;
-              if (gotText !== test.wantText) {
-                throw new Error(`Text received from export is not the one we were expecting.
-             Test Name:
-             ${testName}
-
-             Got:
-             ${JSON.stringify(gotText)}
-
-             Want:
-             ${JSON.stringify(test.wantText)}
-
-             Which is a different version of the originally imported one:
-             ${test.input}`);
-              }
-            });
+            .expect('Content-Type', /json/);
+        assert.equal(res.body.data.text, test.wantText);
       });
     });
   });

--- a/src/tests/backend/specs/api/importexport.js
+++ b/src/tests/backend/specs/api/importexport.js
@@ -239,27 +239,30 @@ describe(__filename, function () {
           done();
         });
       }
-      it('createPad', function (done) {
-        agent.get(`${endPoint('createPad')}&padID=${testPadId}`)
+
+      it('createPad', async function () {
+        await agent.get(`${endPoint('createPad')}&padID=${testPadId}`)
+            .expect(200)
+            .expect('Content-Type', /json/)
             .expect((res) => {
               if (res.body.code !== 0) throw new Error('Unable to create new Pad');
-            })
-            .expect('Content-Type', /json/)
-            .expect(200, done);
+            });
       });
 
-      it('setHTML', function (done) {
-        agent.get(`${endPoint('setHTML')}&padID=${testPadId}` +
-                  `&html=${encodeURIComponent(test.input)}`)
+      it('setHTML', async function () {
+        await agent.get(`${endPoint('setHTML')}&padID=${testPadId}` +
+                        `&html=${encodeURIComponent(test.input)}`)
+            .expect(200)
+            .expect('Content-Type', /json/)
             .expect((res) => {
               if (res.body.code !== 0) throw new Error(`Error:${testName}`);
-            })
-            .expect('Content-Type', /json/)
-            .expect(200, done);
+            });
       });
 
-      it('getHTML', function (done) {
-        agent.get(`${endPoint('getHTML')}&padID=${testPadId}`)
+      it('getHTML', async function () {
+        await agent.get(`${endPoint('getHTML')}&padID=${testPadId}`)
+            .expect(200)
+            .expect('Content-Type', /json/)
             .expect((res) => {
               const gotHtml = res.body.data.html;
               if (gotHtml !== test.wantHTML) {
@@ -276,13 +279,13 @@ describe(__filename, function () {
              Which is a different version of the originally imported one:
              ${test.input}`);
               }
-            })
-            .expect('Content-Type', /json/)
-            .expect(200, done);
+            });
       });
 
-      it('getText', function (done) {
-        agent.get(`${endPoint('getText')}&padID=${testPadId}`)
+      it('getText', async function () {
+        await agent.get(`${endPoint('getText')}&padID=${testPadId}`)
+            .expect(200)
+            .expect('Content-Type', /json/)
             .expect((res) => {
               const gotText = res.body.data.text;
               if (gotText !== test.wantText) {
@@ -299,9 +302,7 @@ describe(__filename, function () {
              Which is a different version of the originally imported one:
              ${test.input}`);
               }
-            })
-            .expect('Content-Type', /json/)
-            .expect(200, done);
+            });
       });
     });
   });

--- a/src/tests/backend/specs/api/importexport.js
+++ b/src/tests/backend/specs/api/importexport.js
@@ -226,6 +226,8 @@ const testImports = {
 };
 
 describe(__filename, function () {
+  this.timeout(1000);
+
   before(async function () { agent = await common.init(); });
 
   Object.keys(testImports).forEach((testName) => {
@@ -238,7 +240,6 @@ describe(__filename, function () {
         });
       }
       it('createPad', function (done) {
-        this.timeout(200);
         agent.get(`${endPoint('createPad')}&padID=${testPadId}`)
             .expect((res) => {
               if (res.body.code !== 0) throw new Error('Unable to create new Pad');
@@ -248,7 +249,6 @@ describe(__filename, function () {
       });
 
       it('setHTML', function (done) {
-        this.timeout(150);
         agent.get(`${endPoint('setHTML')}&padID=${testPadId}` +
                   `&html=${encodeURIComponent(test.input)}`)
             .expect((res) => {
@@ -259,7 +259,6 @@ describe(__filename, function () {
       });
 
       it('getHTML', function (done) {
-        this.timeout(150);
         agent.get(`${endPoint('getHTML')}&padID=${testPadId}`)
             .expect((res) => {
               const gotHtml = res.body.data.html;
@@ -283,7 +282,6 @@ describe(__filename, function () {
       });
 
       it('getText', function (done) {
-        this.timeout(100);
         agent.get(`${endPoint('getText')}&padID=${testPadId}`)
             .expect((res) => {
               const gotText = res.body.data.text;

--- a/src/tests/backend/specs/export.js
+++ b/src/tests/backend/specs/export.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const padManager = require('../../../node/db/PadManager');
+const settings = require('../../../node/utils/Settings');
+
+describe(__filename, function () {
+  let agent;
+  const settingsBackup = {};
+
+  before(async function () {
+    agent = await common.init();
+    settingsBackup.soffice = settings.soffice;
+    await padManager.getPad('testExportPad', 'test content');
+  });
+
+  after(async function () {
+    Object.assign(settings, settingsBackup);
+  });
+
+  it('returns 500 on export error', async function () {
+    settings.soffice = 'false'; // '/bin/false' doesn't work on Windows
+    await agent.get('/p/testExportPad/export/doc')
+        .expect(500);
+  });
+});


### PR DESCRIPTION
Multiple commits:
* tests: Increase import/export test timeouts
* tests: Promisify import/export tests
* tests: Use `assert` to simplify import/export tests
* import/export: Delete unnecessary comments
* Abiword: Reset stdout buffer when starting abiword
* ExportHandler: Replace unnecessary exception with `return`
* import/export: Use Error objects for errors, not strings
* ExportHandler: Pass the error unmodified
* import/export: Spelling fix: "convertor" -> "converter"
* import/export: On export error return 500 instead of crashing
* Abiword: Don't call the callback if null
* Abiword: Reduce log spam
* Abiword: Fix logging of conversion failure
* Abiword: Use the async-provided callback to signal errors
* LibreOffice: Add missing `fileExtension` property on intermediate step
* LibreOffice: Use consistent intermediate filename
* LibreOffice: Use `async.series` to properly handle conversion errors
* LibreOffice: Use the async-provided callback to signal errors
* import/export: Promisify Abiword and LibreOffice conversion
* LibreOffice: Log conversion errors
