### PR TITLE
Improve client-side error display

### DIFF
--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -331,12 +331,12 @@ padutils.setupGlobalExceptionHandler = () => {
           $('<p>')
               .text('If the problem persists, please send this error message to your webmaster:'),
           $('<div>').css('text-align', 'left').css('font-size', '.8em').css('margin-top', '1em')
+              .append($('<b>').addClass('error-msg').text(msg)).append($('<br>'))
+              .append(txt(`at ${url} at line ${linenumber}`)).append($('<br>'))
               .append(txt(`ErrorId: ${errorId}`)).append($('<br>'))
               .append(txt(type)).append($('<br>'))
               .append(txt(`URL: ${window.location.href}`)).append($('<br>'))
-              .append(txt(`UserAgent: ${navigator.userAgent}`)).append($('<br>'))
-              .append($('<b>').addClass('error-msg').text(msg)).append($('<br>'))
-              .append(txt(`at ${url} at line ${linenumber}`)).append($('<br>')),
+              .append(txt(`UserAgent: ${navigator.userAgent}`)).append($('<br>')),
         ];
 
         $.gritter.add({

--- a/src/static/js/pad_utils.js
+++ b/src/static/js/pad_utils.js
@@ -311,6 +311,9 @@ padutils.setupGlobalExceptionHandler = () => {
       } else {
         throw new Error(`unknown event: ${e.toString()}`);
       }
+      if (err.name != null && msg !== err.name && !msg.startsWith(`${err.name}: `)) {
+        msg = `${err.name}: ${msg}`;
+      }
       const errorId = randomString(20);
 
       let msgAlreadyVisible = false;


### PR DESCRIPTION
Multiple commits:
* Display error name in the gritter box
* Move error message to the top of the gritter box
