### PR TITLE
This fixes an issue with lost bold formatting when copying bold text.

### DIFF
--- a/src/static/css/pad/normalize.css
+++ b/src/static/css/pad/normalize.css
@@ -125,7 +125,6 @@ abbr[title] {
  * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
  */
 
-b,
 strong {
   font-weight: bold;
 }


### PR DESCRIPTION
Fixes https://github.com/ether/etherpad-lite/issues/5037

I'm not sure this is the right way, maybe someone else knows it. I observed the following behavior: When I make a line bold and put it into clipboard, apply the patch, restart/reload, and paste it, the text still looses formatting. So it could be that something in our copy&paste logic is wrong (maybe the serialization that's done in contentcollector or https://github.com/ether/etherpad-lite/issues/4668)

