### PR TITLE
ace.js: Don't use srcdoc when creating iframes

### DIFF
--- a/src/static/empty.html
+++ b/src/static/empty.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>Empty</title></head><body></body></html>

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -197,7 +197,9 @@ const Ace2Editor = function () {
     //   - Chrome never fires any events on the frame or document. Eventually the document's
     //     readyState becomes 'complete' even though it never fires a readystatechange event.
     //   - Safari behaves like Chrome.
-    outerFrame.srcdoc = '<!DOCTYPE html>';
+    // srcdoc is avoided because Firefox's Content Security Policy engine does not properly handle
+    // 'self' with nested srcdoc iframes: https://bugzilla.mozilla.org/show_bug.cgi?id=1721296
+    outerFrame.src = '../static/empty.html';
     info.frame = outerFrame;
     document.getElementById(containerId).appendChild(outerFrame);
     const outerWindow = outerFrame.contentWindow;
@@ -240,7 +242,7 @@ const Ace2Editor = function () {
     innerFrame.allowTransparency = true; // for IE
     // The iframe MUST have a src or srcdoc property to avoid browser quirks. See the comment above
     // outerFrame.srcdoc.
-    innerFrame.srcdoc = '<!DOCTYPE html>';
+    innerFrame.src = 'empty.html';
     outerDocument.body.insertBefore(innerFrame, outerDocument.body.firstChild);
     const innerWindow = innerFrame.contentWindow;
 

--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -241,7 +241,6 @@ const Ace2Editor = function () {
     // The iframe MUST have a src or srcdoc property to avoid browser quirks. See the comment above
     // outerFrame.srcdoc.
     innerFrame.srcdoc = '<!DOCTYPE html>';
-    innerFrame.ace_outerWin = outerWindow;
     outerDocument.body.insertBefore(innerFrame, outerDocument.body.firstChild);
     const innerWindow = innerFrame.contentWindow;
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -60,10 +60,10 @@ function Ace2Inner(editorInfo, cssManagers) {
     window.focus();
   };
 
-  const iframe = window.frameElement;
   const outerWin = window.parent;
-  const sideDiv = iframe.nextSibling;
-  const lineMetricsDiv = sideDiv.nextSibling;
+  const outerDoc = outerWin.document;
+  const sideDiv = outerDoc.getElementById('sidediv');
+  const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
   let lineNumbersShown;
   let sideDivInner;
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -61,8 +61,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const iframe = window.frameElement;
-  const outerWin = iframe.ace_outerWin;
-  iframe.ace_outerWin = null; // prevent IE 6 memory leak
+  const outerWin = window.parent;
   const sideDiv = iframe.nextSibling;
   const lineMetricsDiv = sideDiv.nextSibling;
   let lineNumbersShown;


### PR DESCRIPTION
Using srcdoc, especially with multiple nested iframes, seems to be
problematic when using `self` in CSP policies.

Fixes #4975