### PR TITLE
Minify: Improve handling of stat errors

### DIFF
--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -89,7 +89,15 @@ const requestURI = async (url, method, headers) => {
 };
 
 const requestURIs = (locations, method, headers, callback) => {
-  Promise.all(locations.map((loc) => requestURI(loc, method, headers))).then((responses) => {
+  Promise.all(locations.map(async (loc) => {
+    try {
+      return await requestURI(loc, method, headers);
+    } catch (err) {
+      logger.debug(`requestURI(${JSON.stringify(loc)}, ${JSON.stringify(method)}, ` +
+                   `${JSON.stringify(headers)}) failed: ${err.stack || err}`);
+      return [500, headers, ''];
+    }
+  })).then((responses) => {
     const statuss = responses.map((x) => x[0]);
     const headerss = responses.map((x) => x[1]);
     const contentss = responses.map((x) => x[2]);

--- a/src/node/utils/Minify.js
+++ b/src/node/utils/Minify.js
@@ -247,7 +247,7 @@ const statFile = async (filename, dirStatLimit) => {
     try {
       stats = await fs.stat(path.resolve(ROOT_DIR, filename));
     } catch (err) {
-      if (err.code === 'ENOENT') {
+      if (['ENOENT', 'ENOTDIR'].includes(err.code)) {
         // Stat the directory instead.
         const [date] = await statFile(path.dirname(filename), dirStatLimit - 1);
         return [date, false];


### PR DESCRIPTION
Multiple commits:
* Minify: Refactor `requestURI()` for readability
* Minify: Treat `ENOTDIR` like `ENOENT` when statting a file
* Minify: Avoid crash due to unhandled Promise rejection if stat fails
