### PR TITLE
stop closing feature requests by stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,7 @@ exemptLabels:
   - Black hole bug
   - Special case Bug
   - Upstream bug
+  - Feature Request
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
I feel like this is a good idea. We can easily filter feature requests in the issue tab and it's good to see open feature requests, that aren't implemented yet, but seem to be a good idea.
Stale should close issues that aren't labeled (at least as bug or feature request) when they didn't have activity for a longer time.