### PR TITLE
remove custom timeouts

### DIFF
--- a/src/tests/frontend/specs/alphabet.js
+++ b/src/tests/frontend/specs/alphabet.js
@@ -5,7 +5,6 @@ describe('All the alphabet works n stuff', function () {
 
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/authorship_of_editions.js
+++ b/src/tests/frontend/specs/authorship_of_editions.js
@@ -7,7 +7,6 @@ describe('author of pad edition', function () {
 
   // author 1 creates a new pad with some content (regular lines and lists)
   before(async function () {
-    this.timeout(60000);
     const padId = await helper.aNewPad();
 
     // make sure pad has at least 3 lines

--- a/src/tests/frontend/specs/bold.js
+++ b/src/tests/frontend/specs/bold.js
@@ -3,7 +3,6 @@
 describe('bold button', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/change_user_color.js
+++ b/src/tests/frontend/specs/change_user_color.js
@@ -3,7 +3,6 @@
 describe('change user color', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/chat.js
+++ b/src/tests/frontend/specs/chat.js
@@ -87,7 +87,6 @@ describe('Chat messages and UI', function () {
 
   xit('Checks showChat=false URL Parameter hides chat then' +
       ' when removed it shows chat', async function () {
-    this.timeout(60000);
 
     // give it a second to save the username on the server side
     await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/src/tests/frontend/specs/chat_load_messages.js
+++ b/src/tests/frontend/specs/chat_load_messages.js
@@ -4,7 +4,6 @@ describe('chat-load-messages', function () {
   let padName;
 
   it('creates a pad', async function () {
-    this.timeout(60000);
     padName = await helper.aNewPad();
   });
 
@@ -14,8 +13,6 @@ describe('chat-load-messages', function () {
     chatButton.click();
     const chatInput = chrome$('#chatinput');
     const chatText = chrome$('#chattext');
-
-    this.timeout(60000);
 
     const messages = 140;
     for (let i = 1; i <= messages; i++) {

--- a/src/tests/frontend/specs/clear_authorship_colors.js
+++ b/src/tests/frontend/specs/clear_authorship_colors.js
@@ -3,7 +3,6 @@
 describe('clear authorship colors button', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/delete.js
+++ b/src/tests/frontend/specs/delete.js
@@ -3,7 +3,6 @@
 describe('delete keystroke', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/drag_and_drop.js
+++ b/src/tests/frontend/specs/drag_and_drop.js
@@ -3,7 +3,6 @@
 // WARNING: drag and drop is only simulated on these tests, manual testing might also be necessary
 describe('drag and drop', function () {
   before(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
     await createScriptWithSeveralLines();
   });

--- a/src/tests/frontend/specs/embed_value.js
+++ b/src/tests/frontend/specs/embed_value.js
@@ -51,7 +51,6 @@ describe('embed links', function () {
   describe('read and write', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -86,7 +85,6 @@ describe('embed links', function () {
 
   describe('when read only option is set', function () {
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 

--- a/src/tests/frontend/specs/enter.js
+++ b/src/tests/frontend/specs/enter.js
@@ -3,7 +3,6 @@
 describe('enter keystroke', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/font_type.js
+++ b/src/tests/frontend/specs/font_type.js
@@ -3,7 +3,6 @@
 describe('font select', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/helper.js
+++ b/src/tests/frontend/specs/helper.js
@@ -28,8 +28,6 @@ describe('the test helper', function () {
     // timeout may or may end up in the code. None the less, we test here
     // to catch it if the bug comes up again.
     it('clears cookies', async function () {
-      this.timeout(60000);
-
       // set cookies far into the future to make sure they're not expired yet
       window.Cookies.set('token', 'foo', {expires: 7 /* days */});
       window.Cookies.set('language', 'bar', {expires: 7 /* days */});
@@ -95,7 +93,6 @@ describe('the test helper', function () {
     });
 
     it('sets pad prefs cookie', async function () {
-      this.timeout(60000);
       await helper.aNewPad({padPrefs: {foo: 'padPrefs test'}});
       const {padcookie} = helper.padChrome$.window.require('ep_etherpad-lite/static/js/pad_cookie');
       expect(padcookie.getPref('foo')).to.be('padPrefs test');
@@ -239,7 +236,6 @@ describe('the test helper', function () {
     };
 
     before(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
 
       // create some lines to be used on the tests

--- a/src/tests/frontend/specs/importexport.js
+++ b/src/tests/frontend/specs/importexport.js
@@ -499,7 +499,6 @@ describe('importexport.js', function () {
 
   let confirm;
   before(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
     confirm = helper.padChrome$.window.confirm;
     helper.padChrome$.window.confirm = () => true;

--- a/src/tests/frontend/specs/importindents.js
+++ b/src/tests/frontend/specs/importindents.js
@@ -2,7 +2,6 @@
 
 describe('import indents functionality', function () {
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/indentation.js
+++ b/src/tests/frontend/specs/indentation.js
@@ -3,7 +3,6 @@
 describe('indentation button', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/italic.js
+++ b/src/tests/frontend/specs/italic.js
@@ -3,7 +3,6 @@
 describe('italic some text', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/language.js
+++ b/src/tests/frontend/specs/language.js
@@ -6,7 +6,6 @@ describe('Language select and change', function () {
 
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/multiple_authors_clear_authorship_colors.js
+++ b/src/tests/frontend/specs/multiple_authors_clear_authorship_colors.js
@@ -3,7 +3,6 @@
 describe('author of pad edition', function () {
   // author 1 creates a new pad with some content (regular lines and lists)
   before(async function () {
-    this.timeout(60000);
     const padId = await helper.aNewPad();
 
     // make sure pad has at least 3 lines

--- a/src/tests/frontend/specs/ordered_list.js
+++ b/src/tests/frontend/specs/ordered_list.js
@@ -4,7 +4,6 @@ describe('ordered_list.js', function () {
   describe('assign ordered list', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -169,7 +168,6 @@ describe('ordered_list.js', function () {
   describe('Pressing Tab in an OL increases and decreases indentation', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -204,7 +202,6 @@ describe('ordered_list.js', function () {
       'decreases indentation and bullet / ol formatting', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 

--- a/src/tests/frontend/specs/pad_modal.js
+++ b/src/tests/frontend/specs/pad_modal.js
@@ -5,7 +5,6 @@ describe('Pad modal', function () {
     const MODAL_SELECTOR = '#connectivity';
 
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
 
       // force a "slowcommit" error
@@ -46,7 +45,6 @@ describe('Pad modal', function () {
     const MODAL_SELECTOR = '#settings';
 
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
       await openSettingsAndWaitForModalToBeVisible();
     });

--- a/src/tests/frontend/specs/redo.js
+++ b/src/tests/frontend/specs/redo.js
@@ -2,7 +2,6 @@
 
 describe('undo button then redo button', function () {
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/scrollTo.js
+++ b/src/tests/frontend/specs/scrollTo.js
@@ -4,7 +4,6 @@ describe('scrollTo.js', function () {
   describe('scrolls to line', function () {
     // create a new pad with URL hash set before each test run
     before(async function () {
-      this.timeout(60000);
       await helper.aNewPad({hash: 'L4'});
     });
 
@@ -21,7 +20,6 @@ describe('scrollTo.js', function () {
   describe('doesnt break on weird hash input', function () {
     // create a new pad with URL hash set before each test run
     before(async function () {
-      this.timeout(60000);
       await helper.aNewPad({hash: '#DEEZ123123NUTS'});
     });
 

--- a/src/tests/frontend/specs/select_formatting_buttons.js
+++ b/src/tests/frontend/specs/select_formatting_buttons.js
@@ -6,7 +6,6 @@ describe('select formatting buttons when selection has style applied', function 
   const FIRST_LINE = 0;
 
   before(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/strikethrough.js
+++ b/src/tests/frontend/specs/strikethrough.js
@@ -3,7 +3,6 @@
 describe('strikethrough button', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/timeslider.js
+++ b/src/tests/frontend/specs/timeslider.js
@@ -3,7 +3,6 @@
 // deactivated, we need a nice way to get the timeslider, this is ugly
 xdescribe('timeslider button takes you to the timeslider of a pad', function () {
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/timeslider_numeric_padID.js
+++ b/src/tests/frontend/specs/timeslider_numeric_padID.js
@@ -9,7 +9,6 @@ describe('timeslider', function () {
   });
 
   it('Makes sure the export URIs are as expected when the padID is numeric', async function () {
-    this.timeout(60000);
     await helper.edit('a\n');
 
     await helper.gotoTimeslider(1);

--- a/src/tests/frontend/specs/timeslider_revisions.js
+++ b/src/tests/frontend/specs/timeslider_revisions.js
@@ -3,7 +3,6 @@
 describe('timeslider', function () {
   // create a new pad before each test run
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/undo.js
+++ b/src/tests/frontend/specs/undo.js
@@ -2,7 +2,6 @@
 
 describe('undo button', function () {
   beforeEach(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/unordered_list.js
+++ b/src/tests/frontend/specs/unordered_list.js
@@ -4,7 +4,6 @@ describe('unordered_list.js', function () {
   describe('assign unordered list', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -30,7 +29,6 @@ describe('unordered_list.js', function () {
   describe('unassign unordered list', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -57,7 +55,6 @@ describe('unordered_list.js', function () {
   describe('keep unordered list on enter key', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -87,7 +84,6 @@ describe('unordered_list.js', function () {
   describe('Pressing Tab in an UL increases and decreases indentation', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 
@@ -121,7 +117,6 @@ describe('unordered_list.js', function () {
     'and bullet / ol formatting', function () {
     // create a new pad before each test run
     beforeEach(async function () {
-      this.timeout(60000);
       await helper.aNewPad();
     });
 

--- a/src/tests/frontend/specs/urls_become_clickable.js
+++ b/src/tests/frontend/specs/urls_become_clickable.js
@@ -6,7 +6,6 @@ describe('urls', function () {
   const txt = () => helper.padInner$('div').first();
 
   before(async function () {
-    this.timeout(60000);
     await helper.aNewPad();
   });
 

--- a/src/tests/frontend/specs/xxauto_reconnect.js
+++ b/src/tests/frontend/specs/xxauto_reconnect.js
@@ -4,7 +4,6 @@ describe('Automatic pad reload on Force Reconnect message', function () {
   let padId, $originalPadFrame;
 
   beforeEach(async function () {
-    this.timeout(60000);
     padId = await helper.aNewPad();
 
     // enable userdup error to have timer to force reconnect


### PR DESCRIPTION
The default timeout of 60 seconds is defined in https://github.com/ether/etherpad-lite/blob/develop/src/tests/frontend/index.html#L18 for all tests.

Hooks and tests can take approx default timeout seconds to complete, ie the beforeEach hook can take 58 seconds and each test 59 seconds. We shouldn't use suite level timeouts. Timeouts were especially useful for pad loading. The were 20 seconds in the past with a retry max of 3, so 60 seconds was reasonable. Now with better pad loading behavior we could try to decrease it again, but I leave this for the future.

There are more tests that define low timeouts, but I leave them as they are for now, until https://github.com/ether/etherpad-lite/issues/4988 is done.

