### PR TITLE
CSS: Underline links in error dialogs

### DIFF
--- a/src/static/css/pad/popup.css
+++ b/src/static/css/pad/popup.css
@@ -45,9 +45,6 @@
 .popup input[type=text], #users input[type=text] {
   outline: none;
 }
-.popup a {
-  text-decoration: none
-}
 .popup h1 {
   font-size: 1.8rem;
   margin-bottom: 10px;


### PR DESCRIPTION
Underlining was removed for unknown reasons by commit d872b42e31ec4698d9a9e0c3bc04e4f215ae7473.
