### PR TITLE
add test for wrong clientHeight

### DIFF
--- a/src/tests/frontend/specs/inner_height.js
+++ b/src/tests/frontend/specs/inner_height.js
@@ -1,0 +1,31 @@
+'use strict';
+
+describe('height regression after ace.js refactoring', function () {
+  before(function (cb) {
+    helper.newPad(cb);
+  });
+
+  // everything fits inside the viewport
+  it('clientHeight should equal scrollHeight with few lines', function() {
+    const aceOuter = helper.padChrome$('iframe')[0].contentDocument;
+    const clientHeight = aceOuter.documentElement.clientHeight;
+    const scrollHeight = aceOuter.documentElement.scrollHeight;
+    expect(clientHeight).to.be(scrollHeight);
+  });
+
+  it('client height should be less than scrollHeight with many lines', async function () {
+    await helper.clearPad();
+    await helper.edit('Test line\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n' +
+      '\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n');
+    const aceOuter = helper.padChrome$('iframe')[0].contentDocument;
+    const clientHeight = aceOuter.documentElement.clientHeight;
+    const scrollHeight = aceOuter.documentElement.scrollHeight;
+    expect(clientHeight).to.be.lessThan(scrollHeight);
+  });
+});


### PR DESCRIPTION
Small test case for inner height regression, ie clientHeight should be identical to scrollHeight on pads with few lines, but should be less than scrollHeight on pads with lots of lines.

This is useful as a guard against a regression where scrolling, line number links (and maybe other things that depend on [getInnerHeight](https://github.com/ether/etherpad-lite/blob/develop/src/static/js/ace2_inner.js#L3646) or `clientHeight`) stopped working. The solution to this problem was https://github.com/ether/etherpad-lite/commit/cb9f6d67768da5c87651c03bcc24e019574121aa

See https://github.com/ether/etherpad-lite/pull/4954#issuecomment-802954752 for details why this test should be extended to check if the editor "has grown" when the number of pad lines reach below the viewport area and why I struggled implementing it.