### PR TITLE
Docker: Multiple improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,17 @@ RUN groupadd --system ${EP_GID:+--gid "${EP_GID}" --non-unique} etherpad && \
 ARG EP_DIR=/opt/etherpad-lite
 RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 
-# install abiword for DOC/PDF/ODT export
-RUN [ -z "${INSTALL_ABIWORD}" ] || (apt update && apt -y install abiword && apt clean && rm -rf /var/lib/apt/lists/*)
-
-# install libreoffice for DOC/PDF/ODT export
-# the mkdir is needed for configuration of openjdk-11-jre-headless, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
-RUN [ -z "${INSTALL_SOFFICE}" ] || (apt update && mkdir -p /usr/share/man/man1 && apt -y install libreoffice && apt clean && rm -rf /var/lib/apt/lists/*)
+# the mkdir is needed for configuration of openjdk-11-jre-headless, see
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+RUN [ -n "${INSTALL_ABIWORD}${INSTALL_SOFFICE}" ] || exit 0; \
+    mkdir -p /usr/share/man/man1 && \
+    apt update && \
+    apt -y install \
+        ${INSTALL_ABIWORD:+abiword} \
+        ${INSTALL_SOFFICE:+libreoffice} \
+        && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER etherpad
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN [ -n "${INSTALL_ABIWORD}${INSTALL_SOFFICE}" ] || exit 0; \
     export DEBIAN_FRONTEND=noninteractive; \
     mkdir -p /usr/share/man/man1 && \
     apt-get -qq update && \
-    apt-get -qq install \
+    apt-get -qq --no-install-recommends install \
         ${INSTALL_ABIWORD:+abiword} \
         ${INSTALL_SOFFICE:+libreoffice} \
         && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,12 +59,12 @@ RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN [ -n "${INSTALL_ABIWORD}${INSTALL_SOFFICE}" ] || exit 0; \
     mkdir -p /usr/share/man/man1 && \
-    apt update && \
-    apt -y install \
+    apt-get -qq update && \
+    apt-get -qq install \
         ${INSTALL_ABIWORD:+abiword} \
         ${INSTALL_SOFFICE:+libreoffice} \
         && \
-    apt clean && \
+    apt-get -qq clean && \
     rm -rf /var/lib/apt/lists/*
 
 USER etherpad

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 # the mkdir is needed for configuration of openjdk-11-jre-headless, see
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN [ -n "${INSTALL_ABIWORD}${INSTALL_SOFFICE}" ] || exit 0; \
+    export DEBIAN_FRONTEND=noninteractive; \
     mkdir -p /usr/share/man/man1 && \
     apt-get -qq update && \
     apt-get -qq install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,10 @@ WORKDIR "${EP_DIR}"
 
 COPY --chown=etherpad:etherpad ./ ./
 
-# install node dependencies for Etherpad
 RUN src/bin/installDeps.sh && \
-	rm -rf ~/.npm/_cacache
-
-RUN [ -z "${ETHERPAD_PLUGINS}" ] || npm install --no-save ${ETHERPAD_PLUGINS}
+    { [ -z "${ETHERPAD_PLUGINS}" ] || \
+      npm install --no-save ${ETHERPAD_PLUGINS}; } && \
+    rm -rf ~/.npm
 
 # Copy the configuration file.
 COPY --chown=etherpad:etherpad ./settings.json.docker "${EP_DIR}"/settings.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,12 @@ RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 
 # the mkdir is needed for configuration of openjdk-11-jre-headless, see
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
-RUN [ -n "${INSTALL_ABIWORD}${INSTALL_SOFFICE}" ] || exit 0; \
-    export DEBIAN_FRONTEND=noninteractive; \
+RUN export DEBIAN_FRONTEND=noninteractive; \
     mkdir -p /usr/share/man/man1 && \
     apt-get -qq update && \
     apt-get -qq --no-install-recommends install \
+        ca-certificates \
+        git \
         ${INSTALL_ABIWORD:+abiword} \
         ${INSTALL_SOFFICE:+libreoffice} \
         && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ COPY --chown=etherpad:etherpad ./ ./
 RUN src/bin/installDeps.sh && \
 	rm -rf ~/.npm/_cacache
 
-RUN [ -z "${ETHERPAD_PLUGINS}" ] || npm install ${ETHERPAD_PLUGINS}
+RUN [ -z "${ETHERPAD_PLUGINS}" ] || npm install --no-save ${ETHERPAD_PLUGINS}
 
 # Copy the configuration file.
 COPY --chown=etherpad:etherpad ./settings.json.docker "${EP_DIR}"/settings.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,17 @@ WORKDIR "${EP_DIR}"
 
 COPY --chown=etherpad:etherpad ./ ./
 
-RUN src/bin/installDeps.sh && \
-    { [ -z "${ETHERPAD_PLUGINS}" ] || \
+# Plugins must be installed before installing Etherpad's dependencies, otherwise
+# npm will try to hoist common dependencies by removing them from
+# src/node_modules and installing them in the top-level node_modules. As of
+# v6.14.10, npm's hoist logic appears to be buggy, because it sometimes removes
+# dependencies from src/node_modules but fails to add them to the top-level
+# node_modules. Even if npm correctly hoists the dependencies, the hoisting
+# seems to confuse tools such as `npm outdated`, `npm update`, and some ESLint
+# rules.
+RUN { [ -z "${ETHERPAD_PLUGINS}" ] || \
       npm install --no-save ${ETHERPAD_PLUGINS}; } && \
+    src/bin/installDeps.sh && \
     rm -rf ~/.npm
 
 # Copy the configuration file.


### PR DESCRIPTION
Multiple commits:
* Docker: Don't create `package-lock.json` when installing plugins
* Docker: Nuke all of `~/.npm` after installing packages
* Docker: Install plugins before core deps
* Docker: Combine `abiword` and `libreoffice` install steps
* Docker: Use `apt-get` instead of `apt`
* Docker: Set `DEBIAN_FRONTEND=noninteractive` when running `apt-get`
* Docker: Pass `--no-install-recommends` to `apt-get intall`
* Docker: Install `git` and `ca-certificates` packages

@Evadon-Nathan would you please test this to see if it fixes plugin install and uninstall for you?

Note that unless you bind mount `${EP_DIR}/node_modules` to something on your host you will lose all changes to your installed plugins whenever you restart the container.

Fixes #5069