### PR TITLE
error log uncaught exception

### DIFF
--- a/src/node/server.js
+++ b/src/node/server.js
@@ -113,7 +113,7 @@ exports.start = async () => {
     stats.gauge('memoryUsageHeap', () => process.memoryUsage().heapUsed);
 
     process.on('uncaughtException', (err) => {
-      logger.debug(`uncaught exception: ${err.stack || err}`);
+      logger.error(`uncaught exception: ${err.stack || err}`);
       exports.exit(err);
     });
     // As of v14, Node.js does not exit when there is an unhandled Promise rejection. Convert an


### PR DESCRIPTION
In situations with multiple error stack traces (like https://github.com/ether/etherpad-lite/issues/5005), when some of them are benign, it's hard to identify the bad stack trace unless using DEBUG loglevel.

With this PR we can clearly see all uncaught exceptions.