### PR TITLE
await more queries / handle Inactivity timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   from the database when the group is deleted.
 * Fixed race conditions in the `setText`, `appendText`, and `restoreRevision`
   functions (HTTP API).
+* Fixed a crash if the database is busy enough to cause a query timeout.
 
 #### For plugin authors
 

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -139,11 +139,11 @@ exports.getRevisionChangeset = async (padID, rev) => {
     }
 
     // get the changeset for this revision
-    return pad.getRevisionChangeset(rev);
+    return await pad.getRevisionChangeset(rev);
   }
 
   // the client wants the latest changeset, lets return it to him
-  return pad.getRevisionChangeset(head);
+  return await pad.getRevisionChangeset(head);
 };
 
 /**

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -376,12 +376,12 @@ Pad.prototype.copy = async function (destinationID, force) {
   // if force is true and already exists a Pad with the same id, remove that Pad
   await this.removePadIfForceIsTrueAndAlreadyExist(destinationID, force);
 
-  // copy the 'pad' entry
-  const pad = await this._db.get(`pad:${this.id}`);
-  db.set(`pad:${destinationID}`, pad);
-
-  // copy all relations in parallel
-  const promises = [];
+  // copy all records in parallel
+  const promises = [
+    // Copy the 'pad' entry. This is wrapped in an IIFE so that this._db.get() can run in parallel
+    // with the other record copies done below.
+    (async () => await db.set(`pad:${destinationID}`, await this._db.get(`pad:${this.id}`)))(),
+  ];
 
   // copy all chat messages
   const chatHead = this.chatHead;
@@ -399,7 +399,7 @@ Pad.prototype.copy = async function (destinationID, force) {
     promises.push(p);
   }
 
-  this.copyAuthorInfoToDestinationPad(destinationID);
+  promises.push(this.copyAuthorInfoToDestinationPad(destinationID));
 
   // wait for the above to complete
   await Promise.all(promises);
@@ -409,11 +409,8 @@ Pad.prototype.copy = async function (destinationID, force) {
     await db.setSub(`group:${destGroupID}`, ['pads', destinationID], 1);
   }
 
-  // delay still necessary?
-  await new Promise((resolve) => setTimeout(resolve, 10));
-
   // Initialize the new pad (will update the listAllPads cache)
-  await padManager.getPad(destinationID, null); // this runs too early.
+  await padManager.getPad(destinationID, null);
 
   // let the plugins know the pad was copied
   await hooks.aCallAll('padCopy', {originalPad: this, destinationID});
@@ -459,11 +456,10 @@ Pad.prototype.removePadIfForceIsTrueAndAlreadyExist = async function (destinatio
   }
 };
 
-Pad.prototype.copyAuthorInfoToDestinationPad = function (destinationID) {
+Pad.prototype.copyAuthorInfoToDestinationPad = async function (destinationID) {
   // add the new sourcePad to all authors who contributed to the old one
-  this.getAllAuthors().forEach((authorID) => {
-    authorManager.addPad(authorID, destinationID);
-  });
+  await Promise.all(this.getAllAuthors().map(
+      (authorID) => authorManager.addPad(authorID, destinationID)));
 };
 
 Pad.prototype.copyPadWithoutHistory = async function (destinationID, force) {
@@ -481,7 +477,7 @@ Pad.prototype.copyPadWithoutHistory = async function (destinationID, force) {
   const sourcePad = await padManager.getPad(sourceID);
 
   // add the new sourcePad to all authors who contributed to the old one
-  this.copyAuthorInfoToDestinationPad(destinationID);
+  await this.copyAuthorInfoToDestinationPad(destinationID);
 
   // Group pad? Add it to the group's list
   if (destGroupID) {

--- a/src/node/db/ReadOnlyManager.js
+++ b/src/node/db/ReadOnlyManager.js
@@ -41,8 +41,10 @@ exports.getReadOnlyId = async (padId) => {
   // there is no readOnly Entry in the database, let's create one
   if (readOnlyId == null) {
     readOnlyId = `r.${randomString(16)}`;
-    db.set(`pad2readonly:${padId}`, readOnlyId);
-    db.set(`readonly2pad:${readOnlyId}`, padId);
+    await Promise.all([
+      db.set(`pad2readonly:${padId}`, readOnlyId),
+      db.set(`readonly2pad:${readOnlyId}`, padId),
+    ]);
   }
 
   return readOnlyId;
@@ -52,7 +54,7 @@ exports.getReadOnlyId = async (padId) => {
  * returns the padId for a read only id
  * @param {String} readOnlyId read only id
  */
-exports.getPadId = (readOnlyId) => db.get(`readonly2pad:${readOnlyId}`);
+exports.getPadId = async (readOnlyId) => await db.get(`readonly2pad:${readOnlyId}`);
 
 /**
  * returns the padId and readonlyPadId in an object for any id

--- a/src/node/db/SessionStore.js
+++ b/src/node/db/SessionStore.js
@@ -17,18 +17,12 @@ const logger = log4js.getLogger('SessionStore');
 module.exports = class SessionStore extends Store {
   get(sid, fn) {
     logger.debug(`GET ${sid}`);
-    DB.db.get(`sessionstorage:${sid}`, (err, sess) => {
-      if (sess) {
-        sess.cookie.expires = ('string' === typeof sess.cookie.expires
-          ? new Date(sess.cookie.expires) : sess.cookie.expires);
-        if (!sess.cookie.expires || new Date() < sess.cookie.expires) {
-          fn(null, sess);
-        } else {
-          this.destroy(sid, fn);
-        }
-      } else {
-        fn();
-      }
+    DB.db.get(`sessionstorage:${sid}`, (err, s) => {
+      if (err != null) return fn(err);
+      if (!s) return fn(null);
+      if (typeof s.cookie.expires === 'string') s.cookie.expires = new Date(s.cookie.expires);
+      if (s.cookie.expires && new Date() >= s.cookie.expires) return this.destroy(sid, fn);
+      fn(null, s);
     });
   }
 

--- a/src/node/hooks/express/padurlsanitize.js
+++ b/src/node/hooks/express/padurlsanitize.js
@@ -4,24 +4,27 @@ const padManager = require('../../db/PadManager');
 
 exports.expressCreateServer = (hookName, args, cb) => {
   // redirects browser to the pad's sanitized url if needed. otherwise, renders the html
-  args.app.param('pad', async (req, res, next, padId) => {
-    // ensure the padname is valid and the url doesn't end with a /
-    if (!padManager.isValidPadId(padId) || /\/$/.test(req.url)) {
-      res.status(404).send('Such a padname is forbidden');
-      return;
-    }
+  args.app.param('pad', (req, res, next, padId) => {
+    (async () => {
+      // ensure the padname is valid and the url doesn't end with a /
+      if (!padManager.isValidPadId(padId) || /\/$/.test(req.url)) {
+        res.status(404).send('Such a padname is forbidden');
+        return;
+      }
 
-    const sanitizedPadId = await padManager.sanitizePadId(padId);
+      const sanitizedPadId = await padManager.sanitizePadId(padId);
 
-    if (sanitizedPadId === padId) {
-      // the pad id was fine, so just render it
-      next();
-    } else {
-      // the pad id was sanitized, so we redirect to the sanitized version
-      const realURL = encodeURIComponent(sanitizedPadId) + new URL(req.url, 'http://invalid.invalid').search;
-      res.header('Location', realURL);
-      res.status(302).send(`You should be redirected to <a href="${realURL}">${realURL}</a>`);
-    }
+      if (sanitizedPadId === padId) {
+        // the pad id was fine, so just render it
+        next();
+      } else {
+        // the pad id was sanitized, so we redirect to the sanitized version
+        const realURL =
+            encodeURIComponent(sanitizedPadId) + new URL(req.url, 'http://invalid.invalid').search;
+        res.header('Location', realURL);
+        res.status(302).send(`You should be redirected to <a href="${realURL}">${realURL}</a>`);
+      }
+    })().catch((err) => next(err || new Error(err)));
   });
   return cb();
 };


### PR DESCRIPTION
The relevant issue is https://github.com/ether/etherpad-lite/issues/5005

I still see crashes when configuring a READ LOCK. At one point we may need to shutdown Etherpad when there are lots of failing queries, however I think we need to be more robust.

The scenarios are probably one of either:
- read queries for large data or that scan the whole table can timeout
- all pool connection are used with long queries, when new queries arrived, so the latter timeout at one point

When loading pads when a READ LOCK is active, I see crashes due to:
- globalAuthor can't be set in `createAuthor`
- pad state can't be read (don't know which caller)

Theoretically any query can randomly fail (when running with READ or WRITE LOCK). In practice I assume that when all connections are used and long queries are running, at one point all new queries start to timeout and writes might be retried and at some point they start working again. Or they continue failing. The problem is, any of the database queries can start failing so we need to handle that at a lot of places.