### PR TITLE
Accessibility fix for JAWS screen readers

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -284,7 +284,6 @@ const Ace2Editor = function () {
     // <body> tag
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
-    innerDocument.body.setAttribute('role', 'application');
     innerDocument.body.setAttribute('spellcheck', 'false');
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
 

--- a/src/static/js/domline.js
+++ b/src/static/js/domline.js
@@ -61,6 +61,8 @@ domline.createDomLine = (nonEmpty, doesWrap, optBrowser, optDocument) => {
 
   if (document) {
     result.node = document.createElement('div');
+    // JAWS and NVDA screen reader compatibility. Only needed if in a real browser.
+    result.node.setAttribute('aria-live', 'assertive');
   } else {
     result.node = {
       innerHTML: '',


### PR DESCRIPTION
ace.js: removed the role 'application' from innerDocument.body. JAWS do not read any text from the edit lines if this role is set.

domline.createDomLine: to give JAWS the ability to read the lines correctly, it is required to set the attribute 'aria-live' to 'assertive'.
