### PR TITLE
Fix settings.useMonospaceFontGlobal

### DIFF
--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -338,7 +338,7 @@ const handshake = () => {
 
       // If the Monospacefont value is set to true then change it to monospace.
       if (settings.useMonospaceFontGlobal === true) {
-        pad.changeViewOption('padFontFamily', 'monospace');
+        pad.changeViewOption('padFontFamily', 'RobotoMono');
       }
       // if the globalUserName value is set we need to tell the server and
       // the client about the new authorname


### PR DESCRIPTION
When settings.useMonospaceFontGlobal is set to `true`, it sets the default
font to 'monospace'. This font seems to have been removed in
a5164dad430d99f1fc0a7fd045c37ce56e70efa6.

This commit sets the default font to "RobotoMono" which is a valid
option.

Tested in a Docker environment, setting `PAD_OPTIONS_USE_MONOSPACE_FONT`
to `true`

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
