### PR TITLE
Fix adminsettings test

### DIFF
--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Write custom settings.json that enables the Admin UI tests
       run: "sed -i 's/\"enableAdminUITests\": false/\"enableAdminUITests\": true,\\n\"users\":{\"admin\":{\"password\":\"changeme\",\"is_admin\":true}}/' settings.json"
 
+    - name: increase maxHttpBufferSize
+      run: "sed -i 's/\"maxHttpBufferSize\": 10000/\"maxHttpBufferSize\": 100000/' settings.json"
+
     - name: Remove standard frontend test files, so only admin tests are run
       run: mv src/tests/frontend/specs/* /tmp && mv /tmp/admin*.js src/tests/frontend/specs
 

--- a/src/tests/frontend/specs/adminsettings.js
+++ b/src/tests/frontend/specs/adminsettings.js
@@ -38,7 +38,8 @@ describe('Admin > Settings', function () {
     // reset it to the old value
     helper.newAdmin('settings');
     await helper.waitForPromise(
-        () => helper.admin$ && helper.admin$('.settings').val().length > 0, 20000);
+        () => helper.admin$ &&
+                helper.admin$('.settings').val().length === settingsLength + 11, 20000);
 
     // replace the test value with a line break
     helper.admin$('.settings').val((_, text) => text.replace('/* test */\n', ''));
@@ -50,12 +51,11 @@ describe('Admin > Settings', function () {
     // settings should have the old value
     helper.newAdmin('settings');
     await helper.waitForPromise(
-        () => helper.admin$ && helper.admin$('.settings').val().length > 0, 36000);
-    expect(settings).to.be(helper.admin$('.settings').val());
+        () => helper.admin$ && helper.admin$('.settings').val().length === settingsLength &&
+          settings === helper.admin$('.settings').val(), 20000);
   });
 
   it('restart works', async function () {
-    this.timeout(60000);
     const getStartTime = async () => {
       try {
         const {httpStartTime} = await $.ajax({
@@ -66,6 +66,8 @@ describe('Admin > Settings', function () {
         });
         return httpStartTime;
       } catch (err) {
+        document.getElementById('console').append(
+            `an error occurred: ${err.message} of type ${err.name}\n`);
         return null;
       }
     };

--- a/src/tests/frontend/specs/adminsettings.js
+++ b/src/tests/frontend/specs/adminsettings.js
@@ -21,6 +21,16 @@ describe('Admin > Settings', function () {
   });
 
   it('Are Settings visible, populated, does save work', async function () {
+    const save = async () => {
+      const p = new Promise((resolve) => {
+        const observer = new MutationObserver(() => { resolve(); observer.disconnect(); });
+        observer.observe(
+            helper.admin$('#response')[0], {attributes: true, childList: false, subtree: false});
+      });
+      helper.admin$('#saveSettings').click();
+      await p;
+    };
+
     // save old value
     const settings = helper.admin$('.settings').val();
     const settingsLength = settings.length;
@@ -29,10 +39,7 @@ describe('Admin > Settings', function () {
     helper.admin$('.settings').val((_, text) => `/* test */\n${text}`);
     await helper.waitForPromise(
         () => settingsLength + 11 === helper.admin$('.settings').val().length, 5000);
-
-    // saves
-    helper.admin$('#saveSettings').click();
-    await helper.waitForPromise(() => helper.admin$('#response').is(':visible'), 5000);
+    await save();
 
     // new value for settings.json should now be saved
     // reset it to the old value
@@ -44,9 +51,7 @@ describe('Admin > Settings', function () {
     // replace the test value with a line break
     helper.admin$('.settings').val((_, text) => text.replace('/* test */\n', ''));
     await helper.waitForPromise(() => settingsLength === helper.admin$('.settings').val().length);
-
-    helper.admin$('#saveSettings').click(); // saves
-    await helper.waitForPromise(() => helper.admin$('#response').is(':visible'));
+    await save();
 
     // settings should have the old value
     helper.newAdmin('settings');

--- a/src/tests/frontend/specs/adminsettings.js
+++ b/src/tests/frontend/specs/adminsettings.js
@@ -69,15 +69,15 @@ describe('Admin > Settings', function () {
         return null;
       }
     };
+    let oldStartTime;
     await helper.waitForPromise(async () => {
-      const startTime = await getStartTime();
-      return startTime != null && startTime > 0 && Date.now() > startTime;
+      oldStartTime = await getStartTime();
+      return oldStartTime != null && oldStartTime > 0;
     }, 1000, 500);
-    const clickTime = Date.now();
     helper.admin$('#restartEtherpad').click();
     await helper.waitForPromise(async () => {
       const startTime = await getStartTime();
-      return startTime != null && startTime >= clickTime;
+      return startTime != null && startTime > oldStartTime;
     }, 60000, 500);
   });
 });

--- a/src/tests/frontend/specs/adminupdateplugins.js
+++ b/src/tests/frontend/specs/adminupdateplugins.js
@@ -28,8 +28,8 @@ describe('Plugins page', function () {
 
   it('Searches for plugin', async function () {
     helper.admin$('#search-query').val('ep_font_color');
-    await helper.waitForPromise(() => helper.admin$('.results').children().length < 300, 5000);
-    await helper.waitForPromise(() => helper.admin$('.results').children().length > 0, 5000);
+    await helper.waitForPromise(() => helper.admin$('.results').children().length > 0, 10000);
+    await helper.waitForPromise(() => helper.admin$('.results').children().length < 300, 10000);
   });
 
   it('Attempt to Update a plugin', async function () {


### PR DESCRIPTION
The adminsettings.js test was flaky. This PR:
- increases maxHttpBufferSize so that settings.json fits into socketio messages (I'm not sure how it's possible the test was green sometimes)
- avoids comparing the timestamp/clock of the SauceLabs runner and Etherpad instance. When `Date.now()` on SL is in the past (compared to the Etherpad server), tests no longer fail.
- adds a method to log messages to the DOM which are printed when the test suite finishes. It's mainly for debugging but I thought it could be helpful to others. Most Chrome and Firefox versions on SL have a console.json file attached to the test run, but Safari does not.