### PR TITLE
fix frontend tests

### DIFF
--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -7,15 +7,11 @@ const helper = {};
   const jsLibraries = {};
 
   helper.init = async () => {
-    [
-      jsLibraries.jquery,
-      jsLibraries.sendkeys,
-    ] = await Promise.all([
-      $.get('../../static/js/vendors/jquery.js'),
-      $.get('lib/sendkeys.js'),
-    ]);
     // make sure we don't override existing jquery
-    jsLibraries.jquery = `if (typeof $ === 'undefined') {\n${jsLibraries.jquery}\n}`;
+    jsLibraries.jquery = `if (typeof $ === 'undefined') {\n
+      ${await $.get('../../static/js/vendors/jquery.js')}\n}`;
+
+    jsLibraries.sendkeys = await $.get('lib/sendkeys.js');
   };
 
   helper.randomString = (len) => {


### PR DESCRIPTION
Partially revert 20df34bb67f2d45a714e9ce0652d8fd1ceaa434d as it was failing repeatedly in Safari on SL (in my environment it also failed with chrome/chromium).

I must admit, I don't really understand why, but https://github.com/ether/etherpad-lite/actions/workflows/frontend-tests.yml shows a long history of failing tests after that commit.