### PR TITLE
Chat: Input text area improvements

### DIFF
--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -109,6 +109,7 @@
 }
 #chatinputbox #chatinput {
   width: 100%;
+  resize: vertical;
 }
 
 

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -92,6 +92,7 @@
 #chattext p {
   padding: 3px;
   overflow-x: hidden;
+  white-space: pre-wrap;
   word-wrap: break-word;
 }
 #chattext .time {

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -238,7 +238,7 @@ exports.chat = (() => {
 
       $('#chatinput').keypress((evt) => {
         // if the user typed enter, fire the send
-        if (evt.key === 'Enter') {
+        if (evt.key === 'Enter' && !evt.shiftKey) {
           evt.preventDefault();
           this.send();
         }

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -238,7 +238,7 @@ exports.chat = (() => {
 
       $('#chatinput').keypress((evt) => {
         // if the user typed enter, fire the send
-        if (evt.which === 13 || evt.which === 10) {
+        if (evt.key === 'Enter') {
           evt.preventDefault();
           this.send();
         }

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -388,7 +388,7 @@
             </div>
             <div id="chatinputbox">
                 <form>
-                    <input id="chatinput" type="text" maxlength="999" data-l10n-id="pad.chat.writeMessage.placeholder">
+                    <textarea id="chatinput" maxlength="999" data-l10n-id="pad.chat.writeMessage.placeholder"></textarea>
                 </form>
             </div>
           </div>

--- a/src/tests/frontend/lib/sendkeys.js
+++ b/src/tests/frontend/lib/sendkeys.js
@@ -426,8 +426,8 @@ $.fn.sendkeys.defaults = {
   '{enter}': function (rng){
     rng.insertEOL();
     rng.select();
-    var x = '\n'.charCodeAt(0);
-    $(rng._el).trigger({type: 'keypress', keyCode: x, which: x, charCode: x});
+    $(rng._el).trigger(
+        {type: 'keypress', keyCode: 13, which: 13, charCode: 13, code: 'Enter', key: 'Enter'});
   },
   '{backspace}': function (rng){
     var b = rng.bounds();

--- a/src/tests/frontend/specs/change_user_color.js
+++ b/src/tests/frontend/specs/change_user_color.js
@@ -89,7 +89,6 @@ describe('change user color', function () {
     $chatButton.click();
     const $chatInput = chrome$('#chatinput');
     $chatInput.sendkeys('O hi'); // simulate a keypress of typing user
-    // simulate a keypress of enter actually does evt.which = 10 not 13
     $chatInput.sendkeys('{enter}');
 
     // wait until the chat message shows up

--- a/src/tests/frontend/specs/chat.js
+++ b/src/tests/frontend/specs/chat.js
@@ -25,7 +25,9 @@ describe('Chat messages and UI', function () {
     const username = helper.chatTextParagraphs().children('b').text();
     const time = helper.chatTextParagraphs().children('.time').text();
 
-    expect(helper.chatTextParagraphs().text()).to.be(`${username}${time} ${chatValue}`);
+    // TODO: The '\n' is an artifact of $.sendkeys('{enter}'). Figure out how to get rid of it
+    // without breaking the other tests that use $.sendkeys().
+    expect(helper.chatTextParagraphs().text()).to.be(`${username}${time} ${chatValue}\n`);
 
     await helper.hideChat();
   });
@@ -46,7 +48,9 @@ describe('Chat messages and UI', function () {
     const username = chat.children('b').text();
     const time = chat.children('.time').text();
 
-    expect(chat.text()).to.be(`${username}${time} ${chatValue}`);
+    // TODO: Each '\n' is an artifact of $.sendkeys('{enter}'). Figure out how to get rid of them
+    // without breaking the other tests that use $.sendkeys().
+    expect(chat.text()).to.be(`${username}${time} \n${chatValue}\n`);
   });
 
   it('makes chat stick to right side of the screen via settings, ' +


### PR DESCRIPTION
Multiple commits:
* tests: sendkeys: Fix `{enter}` keypress event
* Chat: Use a `<textarea>` for message input
* Chat: Display whitespace in chat messages
* Chat: Use `KeyboardEvent.key` instead of deprecated `.which`
* Chat: Allow Shift-Enter to insert a newline

cc @packardone