### PR TITLE
tests: Configure Firefox to use fake webcam

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -452,88 +452,6 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "optional": true
     },
-    "archiver": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
-      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "^2.1.0",
-        "async": "^2.6.3",
-        "buffer-crc32": "^0.2.1",
-        "glob": "^7.1.4",
-        "readable-stream": "^3.4.0",
-        "tar-stream": "^2.1.0",
-        "zip-stream": "^2.1.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
-      }
-    },
-    "archiver-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -866,12 +784,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
-    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1143,56 +1055,6 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
-    "compress-commons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
-      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^3.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.3.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1253,25 +1115,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.1.0"
-      }
-    },
-    "crc32-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
-      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
-      "dev": true,
-      "requires": {
-        "crc": "^3.4.4",
-        "readable-stream": "^3.4.0"
-      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1504,15 +1347,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "engine.io": {
       "version": "3.5.0",
@@ -2281,12 +2115,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
-    },
     "fs-minipass": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
@@ -2413,7 +2241,8 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "optional": true
     },
     "growl": {
       "version": "1.10.5",
@@ -2644,6 +2473,12 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -2967,49 +2802,16 @@
         "verror": "1.10.0"
       }
     },
-    "just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "kebab-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
-      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ==",
-      "dev": true
-    },
-    "languages4translatewiki": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/languages4translatewiki/-/languages4translatewiki-0.1.3.tgz",
-      "integrity": "sha1-xDYgbgUtIUkLEQF6RNURj5Ih5ds="
-    },
-    "lazystream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+    "jszip": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -3050,6 +2852,42 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "kebab-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
+      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ==",
+      "dev": true
+    },
+    "languages4translatewiki": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/languages4translatewiki/-/languages4translatewiki-0.1.3.tgz",
+      "integrity": "sha1-xDYgbgUtIUkLEQF6RNURj5Ih5ds="
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3058,6 +2896,15 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "locate-path": {
@@ -3095,12 +2942,6 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
-      "dev": true
-    },
     "lodash.filter": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
@@ -3120,12 +2961,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.map": {
@@ -3162,12 +2997,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
-      "dev": true
-    },
-    "lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true
     },
     "log-symbols": {
@@ -7101,6 +6930,12 @@
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7295,12 +7130,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -7555,7 +7384,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "optional": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -7588,6 +7416,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/security/-/security-1.0.0.tgz",
       "integrity": "sha1-gRwwAxNoYTPvAAcSXjsO1wCXiBU="
+    },
+    "selenium-webdriver": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.3.tgz",
+      "integrity": "sha512-R0mGHpQkSKgIWiPgcKDcckh4A6aaK0KTyWxs5ieuiI7zsXQ+Kb6neph+dNoeqq3jSBGyv3ONo2w3oohoL4D/Rg==",
+      "dev": true,
+      "requires": {
+        "jszip": "^3.5.0",
+        "rimraf": "^2.7.1",
+        "tmp": "^0.2.1",
+        "ws": "^7.3.1"
+      }
     },
     "semver": {
       "version": "5.7.1",
@@ -7653,6 +7493,12 @@
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz",
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
+      "dev": true
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "setprototypeof": {
@@ -8223,32 +8069,6 @@
         "inherits": "2"
       }
     },
-    "tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
-    },
     "tarn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
@@ -8358,6 +8178,26 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/tinycon/-/tinycon-0.6.8.tgz",
       "integrity": "sha1-59oiPj7gy/nbeWP6M1aZuyF3enM="
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "to-array": {
       "version": "0.1.4",
@@ -8555,12 +8395,6 @@
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
-    "vargs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz",
-      "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
-      "dev": true
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -8594,82 +8428,6 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
-      }
-    },
-    "wd": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.12.1.tgz",
-      "integrity": "sha512-O99X8OnOgkqfmsPyLIRzG9LmZ+rjmdGFBCyhGpnsSL4MB4xzHoeWmSVcumDiQ5QqPZcwGkszTgeJvjk2VjtiNw==",
-      "dev": true,
-      "requires": {
-        "archiver": "^3.0.0",
-        "async": "^2.0.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.1",
-        "q": "^1.5.1",
-        "request": "2.88.0",
-        "vargs": "^0.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
-          }
-        }
       }
     },
     "web-namespaces": {
@@ -8913,17 +8671,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    },
-    "zip-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
-      "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
-      "dev": true,
-      "requires": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^2.1.1",
-        "readable-stream": "^3.4.0"
-      }
     }
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -91,12 +91,12 @@
     "mocha": "7.1.2",
     "mocha-froth": "^0.2.10",
     "openapi-schema-validation": "^0.4.2",
+    "selenium-webdriver": "^4.0.0-beta.3",
     "set-cookie-parser": "^2.4.6",
     "sinon": "^9.2.0",
     "split-grid": "^1.0.11",
     "superagent": "^3.8.3",
-    "supertest": "4.0.2",
-    "wd": "1.12.1"
+    "supertest": "4.0.2"
   },
   "eslintConfig": {
     "ignorePatterns": [

--- a/src/tests/frontend/travis/remote_runner.js
+++ b/src/tests/frontend/travis/remote_runner.js
@@ -5,14 +5,8 @@
 process.on('unhandledRejection', (err) => { throw err; });
 
 const async = require('async');
-const wd = require('wd');
-
-const config = {
-  hostname: 'ondemand.saucelabs.com',
-  port: 80,
-  user: process.env.SAUCE_USER,
-  pwd: process.env.SAUCE_ACCESS_KEY,
-};
+const swd = require('selenium-webdriver');
+const swdChrome = require('selenium-webdriver/chrome');
 
 const isAdminRunner = process.argv[2] === 'admin';
 
@@ -31,19 +25,28 @@ const log = (msg, pfx = '') => {
 const finishedRegex = /FINISHED.*[0-9]+ tests passed, ([0-9]+) tests failed/;
 
 const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
-  const fullName = [process.env.GIT_HASH].concat(process.env.SAUCE_NAME || [], name).join(' - ');
-  testSettings.name = fullName;
-  testSettings.public = true;
-  testSettings.build = process.env.GIT_HASH;
-  // console.json can be downloaded via saucelabs,
-  // don't know how to print them into output of the tests
-  testSettings.extendedDebugging = true;
-  testSettings.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
-  const browser = wd.remote(config, 'promiseChain');
-  await browser.init(testSettings);
-  const url = `https://saucelabs.com/jobs/${browser.sessionID}`;
+  const chromeOptions = new swdChrome.Options()
+      .addArguments('use-fake-device-for-media-stream');
+  const driver = await new swd.Builder()
+      .usingServer('https://ondemand.saucelabs.com/wd/hub')
+      .withCapabilities(Object.assign({
+        'sauce:options': {
+          username: process.env.SAUCE_USERNAME,
+          accessKey: process.env.SAUCE_ACCESS_KEY,
+          name: [process.env.GIT_HASH].concat(process.env.SAUCE_NAME || [], name).join(' - '),
+          public: true,
+          build: process.env.GIT_HASH,
+          // console.json can be downloaded via saucelabs,
+          // don't know how to print them into output of the tests
+          extendedDebugging: true,
+          tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
+        },
+      }, testSettings))
+      .setChromeOptions(chromeOptions)
+      .build();
+  const url = `https://saucelabs.com/jobs/${(await driver.getSession()).getId()}`;
   try {
-    await browser.get('http://localhost:9001/tests/frontend/');
+    await driver.get('http://localhost:9001/tests/frontend/');
     log(`Remote sauce test started! ${url}`, pfx);
     // @TODO this should be configured in testSettings, see
     // https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Timeouts
@@ -60,7 +63,7 @@ const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
       return text.substring(skipChars);
     };
     while (true) {
-      const consoleText = await browser.eval(`(${remoteFn})(${JSON.stringify(logIndex)})`);
+      const consoleText = await driver.executeScript(remoteFn, logIndex);
       (consoleText ? consoleText.split('\n') : []).forEach((line) => log(line, pfx));
       logIndex += consoleText.length;
       const [finished, nFailedStr] = consoleText.match(finishedRegex) || [];
@@ -77,42 +80,41 @@ const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
     }
   } finally {
     log(`Remote sauce test finished! ${url}`, pfx);
-    await browser.quit();
+    await driver.quit();
   }
 }, 6); // run 6 tests in parrallel
 
 Promise.all([
   {
-    platform: 'macOS 11.00',
+    platformName: 'macOS 11.00',
     browserName: 'safari',
-    version: 'latest',
+    browserVersion: 'latest',
   },
   ...(isAdminRunner ? [] : [
     {
-      platform: 'Windows 10',
+      platformName: 'Windows 10',
       browserName: 'firefox',
-      version: 'latest',
+      browserVersion: 'latest',
     },
     {
-      platform: 'Windows 10',
+      platformName: 'Windows 10',
       browserName: 'MicrosoftEdge',
-      version: 'latest',
+      browserVersion: 'latest',
     },
     {
-      platform: 'Windows 10',
+      platformName: 'Windows 10',
       browserName: 'chrome',
-      version: 'latest',
-      args: ['--use-fake-device-for-media-stream'],
+      browserVersion: 'latest',
     },
     {
-      platform: 'Windows 7',
+      platformName: 'Windows 7',
       browserName: 'chrome',
-      version: '55.0',
-      args: ['--use-fake-device-for-media-stream'],
+      browserVersion: '55.0',
     },
   ]),
 ].map(async (testSettings) => {
-  const name = `${testSettings.browserName} ${testSettings.version}, ${testSettings.platform}`;
+  const name =
+      `${testSettings.browserName} ${testSettings.browserVersion}, ${testSettings.platformName}`;
   const pfx = `[${name}] `;
   try {
     await sauceTestWorker.push({name, pfx, testSettings});

--- a/src/tests/frontend/travis/remote_runner.js
+++ b/src/tests/frontend/travis/remote_runner.js
@@ -7,6 +7,7 @@ process.on('unhandledRejection', (err) => { throw err; });
 const async = require('async');
 const swd = require('selenium-webdriver');
 const swdChrome = require('selenium-webdriver/chrome');
+const swdFirefox = require('selenium-webdriver/firefox');
 
 const isAdminRunner = process.argv[2] === 'admin';
 
@@ -27,6 +28,9 @@ const finishedRegex = /FINISHED.*[0-9]+ tests passed, ([0-9]+) tests failed/;
 const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
   const chromeOptions = new swdChrome.Options()
       .addArguments('use-fake-device-for-media-stream', 'use-fake-ui-for-media-stream');
+  const firefoxOptions = new swdFirefox.Options()
+      .setPreference('media.navigator.permission.disabled', true)
+      .setPreference('media.navigator.streams.fake', true);
   const driver = await new swd.Builder()
       .usingServer('https://ondemand.saucelabs.com/wd/hub')
       .withCapabilities(Object.assign({
@@ -43,6 +47,7 @@ const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
         },
       }, testSettings))
       .setChromeOptions(chromeOptions)
+      .setFirefoxOptions(firefoxOptions)
       .build();
   const url = `https://saucelabs.com/jobs/${(await driver.getSession()).getId()}`;
   try {

--- a/src/tests/frontend/travis/remote_runner.js
+++ b/src/tests/frontend/travis/remote_runner.js
@@ -26,7 +26,7 @@ const finishedRegex = /FINISHED.*[0-9]+ tests passed, ([0-9]+) tests failed/;
 
 const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
   const chromeOptions = new swdChrome.Options()
-      .addArguments('use-fake-device-for-media-stream');
+      .addArguments('use-fake-device-for-media-stream', 'use-fake-ui-for-media-stream');
   const driver = await new swd.Builder()
       .usingServer('https://ondemand.saucelabs.com/wd/hub')
       .withCapabilities(Object.assign({

--- a/src/tests/frontend/travis/remote_runner.js
+++ b/src/tests/frontend/travis/remote_runner.js
@@ -50,9 +50,17 @@ const sauceTestWorker = async.queue(async ({name, pfx, testSettings}) => {
     const deadline = Date.now() + 14.5 * 60 * 1000; // Slightly less than overall test timeout.
     // how many characters of the log have been sent to travis
     let logIndex = 0;
+    const remoteFn = (skipChars) => {
+      const console = document.getElementById('console'); // eslint-disable-line no-undef
+      if (console == null) return '';
+      let text = '';
+      for (const n of console.childNodes) {
+        if (n.nodeType === n.TEXT_NODE) text += n.data;
+      }
+      return text.substring(skipChars);
+    };
     while (true) {
-      const remoteFn = ($, skipChars) => $('#console').text().substring(skipChars);
-      const consoleText = await browser.eval(`(${remoteFn})($, ${JSON.stringify(logIndex)})`);
+      const consoleText = await browser.eval(`(${remoteFn})(${JSON.stringify(logIndex)})`);
       (consoleText ? consoleText.split('\n') : []).forEach((line) => log(line, pfx));
       logIndex += consoleText.length;
       const [finished, nFailedStr] = consoleText.match(finishedRegex) || [];


### PR DESCRIPTION
Multiple commits:
* tests: Avoid jQuery when reading Mocha output
* tests: Migrate from `wd` to `selenium-webdriver`
* tests: Also pass `--use-fake-ui-for-media-stream` to Chrome
* tests: Configure Firefox to use fake webcam

Fixes #4344

cc @packardone