### PR TITLE
fix(perf): Disable wtfnode dump by default

### DIFF
--- a/settings.json.docker
+++ b/settings.json.docker
@@ -463,6 +463,11 @@
    */
   "loadTest": "${LOAD_TEST:false}",
 
+  /**
+  * Disable dump of objects preventing a clean exit
+  */
+  "dumpOnUncleanExit": false,
+
   /*
    * Disable indentation on new line when previous line ends with some special
    * chars (':', '[', '(', '{')

--- a/settings.json.template
+++ b/settings.json.template
@@ -468,6 +468,11 @@
    */
   "loadTest": false,
 
+  /**
+  * Disable dump of objects preventing a clean exit
+  */
+  "dumpOnUncleanExit": false,
+
   /*
    * Disable indentation on new line when previous line ends with some special
    * chars (':', '[', '(', '{')

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -251,6 +251,11 @@ exports.automaticReconnectionTimeout = 0;
 exports.loadTest = false;
 
 /**
+ * Disable dump of objects preventing a clean exit
+ */
+exports.dumpOnUncleanExit = false;
+
+/**
  * Enable indentation on new lines
  */
 exports.indentationOnNewLine = true;


### PR DESCRIPTION
Consumes a lot of CPU (because of https://github.com/myndzi/wtfnode/blob/master/index.js#L123) so it's better to enable it on purpose in production.

