### PR TITLE
tests: fix unaccessible sendkeys

### DIFF
--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -4,19 +4,6 @@ const helper = {};
 
 (() => {
   let $iframe;
-  const jsLibraries = {};
-
-  helper.init = async () => {
-    [
-      jsLibraries.jquery,
-      jsLibraries.sendkeys,
-    ] = await Promise.all([
-      $.get('../../static/js/vendors/jquery.js'),
-      $.get('lib/sendkeys.js'),
-    ]);
-    // make sure we don't override existing jquery
-    jsLibraries.jquery = `if (typeof $ === 'undefined') {\n${jsLibraries.jquery}\n}`;
-  };
 
   helper.randomString = (len) => {
     const chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
@@ -28,20 +15,29 @@ const helper = {};
     return randomstring;
   };
 
-  const getFrameJQuery = ($iframe) => {
-    /*
-      I tried over 9001 ways to inject javascript into iframes.
-      This is the only way I found that worked in IE 7+8+9, FF and Chrome
-    */
+  const getFrameJQuery = async ($iframe, includeJquery = false, includeSendkeys = false) => {
     const win = $iframe[0].contentWindow;
     const doc = win.document;
 
-    // IE 8+9 Hack to make eval appear
-    // https://stackoverflow.com/q/2720444
-    win.execScript && win.execScript('null');
+    const load = async (url) => {
+      const elem = doc.createElement('script');
+      elem.setAttribute('src', url);
+      const p = new Promise((resolve, reject) => {
+        const handler = (evt) => {
+          elem.removeEventListener('load', handler);
+          elem.removeEventListener('error', handler);
+          if (evt.type === 'error') return reject(new Error(`failed to load ${url}`));
+          resolve();
+        };
+        elem.addEventListener('load', handler);
+        elem.addEventListener('error', handler);
+      });
+      doc.head.appendChild(elem);
+      await p;
+    };
 
-    win.eval(jsLibraries.jquery);
-    win.eval(jsLibraries.sendkeys);
+    if (!win.$ && includeJquery) await load('../../static/js/vendors/jquery.js');
+    if (!win.bililiteRange && includeSendkeys) await load('../tests/frontend/lib/sendkeys.js');
 
     win.$.window = win;
     win.$.document = doc;
@@ -125,7 +121,7 @@ const helper = {};
     // set new iframe
     $('#iframe-container').append($iframe);
     await new Promise((resolve) => $iframe.one('load', resolve));
-    helper.padChrome$ = getFrameJQuery($('#iframe-container iframe'));
+    helper.padChrome$ = await getFrameJQuery($('#iframe-container iframe'), true, true);
     helper.padChrome$.padeditor =
         helper.padChrome$.window.require('ep_etherpad-lite/static/js/pad_editor').padeditor;
     if (opts.clearCookies) {
@@ -141,8 +137,10 @@ const helper = {};
       if (opts._retry++ >= 4) throw new Error('Pad never loaded');
       return await helper.aNewPad(opts);
     }
-    helper.padOuter$ = getFrameJQuery(helper.padChrome$('iframe[name="ace_outer"]'));
-    helper.padInner$ = getFrameJQuery(helper.padOuter$('iframe[name="ace_inner"]'));
+    helper.padOuter$ = await getFrameJQuery(
+        helper.padChrome$('iframe[name="ace_outer"]'), true, false);
+    helper.padInner$ = await getFrameJQuery(
+        helper.padOuter$('iframe[name="ace_inner"]'), true, true);
 
     // disable all animations, this makes tests faster and easier
     helper.padChrome$.fx.off = true;
@@ -184,8 +182,8 @@ const helper = {};
     $('#iframe-container iframe').remove();
     // set new iframe
     $('#iframe-container').append($iframe);
-    $iframe.one('load', () => {
-      helper.admin$ = getFrameJQuery($('#iframe-container iframe'));
+    $iframe.one('load', async () => {
+      helper.admin$ = await getFrameJQuery($('#iframe-container iframe'), true, false);
     });
   };
 

--- a/src/tests/frontend/index.html
+++ b/src/tests/frontend/index.html
@@ -16,6 +16,7 @@
 
     <script src="../../static/js/require-kernel.js"></script>
     <script src="../../static/js/vendors/jquery.js"></script>
+    <script src="lib/sendkeys.js"></script>
     <script src="../../static/js/vendors/browser.js"></script>
     <script src="../../static/plugins/js-cookie/src/js.cookie.js"></script>
     <script src="lib/underscore.js"></script>

--- a/src/tests/frontend/runner.js
+++ b/src/tests/frontend/runner.js
@@ -314,7 +314,6 @@ $(() => (async () => {
   }
   $progressArea.remove();
 
-  await helper.init();
   const grep = getURLParameter('grep');
   if (grep != null) {
     mocha.grep(grep);


### PR DESCRIPTION
My idea in https://github.com/ether/etherpad-lite/pull/5103 didn't work, but I have some new insights: I can reproduce this reliably in Chromium when I disable cache and use a remote server, so there is some latency between requests.

sendkeys depends on jQuery to be loaded first. When cache is enabled, jQuery is downloaded via https://github.com/ether/etherpad-lite/blob/develop/src/tests/frontend/index.html#L18 and all later requests are cached, so when issuing the get requests with Promise.all, jQuery will immediately load and sendkeys will work properly.

However, when in a non-cached, higher latency scenario, jQuery will almost always be received after sendkeys was received, because the size of the jQuery file is larger (uncompressed 257kb vs 19kb), so sendkeys gets executed before jQuery was loaded and in essence, sendkeys is not available. Also other tests that require sendkeys will fail. It works again as soon as cache is enabled.

I verified the load sequence with some console.log messages that were placed at the top of the IIFE in sendkeys and jquery respectivily. You can see the load sequence of a failing test below. In cases when the test was successful, jquery preceeds sendkeys at the "<----helper.init" mark.
```
Navigated to http://localhost:8000/tests/frontend/?grep=large%20font
jquery.js:14 evaluating jquery, window is  <----src/tests/frontend/index.html
require-kernel.js:10 [Deprecation] Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.
VM6899:380 evaluating sendkeys, window is <----helper.init
VM6900:14 evaluating jquery, window is <----helper.init
ace2_common.js?callb…efine&v=d6dcf1fc:27 evaluating jquery, window is  <----src/templates/pad.html
VM6915:380 evaluating sendkeys, window is <----src/templates/pad.html
VM6930:29 evaluating jquery, window is ace_inner <----getFrameJQuery
VM6932:15 evaluating jquery, window is ace_outer <----getFrameJQuery
VM6933:380 evaluating sendkeys, window is ace_outer <----getFrameJQuery
VM6935:380 evaluating sendkeys, window is ace_inner <----getFrameJQuery
```

The reason why it's only failing in Safari when running on SL is still unclear to me (probably Safari has another cache strategy). 