### PR TITLE
Pad: Fix `<script>` elements in `aceInitInnerdocbodyHead` hook

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -278,9 +278,8 @@ const Ace2Editor = function () {
     innerDocument.head.appendChild(innerStyle);
     const headLines = [];
     hooks.callAll('aceInitInnerdocbodyHead', {iframeHTML: headLines});
-    const tmp = innerDocument.createElement('div');
-    tmp.innerHTML = headLines.join('\n');
-    while (tmp.firstChild) innerDocument.head.appendChild(tmp.firstChild);
+    innerDocument.head.appendChild(
+        innerDocument.createRange().createContextualFragment(headLines.join('\n')));
 
     // <body> tag
     innerDocument.body.id = 'innerdocbody';


### PR DESCRIPTION
Using `.innerHTML` to create a `<script>` element does create a DOM node, but the script is not actually executed. Fortunately, creating a DocumentFragment does cause the script to execute.

Fixes ether/ep_prompt_for_name#3