### PR TITLE
Settings: Support `null` and `undefined` environment var substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@
   connections to the MySQL/MariaDB server (by default) instead of 1. This might
   cause Etherpad to crash with a "ER_CON_COUNT_ERROR: Too many connections"
   error if your server is configured with a low connection limit.
+* Changes to environment variable substitution in `settings.json` (see the
+  documentation comments in `settings.json.template` for details):
+  * An environment variable set to the string "null" now becomes `null` instead
+    of the string "null". Similarly, if the environment variable is unset and
+    the default value is "null" (e.g., `"${UNSET_VAR:null}"`), the value now
+    becomes `null` instead of the string "null". It is no longer possible to
+    produce the string "null" via environment variable substitution.
+  * An environment variable set to the string "undefined" now causes the setting
+    to be removed instead of set to the string "undefined". Similarly, if the
+    environment variable is unset and the default value is "undefined" (e.g.,
+    `"${UNSET_VAR:undefined}"`), the setting is now removed instead of set to
+    the string "undefined". It is no longer possible to produce the string
+    "undefined" via environment variable substitution.
 
 ### Notable enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
     `"${UNSET_VAR:undefined}"`), the setting is now removed instead of set to
     the string "undefined". It is no longer possible to produce the string
     "undefined" via environment variable substitution.
+  * Support for unset variables without a default value is now deprecated.
+    Please change all instances of `"${FOO}"` in your `settings.json` to
+    `${FOO:null}` to keep the current behavior.
 
 ### Notable enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   * Support for unset variables without a default value is now deprecated.
     Please change all instances of `"${FOO}"` in your `settings.json` to
     `${FOO:null}` to keep the current behavior.
+  * The `DB_*` variable substitutions in `settings.json.docker` that previously
+    defaulted to `null` now default to "undefined".
 
 ### Notable enhancements
 

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -24,6 +24,29 @@
  *
  * This is useful, for example, when running in a Docker container.
  *
+ * DETAILED RULES:
+ *   - If the environment variable is set to the string "true" or "false", the
+ *     value becomes Boolean true or false.
+ *   - If the environment variable is set to the string "null", the value
+ *     becomes null.
+ *   - If the environment variable is set to the string "undefined", the setting
+ *     is removed entirely, except when used as the member of an array in which
+ *     case it becomes null.
+ *   - If the environment variable is set to a string representation of a finite
+ *     number, the string is converted to that number.
+ *   - If the environment variable is set to any other string, including the
+ *     empty string, the value is that string.
+ *   - If the environment variable is unset and a default value is provided, the
+ *     value is as if the environment variable was set to the provided default:
+ *       - "${UNSET_VAR:}" becomes the empty string.
+ *       - "${UNSET_VAR:foo}" becomes the string "foo".
+ *       - "${UNSET_VAR:true}" and "${UNSET_VAR:false}" become true and false.
+ *       - "${UNSET_VAR:null}" becomes null.
+ *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
+ *         to null, if used as a member of an array).
+ *   - If the environment variable is unset and no default value is provided,
+ *     the value becomes null.
+ *
  * EXAMPLE:
  *    "port":     "${PORT:9001}"
  *    "minify":   "${MINIFY}"

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -207,12 +207,12 @@
 
   "dbType": "${DB_TYPE:dirty}",
   "dbSettings": {
-    "host":     "${DB_HOST:null}",
-    "port":     "${DB_PORT:null}",
-    "database": "${DB_NAME:null}",
-    "user":     "${DB_USER:null}",
-    "password": "${DB_PASS:null}",
-    "charset":  "${DB_CHARSET:null}",
+    "host":     "${DB_HOST:undefined}",
+    "port":     "${DB_PORT:undefined}",
+    "database": "${DB_NAME:undefined}",
+    "user":     "${DB_USER:undefined}",
+    "password": "${DB_PASS:undefined}",
+    "charset":  "${DB_CHARSET:undefined}",
     "filename": "${DB_FILENAME:var/dirty.db}"
   },
 

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -108,7 +108,7 @@
    * is used. If this is a relative path it is interpreted as relative to the
    * Etherpad root directory.
    */
-  "favicon": "${FAVICON}",
+  "favicon": "${FAVICON:null}",
 
   /*
    * Skin name.
@@ -205,12 +205,12 @@
 
   "dbType": "${DB_TYPE:dirty}",
   "dbSettings": {
-    "host":     "${DB_HOST}",
-    "port":     "${DB_PORT}",
-    "database": "${DB_NAME}",
-    "user":     "${DB_USER}",
-    "password": "${DB_PASS}",
-    "charset":  "${DB_CHARSET}",
+    "host":     "${DB_HOST:null}",
+    "port":     "${DB_PORT:null}",
+    "database": "${DB_NAME:null}",
+    "user":     "${DB_USER:null}",
+    "password": "${DB_PASS:null}",
+    "charset":  "${DB_CHARSET:null}",
     "filename": "${DB_FILENAME:var/dirty.db}"
   },
 
@@ -308,7 +308,7 @@
    * it to null disables Abiword and will only allow plain text and HTML
    * import/exports.
    */
-  "abiword": "${ABIWORD}",
+  "abiword": "${ABIWORD:null}",
 
   /*
    * This is the absolute path to the soffice executable.
@@ -316,7 +316,7 @@
    * LibreOffice can be used in lieu of Abiword to export pads.
    * Setting it to null disables LibreOffice exporting.
    */
-  "soffice": "${SOFFICE}",
+  "soffice": "${SOFFICE:null}",
 
   /*
    * Path to the Tidy executable.
@@ -324,7 +324,7 @@
    * Tidy is used to improve the quality of exported pads.
    * Setting it to null disables Tidy.
    */
-  "tidyHtml": "${TIDY_HTML}",
+  "tidyHtml": "${TIDY_HTML:null}",
 
   /*
    * Allow import of file types other than the supported ones:
@@ -454,13 +454,13 @@
     "admin": {
       // 1) "password" can be replaced with "hash" if you install ep_hash_auth
       // 2) please note that if password is null, the user will not be created
-      "password": "${ADMIN_PASSWORD}",
+      "password": "${ADMIN_PASSWORD:null}",
       "is_admin": true
     },
     "user": {
       // 1) "password" can be replaced with "hash" if you install ep_hash_auth
       // 2) please note that if password is null, the user will not be created
-      "password": "${USER_PASSWORD}",
+      "password": "${USER_PASSWORD:null}",
       "is_admin": false
     }
   },

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -45,7 +45,9 @@
  *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
  *         to null, if used as a member of an array).
  *   - If the environment variable is unset and no default value is provided,
- *     the value becomes null.
+ *     the value becomes null. THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF
+ *     ETHERPAD; if you want the default value to be null, you should explicitly
+ *     specify "null" as the default value.
  *
  * EXAMPLE:
  *    "port":     "${PORT:9001}"

--- a/settings.json.template
+++ b/settings.json.template
@@ -15,6 +15,29 @@
  *
  * This is useful, for example, when running in a Docker container.
  *
+ * DETAILED RULES:
+ *   - If the environment variable is set to the string "true" or "false", the
+ *     value becomes Boolean true or false.
+ *   - If the environment variable is set to the string "null", the value
+ *     becomes null.
+ *   - If the environment variable is set to the string "undefined", the setting
+ *     is removed entirely, except when used as the member of an array in which
+ *     case it becomes null.
+ *   - If the environment variable is set to a string representation of a finite
+ *     number, the string is converted to that number.
+ *   - If the environment variable is set to any other string, including the
+ *     empty string, the value is that string.
+ *   - If the environment variable is unset and a default value is provided, the
+ *     value is as if the environment variable was set to the provided default:
+ *       - "${UNSET_VAR:}" becomes the empty string.
+ *       - "${UNSET_VAR:foo}" becomes the string "foo".
+ *       - "${UNSET_VAR:true}" and "${UNSET_VAR:false}" become true and false.
+ *       - "${UNSET_VAR:null}" becomes null.
+ *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
+ *         to null, if used as a member of an array).
+ *   - If the environment variable is unset and no default value is provided,
+ *     the value becomes null.
+ *
  * EXAMPLE:
  *    "port":     "${PORT:9001}"
  *    "minify":   "${MINIFY}"

--- a/settings.json.template
+++ b/settings.json.template
@@ -36,7 +36,9 @@
  *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
  *         to null, if used as a member of an array).
  *   - If the environment variable is unset and no default value is provided,
- *     the value becomes null.
+ *     the value becomes null. THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF
+ *     ETHERPAD; if you want the default value to be null, you should explicitly
+ *     specify "null" as the default value.
  *
  * EXAMPLE:
  *    "port":     "${PORT:9001}"

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -599,7 +599,9 @@ const lookupEnvironmentVariables = (obj) => {
 
     if ((envVarValue === undefined) && (defaultValue === undefined)) {
       console.warn(`Environment variable "${envVarName}" does not contain any value for ` +
-                   `configuration key "${key}", and no default was given. Returning null.`);
+                   `configuration key "${key}", and no default was given. Using null. ` +
+                   'THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF ETHERPAD; you should ' +
+                   'explicitly use "null" as the default if you want to continue to use null.');
 
       /*
        * We have to return null, because if we just returned undefined, the

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -825,5 +825,9 @@ exports.reloadSettings = () => {
   console.log(`Random string used for versioning assets: ${exports.randomVersionString}`);
 };
 
+exports.exportedForTestingOnly = {
+  parseSettings,
+};
+
 // initially load settings
 exports.reloadSettings();

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -509,17 +509,13 @@ const coerceValue = (stringValue) => {
     return +stringValue;
   }
 
-  // the boolean literal case is easy.
-  if (stringValue === 'true') {
-    return true;
+  switch (stringValue) {
+    case 'true': return true;
+    case 'false': return false;
+    case 'undefined': return undefined;
+    case 'null': return null;
+    default: return stringValue;
   }
-
-  if (stringValue === 'false') {
-    return false;
-  }
-
-  // otherwise, return this value as-is
-  return stringValue;
 };
 
 /**

--- a/src/tests/backend/specs/settings.js
+++ b/src/tests/backend/specs/settings.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('assert').strict;
+const {parseSettings} = require('../../../node/utils/Settings').exportedForTestingOnly;
+const path = require('path');
+const process = require('process');
+
+describe(__filename, function () {
+  describe('parseSettings', function () {
+    let settings;
+    const envVarSubstTestCases = [
+      {name: 'true', val: 'true', var: 'SET_VAR_TRUE', want: true},
+      {name: 'false', val: 'false', var: 'SET_VAR_FALSE', want: false},
+      {name: 'null', val: 'null', var: 'SET_VAR_NULL', want: null},
+      {name: 'undefined', val: 'undefined', var: 'SET_VAR_UNDEFINED', want: undefined},
+      {name: 'number', val: '123', var: 'SET_VAR_NUMBER', want: 123},
+      {name: 'string', val: 'foo', var: 'SET_VAR_STRING', want: 'foo'},
+      {name: 'empty string', val: '', var: 'SET_VAR_EMPTY_STRING', want: ''},
+    ];
+
+    before(async function () {
+      for (const tc of envVarSubstTestCases) process.env[tc.var] = tc.val;
+      delete process.env.UNSET_VAR;
+      settings = parseSettings(path.join(__dirname, 'settings.json'), true);
+      assert(settings != null);
+    });
+
+    describe('environment variable substitution', function () {
+      describe('set', function () {
+        for (const tc of envVarSubstTestCases) {
+          it(tc.name, async function () {
+            const obj = settings['environment variable substitution'].set;
+            if (tc.name === 'undefined') {
+              assert(!(tc.name in obj));
+            } else {
+              assert.equal(obj[tc.name], tc.want);
+            }
+          });
+        }
+      });
+
+      describe('unset', function () {
+        it('no default', async function () {
+          const obj = settings['environment variable substitution'].unset;
+          assert.equal(obj['no default'], null);
+        });
+
+        for (const tc of envVarSubstTestCases) {
+          it(tc.name, async function () {
+            const obj = settings['environment variable substitution'].unset;
+            if (tc.name === 'undefined') {
+              assert(!(tc.name in obj));
+            } else {
+              assert.equal(obj[tc.name], tc.want);
+            }
+          });
+        }
+      });
+    });
+  });
+});

--- a/src/tests/backend/specs/settings.json
+++ b/src/tests/backend/specs/settings.json
@@ -1,0 +1,39 @@
+// line comment
+/*
+ * block comment
+ */
+{
+  "trailing commas": {
+    "lists": {
+      "multiple lines": [
+        "",
+      ]
+    },
+    "objects": {
+      "multiple lines": {
+        "key": "",
+      }
+    }
+  },
+  "environment variable substitution": {
+    "set": {
+      "true": "${SET_VAR_TRUE}",
+      "false": "${SET_VAR_FALSE}",
+      "null": "${SET_VAR_NULL}",
+      "undefined": "${SET_VAR_UNDEFINED}",
+      "number": "${SET_VAR_NUMBER}",
+      "string": "${SET_VAR_STRING}",
+      "empty string": "${SET_VAR_EMPTY_STRING}"
+    },
+    "unset": {
+      "no default": "${UNSET_VAR}",
+      "true": "${UNSET_VAR:true}",
+      "false": "${UNSET_VAR:false}",
+      "null": "${UNSET_VAR:null}",
+      "undefined": "${UNSET_VAR:undefined}",
+      "number": "${UNSET_VAR:123}",
+      "string": "${UNSET_VAR:foo}",
+      "empty string": "${UNSET_VAR:}"
+    }
+  }
+}


### PR DESCRIPTION
Multiple commits:
* Settings: Support null and undefined env var substitutions
* Docker: Explicitly default env var substitutions to null
* Settings: Deprecate null as the default default value
* Docker: If `DB_*` env var is unset, remove the corresponding setting
* tests: Add tests for `settings.json` parsing

Fixes #5048

@JustAnotherArchivist: Would you test this PR to see if it fixes the bug you reported?