### PR TITLE
skiplist: Readability improvements and sanity checks

### DIFF
--- a/src/static/js/AttributeManager.js
+++ b/src/static/js/AttributeManager.js
@@ -68,10 +68,7 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
     // see https://github.com/ether/etherpad-lite/issues/2772
     let allChangesets;
     for (let row = start[0]; row <= end[0]; row++) {
-      const rowRange = this._findRowRange(row, start, end);
-      const startCol = rowRange[0];
-      const endCol = rowRange[1];
-
+      const [startCol, endCol] = this._findRowRange(row, start, end);
       const rowChangeset = this._setAttributesOnRangeByLine(row, startCol, endCol, attribs);
 
       // compose changesets of all rows into a single changeset
@@ -89,26 +86,12 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
   },
 
   _findRowRange(row, start, end) {
-    let startCol, endCol;
-
-    const startLineOffset = this.rep.lines.offsetOfIndex(row);
-    const endLineOffset = this.rep.lines.offsetOfIndex(row + 1);
-    const lineLength = endLineOffset - startLineOffset;
-
-    // find column where range on this row starts
-    if (row === start[0]) { // are we on the first row of range?
-      startCol = start[1];
-    } else {
-      startCol = this.lineHasMarker(row) ? 1 : 0; // remove "*" used as line marker
-    }
-
-    // find column where range on this row ends
-    if (row === end[0]) { // are we on the last row of range?
-      endCol = end[1]; // if so, get the end of range, not end of row
-    } else {
-      endCol = lineLength - 1; // remove "\n"
-    }
-
+    // Subtract 1 for the end-of-line '\n' (it is never selected).
+    const lineLength =
+        this.rep.lines.offsetOfIndex(row + 1) - this.rep.lines.offsetOfIndex(row) - 1;
+    const markerWidth = this.lineHasMarker(row) ? 1 : 0;
+    const startCol = row === start[0] ? start[1] : markerWidth;
+    const endCol = row === end[0] ? end[1] : lineLength;
     return [startCol, endCol];
   },
 

--- a/src/static/js/AttributeManager.js
+++ b/src/static/js/AttributeManager.js
@@ -115,13 +115,13 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
     return [startCol, endCol];
   },
 
-  /*
-    Sets attributes on a range, by line
-    @param row the row where range is
-    @param startCol column where range starts
-    @param endCol column where range ends
-    @param attribs: an array of attributes
-  */
+  /**
+   * Sets attributes on a range, by line
+   * @param row the row where range is
+   * @param startCol column where range starts
+   * @param endCol column where range ends (one past the last selected column)
+   * @param attribs an array of attributes
+   */
   _setAttributesOnRangeByLine(row, startCol, endCol, attribs) {
     const builder = Changeset.builder(this.rep.lines.totalWidth());
     ChangesetUtils.buildKeepToStartOfRange(this.rep, builder, [row, startCol]);

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -108,7 +108,6 @@ exports.newLen = (cs) => exports.unpack(cs).newLen;
  * @return {Op} type object iterator
  */
 exports.opIterator = (opsStr, optStartIndex) => {
-  // print(opsStr);
   const regex = /((?:\*[0-9a-z]+)*)(?:\|([0-9a-z]+))?([-+=])([0-9a-z]+)|\?|/g;
   const startIndex = (optStartIndex || 0);
   let curIndex = startIndex;
@@ -644,15 +643,8 @@ exports.textLinesMutator = (lines) => {
         curLine += L;
         curCol = 0;
       }
-      // print(inSplice+" / "+isCurLineInSplice()+" / "+curSplice[0]+" /
-      // "+curSplice[1]+" / "+lines.length);
-      /* if (inSplice && (! isCurLineInSplice()) && (curSplice[0] + curSplice[1] < lines.length)) {
-  print("BLAH");
-  putCurLineInSplice();
-}*/
       // tests case foo in remove(), which isn't otherwise covered in current impl
     }
-    // debugPrint("skip");
   };
 
   const skip = (N, L, includeInSplice) => {
@@ -667,7 +659,6 @@ exports.textLinesMutator = (lines) => {
           putCurLineInSplice();
         }
         curCol += N;
-        // debugPrint("skip");
       }
     }
   };
@@ -684,10 +675,8 @@ exports.textLinesMutator = (lines) => {
         return lines_slice(m, m + k).join('');
       };
       if (isCurLineInSplice()) {
-        // print(curCol);
         if (curCol === 0) {
           removed = curSplice[curSplice.length - 1];
-          // print("FOO"); // case foo
           curSplice.length--;
           removed += nextKLinesText(L - 1);
           curSplice[1] += L - 1;
@@ -704,7 +693,6 @@ exports.textLinesMutator = (lines) => {
         removed = nextKLinesText(L);
         curSplice[1] += L;
       }
-      // debugPrint("remove");
     }
     return removed;
   };
@@ -722,7 +710,6 @@ exports.textLinesMutator = (lines) => {
         removed = curSplice[sline].substring(curCol, curCol + N);
         curSplice[sline] = curSplice[sline].substring(0, curCol) +
             curSplice[sline].substring(curCol + N);
-        // debugPrint("remove");
       }
     }
     return removed;
@@ -736,13 +723,6 @@ exports.textLinesMutator = (lines) => {
       if (L) {
         const newLines = exports.splitTextLines(text);
         if (isCurLineInSplice()) {
-          // if (curCol == 0) {
-          // curSplice.length--;
-          // curSplice[1]--;
-          // Array.prototype.push.apply(curSplice, newLines);
-          // curLine += newLines.length;
-          // }
-          // else {
           const sline = curSplice.length - 1;
           const theLine = curSplice[sline];
           const lineCol = curCol;
@@ -753,7 +733,6 @@ exports.textLinesMutator = (lines) => {
           curLine += newLines.length;
           curSplice.push(theLine.substring(lineCol));
           curCol = 0;
-          // }
         } else {
           Array.prototype.push.apply(curSplice, newLines);
           curLine += newLines.length;
@@ -767,12 +746,10 @@ exports.textLinesMutator = (lines) => {
             curSplice[sline].substring(curCol);
         curCol += text.length;
       }
-      // debugPrint("insert");
     }
   };
 
   const hasMore = () => {
-    // print(lines.length+" / "+inSplice+" / "+(curSplice.length - 2)+" / "+curSplice[1]);
     let docLines = lines_length();
     if (inSplice) {
       docLines += curSplice.length - 2 - curSplice[1];
@@ -784,7 +761,6 @@ exports.textLinesMutator = (lines) => {
     if (inSplice) {
       leaveSplice();
     }
-    // debugPrint("close");
   };
 
   const self = {
@@ -826,7 +802,6 @@ exports.applyZip = (in1, idx1, in2, idx2, func) => {
     if ((!op2.opcode) && iter2.hasNext()) iter2.next(op2);
     func(op1, op2, opOut);
     if (opOut.opcode) {
-      // print(opOut.toSource());
       assem.append(opOut);
       opOut.opcode = '';
     }
@@ -1011,7 +986,6 @@ exports.composeAttributes = (att1, att2, resultIsMutation, pool) => {
     buf.append('*');
     buf.append(exports.numToString(pool.putAttrib(atts[i])));
   }
-  // print(att1+" / "+att2+" / "+buf.toString());
   return buf.toString();
 };
 
@@ -1023,7 +997,6 @@ exports._slicerZipperFunc = (attOp, csOp, opOut, pool) => {
   // attOp is the op from the sequence that is being operated on, either an
   // attribution string or the earlier of two exportss being composed.
   // pool can be null if definitely not needed.
-  // print(csOp.toSource()+" "+attOp.toSource()+" "+opOut.toSource());
   if (attOp.opcode === '-') {
     exports.copyOp(attOp, opOut);
     attOp.opcode = '';
@@ -1120,15 +1093,7 @@ exports.applyToAttribution = (cs, astr, pool) => {
       (op1, op2, opOut) => exports._slicerZipperFunc(op1, op2, opOut, pool));
 };
 
-/* exports.oneInsertedLineAtATimeOpIterator = function(opsStr, optStartIndex, charBank) {
-  var iter = exports.opIterator(opsStr, optStartIndex);
-  var bankIndex = 0;
-
-};*/
-
 exports.mutateAttributionLines = (cs, lines, pool) => {
-  // dmesg(cs);
-  // dmesg(lines.toSource()+" ->");
   const unpacked = exports.unpack(cs);
   const csIter = exports.opIterator(unpacked.ops);
   const csBank = unpacked.charBank;
@@ -1154,7 +1119,6 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
   let lineAssem = null;
 
   const outputMutOp = (op) => {
-    // print("outputMutOp: "+op.toSource());
     if (!lineAssem) {
       lineAssem = exports.mergingOpAssembler();
     }
@@ -1174,17 +1138,12 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
     if ((!csOp.opcode) && csIter.hasNext()) {
       csIter.next(csOp);
     }
-    // print(csOp.toSource()+" "+attOp.toSource()+" "+opOut.toSource());
-    // print(csOp.opcode+"/"+csOp.lines+"/"+csOp.attribs+"/"+lineAssem+
-    // "/"+lineIter+"/"+(lineIter?lineIter.hasNext():null));
-    // print("csOp: "+csOp.toSource());
     if ((!csOp.opcode) && (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
       break; // done
     } else if (csOp.opcode === '=' && csOp.lines > 0 && (!csOp.attribs) &&
         (!attOp.opcode) && (!lineAssem) && (!(lineIter && lineIter.hasNext()))) {
       // skip multiple lines; this is what makes small changes not order of the document size
       mut.skipLines(csOp.lines);
-      // print("skipped: "+csOp.lines);
       csOp.opcode = '';
     } else if (csOp.opcode === '+') {
       if (csOp.lines > 1) {
@@ -1205,7 +1164,6 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
       if ((!attOp.opcode) && isNextMutOp()) {
         nextMutOp(attOp);
       }
-      // print("attOp: "+attOp.toSource());
       exports._slicerZipperFunc(attOp, csOp, opOut, pool);
       if (opOut.opcode) {
         outputMutOp(opOut);
@@ -1216,8 +1174,6 @@ exports.mutateAttributionLines = (cs, lines, pool) => {
 
   exports.assert(!lineAssem, `line assembler not finished:${cs}`);
   mut.close();
-
-  // dmesg("-> "+lines.toSource());
 };
 
 /**
@@ -1299,11 +1255,6 @@ exports.compose = (cs1, cs2, pool) => {
   const bankAssem = exports.stringAssembler();
 
   const newOps = exports.applyZip(unpacked1.ops, 0, unpacked2.ops, 0, (op1, op2, opOut) => {
-    // var debugBuilder = exports.stringAssembler();
-    // debugBuilder.append(exports.opString(op1));
-    // debugBuilder.append(',');
-    // debugBuilder.append(exports.opString(op2));
-    // debugBuilder.append(' / ');
     const op1code = op1.opcode;
     const op2code = op2.opcode;
     if (op1code === '+' && op2code === '-') {
@@ -1317,13 +1268,6 @@ exports.compose = (cs1, cs2, pool) => {
         bankAssem.append(bankIter1.take(opOut.chars));
       }
     }
-
-    // debugBuilder.append(exports.opString(op1));
-    // debugBuilder.append(',');
-    // debugBuilder.append(exports.opString(op2));
-    // debugBuilder.append(' -> ');
-    // debugBuilder.append(exports.opString(opOut));
-    // print(debugBuilder.toString());
   });
 
   return exports.pack(len1, len3, newOps, bankAssem.toString());
@@ -2196,7 +2140,6 @@ exports._slicerZipperFuncWithDeletions = (attOp, csOp, opOut, pool) => {
   // attOp is the op from the sequence that is being operated on, either an
   // attribution string or the earlier of two exportss being composed.
   // pool can be null if definitely not needed.
-  // print(csOp.toSource()+" "+attOp.toSource()+" "+opOut.toSource());
   if (attOp.opcode === '-') {
     exports.copyOp(attOp, opOut);
     attOp.opcode = '';

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -301,12 +301,6 @@ function Ace2Inner(editorInfo, cssManagers) {
   const inCallStack = (type, action) => {
     if (disposed) return;
 
-    if (currentCallStack) {
-      // Do not uncomment this in production.  It will break Etherpad being provided in iFrames.
-      // I am leaving this in for testing usefulness.
-      // top.console.error(`Can't enter callstack ${type}, already in ${currentCallStack.type}`);
-    }
-
     const newEditEvent = (eventType) => ({
       eventType,
       backset: null,
@@ -388,11 +382,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       if (cleanExit) {
         submitOldEvent(cs.editEvent);
         if (cs.domClean && cs.type !== 'setup') {
-          // if (cs.isUserChange)
-          // {
-          //  if (cs.repChanged) parenModule.notifyChange();
-          //  else parenModule.notifyTick();
-          // }
           if (cs.selectionAffected) {
             updateBrowserSelectionFromRep();
           }
@@ -753,7 +742,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     let printedTrace = false;
     const isTimeUp = () => {
       if (exceededAlready) {
-        if ((!printedTrace)) { // && now() - startTime - ms > 300) {
+        if ((!printedTrace)) {
           printedTrace = true;
         }
         return true;
@@ -1176,7 +1165,6 @@ function Ace2Inner(editorInfo, cssManagers) {
           entries.push(newEntry);
           lineNodeInfos[k] = newEntry.domInfo;
         }
-        // var fragment = magicdom.wrapDom(document.createDocumentFragment());
         domInsertsNeeded.push([nodeToAddAfter, lineNodeInfos]);
         dirtyNodes.forEach((n) => {
           toDeleteAtEnd.push(n);
@@ -1212,11 +1200,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     p.mark('del');
     // delete old dom nodes
     toDeleteAtEnd.forEach((n) => {
-      // var id = n.uniqueId();
       // parent of n may not be "root" in IE due to non-tree-shaped DOM (wtf)
       if (n.parentNode) n.parentNode.removeChild(n);
-
-      // dmesg(htmlPrettyEscape(htmlForRemovedChild(n)));
     });
 
     // needed to stop chrome from breaking the ui when long strings without spaces are pasted
@@ -1228,7 +1213,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     // if the nodes that define the selection weren't encountered during
     // content collection, figure out where those nodes are now.
     if (selection && !selStart) {
-      // if (domChanges) dmesg("selection not collected");
       const selStartFromHook = hooks.callAll('aceStartLineAndCharForPoint', {
         callstack: currentCallStack,
         editorInfo,
@@ -1398,9 +1382,6 @@ function Ace2Inner(editorInfo, cssManagers) {
   const getPointForLineAndChar = (lineAndChar) => {
     const line = lineAndChar[0];
     let charsLeft = lineAndChar[1];
-    // Do not uncomment this in production it will break iFrames.
-    // top.console.log("line: %d, key: %s, node: %o", line, rep.lines.atIndex(line).key,
-    // getCleanNodeByKey(rep.lines.atIndex(line).key));
     const lineEntry = rep.lines.atIndex(line);
     charsLeft -= lineEntry.lineMarker;
     if (charsLeft < 0) {
@@ -1574,7 +1555,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       throw new Error(`doRepApplyChangeset length mismatch: ${errMsg}`);
     }
 
-    // (function doRecordUndoInformation(changes) {
     ((changes) => {
       const editEvent = currentCallStack.editEvent;
       if (editEvent.eventType === 'nonundoable') {
@@ -1597,7 +1577,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     })(changes);
 
-    // rep.alltext = Changeset.applyToText(changes, rep.alltext);
     Changeset.mutateAttributionLines(changes, rep.alines, rep.apool);
 
     if (changesetTracker.isTracking()) {
@@ -1994,7 +1973,6 @@ function Ace2Inner(editorInfo, cssManagers) {
         theChangeset = builder.toString();
       }
 
-      // dmesg(htmlPrettyEscape(theChangeset));
       doRepApplyChangeset(theChangeset);
     }
 
@@ -2170,13 +2148,8 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
 
       return true;
-      // Do not uncomment this in production it will break iFrames.
-      // top.console.log("selStart: %o, selEnd: %o, focusAtStart: %s", rep.selStart, rep.selEnd,
-      // String(!!rep.selFocusAtStart));
     }
     return false;
-  // Do not uncomment this in production it will break iFrames.
-  // top.console.log("%o %o %s", rep.selStart, rep.selEnd, rep.selFocusAtStart);
   };
 
   const isPadLoading = (eventType) => (
@@ -2641,7 +2614,6 @@ function Ace2Inner(editorInfo, cssManagers) {
           const tabSize = THE_TAB.length;
           const toDelete = ((col2 - 1) % tabSize) + 1;
           performDocumentReplaceRange([lineNum, col - toDelete], [lineNum, col], '');
-          // scrollSelectionIntoView();
           handled = true;
         }
       }
@@ -2730,7 +2702,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     const altKey = evt.altKey;
     const shiftKey = evt.shiftKey;
 
-    // dmesg("keyevent type: "+type+", which: "+which);
     // Don't take action based on modifier keys going up and down.
     // Modifier keys do not generate "keypress" events.
     // 224 is the command-key under Mac Firefox.
@@ -2930,7 +2901,6 @@ function Ace2Inner(editorInfo, cssManagers) {
           fastIncorp(4);
           evt.preventDefault();
           doReturnKey();
-          // scrollSelectionIntoView();
           scheduler.setTimeout(() => {
             outerWin.scrollBy(-100, 0);
           }, 0);
@@ -2979,7 +2949,6 @@ function Ace2Inner(editorInfo, cssManagers) {
           fastIncorp(5);
           evt.preventDefault();
           doTabKey(evt.shiftKey);
-          // scrollSelectionIntoView();
           specialHandled = true;
         }
         if ((!specialHandled) &&
@@ -3273,7 +3242,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       if (isCollapsed) {
         const diveDeep = () => {
           while (p.node.childNodes.length > 0) {
-            // && (p.node == root || p.node.parentNode == root)) {
             if (p.index === 0) {
               p.node = p.node.firstChild;
               p.maxIndex = nodeMaxIndex(p.node);
@@ -3514,9 +3482,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     $(document).on('click', handleClick);
     // dropdowns on edit bar need to be closed on clicks on both pad inner and pad outer
     $(outerWin.document).on('click', hideEditBarDropdowns);
-    // Disabled: https://github.com/ether/etherpad-lite/issues/2546
-    // Will break OL re-numbering: https://github.com/ether/etherpad-lite/pull/2533
-    // $(document).on("cut", handleCut);
 
     // If non-nullish, pasting on a link should be suppressed.
     let suppressPasteOnLink = null;
@@ -3715,7 +3680,6 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     const mods = [];
     for (let n = firstLine; n <= lastLine; n++) {
-      // var t = '';
       let level = 0;
       let togglingOn = true;
       const listType = /([a-z]+)([0-9]+)/.exec(getLineListType(n));
@@ -3726,7 +3690,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
 
       if (listType) {
-        // t = listType[1];
         level = Number(listType[2]);
       }
       const t = getLineListType(n);

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -86,14 +86,24 @@ function Ace2Inner(editorInfo, cssManagers) {
   let outsideKeyPress = (e) => true;
   let outsideNotifyDirty = noop;
 
-  // selFocusAtStart -- determines whether the selection extends "backwards", so that the focus
-  // point (controlled with the arrow keys) is at the beginning; not supported in IE, though
-  // native IE selections have that behavior (which we try not to interfere with).
-  // Must be false if selection is collapsed!
+  // Document representation.
   const rep = {
+    // Each entry in this skip list is an object created by createDomLineEntry(). The object
+    // represents a line (paragraph) of content.
     lines: new SkipList(),
+    // Points at the start of the selection. Represented as [zeroBasedLineNumber,
+    // zeroBasedColumnNumber].
+    // TODO: If the selection starts at the beginning of a line, I think this could be either
+    // [lineNumber, 0] or [previousLineNumber, previousLineLength]. Need to confirm.
     selStart: null,
+    // Points at the character just past the last selected character. Same representation as
+    // selStart.
+    // TODO: If the last selected character is the last character of a line, I think this could be
+    // either [lineNumber, lineLength] or [lineNumber+1, 0]. Need to confirm.
     selEnd: null,
+    // Whether the selection extends "backwards", so that the focus point (controlled with the arrow
+    // keys) is at the beginning. This is not supported in IE, though native IE selections have that
+    // behavior (which we try not to interfere with). Must be false if selection is collapsed!
     selFocusAtStart: false,
     alltext: '',
     alines: [],
@@ -646,9 +656,11 @@ function Ace2Inner(editorInfo, cssManagers) {
     }
   };
 
-  // This methed exposes a setter for some ace properties
-  // @param key the name of the parameter
-  // @param value the value to set to
+  /**
+   * This methed exposes a setter for some ace properties
+   * @param key the name of the parameter
+   * @param value the value to set to
+   */
   editorInfo.ace_setProperty = (key, value) => {
     // These properties are exposed
     const setters = {
@@ -1301,8 +1313,6 @@ function Ace2Inner(editorInfo, cssManagers) {
   editorInfo.ace_isCaret = isCaret;
 
   // prereq: isCaret()
-
-
   const caretLine = () => rep.selStart[0];
 
   editorInfo.ace_caretLine = caretLine;
@@ -1542,9 +1552,9 @@ function Ace2Inner(editorInfo, cssManagers) {
     }
   };
 
-  /*
-    Converts the position of a char (index in String) into a [row, col] tuple
-  */
+  /**
+   * Converts the position of a char (index in String) into a [row, col] tuple
+   */
   const lineAndColumnFromChar = (x) => {
     const lineEntry = rep.lines.atOffset(x);
     const lineStart = rep.lines.offsetOfEntry(lineEntry);

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -24,6 +24,10 @@
 
 const _ = require('./underscore');
 
+/**
+ * The skip-list contains "entries", JavaScript objects that each must have a unique "key"
+ * property that is a string.
+ */
 function SkipList() {
   // if there are N elements in the skiplist, "start" is element -1 and "end" is element N
   const start = {
@@ -47,13 +51,12 @@ function SkipList() {
   const keyToNodeMap = {};
   start.downPtrs[0] = end;
   end.upPtrs[0] = start;
+
   // a "point" object at location x allows modifications immediately after the first
   // x elements of the skiplist, such as multiple inserts or deletes.
   // After an insert or delete using point P, the point is still valid and points
   // to the same index in the skiplist.  Other operations with other points invalidate
   // this point.
-
-
   const _getPoint = (targetLoc) => {
     const numLevels = start.levels;
     let lvl = numLevels - 1;
@@ -225,8 +228,6 @@ function SkipList() {
   // Returns index of first entry such that entryFunc(entry) is truthy,
   // or length() if no such entry.  Assumes all falsy entries come before
   // all truthy entries.
-
-
   const _search = (entryFunc) => {
     let low = start;
     let lvl = start.levels - 1;
@@ -250,10 +251,6 @@ function SkipList() {
     return lowIndex + 1;
   };
 
-  /*
-The skip-list contains "entries", JavaScript objects that each must have a unique "key" property
-that is a string.
-  */
   const self = this;
   _.extend(this, {
     length: () => numNodes,

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -335,8 +335,6 @@ that is a string.
       return self.indexOfEntry(self.atOffset(offset));
     },
     search: (entryFunc) => _search(entryFunc),
-    debugGetPoint: _getPoint,
-    debugDepth: () => start.levels,
   });
 }
 

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -116,6 +116,7 @@ class SkipList {
   _insertKeyAtPoint(point, entry) {
     const newNode = {
       key: entry.key,
+      entry,
       levels: 0,
       upPtrs: [],
       downPtrs: [],
@@ -277,8 +278,6 @@ class SkipList {
     for (let i = (newEntryArray.length - 1); i >= 0; i--) {
       const entry = newEntryArray[i];
       this._insertKeyAtPoint(pt, entry);
-      const node = this._getNodeByKey(entry.key);
-      node.entry = entry;
     }
   }
 

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -356,7 +356,6 @@ that is a string.
       return self.indexOfEntry(self.atOffset(offset));
     },
     search: (entryFunc) => _search(entryFunc),
-    // debugToString: _debugToString,
     debugGetPoint: _getPoint,
     debugDepth: () => start.levels,
   });

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -121,7 +121,7 @@ class Point {
         this._skipList._end.levels++;
         this._skipList._start.downPtrs[lvl] = this._skipList._end;
         this._skipList._end.upPtrs[lvl] = this._skipList._start;
-        this._skipList._start.downSkips[lvl] = this._skipList._numNodes + 1;
+        this._skipList._start.downSkips[lvl] = this._skipList._keyToNodeMap.size + 1;
         this._skipList._start.downSkipWidths[lvl] = this._skipList._totalWidth;
         this.widthSkips[lvl] = 0;
       }
@@ -147,7 +147,6 @@ class Point {
       up.downSkipWidths[lvl] += newWidth;
     }
     this._skipList._keyToNodeMap.set(newNode.key, newNode);
-    this._skipList._numNodes++;
     this._skipList._totalWidth += newWidth;
   }
 
@@ -171,7 +170,6 @@ class Point {
       }
     }
     this._skipList._keyToNodeMap.delete(elem.key);
-    this._skipList._numNodes--;
     this._skipList._totalWidth -= elemWidth;
   }
 
@@ -189,7 +187,6 @@ class SkipList {
     // if there are N elements in the skiplist, "start" is element -1 and "end" is element N
     this._start = new Node(null, 1);
     this._end = new Node(null, 1, null, null);
-    this._numNodes = 0;
     this._totalWidth = 0;
     this._keyToNodeMap = new Map();
     this._start.downPtrs[0] = this._end;
@@ -252,20 +249,20 @@ class SkipList {
     return lowIndex + 1;
   }
 
-  length() { return this._numNodes; }
+  length() { return this._keyToNodeMap.size; }
 
   atIndex(i) {
     if (i < 0) console.warn(`atIndex(${i})`);
-    if (i >= this._numNodes) console.warn(`atIndex(${i}>=${this._numNodes})`);
+    if (i >= this._keyToNodeMap.size) console.warn(`atIndex(${i}>=${this._keyToNodeMap.size})`);
     return (new Point(this, i)).getNode().entry;
   }
 
   // differs from Array.splice() in that new elements are in an array, not varargs
   splice(start, deleteCount, newEntryArray) {
     if (start < 0) console.warn(`splice(${start}, ...)`);
-    if (start + deleteCount > this._numNodes) {
-      console.warn(`splice(${start}, ${deleteCount}, ...), N=${this._numNodes}`);
-      console.warn('%s %s %s', typeof start, typeof deleteCount, typeof this._numNodes);
+    if (start + deleteCount > this._keyToNodeMap.size) {
+      console.warn(`splice(${start}, ${deleteCount}, ...), N=${this._keyToNodeMap.size}`);
+      console.warn('%s %s %s', typeof start, typeof deleteCount, typeof this._keyToNodeMap.size);
       console.trace();
     }
 
@@ -280,21 +277,21 @@ class SkipList {
 
   next(entry) { return this._keyToNodeMap.get(entry.key).downPtrs[0].entry || null; }
   prev(entry) { return this._keyToNodeMap.get(entry.key).upPtrs[0].entry || null; }
-  push(entry) { this.splice(this._numNodes, 0, [entry]); }
+  push(entry) { this.splice(this._keyToNodeMap.size, 0, [entry]); }
 
   slice(start, end) {
     // act like Array.slice()
     if (start === undefined) start = 0;
-    else if (start < 0) start += this._numNodes;
-    if (end === undefined) end = this._numNodes;
-    else if (end < 0) end += this._numNodes;
+    else if (start < 0) start += this._keyToNodeMap.size;
+    if (end === undefined) end = this._keyToNodeMap.size;
+    else if (end < 0) end += this._keyToNodeMap.size;
 
     if (start < 0) start = 0;
-    if (start > this._numNodes) start = this._numNodes;
+    if (start > this._keyToNodeMap.size) start = this._keyToNodeMap.size;
     if (end < 0) end = 0;
-    if (end > this._numNodes) end = this._numNodes;
+    if (end > this._keyToNodeMap.size) end = this._keyToNodeMap.size;
 
-    window.dmesg(String([start, end, this._numNodes]));
+    window.dmesg(String([start, end, this._keyToNodeMap.size]));
     if (end <= start) return [];
     let n = this.atIndex(start);
     const array = [n];
@@ -321,12 +318,12 @@ class SkipList {
   totalWidth() { return this._totalWidth; }
   offsetOfIndex(i) {
     if (i < 0) return 0;
-    if (i >= this._numNodes) return this._totalWidth;
+    if (i >= this._keyToNodeMap.size) return this._totalWidth;
     return this.offsetOfEntry(this.atIndex(i));
   }
   indexOfOffset(offset) {
     if (offset <= 0) return 0;
-    if (offset >= this._totalWidth) return this._numNodes;
+    if (offset >= this._totalWidth) return this._keyToNodeMap.size;
     return this.indexOfEntry(this.atOffset(offset));
   }
 }

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -24,6 +24,18 @@
 
 const _entryWidth = (e) => (e && e.width) || 0;
 
+class Node {
+  constructor(entry, levels = 0, downSkips = 1, downSkipWidths = 0) {
+    this.key = entry != null ? entry.key : null;
+    this.entry = entry;
+    this.levels = levels;
+    this.upPtrs = Array(levels).fill(null);
+    this.downPtrs = Array(levels).fill(null);
+    this.downSkips = Array(levels).fill(downSkips);
+    this.downSkipWidths = Array(levels).fill(downSkipWidths);
+  }
+}
+
 // A "point" object at index x allows modifications immediately after the first x elements of the
 // skiplist, such as multiple inserts or deletes. After an insert or delete using point P, the point
 // is still valid and points to the same index in the skiplist. Other operations with other points
@@ -67,15 +79,7 @@ class Point {
   }
 
   insert(entry) {
-    const newNode = {
-      key: entry.key,
-      entry,
-      levels: 0,
-      upPtrs: [],
-      downPtrs: [],
-      downSkips: [],
-      downSkipWidths: [],
-    };
+    const newNode = new Node(entry);
     const pNodes = this.nodes;
     const pIdxs = this.idxs;
     const pLoc = this.loc;
@@ -162,22 +166,8 @@ class Point {
 class SkipList {
   constructor() {
     // if there are N elements in the skiplist, "start" is element -1 and "end" is element N
-    this._start = {
-      key: null,
-      levels: 1,
-      upPtrs: [null],
-      downPtrs: [null],
-      downSkips: [1],
-      downSkipWidths: [0],
-    };
-    this._end = {
-      key: null,
-      levels: 1,
-      upPtrs: [null],
-      downPtrs: [null],
-      downSkips: [null],
-      downSkipWidths: [null],
-    };
+    this._start = new Node(null, 1);
+    this._end = new Node(null, 1, null, null);
     this._numNodes = 0;
     this._totalWidth = 0;
     this._keyToNodeMap = {};

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -146,7 +146,7 @@ class Point {
       up.downSkips[lvl]++;
       up.downSkipWidths[lvl] += newWidth;
     }
-    this._skipList._keyToNodeMap[`$KEY$${newNode.key}`] = newNode;
+    this._skipList._keyToNodeMap.set(newNode.key, newNode);
     this._skipList._numNodes++;
     this._skipList._totalWidth += newWidth;
   }
@@ -170,7 +170,7 @@ class Point {
         up.downSkipWidths[i] -= elemWidth;
       }
     }
-    delete this._skipList._keyToNodeMap[`$KEY$${elem.key}`];
+    this._skipList._keyToNodeMap.delete(elem.key);
     this._skipList._numNodes--;
     this._skipList._totalWidth -= elemWidth;
   }
@@ -191,7 +191,7 @@ class SkipList {
     this._end = new Node(null, 1, null, null);
     this._numNodes = 0;
     this._totalWidth = 0;
-    this._keyToNodeMap = {};
+    this._keyToNodeMap = new Map();
     this._start.downPtrs[0] = this._end;
     this._end.upPtrs[0] = this._start;
   }
@@ -225,8 +225,6 @@ class SkipList {
     }
     return dist;
   }
-
-  _getNodeByKey(key) { return this._keyToNodeMap[`$KEY$${key}`]; }
 
   // Returns index of first entry such that entryFunc(entry) is truthy,
   // or length() if no such entry.  Assumes all falsy entries come before
@@ -280,8 +278,8 @@ class SkipList {
     }
   }
 
-  next(entry) { return this._getNodeByKey(entry.key).downPtrs[0].entry || null; }
-  prev(entry) { return this._getNodeByKey(entry.key).upPtrs[0].entry || null; }
+  next(entry) { return this._keyToNodeMap.get(entry.key).downPtrs[0].entry || null; }
+  prev(entry) { return this._keyToNodeMap.get(entry.key).upPtrs[0].entry || null; }
   push(entry) { this.splice(this._numNodes, 0, [entry]); }
 
   slice(start, end) {
@@ -307,14 +305,14 @@ class SkipList {
     return array;
   }
 
-  atKey(key) { return this._getNodeByKey(key).entry; }
-  indexOfKey(key) { return this._getNodeIndex(this._getNodeByKey(key)); }
+  atKey(key) { return this._keyToNodeMap.get(key).entry; }
+  indexOfKey(key) { return this._getNodeIndex(this._keyToNodeMap.get(key)); }
   indexOfEntry(entry) { return this.indexOfKey(entry.key); }
-  containsKey(key) { return !!this._getNodeByKey(key); }
+  containsKey(key) { return this._keyToNodeMap.has(key); }
   // gets the last entry starting at or before the offset
   atOffset(offset) { return this._getNodeAtOffset(offset).entry; }
   keyAtOffset(offset) { return this.atOffset(offset).key; }
-  offsetOfKey(key) { return this._getNodeIndex(this._getNodeByKey(key), true); }
+  offsetOfKey(key) { return this._getNodeIndex(this._keyToNodeMap.get(key), true); }
   offsetOfEntry(entry) { return this.offsetOfKey(entry.key); }
   setEntryWidth(entry, width) {
     entry.width = width;

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -95,6 +95,11 @@ class Point {
   }
 
   insert(entry) {
+    if (entry.key == null) throw new Error('entry.key must not be null');
+    if (this._skipList.containsKey(entry.key)) {
+      throw new Error(`an entry with key ${entry.key} already exists`);
+    }
+
     const newNode = new Node(entry);
     const pNodes = this.nodes;
     const pIdxs = this.idxs;

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -113,9 +113,9 @@ class SkipList {
     return n;
   }
 
-  _insertKeyAtPoint(point, newKey, entry) {
+  _insertKeyAtPoint(point, entry) {
     const newNode = {
-      key: newKey,
+      key: entry.key,
       levels: 0,
       upPtrs: [],
       downPtrs: [],
@@ -167,7 +167,7 @@ class SkipList {
       up.downSkips[lvl]++;
       up.downSkipWidths[lvl] += newWidth;
     }
-    this._keyToNodeMap[`$KEY$${newKey}`] = newNode;
+    this._keyToNodeMap[`$KEY$${newNode.key}`] = newNode;
     this._numNodes++;
     this._totalWidth += newWidth;
   }
@@ -276,7 +276,7 @@ class SkipList {
     }
     for (let i = (newEntryArray.length - 1); i >= 0; i--) {
       const entry = newEntryArray[i];
-      this._insertKeyAtPoint(pt, entry.key, entry);
+      this._insertKeyAtPoint(pt, entry);
       const node = this._getNodeByKey(entry.key);
       node.entry = entry;
     }

--- a/src/static/js/skiplist.js
+++ b/src/static/js/skiplist.js
@@ -22,23 +22,9 @@
  * limitations under the License.
  */
 
-const Ace2Common = require('./ace2_common');
 const _ = require('./underscore');
 
-const noop = Ace2Common.noop;
-
 function SkipList() {
-  let PROFILER = window.PROFILER;
-  if (!PROFILER) {
-    PROFILER = () => ({
-      start: noop,
-      mark: noop,
-      literal: noop,
-      end: noop,
-      cancel: noop,
-    });
-  }
-
   // if there are N elements in the skiplist, "start" is element -1 and "end" is element N
   const start = {
     key: null,
@@ -122,7 +108,6 @@ function SkipList() {
   const _entryWidth = (e) => (e && e.width) || 0;
 
   const _insertKeyAtPoint = (point, newKey, entry) => {
-    const p = PROFILER('insertKey', false); // eslint-disable-line new-cap
     const newNode = {
       key: newKey,
       levels: 0,
@@ -131,13 +116,11 @@ function SkipList() {
       downSkips: [],
       downSkipWidths: [],
     };
-    p.mark('donealloc');
     const pNodes = point.nodes;
     const pIdxs = point.idxs;
     const pLoc = point.loc;
     const widthLoc = point.widthSkips[0] + point.nodes[0].downSkipWidths[0];
     const newWidth = _entryWidth(entry);
-    p.mark('loop1');
 
     // The new node will have at least level 1
     // With a proability of 0.01^(n-1) the nodes level will be >= n
@@ -173,18 +156,14 @@ function SkipList() {
       up.downSkipWidths[lvl] = widthSkip1;
       me.downSkipWidths[lvl] = widthSkip2;
     }
-    p.mark('loop2');
-    p.literal(pNodes.length, 'PNL');
     for (let lvl = newNode.levels; lvl < pNodes.length; lvl++) {
       const up = pNodes[lvl];
       up.downSkips[lvl]++;
       up.downSkipWidths[lvl] += newWidth;
     }
-    p.mark('map');
     keyToNodeMap[`$KEY$${newKey}`] = newNode;
     numNodes++;
     totalWidth += newWidth;
-    p.end();
   };
 
   const _getNodeAtPoint = (point) => point.nodes[0].downPtrs[0];

--- a/src/tests/frontend/index.html
+++ b/src/tests/frontend/index.html
@@ -9,6 +9,7 @@
     <div id="mocha"></div>
     <div id="iframe-container"></div>
 
+    <script src="/static/js/require-kernel.js"></script>
     <script src="/static/js/vendors/jquery.js"></script>
     <script src="/static/js/vendors/browser.js"></script>
     <script src="/static/plugins/js-cookie/src/js.cookie.js"></script>

--- a/src/tests/frontend/runner.js
+++ b/src/tests/frontend/runner.js
@@ -159,6 +159,11 @@ $(() => {
   // get the list of specs and filter it if requested
   const specs = specs_list.slice();
 
+  const absUrl = (url) => new URL(url, window.location.href).href;
+  require.setRootURI(absUrl('../../javascripts/src'));
+  require.setLibraryURI(absUrl('../../javascripts/lib'));
+  require.setGlobalKeyPath('require');
+
   // inject spec scripts into the dom
   const $body = $('body');
   $.each(specs, (i, spec) => {

--- a/src/tests/frontend/specs/skiplist.js
+++ b/src/tests/frontend/specs/skiplist.js
@@ -15,4 +15,40 @@ describe('skiplist.js', function () {
     skiplist.push({key: 'foo'});
     expect(() => skiplist.push({key: 'foo'})).to.throwError();
   });
+
+  it('atOffset() returns last entry that touches offset', async function () {
+    const skiplist = new SkipList();
+    const entries = [];
+    let nextId = 0;
+    const makeEntry = (width) => {
+      const entry = {key: `id${nextId++}`, width};
+      entries.push(entry);
+      return entry;
+    };
+
+    skiplist.push(makeEntry(5));
+    expect(skiplist.atOffset(4)).to.be(entries[0]);
+    expect(skiplist.atOffset(5)).to.be(entries[0]);
+    expect(() => skiplist.atOffset(6)).to.throwError();
+
+    skiplist.push(makeEntry(0));
+    expect(skiplist.atOffset(4)).to.be(entries[0]);
+    expect(skiplist.atOffset(5)).to.be(entries[1]);
+    expect(() => skiplist.atOffset(6)).to.throwError();
+
+    skiplist.push(makeEntry(0));
+    expect(skiplist.atOffset(4)).to.be(entries[0]);
+    expect(skiplist.atOffset(5)).to.be(entries[2]);
+    expect(() => skiplist.atOffset(6)).to.throwError();
+
+    skiplist.splice(2, 0, [makeEntry(0)]);
+    expect(skiplist.atOffset(4)).to.be(entries[0]);
+    expect(skiplist.atOffset(5)).to.be(entries[2]);
+    expect(() => skiplist.atOffset(6)).to.throwError();
+
+    skiplist.push(makeEntry(3));
+    expect(skiplist.atOffset(4)).to.be(entries[0]);
+    expect(skiplist.atOffset(5)).to.be(entries[4]);
+    expect(skiplist.atOffset(6)).to.be(entries[4]);
+  });
 });

--- a/src/tests/frontend/specs/skiplist.js
+++ b/src/tests/frontend/specs/skiplist.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const SkipList = require('ep_etherpad-lite/static/js/skiplist');
+
+describe('skiplist.js', function () {
+  it('rejects null keys', async function () {
+    const skiplist = new SkipList();
+    for (const key of [undefined, null]) {
+      expect(() => skiplist.push({key})).to.throwError();
+    }
+  });
+
+  it('rejects duplicate keys', async function () {
+    const skiplist = new SkipList();
+    skiplist.push({key: 'foo'});
+    expect(() => skiplist.push({key: 'foo'})).to.throwError();
+  });
+});


### PR DESCRIPTION
Multiple commits:
* editor: Delete commented-out code
* editor: Delete unused `PROFILER` code
* skiplist: Delete unused methods
* AttributeManager: Simplify logic
* AttributeManager: Add sanity checks
* editor: Improve documentation comments
* skiplist: Use ES6 class syntax
* skiplist: Remove unnecessary `newKey` arg from `_insertKeyAtPoint()`
* skiplist: Save entry in `_insertKeyAtPoint()`
* skiplist: Move point creation to a new `Point` class
* skiplist: Convert point operations into `Point` methods
* skiplist: Define a new `Node` class
* skiplist: Move `propagateWidthChange()` to `Node` class
* skiplist: Sanity check inserted entries
* skiplist: Convert `_keyToNodeMap` to a `Map` object
* skiplist: Use `Map.size` to get number of nodes
* tests: Add tests for `SkipList.atOffset()`
