### PR TITLE
pad_editbar: Various cleanups

### DIFF
--- a/doc/api/editbar.md
+++ b/doc/api/editbar.md
@@ -5,7 +5,7 @@ src/static/js/pad_editbar.js
 
 ## disable()
 
-## toggleDropDown(dropdown, callback)
+## toggleDropDown(dropdown)
 Shows the dropdown `div.popup` whose `id` equals `dropdown`.
 
 ## registerCommand(cmd, callback)

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -79,7 +79,7 @@ ToolbarItem.prototype.bind = function (callback) {
 
 
 const padeditbar = (() => {
-  const syncAnimationFn = () => {
+  const syncAnimation = (() => {
     const SYNCING = -100;
     const DONE = 100;
     let state = DONE;
@@ -122,8 +122,7 @@ const padeditbar = (() => {
         animator.scheduleAnimation();
       },
     };
-  };
-  const syncAnimation = syncAnimationFn();
+  })();
 
   return {
     _editbarPosition: 0,

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -125,7 +125,7 @@ const padeditbar = (() => {
   };
   const syncAnimation = syncAnimationFn();
 
-  const self = {
+  return {
     _editbarPosition: 0,
 
     init() {
@@ -150,7 +150,7 @@ const padeditbar = (() => {
       this.checkAllIconsAreDisplayedInToolbar();
       $(window).resize(_.debounce(() => this.checkAllIconsAreDisplayedInToolbar(), 100));
 
-      registerDefaultCommands(this);
+      this._registerDefaultCommands();
 
       hooks.callAll('postToolbarInit', {
         toolbar: this,
@@ -356,136 +356,133 @@ const padeditbar = (() => {
         }
       }
     },
-  };
 
-  const aceAttributeCommand = (cmd, ace) => {
-    ace.ace_toggleAttributeOnSelection(cmd);
-  };
+    _registerDefaultCommands() {
+      this.registerDropdownCommand('showusers', 'users');
+      this.registerDropdownCommand('settings');
+      this.registerDropdownCommand('connectivity');
+      this.registerDropdownCommand('import_export');
+      this.registerDropdownCommand('embed');
 
-  const registerDefaultCommands = (toolbar) => {
-    toolbar.registerDropdownCommand('showusers', 'users');
-    toolbar.registerDropdownCommand('settings');
-    toolbar.registerDropdownCommand('connectivity');
-    toolbar.registerDropdownCommand('import_export');
-    toolbar.registerDropdownCommand('embed');
-
-    toolbar.registerCommand('settings', () => {
-      toolbar.toggleDropDown('settings', () => {
-        $('#options-stickychat').focus();
+      this.registerCommand('settings', () => {
+        this.toggleDropDown('settings', () => {
+          $('#options-stickychat').focus();
+        });
       });
-    });
 
-    toolbar.registerCommand('import_export', () => {
-      toolbar.toggleDropDown('import_export', () => {
-        // If Import file input exists then focus on it..
-        if ($('#importfileinput').length !== 0) {
-          setTimeout(() => {
-            $('#importfileinput').focus();
-          }, 100);
-        } else {
-          $('.exportlink').first().focus();
-        }
+      this.registerCommand('import_export', () => {
+        this.toggleDropDown('import_export', () => {
+          // If Import file input exists then focus on it..
+          if ($('#importfileinput').length !== 0) {
+            setTimeout(() => {
+              $('#importfileinput').focus();
+            }, 100);
+          } else {
+            $('.exportlink').first().focus();
+          }
+        });
       });
-    });
 
-    toolbar.registerCommand('showusers', () => {
-      toolbar.toggleDropDown('users', () => {
-        $('#myusernameedit').focus();
+      this.registerCommand('showusers', () => {
+        this.toggleDropDown('users', () => {
+          $('#myusernameedit').focus();
+        });
       });
-    });
 
-    toolbar.registerCommand('embed', () => {
-      toolbar.setEmbedLinks();
-      toolbar.toggleDropDown('embed', () => {
-        $('#linkinput').focus().select();
+      this.registerCommand('embed', () => {
+        this.setEmbedLinks();
+        this.toggleDropDown('embed', () => {
+          $('#linkinput').focus().select();
+        });
       });
-    });
 
-    toolbar.registerCommand('savedRevision', () => {
-      padsavedrevs.saveNow();
-    });
+      this.registerCommand('savedRevision', () => {
+        padsavedrevs.saveNow();
+      });
 
-    toolbar.registerCommand('showTimeSlider', () => {
-      document.location = `${document.location.pathname}/timeslider`;
-    });
+      this.registerCommand('showTimeSlider', () => {
+        document.location = `${document.location.pathname}/timeslider`;
+      });
 
-    toolbar.registerAceCommand('bold', aceAttributeCommand);
-    toolbar.registerAceCommand('italic', aceAttributeCommand);
-    toolbar.registerAceCommand('underline', aceAttributeCommand);
-    toolbar.registerAceCommand('strikethrough', aceAttributeCommand);
+      const aceAttributeCommand = (cmd, ace) => {
+        ace.ace_toggleAttributeOnSelection(cmd);
+      };
+      this.registerAceCommand('bold', aceAttributeCommand);
+      this.registerAceCommand('italic', aceAttributeCommand);
+      this.registerAceCommand('underline', aceAttributeCommand);
+      this.registerAceCommand('strikethrough', aceAttributeCommand);
 
-    toolbar.registerAceCommand('undo', (cmd, ace) => {
-      ace.ace_doUndoRedo(cmd);
-    });
+      this.registerAceCommand('undo', (cmd, ace) => {
+        ace.ace_doUndoRedo(cmd);
+      });
 
-    toolbar.registerAceCommand('redo', (cmd, ace) => {
-      ace.ace_doUndoRedo(cmd);
-    });
+      this.registerAceCommand('redo', (cmd, ace) => {
+        ace.ace_doUndoRedo(cmd);
+      });
 
-    toolbar.registerAceCommand('insertunorderedlist', (cmd, ace) => {
-      ace.ace_doInsertUnorderedList();
-    });
-
-    toolbar.registerAceCommand('insertorderedlist', (cmd, ace) => {
-      ace.ace_doInsertOrderedList();
-    });
-
-    toolbar.registerAceCommand('indent', (cmd, ace) => {
-      if (!ace.ace_doIndentOutdent(false)) {
+      this.registerAceCommand('insertunorderedlist', (cmd, ace) => {
         ace.ace_doInsertUnorderedList();
-      }
-    });
+      });
 
-    toolbar.registerAceCommand('outdent', (cmd, ace) => {
-      ace.ace_doIndentOutdent(true);
-    });
+      this.registerAceCommand('insertorderedlist', (cmd, ace) => {
+        ace.ace_doInsertOrderedList();
+      });
 
-    toolbar.registerAceCommand('clearauthorship', (cmd, ace) => {
-      // If we have the whole document selected IE control A has been hit
-      const rep = ace.ace_getRep();
-      let doPrompt = false;
-      const lastChar = rep.lines.atIndex(rep.lines.length() - 1).width - 1;
-      const lastLineIndex = rep.lines.length() - 1;
-      if (rep.selStart[0] === 0 && rep.selStart[1] === 0) {
-        // nesting intentionally here to make things readable
-        if (rep.selEnd[0] === lastLineIndex && rep.selEnd[1] === lastChar) {
-          doPrompt = true;
+      this.registerAceCommand('indent', (cmd, ace) => {
+        if (!ace.ace_doIndentOutdent(false)) {
+          ace.ace_doInsertUnorderedList();
         }
-      }
-      /*
-      * NOTICE: This command isn't fired on Control Shift C.
-      * I intentionally didn't create duplicate code because if you are hitting
-      * Control Shift C we make the assumption you are a "power user"
-      * and as such we assume you don't need the prompt to bug you each time!
-      * This does make wonder if it's worth having a checkbox to avoid being
-      * prompted again but that's probably overkill for this contribution.
-      */
+      });
 
-      // if we don't have any text selected, we have a caret or we have already said to prompt
-      if ((!(rep.selStart && rep.selEnd)) || ace.ace_isCaret() || doPrompt) {
-        if (window.confirm(html10n.get('pad.editbar.clearcolors'))) {
-          ace.ace_performDocumentApplyAttributesToCharRange(0, ace.ace_getRep().alltext.length, [
-            ['author', ''],
-          ]);
+      this.registerAceCommand('outdent', (cmd, ace) => {
+        ace.ace_doIndentOutdent(true);
+      });
+
+      this.registerAceCommand('clearauthorship', (cmd, ace) => {
+        // If we have the whole document selected IE control A has been hit
+        const rep = ace.ace_getRep();
+        let doPrompt = false;
+        const lastChar = rep.lines.atIndex(rep.lines.length() - 1).width - 1;
+        const lastLineIndex = rep.lines.length() - 1;
+        if (rep.selStart[0] === 0 && rep.selStart[1] === 0) {
+          // nesting intentionally here to make things readable
+          if (rep.selEnd[0] === lastLineIndex && rep.selEnd[1] === lastChar) {
+            doPrompt = true;
+          }
         }
-      } else {
-        ace.ace_setAttributeOnSelection('author', '');
-      }
-    });
+        /*
+         * NOTICE: This command isn't fired on Control Shift C.
+         * I intentionally didn't create duplicate code because if you are hitting
+         * Control Shift C we make the assumption you are a "power user"
+         * and as such we assume you don't need the prompt to bug you each time!
+         * This does make wonder if it's worth having a checkbox to avoid being
+         * prompted again but that's probably overkill for this contribution.
+         */
 
-    toolbar.registerCommand('timeslider_returnToPad', (cmd) => {
-      if (document.referrer.length > 0 &&
+        // if we don't have any text selected, we have a caret or we have already said to prompt
+        if ((!(rep.selStart && rep.selEnd)) || ace.ace_isCaret() || doPrompt) {
+          if (window.confirm(html10n.get('pad.editbar.clearcolors'))) {
+            ace.ace_performDocumentApplyAttributesToCharRange(0, ace.ace_getRep().alltext.length, [
+              ['author', ''],
+            ]);
+          }
+        } else {
+          ace.ace_setAttributeOnSelection('author', '');
+        }
+      });
+
+      this.registerCommand('timeslider_returnToPad', (cmd) => {
+        if (document.referrer.length > 0 &&
             document.referrer.substring(document.referrer.lastIndexOf('/') - 1,
                 document.referrer.lastIndexOf('/')) === 'p') {
-        document.location = document.referrer;
-      } else {
-        document.location = document.location.href
-            .substring(0, document.location.href.lastIndexOf('/'));
-      }
-    });
+          document.location = document.referrer;
+        } else {
+          document.location = document.location.href
+              .substring(0, document.location.href.lastIndexOf('/'));
+        }
+      });
+    },
   };
-
-  return self;
 })();
 
 exports.padeditbar = padeditbar;

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -301,16 +301,14 @@ exports.padeditbar = {
         // If we're in the editbar already..
         // Close any dropdowns we have open..
         this.toggleDropDown('none');
+        // Shift focus away from any drop downs
+        $(':focus').blur(); // required to do not try to remove!
         // Check we're on a pad and not on the timeslider
         // Or some other window I haven't thought about!
         if (typeof pad === 'undefined') {
           // Timeslider probably..
-          // Shift focus away from any drop downs
-          $(':focus').blur(); // required to do not try to remove!
           $('#editorcontainerbox').focus(); // Focus back onto the pad
         } else {
-          // Shift focus away from any drop downs
-          $(':focus').blur(); // required to do not try to remove!
           padeditor.ace.focus(); // Sends focus back to pad
           // The above focus doesn't always work in FF, you have to hit enter afterwards
           evt.preventDefault();

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -77,411 +77,406 @@ ToolbarItem.prototype.bind = function (callback) {
   }
 };
 
-
-const padeditbar = (() => {
-  const syncAnimation = (() => {
-    const SYNCING = -100;
-    const DONE = 100;
-    let state = DONE;
-    const fps = 25;
-    const step = 1 / fps;
-    const T_START = -0.5;
-    const T_FADE = 1.0;
-    const T_GONE = 1.5;
-    const animator = padutils.makeAnimationScheduler(() => {
-      if (state === SYNCING || state === DONE) {
-        return false;
-      } else if (state >= T_GONE) {
-        state = DONE;
+const syncAnimation = (() => {
+  const SYNCING = -100;
+  const DONE = 100;
+  let state = DONE;
+  const fps = 25;
+  const step = 1 / fps;
+  const T_START = -0.5;
+  const T_FADE = 1.0;
+  const T_GONE = 1.5;
+  const animator = padutils.makeAnimationScheduler(() => {
+    if (state === SYNCING || state === DONE) {
+      return false;
+    } else if (state >= T_GONE) {
+      state = DONE;
+      $('#syncstatussyncing').css('display', 'none');
+      $('#syncstatusdone').css('display', 'none');
+      return false;
+    } else if (state < 0) {
+      state += step;
+      if (state >= 0) {
         $('#syncstatussyncing').css('display', 'none');
-        $('#syncstatusdone').css('display', 'none');
-        return false;
-      } else if (state < 0) {
-        state += step;
-        if (state >= 0) {
-          $('#syncstatussyncing').css('display', 'none');
-          $('#syncstatusdone').css('display', 'block').css('opacity', 1);
-        }
-        return true;
-      } else {
-        state += step;
-        if (state >= T_FADE) {
-          $('#syncstatusdone').css('opacity', (T_GONE - state) / (T_GONE - T_FADE));
-        }
-        return true;
+        $('#syncstatusdone').css('display', 'block').css('opacity', 1);
       }
-    }, step * 1000);
-    return {
-      syncing: () => {
-        state = SYNCING;
-        $('#syncstatussyncing').css('display', 'block');
-        $('#syncstatusdone').css('display', 'none');
-      },
-      done: () => {
-        state = T_START;
-        animator.scheduleAnimation();
-      },
-    };
-  })();
-
+      return true;
+    } else {
+      state += step;
+      if (state >= T_FADE) {
+        $('#syncstatusdone').css('opacity', (T_GONE - state) / (T_GONE - T_FADE));
+      }
+      return true;
+    }
+  }, step * 1000);
   return {
-    _editbarPosition: 0,
-
-    init() {
-      this.dropdowns = [];
-
-      $('#editbar .editbarbutton').attr('unselectable', 'on'); // for IE
-      this.enable();
-      $('#editbar [data-key]').each((i, elt) => {
-        $(elt).unbind('click');
-        new ToolbarItem($(elt)).bind((command, item) => {
-          this.triggerCommand(command, item);
-        });
-      });
-
-      $('body:not(#editorcontainerbox)').on('keydown', (evt) => {
-        this._bodyKeyEvent(evt);
-      });
-
-      $('.show-more-icon-btn').click(() => {
-        $('.toolbar').toggleClass('full-icons');
-      });
-      this.checkAllIconsAreDisplayedInToolbar();
-      $(window).resize(_.debounce(() => this.checkAllIconsAreDisplayedInToolbar(), 100));
-
-      this._registerDefaultCommands();
-
-      hooks.callAll('postToolbarInit', {
-        toolbar: this,
-        ace: padeditor.ace,
-      });
-
-      /*
-       * On safari, the dropdown in the toolbar gets hidden because of toolbar
-       * overflow:hidden property. This is a bug from Safari: any children with
-       * position:fixed (like the dropdown) should be displayed no matter
-       * overflow:hidden on parent
-       */
-      if (!browser.safari) {
-        $('select').niceSelect();
-      }
-
-      // When editor is scrolled, we add a class to style the editbar differently
-      $('iframe[name="ace_outer"]').contents().scroll((ev) => {
-        $('#editbar').toggleClass('editor-scrolled', $(ev.currentTarget).scrollTop() > 2);
-      });
+    syncing: () => {
+      state = SYNCING;
+      $('#syncstatussyncing').css('display', 'block');
+      $('#syncstatusdone').css('display', 'none');
     },
-    isEnabled: () => true,
-    disable: () => {
-      $('#editbar').addClass('disabledtoolbar').removeClass('enabledtoolbar');
-    },
-    enable: () => {
-      $('#editbar').addClass('enabledtoolbar').removeClass('disabledtoolbar');
-    },
-    commands: {},
-    registerCommand(cmd, callback) {
-      this.commands[cmd] = callback;
-      return this;
-    },
-    registerDropdownCommand(cmd, dropdown) {
-      dropdown = dropdown || cmd;
-      this.dropdowns.push(dropdown);
-      this.registerCommand(cmd, () => {
-        this.toggleDropDown(dropdown);
-      });
-    },
-    registerAceCommand(cmd, callback) {
-      this.registerCommand(cmd, (cmd, ace, item) => {
-        ace.callWithAce((ace) => {
-          callback(cmd, ace, item);
-        }, cmd, true);
-      });
-    },
-    triggerCommand(cmd, item) {
-      if (this.isEnabled() && this.commands[cmd]) {
-        this.commands[cmd](cmd, padeditor.ace, item);
-      }
-      if (padeditor.ace) padeditor.ace.focus();
-    },
-    toggleDropDown(moduleName, cb) {
-      // do nothing if users are sticked
-      if (moduleName === 'users' && $('#users').hasClass('stickyUsers')) {
-        return;
-      }
-
-      $('.nice-select').removeClass('open');
-      $('.toolbar-popup').removeClass('popup-show');
-
-      // hide all modules and remove highlighting of all buttons
-      if (moduleName === 'none') {
-        const returned = false;
-        for (const thisModuleName of this.dropdowns) {
-          // skip the userlist
-          if (thisModuleName === 'users') continue;
-
-          const module = $(`#${thisModuleName}`);
-
-          // skip any "force reconnect" message
-          const isAForceReconnectMessage = module.find('button#forcereconnect:visible').length > 0;
-          if (isAForceReconnectMessage) continue;
-          if (module.hasClass('popup-show')) {
-            $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
-            module.removeClass('popup-show');
-          }
-        }
-
-        if (!returned && cb) return cb();
-      } else {
-        // hide all modules that are not selected and remove highlighting
-        // respectively add highlighting to the corresponding button
-        for (const thisModuleName of this.dropdowns) {
-          const module = $(`#${thisModuleName}`);
-
-          if (module.hasClass('popup-show')) {
-            $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
-            module.removeClass('popup-show');
-          } else if (thisModuleName === moduleName) {
-            $(`li[data-key=${thisModuleName}] > a`).addClass('selected');
-            module.addClass('popup-show');
-            if (cb) {
-              cb();
-            }
-          }
-        }
-      }
-    },
-    setSyncStatus: (status) => {
-      if (status === 'syncing') {
-        syncAnimation.syncing();
-      } else if (status === 'done') {
-        syncAnimation.done();
-      }
-    },
-    setEmbedLinks: () => {
-      const padUrl = window.location.href.split('?')[0];
-      const params = '?showControls=true&showChat=true&showLineNumbers=true&useMonospaceFont=false';
-      const props = 'width="100%" height="600" frameborder="0"';
-
-      if ($('#readonlyinput').is(':checked')) {
-        const urlParts = padUrl.split('/');
-        urlParts.pop();
-        const readonlyLink = `${urlParts.join('/')}/${clientVars.readOnlyId}`;
-        $('#embedinput')
-            .val(`<iframe name="embed_readonly" src="${readonlyLink}${params}" ${props}></iframe>`);
-        $('#linkinput').val(readonlyLink);
-      } else {
-        $('#embedinput')
-            .val(`<iframe name="embed_readwrite" src="${padUrl}${params}" ${props}></iframe>`);
-        $('#linkinput').val(padUrl);
-      }
-    },
-    checkAllIconsAreDisplayedInToolbar: () => {
-      // reset style
-      $('.toolbar').removeClass('cropped');
-      $('body').removeClass('mobile-layout');
-      const menu_left = $('.toolbar .menu_left')[0];
-
-      // this is approximate, we cannot measure it because on mobile
-      // Layout it takes the full width on the bottom of the page
-      const menuRightWidth = 280;
-      if (menu_left && menu_left.scrollWidth > $('.toolbar').width() - menuRightWidth ||
-          $('.toolbar').width() < 1000) {
-        $('body').addClass('mobile-layout');
-      }
-      if (menu_left && menu_left.scrollWidth > $('.toolbar').width()) {
-        $('.toolbar').addClass('cropped');
-      }
-    },
-
-    _bodyKeyEvent(evt) {
-      // If the event is Alt F9 or Escape & we're already in the editbar menu
-      // Send the users focus back to the pad
-      if ((evt.keyCode === 120 && evt.altKey) || evt.keyCode === 27) {
-        if ($(':focus').parents('.toolbar').length === 1) {
-          // If we're in the editbar already..
-          // Close any dropdowns we have open..
-          this.toggleDropDown('none');
-          // Check we're on a pad and not on the timeslider
-          // Or some other window I haven't thought about!
-          if (typeof pad === 'undefined') {
-            // Timeslider probably..
-            // Shift focus away from any drop downs
-            $(':focus').blur(); // required to do not try to remove!
-            $('#editorcontainerbox').focus(); // Focus back onto the pad
-          } else {
-            // Shift focus away from any drop downs
-            $(':focus').blur(); // required to do not try to remove!
-            padeditor.ace.focus(); // Sends focus back to pad
-            // The above focus doesn't always work in FF, you have to hit enter afterwards
-            evt.preventDefault();
-          }
-        } else {
-          // Focus on the editbar :)
-          const firstEditbarElement = parent.parent.$('#editbar button').first();
-
-          $(evt.currentTarget).blur();
-          firstEditbarElement.focus();
-          evt.preventDefault();
-        }
-      }
-      // Are we in the toolbar??
-      if ($(':focus').parents('.toolbar').length === 1) {
-        // On arrow keys go to next/previous button item in editbar
-        if (evt.keyCode !== 39 && evt.keyCode !== 37) return;
-
-        // Get all the focusable items in the editbar
-        const focusItems = $('#editbar').find('button, select');
-
-        // On left arrow move to next button in editbar
-        if (evt.keyCode === 37) {
-          // If a dropdown is visible or we're in an input don't move to the next button
-          if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
-
-          this._editbarPosition--;
-          // Allow focus to shift back to end of row and start of row
-          if (this._editbarPosition === -1) this._editbarPosition = focusItems.length - 1;
-          $(focusItems[this._editbarPosition]).focus();
-        }
-
-        // On right arrow move to next button in editbar
-        if (evt.keyCode === 39) {
-          // If a dropdown is visible or we're in an input don't move to the next button
-          if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
-
-          this._editbarPosition++;
-          // Allow focus to shift back to end of row and start of row
-          if (this._editbarPosition >= focusItems.length) this._editbarPosition = 0;
-          $(focusItems[this._editbarPosition]).focus();
-        }
-      }
-    },
-
-    _registerDefaultCommands() {
-      this.registerDropdownCommand('showusers', 'users');
-      this.registerDropdownCommand('settings');
-      this.registerDropdownCommand('connectivity');
-      this.registerDropdownCommand('import_export');
-      this.registerDropdownCommand('embed');
-
-      this.registerCommand('settings', () => {
-        this.toggleDropDown('settings', () => {
-          $('#options-stickychat').focus();
-        });
-      });
-
-      this.registerCommand('import_export', () => {
-        this.toggleDropDown('import_export', () => {
-          // If Import file input exists then focus on it..
-          if ($('#importfileinput').length !== 0) {
-            setTimeout(() => {
-              $('#importfileinput').focus();
-            }, 100);
-          } else {
-            $('.exportlink').first().focus();
-          }
-        });
-      });
-
-      this.registerCommand('showusers', () => {
-        this.toggleDropDown('users', () => {
-          $('#myusernameedit').focus();
-        });
-      });
-
-      this.registerCommand('embed', () => {
-        this.setEmbedLinks();
-        this.toggleDropDown('embed', () => {
-          $('#linkinput').focus().select();
-        });
-      });
-
-      this.registerCommand('savedRevision', () => {
-        padsavedrevs.saveNow();
-      });
-
-      this.registerCommand('showTimeSlider', () => {
-        document.location = `${document.location.pathname}/timeslider`;
-      });
-
-      const aceAttributeCommand = (cmd, ace) => {
-        ace.ace_toggleAttributeOnSelection(cmd);
-      };
-      this.registerAceCommand('bold', aceAttributeCommand);
-      this.registerAceCommand('italic', aceAttributeCommand);
-      this.registerAceCommand('underline', aceAttributeCommand);
-      this.registerAceCommand('strikethrough', aceAttributeCommand);
-
-      this.registerAceCommand('undo', (cmd, ace) => {
-        ace.ace_doUndoRedo(cmd);
-      });
-
-      this.registerAceCommand('redo', (cmd, ace) => {
-        ace.ace_doUndoRedo(cmd);
-      });
-
-      this.registerAceCommand('insertunorderedlist', (cmd, ace) => {
-        ace.ace_doInsertUnorderedList();
-      });
-
-      this.registerAceCommand('insertorderedlist', (cmd, ace) => {
-        ace.ace_doInsertOrderedList();
-      });
-
-      this.registerAceCommand('indent', (cmd, ace) => {
-        if (!ace.ace_doIndentOutdent(false)) {
-          ace.ace_doInsertUnorderedList();
-        }
-      });
-
-      this.registerAceCommand('outdent', (cmd, ace) => {
-        ace.ace_doIndentOutdent(true);
-      });
-
-      this.registerAceCommand('clearauthorship', (cmd, ace) => {
-        // If we have the whole document selected IE control A has been hit
-        const rep = ace.ace_getRep();
-        let doPrompt = false;
-        const lastChar = rep.lines.atIndex(rep.lines.length() - 1).width - 1;
-        const lastLineIndex = rep.lines.length() - 1;
-        if (rep.selStart[0] === 0 && rep.selStart[1] === 0) {
-          // nesting intentionally here to make things readable
-          if (rep.selEnd[0] === lastLineIndex && rep.selEnd[1] === lastChar) {
-            doPrompt = true;
-          }
-        }
-        /*
-         * NOTICE: This command isn't fired on Control Shift C.
-         * I intentionally didn't create duplicate code because if you are hitting
-         * Control Shift C we make the assumption you are a "power user"
-         * and as such we assume you don't need the prompt to bug you each time!
-         * This does make wonder if it's worth having a checkbox to avoid being
-         * prompted again but that's probably overkill for this contribution.
-         */
-
-        // if we don't have any text selected, we have a caret or we have already said to prompt
-        if ((!(rep.selStart && rep.selEnd)) || ace.ace_isCaret() || doPrompt) {
-          if (window.confirm(html10n.get('pad.editbar.clearcolors'))) {
-            ace.ace_performDocumentApplyAttributesToCharRange(0, ace.ace_getRep().alltext.length, [
-              ['author', ''],
-            ]);
-          }
-        } else {
-          ace.ace_setAttributeOnSelection('author', '');
-        }
-      });
-
-      this.registerCommand('timeslider_returnToPad', (cmd) => {
-        if (document.referrer.length > 0 &&
-            document.referrer.substring(document.referrer.lastIndexOf('/') - 1,
-                document.referrer.lastIndexOf('/')) === 'p') {
-          document.location = document.referrer;
-        } else {
-          document.location = document.location.href
-              .substring(0, document.location.href.lastIndexOf('/'));
-        }
-      });
+    done: () => {
+      state = T_START;
+      animator.scheduleAnimation();
     },
   };
 })();
 
-exports.padeditbar = padeditbar;
+exports.padeditbar = {
+  _editbarPosition: 0,
+
+  init() {
+    this.dropdowns = [];
+
+    $('#editbar .editbarbutton').attr('unselectable', 'on'); // for IE
+    this.enable();
+    $('#editbar [data-key]').each((i, elt) => {
+      $(elt).unbind('click');
+      new ToolbarItem($(elt)).bind((command, item) => {
+        this.triggerCommand(command, item);
+      });
+    });
+
+    $('body:not(#editorcontainerbox)').on('keydown', (evt) => {
+      this._bodyKeyEvent(evt);
+    });
+
+    $('.show-more-icon-btn').click(() => {
+      $('.toolbar').toggleClass('full-icons');
+    });
+    this.checkAllIconsAreDisplayedInToolbar();
+    $(window).resize(_.debounce(() => this.checkAllIconsAreDisplayedInToolbar(), 100));
+
+    this._registerDefaultCommands();
+
+    hooks.callAll('postToolbarInit', {
+      toolbar: this,
+      ace: padeditor.ace,
+    });
+
+    /*
+     * On safari, the dropdown in the toolbar gets hidden because of toolbar
+     * overflow:hidden property. This is a bug from Safari: any children with
+     * position:fixed (like the dropdown) should be displayed no matter
+     * overflow:hidden on parent
+     */
+    if (!browser.safari) {
+      $('select').niceSelect();
+    }
+
+    // When editor is scrolled, we add a class to style the editbar differently
+    $('iframe[name="ace_outer"]').contents().scroll((ev) => {
+      $('#editbar').toggleClass('editor-scrolled', $(ev.currentTarget).scrollTop() > 2);
+    });
+  },
+  isEnabled: () => true,
+  disable: () => {
+    $('#editbar').addClass('disabledtoolbar').removeClass('enabledtoolbar');
+  },
+  enable: () => {
+    $('#editbar').addClass('enabledtoolbar').removeClass('disabledtoolbar');
+  },
+  commands: {},
+  registerCommand(cmd, callback) {
+    this.commands[cmd] = callback;
+    return this;
+  },
+  registerDropdownCommand(cmd, dropdown) {
+    dropdown = dropdown || cmd;
+    this.dropdowns.push(dropdown);
+    this.registerCommand(cmd, () => {
+      this.toggleDropDown(dropdown);
+    });
+  },
+  registerAceCommand(cmd, callback) {
+    this.registerCommand(cmd, (cmd, ace, item) => {
+      ace.callWithAce((ace) => {
+        callback(cmd, ace, item);
+      }, cmd, true);
+    });
+  },
+  triggerCommand(cmd, item) {
+    if (this.isEnabled() && this.commands[cmd]) {
+      this.commands[cmd](cmd, padeditor.ace, item);
+    }
+    if (padeditor.ace) padeditor.ace.focus();
+  },
+  toggleDropDown(moduleName, cb) {
+    // do nothing if users are sticked
+    if (moduleName === 'users' && $('#users').hasClass('stickyUsers')) {
+      return;
+    }
+
+    $('.nice-select').removeClass('open');
+    $('.toolbar-popup').removeClass('popup-show');
+
+    // hide all modules and remove highlighting of all buttons
+    if (moduleName === 'none') {
+      const returned = false;
+      for (const thisModuleName of this.dropdowns) {
+        // skip the userlist
+        if (thisModuleName === 'users') continue;
+
+        const module = $(`#${thisModuleName}`);
+
+        // skip any "force reconnect" message
+        const isAForceReconnectMessage = module.find('button#forcereconnect:visible').length > 0;
+        if (isAForceReconnectMessage) continue;
+        if (module.hasClass('popup-show')) {
+          $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
+          module.removeClass('popup-show');
+        }
+      }
+
+      if (!returned && cb) return cb();
+    } else {
+      // hide all modules that are not selected and remove highlighting
+      // respectively add highlighting to the corresponding button
+      for (const thisModuleName of this.dropdowns) {
+        const module = $(`#${thisModuleName}`);
+
+        if (module.hasClass('popup-show')) {
+          $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
+          module.removeClass('popup-show');
+        } else if (thisModuleName === moduleName) {
+          $(`li[data-key=${thisModuleName}] > a`).addClass('selected');
+          module.addClass('popup-show');
+          if (cb) {
+            cb();
+          }
+        }
+      }
+    }
+  },
+  setSyncStatus: (status) => {
+    if (status === 'syncing') {
+      syncAnimation.syncing();
+    } else if (status === 'done') {
+      syncAnimation.done();
+    }
+  },
+  setEmbedLinks: () => {
+    const padUrl = window.location.href.split('?')[0];
+    const params = '?showControls=true&showChat=true&showLineNumbers=true&useMonospaceFont=false';
+    const props = 'width="100%" height="600" frameborder="0"';
+
+    if ($('#readonlyinput').is(':checked')) {
+      const urlParts = padUrl.split('/');
+      urlParts.pop();
+      const readonlyLink = `${urlParts.join('/')}/${clientVars.readOnlyId}`;
+      $('#embedinput')
+          .val(`<iframe name="embed_readonly" src="${readonlyLink}${params}" ${props}></iframe>`);
+      $('#linkinput').val(readonlyLink);
+    } else {
+      $('#embedinput')
+          .val(`<iframe name="embed_readwrite" src="${padUrl}${params}" ${props}></iframe>`);
+      $('#linkinput').val(padUrl);
+    }
+  },
+  checkAllIconsAreDisplayedInToolbar: () => {
+    // reset style
+    $('.toolbar').removeClass('cropped');
+    $('body').removeClass('mobile-layout');
+    const menu_left = $('.toolbar .menu_left')[0];
+
+    // this is approximate, we cannot measure it because on mobile
+    // Layout it takes the full width on the bottom of the page
+    const menuRightWidth = 280;
+    if (menu_left && menu_left.scrollWidth > $('.toolbar').width() - menuRightWidth ||
+        $('.toolbar').width() < 1000) {
+      $('body').addClass('mobile-layout');
+    }
+    if (menu_left && menu_left.scrollWidth > $('.toolbar').width()) {
+      $('.toolbar').addClass('cropped');
+    }
+  },
+
+  _bodyKeyEvent(evt) {
+    // If the event is Alt F9 or Escape & we're already in the editbar menu
+    // Send the users focus back to the pad
+    if ((evt.keyCode === 120 && evt.altKey) || evt.keyCode === 27) {
+      if ($(':focus').parents('.toolbar').length === 1) {
+        // If we're in the editbar already..
+        // Close any dropdowns we have open..
+        this.toggleDropDown('none');
+        // Check we're on a pad and not on the timeslider
+        // Or some other window I haven't thought about!
+        if (typeof pad === 'undefined') {
+          // Timeslider probably..
+          // Shift focus away from any drop downs
+          $(':focus').blur(); // required to do not try to remove!
+          $('#editorcontainerbox').focus(); // Focus back onto the pad
+        } else {
+          // Shift focus away from any drop downs
+          $(':focus').blur(); // required to do not try to remove!
+          padeditor.ace.focus(); // Sends focus back to pad
+          // The above focus doesn't always work in FF, you have to hit enter afterwards
+          evt.preventDefault();
+        }
+      } else {
+        // Focus on the editbar :)
+        const firstEditbarElement = parent.parent.$('#editbar button').first();
+
+        $(evt.currentTarget).blur();
+        firstEditbarElement.focus();
+        evt.preventDefault();
+      }
+    }
+    // Are we in the toolbar??
+    if ($(':focus').parents('.toolbar').length === 1) {
+      // On arrow keys go to next/previous button item in editbar
+      if (evt.keyCode !== 39 && evt.keyCode !== 37) return;
+
+      // Get all the focusable items in the editbar
+      const focusItems = $('#editbar').find('button, select');
+
+      // On left arrow move to next button in editbar
+      if (evt.keyCode === 37) {
+        // If a dropdown is visible or we're in an input don't move to the next button
+        if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
+
+        this._editbarPosition--;
+        // Allow focus to shift back to end of row and start of row
+        if (this._editbarPosition === -1) this._editbarPosition = focusItems.length - 1;
+        $(focusItems[this._editbarPosition]).focus();
+      }
+
+      // On right arrow move to next button in editbar
+      if (evt.keyCode === 39) {
+        // If a dropdown is visible or we're in an input don't move to the next button
+        if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
+
+        this._editbarPosition++;
+        // Allow focus to shift back to end of row and start of row
+        if (this._editbarPosition >= focusItems.length) this._editbarPosition = 0;
+        $(focusItems[this._editbarPosition]).focus();
+      }
+    }
+  },
+
+  _registerDefaultCommands() {
+    this.registerDropdownCommand('showusers', 'users');
+    this.registerDropdownCommand('settings');
+    this.registerDropdownCommand('connectivity');
+    this.registerDropdownCommand('import_export');
+    this.registerDropdownCommand('embed');
+
+    this.registerCommand('settings', () => {
+      this.toggleDropDown('settings', () => {
+        $('#options-stickychat').focus();
+      });
+    });
+
+    this.registerCommand('import_export', () => {
+      this.toggleDropDown('import_export', () => {
+        // If Import file input exists then focus on it..
+        if ($('#importfileinput').length !== 0) {
+          setTimeout(() => {
+            $('#importfileinput').focus();
+          }, 100);
+        } else {
+          $('.exportlink').first().focus();
+        }
+      });
+    });
+
+    this.registerCommand('showusers', () => {
+      this.toggleDropDown('users', () => {
+        $('#myusernameedit').focus();
+      });
+    });
+
+    this.registerCommand('embed', () => {
+      this.setEmbedLinks();
+      this.toggleDropDown('embed', () => {
+        $('#linkinput').focus().select();
+      });
+    });
+
+    this.registerCommand('savedRevision', () => {
+      padsavedrevs.saveNow();
+    });
+
+    this.registerCommand('showTimeSlider', () => {
+      document.location = `${document.location.pathname}/timeslider`;
+    });
+
+    const aceAttributeCommand = (cmd, ace) => {
+      ace.ace_toggleAttributeOnSelection(cmd);
+    };
+    this.registerAceCommand('bold', aceAttributeCommand);
+    this.registerAceCommand('italic', aceAttributeCommand);
+    this.registerAceCommand('underline', aceAttributeCommand);
+    this.registerAceCommand('strikethrough', aceAttributeCommand);
+
+    this.registerAceCommand('undo', (cmd, ace) => {
+      ace.ace_doUndoRedo(cmd);
+    });
+
+    this.registerAceCommand('redo', (cmd, ace) => {
+      ace.ace_doUndoRedo(cmd);
+    });
+
+    this.registerAceCommand('insertunorderedlist', (cmd, ace) => {
+      ace.ace_doInsertUnorderedList();
+    });
+
+    this.registerAceCommand('insertorderedlist', (cmd, ace) => {
+      ace.ace_doInsertOrderedList();
+    });
+
+    this.registerAceCommand('indent', (cmd, ace) => {
+      if (!ace.ace_doIndentOutdent(false)) {
+        ace.ace_doInsertUnorderedList();
+      }
+    });
+
+    this.registerAceCommand('outdent', (cmd, ace) => {
+      ace.ace_doIndentOutdent(true);
+    });
+
+    this.registerAceCommand('clearauthorship', (cmd, ace) => {
+      // If we have the whole document selected IE control A has been hit
+      const rep = ace.ace_getRep();
+      let doPrompt = false;
+      const lastChar = rep.lines.atIndex(rep.lines.length() - 1).width - 1;
+      const lastLineIndex = rep.lines.length() - 1;
+      if (rep.selStart[0] === 0 && rep.selStart[1] === 0) {
+        // nesting intentionally here to make things readable
+        if (rep.selEnd[0] === lastLineIndex && rep.selEnd[1] === lastChar) {
+          doPrompt = true;
+        }
+      }
+      /*
+       * NOTICE: This command isn't fired on Control Shift C.
+       * I intentionally didn't create duplicate code because if you are hitting
+       * Control Shift C we make the assumption you are a "power user"
+       * and as such we assume you don't need the prompt to bug you each time!
+       * This does make wonder if it's worth having a checkbox to avoid being
+       * prompted again but that's probably overkill for this contribution.
+       */
+
+      // if we don't have any text selected, we have a caret or we have already said to prompt
+      if ((!(rep.selStart && rep.selEnd)) || ace.ace_isCaret() || doPrompt) {
+        if (window.confirm(html10n.get('pad.editbar.clearcolors'))) {
+          ace.ace_performDocumentApplyAttributesToCharRange(0, ace.ace_getRep().alltext.length, [
+            ['author', ''],
+          ]);
+        }
+      } else {
+        ace.ace_setAttributeOnSelection('author', '');
+      }
+    });
+
+    this.registerCommand('timeslider_returnToPad', (cmd) => {
+      if (document.referrer.length > 0 &&
+          document.referrer.substring(document.referrer.lastIndexOf('/') - 1,
+              document.referrer.lastIndexOf('/')) === 'p') {
+        document.location = document.referrer;
+      } else {
+        document.location = document.location.href
+            .substring(0, document.location.href.lastIndexOf('/'));
+      }
+    });
+  },
+};

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -200,7 +200,9 @@ exports.padeditbar = {
     }
     if (padeditor.ace) padeditor.ace.focus();
   },
-  toggleDropDown(moduleName, cb) {
+
+  // cb is deprecated (this function is synchronous so a callback is unnecessary).
+  toggleDropDown(moduleName, cb = null) {
     let cbErr = null;
     try {
       // do nothing if users are sticked

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -360,35 +360,31 @@ exports.padeditbar = {
     this.registerDropdownCommand('embed');
 
     this.registerCommand('settings', () => {
-      this.toggleDropDown('settings', () => {
-        $('#options-stickychat').focus();
-      });
+      this.toggleDropDown('settings');
+      $('#options-stickychat').focus();
     });
 
     this.registerCommand('import_export', () => {
-      this.toggleDropDown('import_export', () => {
-        // If Import file input exists then focus on it..
-        if ($('#importfileinput').length !== 0) {
-          setTimeout(() => {
-            $('#importfileinput').focus();
-          }, 100);
-        } else {
-          $('.exportlink').first().focus();
-        }
-      });
+      this.toggleDropDown('import_export');
+      // If Import file input exists then focus on it..
+      if ($('#importfileinput').length !== 0) {
+        setTimeout(() => {
+          $('#importfileinput').focus();
+        }, 100);
+      } else {
+        $('.exportlink').first().focus();
+      }
     });
 
     this.registerCommand('showusers', () => {
-      this.toggleDropDown('users', () => {
-        $('#myusernameedit').focus();
-      });
+      this.toggleDropDown('users');
+      $('#myusernameedit').focus();
     });
 
     this.registerCommand('embed', () => {
       this.setEmbedLinks();
-      this.toggleDropDown('embed', () => {
-        $('#linkinput').focus().select();
-      });
+      this.toggleDropDown('embed');
+      $('#linkinput').focus().select();
     });
 
     this.registerCommand('savedRevision', () => {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -324,7 +324,7 @@ const padeditbar = (() => {
         // Focus on the editbar :)
         const firstEditbarElement = parent.parent.$('#editbar button').first();
 
-        $(this).blur();
+        $(evt.currentTarget).blur();
         firstEditbarElement.focus();
         evt.preventDefault();
       }

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -245,7 +245,7 @@ exports.padeditbar = {
     } catch (err) {
       cbErr = err || new Error(err);
     } finally {
-      if (cb) cb(cbErr);
+      if (cb) Promise.resolve().then(() => cb(cbErr));
     }
   },
   setSyncStatus: (status) => {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -126,6 +126,8 @@ const padeditbar = (() => {
   const syncAnimation = syncAnimationFn();
 
   const self = {
+    _editbarPosition: 0,
+
     init() {
       this.dropdowns = [];
 
@@ -139,7 +141,7 @@ const padeditbar = (() => {
       });
 
       $('body:not(#editorcontainerbox)').on('keydown', (evt) => {
-        bodyKeyEvent(evt);
+        this._bodyKeyEvent(evt);
       });
 
       $('.show-more-icon-btn').click(() => {
@@ -294,71 +296,69 @@ const padeditbar = (() => {
         $('.toolbar').addClass('cropped');
       }
     },
-  };
 
-  let editbarPosition = 0;
-
-  const bodyKeyEvent = (evt) => {
-    // If the event is Alt F9 or Escape & we're already in the editbar menu
-    // Send the users focus back to the pad
-    if ((evt.keyCode === 120 && evt.altKey) || evt.keyCode === 27) {
-      if ($(':focus').parents('.toolbar').length === 1) {
-        // If we're in the editbar already..
-        // Close any dropdowns we have open..
-        padeditbar.toggleDropDown('none');
-        // Check we're on a pad and not on the timeslider
-        // Or some other window I haven't thought about!
-        if (typeof pad === 'undefined') {
-          // Timeslider probably..
-          // Shift focus away from any drop downs
-          $(':focus').blur(); // required to do not try to remove!
-          $('#editorcontainerbox').focus(); // Focus back onto the pad
+    _bodyKeyEvent(evt) {
+      // If the event is Alt F9 or Escape & we're already in the editbar menu
+      // Send the users focus back to the pad
+      if ((evt.keyCode === 120 && evt.altKey) || evt.keyCode === 27) {
+        if ($(':focus').parents('.toolbar').length === 1) {
+          // If we're in the editbar already..
+          // Close any dropdowns we have open..
+          this.toggleDropDown('none');
+          // Check we're on a pad and not on the timeslider
+          // Or some other window I haven't thought about!
+          if (typeof pad === 'undefined') {
+            // Timeslider probably..
+            // Shift focus away from any drop downs
+            $(':focus').blur(); // required to do not try to remove!
+            $('#editorcontainerbox').focus(); // Focus back onto the pad
+          } else {
+            // Shift focus away from any drop downs
+            $(':focus').blur(); // required to do not try to remove!
+            padeditor.ace.focus(); // Sends focus back to pad
+            // The above focus doesn't always work in FF, you have to hit enter afterwards
+            evt.preventDefault();
+          }
         } else {
-          // Shift focus away from any drop downs
-          $(':focus').blur(); // required to do not try to remove!
-          padeditor.ace.focus(); // Sends focus back to pad
-          // The above focus doesn't always work in FF, you have to hit enter afterwards
+          // Focus on the editbar :)
+          const firstEditbarElement = parent.parent.$('#editbar button').first();
+
+          $(evt.currentTarget).blur();
+          firstEditbarElement.focus();
           evt.preventDefault();
         }
-      } else {
-        // Focus on the editbar :)
-        const firstEditbarElement = parent.parent.$('#editbar button').first();
-
-        $(evt.currentTarget).blur();
-        firstEditbarElement.focus();
-        evt.preventDefault();
       }
-    }
-    // Are we in the toolbar??
-    if ($(':focus').parents('.toolbar').length === 1) {
-      // On arrow keys go to next/previous button item in editbar
-      if (evt.keyCode !== 39 && evt.keyCode !== 37) return;
+      // Are we in the toolbar??
+      if ($(':focus').parents('.toolbar').length === 1) {
+        // On arrow keys go to next/previous button item in editbar
+        if (evt.keyCode !== 39 && evt.keyCode !== 37) return;
 
-      // Get all the focusable items in the editbar
-      const focusItems = $('#editbar').find('button, select');
+        // Get all the focusable items in the editbar
+        const focusItems = $('#editbar').find('button, select');
 
-      // On left arrow move to next button in editbar
-      if (evt.keyCode === 37) {
-        // If a dropdown is visible or we're in an input don't move to the next button
-        if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
+        // On left arrow move to next button in editbar
+        if (evt.keyCode === 37) {
+          // If a dropdown is visible or we're in an input don't move to the next button
+          if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
 
-        editbarPosition--;
-        // Allow focus to shift back to end of row and start of row
-        if (editbarPosition === -1) editbarPosition = focusItems.length - 1;
-        $(focusItems[editbarPosition]).focus();
+          this._editbarPosition--;
+          // Allow focus to shift back to end of row and start of row
+          if (this._editbarPosition === -1) this._editbarPosition = focusItems.length - 1;
+          $(focusItems[this._editbarPosition]).focus();
+        }
+
+        // On right arrow move to next button in editbar
+        if (evt.keyCode === 39) {
+          // If a dropdown is visible or we're in an input don't move to the next button
+          if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
+
+          this._editbarPosition++;
+          // Allow focus to shift back to end of row and start of row
+          if (this._editbarPosition >= focusItems.length) this._editbarPosition = 0;
+          $(focusItems[this._editbarPosition]).focus();
+        }
       }
-
-      // On right arrow move to next button in editbar
-      if (evt.keyCode === 39) {
-        // If a dropdown is visible or we're in an input don't move to the next button
-        if ($('.popup').is(':visible') || evt.target.localName === 'input') return;
-
-        editbarPosition++;
-        // Allow focus to shift back to end of row and start of row
-        if (editbarPosition >= focusItems.length) editbarPosition = 0;
-        $(focusItems[editbarPosition]).focus();
-      }
-    }
+    },
   };
 
   const aceAttributeCommand = (cmd, ace) => {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -30,52 +30,53 @@ const padsavedrevs = require('./pad_savedrevs');
 const _ = require('underscore');
 require('./vendors/nice-select');
 
-const ToolbarItem = function (element) {
-  this.$el = element;
-};
-
-ToolbarItem.prototype.getCommand = function () {
-  return this.$el.attr('data-key');
-};
-
-ToolbarItem.prototype.getValue = function () {
-  if (this.isSelect()) {
-    return this.$el.find('select').val();
+class ToolbarItem {
+  constructor(element) {
+    this.$el = element;
   }
-};
 
-ToolbarItem.prototype.setValue = function (val) {
-  if (this.isSelect()) {
-    return this.$el.find('select').val(val);
+  getCommand() {
+    return this.$el.attr('data-key');
   }
-};
 
-
-ToolbarItem.prototype.getType = function () {
-  return this.$el.attr('data-type');
-};
-
-ToolbarItem.prototype.isSelect = function () {
-  return this.getType() === 'select';
-};
-
-ToolbarItem.prototype.isButton = function () {
-  return this.getType() === 'button';
-};
-
-ToolbarItem.prototype.bind = function (callback) {
-  if (this.isButton()) {
-    this.$el.click((event) => {
-      $(':focus').blur();
-      callback(this.getCommand(), this);
-      event.preventDefault();
-    });
-  } else if (this.isSelect()) {
-    this.$el.find('select').change(() => {
-      callback(this.getCommand(), this);
-    });
+  getValue() {
+    if (this.isSelect()) {
+      return this.$el.find('select').val();
+    }
   }
-};
+
+  setValue(val) {
+    if (this.isSelect()) {
+      return this.$el.find('select').val(val);
+    }
+  }
+
+  getType() {
+    return this.$el.attr('data-type');
+  }
+
+  isSelect() {
+    return this.getType() === 'select';
+  }
+
+  isButton() {
+    return this.getType() === 'button';
+  }
+
+  bind(callback) {
+    if (this.isButton()) {
+      this.$el.click((event) => {
+        $(':focus').blur();
+        callback(this.getCommand(), this);
+        event.preventDefault();
+      });
+    } else if (this.isSelect()) {
+      this.$el.find('select').change(() => {
+        callback(this.getCommand(), this);
+      });
+    }
+  }
+}
 
 const syncAnimation = (() => {
   const SYNCING = -100;
@@ -122,10 +123,12 @@ const syncAnimation = (() => {
   };
 })();
 
-exports.padeditbar = {
-  _editbarPosition: 0,
-  commands: {},
-  dropdowns: [],
+exports.padeditbar = new class {
+  constructor() {
+    this._editbarPosition = 0;
+    this.commands = {};
+    this.dropdowns = [];
+  }
 
   init() {
     $('#editbar .editbarbutton').attr('unselectable', 'on'); // for IE
@@ -168,38 +171,38 @@ exports.padeditbar = {
     $('iframe[name="ace_outer"]').contents().scroll((ev) => {
       $('#editbar').toggleClass('editor-scrolled', $(ev.currentTarget).scrollTop() > 2);
     });
-  },
-  isEnabled: () => true,
-  disable: () => {
+  }
+  isEnabled() { return true; }
+  disable() {
     $('#editbar').addClass('disabledtoolbar').removeClass('enabledtoolbar');
-  },
-  enable: () => {
+  }
+  enable() {
     $('#editbar').addClass('enabledtoolbar').removeClass('disabledtoolbar');
-  },
+  }
   registerCommand(cmd, callback) {
     this.commands[cmd] = callback;
     return this;
-  },
+  }
   registerDropdownCommand(cmd, dropdown) {
     dropdown = dropdown || cmd;
     this.dropdowns.push(dropdown);
     this.registerCommand(cmd, () => {
       this.toggleDropDown(dropdown);
     });
-  },
+  }
   registerAceCommand(cmd, callback) {
     this.registerCommand(cmd, (cmd, ace, item) => {
       ace.callWithAce((ace) => {
         callback(cmd, ace, item);
       }, cmd, true);
     });
-  },
+  }
   triggerCommand(cmd, item) {
     if (this.isEnabled() && this.commands[cmd]) {
       this.commands[cmd](cmd, padeditor.ace, item);
     }
     if (padeditor.ace) padeditor.ace.focus();
-  },
+  }
 
   // cb is deprecated (this function is synchronous so a callback is unnecessary).
   toggleDropDown(moduleName, cb = null) {
@@ -249,15 +252,15 @@ exports.padeditbar = {
     } finally {
       if (cb) Promise.resolve().then(() => cb(cbErr));
     }
-  },
-  setSyncStatus: (status) => {
+  }
+  setSyncStatus(status) {
     if (status === 'syncing') {
       syncAnimation.syncing();
     } else if (status === 'done') {
       syncAnimation.done();
     }
-  },
-  setEmbedLinks: () => {
+  }
+  setEmbedLinks() {
     const padUrl = window.location.href.split('?')[0];
     const params = '?showControls=true&showChat=true&showLineNumbers=true&useMonospaceFont=false';
     const props = 'width="100%" height="600" frameborder="0"';
@@ -274,8 +277,8 @@ exports.padeditbar = {
           .val(`<iframe name="embed_readwrite" src="${padUrl}${params}" ${props}></iframe>`);
       $('#linkinput').val(padUrl);
     }
-  },
-  checkAllIconsAreDisplayedInToolbar: () => {
+  }
+  checkAllIconsAreDisplayedInToolbar() {
     // reset style
     $('.toolbar').removeClass('cropped');
     $('body').removeClass('mobile-layout');
@@ -291,7 +294,7 @@ exports.padeditbar = {
     if (menu_left && menu_left.scrollWidth > $('.toolbar').width()) {
       $('.toolbar').addClass('cropped');
     }
-  },
+  }
 
   _bodyKeyEvent(evt) {
     // If the event is Alt F9 or Escape & we're already in the editbar menu
@@ -352,7 +355,7 @@ exports.padeditbar = {
         $(focusItems[this._editbarPosition]).focus();
       }
     }
-  },
+  }
 
   _registerDefaultCommands() {
     this.registerDropdownCommand('showusers', 'users');
@@ -474,5 +477,5 @@ exports.padeditbar = {
             .substring(0, document.location.href.lastIndexOf('/'));
       }
     });
-  },
-};
+  }
+}();

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -124,6 +124,7 @@ const syncAnimation = (() => {
 
 exports.padeditbar = {
   _editbarPosition: 0,
+  commands: {},
   dropdowns: [],
 
   init() {
@@ -175,7 +176,6 @@ exports.padeditbar = {
   enable: () => {
     $('#editbar').addClass('enabledtoolbar').removeClass('disabledtoolbar');
   },
-  commands: {},
   registerCommand(cmd, callback) {
     this.commands[cmd] = callback;
     return this;

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -64,17 +64,15 @@ ToolbarItem.prototype.isButton = function () {
 };
 
 ToolbarItem.prototype.bind = function (callback) {
-  const self = this;
-
-  if (self.isButton()) {
-    self.$el.click((event) => {
+  if (this.isButton()) {
+    this.$el.click((event) => {
       $(':focus').blur();
-      callback(self.getCommand(), self);
+      callback(this.getCommand(), this);
       event.preventDefault();
     });
-  } else if (self.isSelect()) {
-    self.$el.find('select').change(() => {
-      callback(self.getCommand(), self);
+  } else if (this.isSelect()) {
+    this.$el.find('select').change(() => {
+      callback(this.getCommand(), this);
     });
   }
 };
@@ -129,15 +127,14 @@ const padeditbar = (function () {
 
   const self = {
     init() {
-      const self = this;
-      self.dropdowns = [];
+      this.dropdowns = [];
 
       $('#editbar .editbarbutton').attr('unselectable', 'on'); // for IE
       this.enable();
-      $('#editbar [data-key]').each(function () {
-        $(this).unbind('click');
-        (new ToolbarItem($(this))).bind((command, item) => {
-          self.triggerCommand(command, item);
+      $('#editbar [data-key]').each((i, elt) => {
+        $(elt).unbind('click');
+        new ToolbarItem($(elt)).bind((command, item) => {
+          this.triggerCommand(command, item);
         });
       });
 
@@ -148,13 +145,13 @@ const padeditbar = (function () {
       $('.show-more-icon-btn').click(() => {
         $('.toolbar').toggleClass('full-icons');
       });
-      self.checkAllIconsAreDisplayedInToolbar();
-      $(window).resize(_.debounce(self.checkAllIconsAreDisplayedInToolbar, 100));
+      this.checkAllIconsAreDisplayedInToolbar();
+      $(window).resize(_.debounce(() => this.checkAllIconsAreDisplayedInToolbar(), 100));
 
-      registerDefaultCommands(self);
+      registerDefaultCommands(this);
 
       hooks.callAll('postToolbarInit', {
-        toolbar: self,
+        toolbar: this,
         ace: padeditor.ace,
       });
 
@@ -187,9 +184,9 @@ const padeditbar = (function () {
     },
     registerDropdownCommand(cmd, dropdown) {
       dropdown = dropdown || cmd;
-      self.dropdowns.push(dropdown);
+      this.dropdowns.push(dropdown);
       this.registerCommand(cmd, () => {
-        self.toggleDropDown(dropdown);
+        this.toggleDropDown(dropdown);
       });
     },
     registerAceCommand(cmd, callback) {
@@ -200,12 +197,12 @@ const padeditbar = (function () {
       });
     },
     triggerCommand(cmd, item) {
-      if (self.isEnabled() && this.commands[cmd]) {
+      if (this.isEnabled() && this.commands[cmd]) {
         this.commands[cmd](cmd, padeditor.ace, item);
       }
       if (padeditor.ace) padeditor.ace.focus();
     },
-    toggleDropDown: (moduleName, cb) => {
+    toggleDropDown(moduleName, cb) {
       // do nothing if users are sticked
       if (moduleName === 'users' && $('#users').hasClass('stickyUsers')) {
         return;
@@ -217,8 +214,8 @@ const padeditbar = (function () {
       // hide all modules and remove highlighting of all buttons
       if (moduleName === 'none') {
         const returned = false;
-        for (let i = 0; i < self.dropdowns.length; i++) {
-          const thisModuleName = self.dropdowns[i];
+        for (let i = 0; i < this.dropdowns.length; i++) {
+          const thisModuleName = this.dropdowns[i];
 
           // skip the userlist
           if (thisModuleName === 'users') continue;
@@ -238,8 +235,8 @@ const padeditbar = (function () {
       } else {
         // hide all modules that are not selected and remove highlighting
         // respectively add highlighting to the corresponding button
-        for (let i = 0; i < self.dropdowns.length; i++) {
-          const thisModuleName = self.dropdowns[i];
+        for (let i = 0; i < this.dropdowns.length; i++) {
+          const thisModuleName = this.dropdowns[i];
           const module = $(`#${thisModuleName}`);
 
           if (module.hasClass('popup-show')) {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -225,8 +225,6 @@ exports.padeditbar = {
           module.removeClass('popup-show');
         }
       }
-
-      if (cb) return cb();
     } else {
       // hide all modules that are not selected and remove highlighting
       // respectively add highlighting to the corresponding button
@@ -239,12 +237,10 @@ exports.padeditbar = {
         } else if (thisModuleName === moduleName) {
           $(`li[data-key=${thisModuleName}] > a`).addClass('selected');
           module.addClass('popup-show');
-          if (cb) {
-            cb();
-          }
         }
       }
     }
+    if (cb) cb();
   },
   setSyncStatus: (status) => {
     if (status === 'syncing') {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -78,7 +78,7 @@ ToolbarItem.prototype.bind = function (callback) {
 };
 
 
-const padeditbar = (function () {
+const padeditbar = (() => {
   const syncAnimationFn = () => {
     const SYNCING = -100;
     const DONE = 100;
@@ -166,8 +166,8 @@ const padeditbar = (function () {
       }
 
       // When editor is scrolled, we add a class to style the editbar differently
-      $('iframe[name="ace_outer"]').contents().scroll(function () {
-        $('#editbar').toggleClass('editor-scrolled', $(this).scrollTop() > 2);
+      $('iframe[name="ace_outer"]').contents().scroll((ev) => {
+        $('#editbar').toggleClass('editor-scrolled', $(ev.currentTarget).scrollTop() > 2);
       });
     },
     isEnabled: () => true,
@@ -489,6 +489,6 @@ const padeditbar = (function () {
   };
 
   return self;
-}());
+})();
 
 exports.padeditbar = padeditbar;

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -201,46 +201,52 @@ exports.padeditbar = {
     if (padeditor.ace) padeditor.ace.focus();
   },
   toggleDropDown(moduleName, cb) {
-    // do nothing if users are sticked
-    if (moduleName === 'users' && $('#users').hasClass('stickyUsers')) {
-      return;
-    }
+    let cbErr = null;
+    try {
+      // do nothing if users are sticked
+      if (moduleName === 'users' && $('#users').hasClass('stickyUsers')) {
+        return;
+      }
 
-    $('.nice-select').removeClass('open');
-    $('.toolbar-popup').removeClass('popup-show');
+      $('.nice-select').removeClass('open');
+      $('.toolbar-popup').removeClass('popup-show');
 
-    // hide all modules and remove highlighting of all buttons
-    if (moduleName === 'none') {
-      for (const thisModuleName of this.dropdowns) {
-        // skip the userlist
-        if (thisModuleName === 'users') continue;
+      // hide all modules and remove highlighting of all buttons
+      if (moduleName === 'none') {
+        for (const thisModuleName of this.dropdowns) {
+          // skip the userlist
+          if (thisModuleName === 'users') continue;
 
-        const module = $(`#${thisModuleName}`);
+          const module = $(`#${thisModuleName}`);
 
-        // skip any "force reconnect" message
-        const isAForceReconnectMessage = module.find('button#forcereconnect:visible').length > 0;
-        if (isAForceReconnectMessage) continue;
-        if (module.hasClass('popup-show')) {
-          $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
-          module.removeClass('popup-show');
+          // skip any "force reconnect" message
+          const isAForceReconnectMessage = module.find('button#forcereconnect:visible').length > 0;
+          if (isAForceReconnectMessage) continue;
+          if (module.hasClass('popup-show')) {
+            $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
+            module.removeClass('popup-show');
+          }
+        }
+      } else {
+        // hide all modules that are not selected and remove highlighting
+        // respectively add highlighting to the corresponding button
+        for (const thisModuleName of this.dropdowns) {
+          const module = $(`#${thisModuleName}`);
+
+          if (module.hasClass('popup-show')) {
+            $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
+            module.removeClass('popup-show');
+          } else if (thisModuleName === moduleName) {
+            $(`li[data-key=${thisModuleName}] > a`).addClass('selected');
+            module.addClass('popup-show');
+          }
         }
       }
-    } else {
-      // hide all modules that are not selected and remove highlighting
-      // respectively add highlighting to the corresponding button
-      for (const thisModuleName of this.dropdowns) {
-        const module = $(`#${thisModuleName}`);
-
-        if (module.hasClass('popup-show')) {
-          $(`li[data-key=${thisModuleName}] > a`).removeClass('selected');
-          module.removeClass('popup-show');
-        } else if (thisModuleName === moduleName) {
-          $(`li[data-key=${thisModuleName}] > a`).addClass('selected');
-          module.addClass('popup-show');
-        }
-      }
+    } catch (err) {
+      cbErr = err || new Error(err);
+    } finally {
+      if (cb) cb(cbErr);
     }
-    if (cb) cb();
   },
   setSyncStatus: (status) => {
     if (status === 'syncing') {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -124,10 +124,9 @@ const syncAnimation = (() => {
 
 exports.padeditbar = {
   _editbarPosition: 0,
+  dropdowns: [],
 
   init() {
-    this.dropdowns = [];
-
     $('#editbar .editbarbutton').attr('unselectable', 'on'); // for IE
     this.enable();
     $('#editbar [data-key]').each((i, elt) => {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -216,9 +216,7 @@ const padeditbar = (() => {
       // hide all modules and remove highlighting of all buttons
       if (moduleName === 'none') {
         const returned = false;
-        for (let i = 0; i < this.dropdowns.length; i++) {
-          const thisModuleName = this.dropdowns[i];
-
+        for (const thisModuleName of this.dropdowns) {
           // skip the userlist
           if (thisModuleName === 'users') continue;
 
@@ -237,8 +235,7 @@ const padeditbar = (() => {
       } else {
         // hide all modules that are not selected and remove highlighting
         // respectively add highlighting to the corresponding button
-        for (let i = 0; i < this.dropdowns.length; i++) {
-          const thisModuleName = this.dropdowns[i];
+        for (const thisModuleName of this.dropdowns) {
           const module = $(`#${thisModuleName}`);
 
           if (module.hasClass('popup-show')) {

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -282,16 +282,16 @@ exports.padeditbar = new class {
     // reset style
     $('.toolbar').removeClass('cropped');
     $('body').removeClass('mobile-layout');
-    const menu_left = $('.toolbar .menu_left')[0];
+    const menuLeft = $('.toolbar .menu_left')[0];
 
     // this is approximate, we cannot measure it because on mobile
     // Layout it takes the full width on the bottom of the page
     const menuRightWidth = 280;
-    if (menu_left && menu_left.scrollWidth > $('.toolbar').width() - menuRightWidth ||
+    if (menuLeft && menuLeft.scrollWidth > $('.toolbar').width() - menuRightWidth ||
         $('.toolbar').width() < 1000) {
       $('body').addClass('mobile-layout');
     }
-    if (menu_left && menu_left.scrollWidth > $('.toolbar').width()) {
+    if (menuLeft && menuLeft.scrollWidth > $('.toolbar').width()) {
       $('.toolbar').addClass('cropped');
     }
   }

--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -211,7 +211,6 @@ exports.padeditbar = {
 
     // hide all modules and remove highlighting of all buttons
     if (moduleName === 'none') {
-      const returned = false;
       for (const thisModuleName of this.dropdowns) {
         // skip the userlist
         if (thisModuleName === 'users') continue;
@@ -227,7 +226,7 @@ exports.padeditbar = {
         }
       }
 
-      if (!returned && cb) return cb();
+      if (cb) return cb();
     } else {
       // hide all modules that are not selected and remove highlighting
       // respectively add highlighting to the corresponding button

--- a/src/static/js/pad_modals.js
+++ b/src/static/js/pad_modals.js
@@ -32,15 +32,14 @@ const padmodals = (() => {
       pad = _pad;
     },
     showModal: (messageId) => {
-      padeditbar.toggleDropDown('none', () => {
-        $('#connectivity .visible').removeClass('visible');
-        $(`#connectivity .${messageId}`).addClass('visible');
+      padeditbar.toggleDropDown('none');
+      $('#connectivity .visible').removeClass('visible');
+      $(`#connectivity .${messageId}`).addClass('visible');
 
-        const $modal = $(`#connectivity .${messageId}`);
-        automaticReconnect.showCountDownTimerToReconnectOnModal($modal, pad);
+      const $modal = $(`#connectivity .${messageId}`);
+      automaticReconnect.showCountDownTimerToReconnectOnModal($modal, pad);
 
-        padeditbar.toggleDropDown('connectivity');
-      });
+      padeditbar.toggleDropDown('connectivity');
     },
     showOverlay: () => {
       // Prevent the user to interact with the toolbar. Useful when user is disconnected for example


### PR DESCRIPTION
Multiple commits:
* pad_editbar: Use `this` instead of `self`
* pad_editbar: Use arrow functions for callbacks, IIFEs
* pad_editbar: Fix invalid use of `this`
* pad_editbar: Convert `bodyKeyEvent()` into a method
* pad_editbar: Simplify iteration
* pad_editbar: Convert `registerDefaultCommands()` into a method
* pad_editbar: Remove unnecessary `syncAnimationFn` variable
* pad_editbar: Move `syncAnimation` out of `padeditbar` IIFE
* pad_editbar: Move `dropdowns` initialization to constructor
* pad_editbar: Move `commands` up for readability
* pad_editbar: Delete unnecessary `returned` variable
* pad_editbar: Don't pass a callback to `toggleDropDown()`
* pad_editbar: Call the callback after all work is done
* pad_editbar: Always call the callback
* pad_editbar: Call the callback asynchronously
* pad_editbar: Deprecate the `toggleDropDown` callback
* pad_editbar: Factor out duplicate code
* pad_editbar: Use ES6 class syntax for readability
* pad_editbar: Convert snake case to camel case
