### PR TITLE
chat: Safer construction of chat message DOM object

### DIFF
--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -294,6 +294,11 @@ Things in context:
 
 This hook is called on the client side whenever a chat message is received from
 the server. It can be used to create different notifications for chat messages.
+Hoook functions can modify the `author`, `authorName`, `duration`, `sticky`,
+`text`, and `timeStr` context properties to change how the message is processed.
+The `text` and `timeStr` properties may contain HTML, but plugins should be
+careful to sanitize any added user input to avoid introducing an XSS
+vulnerability.
 
 ## collectContentPre
 

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -194,7 +194,7 @@ exports.chat = (() => {
                   .append($('<span>').addClass('author-name').text(ctx.authorName))
                   // ctx.text was HTML-escaped before calling the hook. Hook functions are trusted
                   // to not introduce an XSS vulnerability by adding unescaped user input.
-                  .append(ctx.text),
+                  .append($('<div>').html(ctx.text).contents()),
               sticky: ctx.sticky,
               time: 5000,
               position: 'bottom',

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -164,15 +164,22 @@ exports.chat = (() => {
       // Call chat message hook
       hooks.aCallAll('chatNewMessage', ctx, () => {
         const cls = authorClass(ctx.author);
-        const html =
-            `<p data-authorId='${padutils.escapeHtml(ctx.author)}' class='${cls}'>` +
-            `<b>${padutils.escapeHtml(ctx.authorName)}:</b>` +
-            // ctx.text was HTML-escaped before calling the hook, and ctx.timeStr couldn't have had
-            // any HTML. Hook functions are trusted to not introduce an XSS vulnerability by adding
-            // unescaped user input to either ctx.text or ctx.timeStr.
-            `<span class='time ${cls}'>${ctx.timeStr}</span> ${ctx.text}</p>`;
-        if (isHistoryAdd) $(html).insertAfter('#chatloadmessagesbutton');
-        else $('#chattext').append(html);
+        const chatMsg = $('<p>')
+            .attr('data-authorId', ctx.author)
+            .addClass(cls)
+            .append($('<b>').text(`${ctx.authorName}:`))
+            .append($('<span>')
+                .addClass('time')
+                .addClass(cls)
+                // Hook functions are trusted to not introduce an XSS vulnerability by adding
+                // unescaped user input to ctx.timeStr.
+                .html(ctx.timeStr))
+            .append(' ')
+            // ctx.text was HTML-escaped before calling the hook. Hook functions are trusted to not
+            // introduce an XSS vulnerability by adding unescaped user input.
+            .append($('<div>').html(ctx.text).contents());
+        if (isHistoryAdd) chatMsg.insertAfter('#chatloadmessagesbutton');
+        else $('#chattext').append(chatMsg);
 
         // should we increment the counter??
         if (increment && !isHistoryAdd) {


### PR DESCRIPTION
Multiple commits:
* chat: Allow `chatNewMessage` hook to modify more values
* chat: Use jQuery to build the chat message DOM object
* chat: Ensure that `ctx.text` is interpreted as HTML

This is a follow-up to PR #4992.

cc @webzwo0i 