### PR TITLE
DOCS: Fix TOC links. Add basic styling for tables in the docs. Add "Resources / further reading" section to the Changeset documentation. 

### DIFF
--- a/doc/api/changeset_library.md
+++ b/doc/api/changeset_library.md
@@ -148,4 +148,9 @@ This is an atext. An atext has two parts: text and attribs. The text is just the
 
 The attribs are again a bunch of operators like .ops in the changeset was. But these operators are only + operators. They describe which part of the text has which attributes
 
-For more information see /doc/easysync/easysync-notes.txt in the source.
+## Resources / further reading
+
+Detailed information about the changesets & Easysync protocol:
+
+* Easysync Protocol - [/doc/easysync/easysync-notes.pdf](https://github.com/ether/etherpad-lite/blob/develop/doc/easysync/easysync-notes.pdf)
+* Etherpad and EasySync Technical Manual - [/doc/easysync/easysync-full-description.pdf](https://github.com/ether/etherpad-lite/blob/develop/doc/easysync/easysync-full-description.pdf)

--- a/doc/assets/style.css
+++ b/doc/assets/style.css
@@ -1,4 +1,4 @@
-body{
+body {
   border-top: solid #44b492 5pt;
   line-height:150%;
   font-family: 'Quicksand',sans-serif;
@@ -8,28 +8,43 @@ body{
   padding: 20px;
 }
 
-a{
+a {
   color: #555;
 }
 
-h1{
+h1 {
   color: #44b492;
   line-height:100%;
 }
 
-a:hover{
+a:hover {
   color: #44b492;
 }
 
-pre{
+pre {
   background-color: #e0e0e0;
   padding:20px;
 }
 
-code{
+code {
   background-color: #e0e0e0;
 }
 
 img {
   max-width: 100%;
+}
+
+table, th, td {
+  text-align: left;
+  border: 1px solid gray;
+  border-collapse: collapse;
+}
+
+th {
+  padding: 0.5em;
+  background: #EEE;
+}
+
+td {
+  padding: 0.5em;
 }

--- a/src/bin/doc/html.js
+++ b/src/bin/doc/html.js
@@ -146,33 +146,20 @@ const buildToc = (lexed, filename, cb) => {
   lexed.forEach((tok) => {
     if (tok.type !== 'heading') return;
     if (tok.depth - depth > 1) {
-      return cb(new Error(`Inappropriate heading level\n${
-        JSON.stringify(tok)}`));
+      return cb(new Error(`Inappropriate heading level\n${JSON.stringify(tok)}`));
     }
 
     depth = tok.depth;
-    const id = getId(`${filename}_${tok.text.trim()}`);
-    toc.push(`${new Array((depth - 1) * 2 + 1).join(' ')
-    }* <a href="#${id}">${
-      tok.text}</a>`);
+
+    const slugger = new marked.Slugger();
+    const id = slugger.slug(`${filename}_${tok.text.trim()}`);
+
+    toc.push(`${new Array((depth - 1) * 2 + 1).join(' ')}* <a href="#${id}">${tok.text}</a>`);
+
     tok.text += `<span><a class="mark" href="#${id}" ` +
                 `id="${id}">#</a></span>`;
   });
 
   toc = marked.parse(toc.join('\n'));
   cb(null, toc);
-};
-
-const idCounters = {};
-const getId = (text) => {
-  text = text.toLowerCase();
-  text = text.replace(/[^a-z0-9]+/g, '_');
-  text = text.replace(/^_+|_+$/, '');
-  text = text.replace(/^([^a-z])/, '_$1');
-  if (Object.prototype.hasOwnProperty.call(idCounters, text)) {
-    text += `_${++idCounters[text]}`;
-  } else {
-    idCounters[text] = 0;
-  }
-  return text;
 };


### PR DESCRIPTION
### Fix TOC links.

Some links in the docs were broken as there were 2 different implementations generating ID slugs - homebrew and the Marked one. Using Marked all over.

Example broken link in docs: https://etherpad.org/doc/v1.8.12/#index_server_side - does not take to correct section.

### Add basic styling for tables in the docs.

![image](https://user-images.githubusercontent.com/7405383/113728518-d8e9e980-96fe-11eb-9c99-eabd959261fa.png)

### Add "Resources / further reading" section to the Changeset documentation

![image](https://user-images.githubusercontent.com/7405383/113728338-b0fa8600-96fe-11eb-94fe-d961685b9333.png)