### PR TITLE
doc/docker.md - add sqlite to DB_FILENAME

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -102,7 +102,7 @@ The `settings.json.docker` available by default allows to control almost every s
 | `DB_USER`     | a database user with sufficient permissions to create tables   |                                                                       |
 | `DB_PASS`     | the password for the database username                         |                                                                       |
 | `DB_CHARSET`  | the character set for the tables (only required for MySQL)     |                                                                       |
-| `DB_FILENAME` | in case `DB_TYPE` is `DirtyDB`, the database filename.         | `var/dirty.db`                                                        |
+| `DB_FILENAME` | in case `DB_TYPE` is `DirtyDB` or `sqlite`, the database file. | `var/dirty.db`, `var/etherpad.sq3`                                    |
 
 If your database needs additional settings, you will have to use a personalized `settings.json.docker` and rebuild the container (or otherwise put the updated `settings.json` inside your image).
 


### PR DESCRIPTION
The configuration option `DB_FILENAME` is also used in conjunction with the `sqlite` ueberdb2 adapter.
