### PR TITLE
bin/updatePlugins.sh: Many refinements

### DIFF
--- a/src/bin/updatePlugins.sh
+++ b/src/bin/updatePlugins.sh
@@ -1,20 +1,11 @@
 #!/bin/sh
-
-#Move to the folder where ep-lite is installed
-cd $(dirname $0)
-
-#Was this script started in the bin folder? if yes move out
-if [ -d "../bin" ]; then
-  cd "../"
-fi
-
-# npm outdated --depth=0 | grep -v "^Package" | awk '{print $1}' | xargs npm install $1 --save-dev
-OUTDATED=$(npm outdated --depth=0 | grep -v "^Package" | awk '{print $1}')
-# echo $OUTDATED
-if test -n "$OUTDATED"; then
-  echo "Plugins require update, doing this now..."
-  echo "Updating $OUTDATED"
-  npm install $OUTDATED --save-dev
-else
-  echo "Plugins are all up to date"
-fi
+set -e
+mydir=$(cd "${0%/*}" && pwd -P) || exit 1
+cd "${mydir}"/../..
+OUTDATED=$(npm outdated --depth=0 | awk '{print $1}' | grep '^ep_') || {
+  echo "All plugins are up-to-date"
+  exit 0
+}
+set -- ${OUTDATED}
+echo "Updating plugins: $*"
+exec npm install --no-save "$@"


### PR DESCRIPTION
  * cd to top-level Etherpad directory is now more robust.
  * Only attempt to update packages whose names begin with `ep_`.
  * Don't create `package-lock.json`.
  * Improve logging.
  * Improve error handling.