### PR TITLE
import/export: Minor fixes

### DIFF
--- a/src/node/utils/Abiword.js
+++ b/src/node/utils/Abiword.js
@@ -55,7 +55,10 @@ if (os.type().indexOf('Windows') > -1) {
     abiword.stderr.on('data', (data) => { stdoutBuffer += data.toString(); });
     abiword.on('exit', (code) => {
       spawnAbiword();
-      if (stdoutCallback != null) stdoutCallback(new Error(`Abiword died with exit code ${code}`));
+      if (stdoutCallback != null) {
+        stdoutCallback(new Error(`Abiword died with exit code ${code}`));
+        stdoutCallback = null;
+      }
     });
     abiword.stdout.on('data', (data) => {
       stdoutBuffer += data.toString();

--- a/src/node/utils/LibreOffice.js
+++ b/src/node/utils/LibreOffice.js
@@ -74,10 +74,7 @@ const doConvertTask = async (task) => {
 };
 
 // Conversion tasks will be queued up, so we don't overload the system
-const queue = async.queue(
-    // For some reason util.callbackify() throws "TypeError [ERR_INVALID_ARG_TYPE]: The last
-    // argument must be of type Function. Received type object" on Node.js 10.x.
-    (task, cb) => doConvertTask(task).then(() => cb(), (err) => cb(err || new Error(err))), 1);
+const queue = async.queue(doConvertTask, 1);
 
 /**
  * Convert a file from one type to another


### PR DESCRIPTION
Follow-up to PR #4957:
* Abiword: Avoid calling `stdoutCallback` multiple times
* LibreOffice: Remove unnecessary callbackification