### PR TITLE
CSS: Move author color padding to `setAuthorStyle()`

### DIFF
--- a/src/static/css/iframe_editor.css
+++ b/src/static/css/iframe_editor.css
@@ -58,11 +58,6 @@ html.outer-editor, html.inner-editor {
   color: inherit;
 }
 
-#innerdocbody.authorColors span {
-  padding-top: 3px;
-  padding-bottom: 4px;
-}
-
 option {
   text-transform: capitalize;
 }

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -226,18 +226,18 @@ function Ace2Inner(editorInfo, cssManagers) {
       if ((typeof info.fade) === 'number') {
         bgcolor = fadeColor(bgcolor, info.fade);
       }
-
-      const authorStyle = cssManagers.inner.selectorStyle(authorSelector);
-      const parentAuthorStyle = cssManagers.parent.selectorStyle(authorSelector);
-
-      // author color
-      authorStyle.backgroundColor = bgcolor;
-      parentAuthorStyle.backgroundColor = bgcolor;
-
       const textColor =
           colorutils.textColorFromBackgroundColor(bgcolor, parent.parent.clientVars.skinName);
-      authorStyle.color = textColor;
-      parentAuthorStyle.color = textColor;
+      const styles = [
+        cssManagers.inner.selectorStyle(authorSelector),
+        cssManagers.parent.selectorStyle(authorSelector),
+      ];
+      for (const style of styles) {
+        style.backgroundColor = bgcolor;
+        style.color = textColor;
+        style['padding-top'] = '3px';
+        style['padding-bottom'] = '4px';
+      }
     }
   };
 


### PR DESCRIPTION
This prevents the padding from clashing with plugins that use the `aceSetAuthorStyle` hook.