### PR TITLE
Don't make browsers fail on sync-xhr until require-kernel is dropped

### DIFF
--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -54,6 +54,8 @@ exports.expressCreateServer = (hookName, args, cb) => {
       isReadOnly,
     });
 
+    // can be removed when require-kernel is dropped
+    res.header('Feature-Policy', 'sync-xhr \'self\'');
     res.send(eejs.require('ep_etherpad-lite/templates/pad.html', {
       req,
       toolbar,


### PR DESCRIPTION
See https://github.com/ether/etherpad-lite/issues/4976#issuecomment-809200250