### PR TITLE
caretPosition: fix loading when iframe is hidden

### DIFF
--- a/src/static/js/caretPosition.js
+++ b/src/static/js/caretPosition.js
@@ -195,7 +195,7 @@ const getSelectionRange = () => {
     return;
   }
   const selection = window.getSelection();
-  if (selection.rangeCount > 0) {
+  if (selection && selection.type !== 'None' && selection.rangeCount > 0) {
     return selection.getRangeAt(0);
   } else {
     return null;


### PR DESCRIPTION
as per https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection browser either return `null` or set selection.type to `None` when the loaded iframe is hidden