### PR TITLE
update lodash 4.17.20 -> 4.17.21 due to CVE-2021-23337

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3082,9 +3082,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.assignin": {
       "version": "4.2.0",


### PR DESCRIPTION
Hi there,

this PR updates lodash from 4.17.20 to 4.17.21 to mitigate [CVE-2021-23337](http://cve.circl.lu/cve/CVE-2021-23337). This only affects package-lock.json, no application code is changed.

Cheers,
tpltnt