### PR TITLE
ace2_inner: Various cleanups

### DIFF
--- a/src/static/js/ace.js
+++ b/src/static/js/ace.js
@@ -229,6 +229,10 @@ const Ace2Editor = function () {
     sideDiv.id = 'sidediv';
     sideDiv.classList.add('sidediv');
     outerDocument.body.appendChild(sideDiv);
+    const sideDivInner = outerDocument.createElement('div');
+    sideDivInner.id = 'sidedivinner';
+    sideDivInner.classList.add('sidedivinner');
+    sideDiv.appendChild(sideDivInner);
     const lineMetricsDiv = outerDocument.createElement('div');
     lineMetricsDiv.id = 'linemetricsdiv';
     lineMetricsDiv.appendChild(outerDocument.createTextNode('x'));

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -73,7 +73,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     lineNumbersShown = 1;
     sideDiv.innerHTML = `${htmlOpen}${htmlClose}`;
     sideDivInner = outerWin.document.getElementById('sidedivinner');
-    $(sideDiv).addClass('sidediv');
   };
 
   initLineNumbers();

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -64,14 +64,13 @@ function Ace2Inner(editorInfo, cssManagers) {
   const outerDoc = outerWin.document;
   const sideDiv = outerDoc.getElementById('sidediv');
   const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
-  let lineNumbersShown;
   const sideDivInner = (() => {
     const htmlOpen = '<div id="sidedivinner" class="sidedivinner"><div><span class="line-number">1';
     const htmlClose = '</span></div></div>';
-    lineNumbersShown = 1;
     sideDiv.innerHTML = `${htmlOpen}${htmlClose}`;
     return outerDoc.getElementById('sidedivinner');
   })();
+  let lineNumbersShown = 1;
 
   const scroll = Scroll.init(outerWin);
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -64,10 +64,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   const outerDoc = outerWin.document;
   const sideDiv = outerDoc.getElementById('sidediv');
   const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
-  const sideDivInner = outerDoc.createElement('div');
-  sideDivInner.id = 'sidedivinner';
-  sideDivInner.classList.add('sidedivinner');
-  sideDiv.appendChild(sideDivInner);
+  const sideDivInner = outerDoc.getElementById('sidedivinner');
   (() => {
     const lineDiv = outerDoc.createElement('div');
     sideDivInner.appendChild(lineDiv);

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -65,17 +65,13 @@ function Ace2Inner(editorInfo, cssManagers) {
   const sideDiv = outerDoc.getElementById('sidediv');
   const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
   let lineNumbersShown;
-  let sideDivInner;
-
-  const initLineNumbers = () => {
+  const sideDivInner = (() => {
     const htmlOpen = '<div id="sidedivinner" class="sidedivinner"><div><span class="line-number">1';
     const htmlClose = '</span></div></div>';
     lineNumbersShown = 1;
     sideDiv.innerHTML = `${htmlOpen}${htmlClose}`;
-    sideDivInner = outerWin.document.getElementById('sidedivinner');
-  };
-
-  initLineNumbers();
+    return outerDoc.getElementById('sidedivinner');
+  })();
 
   const scroll = Scroll.init(outerWin);
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -64,11 +64,17 @@ function Ace2Inner(editorInfo, cssManagers) {
   const outerDoc = outerWin.document;
   const sideDiv = outerDoc.getElementById('sidediv');
   const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
-  const sideDivInner = (() => {
-    const htmlOpen = '<div id="sidedivinner" class="sidedivinner"><div><span class="line-number">1';
-    const htmlClose = '</span></div></div>';
-    sideDiv.innerHTML = `${htmlOpen}${htmlClose}`;
-    return outerDoc.getElementById('sidedivinner');
+  const sideDivInner = outerDoc.createElement('div');
+  sideDivInner.id = 'sidedivinner';
+  sideDivInner.classList.add('sidedivinner');
+  sideDiv.appendChild(sideDivInner);
+  (() => {
+    const lineDiv = outerDoc.createElement('div');
+    sideDivInner.appendChild(lineDiv);
+    const lineSpan = outerDoc.createElement('span');
+    lineSpan.classList.add('line-number');
+    lineSpan.appendChild(outerDoc.createTextNode('1'));
+    lineDiv.appendChild(lineSpan);
   })();
   let lineNumbersShown = 1;
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2596,7 +2596,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       // tab keypress, adding keyCode == 9 to this doesn't help as the event is fired twice
       return;
     }
-    let specialHandled = false;
 
     const isTypeForSpecialKey = browser.safari || browser.chrome || browser.firefox
       ? type === 'keydown' : type === 'keypress';
@@ -2619,6 +2618,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       } else if (type === 'keydown') {
         outsideKeyDown(evt);
       }
+      let specialHandled = false;
       if (!stopped) {
         const specialHandledInHook = hooks.callAll('aceKeyEvent', {
           callstack: currentCallStack,
@@ -3543,10 +3543,10 @@ function Ace2Inner(editorInfo, cssManagers) {
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 
     let docLine = document.body.firstElementChild;
-    let h = null;
 
     // First loop to calculate the heights from doc body
     while (docLine) {
+      let h;
       const nextDocLine = docLine.nextElementSibling;
       if (nextDocLine) {
         if (lineOffsets.length === 0) {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -137,7 +137,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       'profileEnd',
     ];
     console = {};
-    for (let i = 0; i < names.length; ++i) console[names[i]] = noop;
+    for (const name of names) console[name] = noop;
   }
 
   const scheduler = parent; // hack for opera required
@@ -275,9 +275,9 @@ function Ace2Inner(editorInfo, cssManagers) {
     applyChangesToBase: 1,
   };
 
-  hooks.callAll('aceRegisterNonScrollableEditEvents').forEach((eventType) => {
+  for (const eventType of hooks.callAll('aceRegisterNonScrollableEditEvents')) {
     _nonScrollableEditEvents[eventType] = 1;
-  });
+  }
 
   const isScrollableEditEvent = (eventType) => !_nonScrollableEditEvents[eventType];
 
@@ -987,9 +987,9 @@ function Ace2Inner(editorInfo, cssManagers) {
     // inspired by Firefox bug #473255, where pasting formatted text
     // causes the cursor to jump away, making the new HTML never found.
     if (document.body.getElementsByTagName) {
-      const nds = document.body.getElementsByTagName('style');
-      for (let i = 0; i < nds.length; i++) {
-        const n = topLevel(nds[i]);
+      const elts = document.body.getElementsByTagName('style');
+      for (const elt of elts) {
+        const n = topLevel(elt);
         if (n && n.parentNode === document.body) {
           observeChangesAroundNode(n);
         }
@@ -1028,9 +1028,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       j++;
     }
     if (!dirtyRangesCheckOut) {
-      const numBodyNodes = document.body.childNodes.length;
-      for (let k = 0; k < numBodyNodes; k++) {
-        const bodyNode = document.body.childNodes.item(k);
+      for (const bodyNode of document.body.childNodes) {
         if ((bodyNode.tagName) && ((!bodyNode.id) || (!rep.lines.containsKey(bodyNode.id)))) {
           observeChangesAroundNode(bodyNode);
         }
@@ -1106,17 +1104,14 @@ function Ace2Inner(editorInfo, cssManagers) {
 
         const entries = [];
         const nodeToAddAfter = lastDirtyNode;
-        const lineNodeInfos = new Array(lines.length);
-        for (let k = 0; k < lines.length; k++) {
-          const lineString = lines[k];
+        const lineNodeInfos = [];
+        for (const lineString of lines) {
           const newEntry = createDomLineEntry(lineString);
           entries.push(newEntry);
-          lineNodeInfos[k] = newEntry.domInfo;
+          lineNodeInfos.push(newEntry.domInfo);
         }
         domInsertsNeeded.push([nodeToAddAfter, lineNodeInfos]);
-        dirtyNodes.forEach((n) => {
-          toDeleteAtEnd.push(n);
-        });
+        for (const n of dirtyNodes) toDeleteAtEnd.push(n);
         const spliceHints = {};
         if (selStart) spliceHints.selStart = selStart;
         if (selEnd) spliceHints.selEnd = selEnd;
@@ -1131,20 +1126,18 @@ function Ace2Inner(editorInfo, cssManagers) {
     const domChanges = (splicesToDo.length > 0);
 
     // update the representation
-    splicesToDo.forEach((splice) => {
+    for (const splice of splicesToDo) {
       doIncorpLineSplice(splice[0], splice[1], splice[2], splice[3], splice[4]);
-    });
+    }
 
     // do DOM inserts
-    domInsertsNeeded.forEach((ins) => {
-      insertDomLines(ins[0], ins[1]);
-    });
+    for (const ins of domInsertsNeeded) insertDomLines(ins[0], ins[1]);
 
     // delete old dom nodes
-    toDeleteAtEnd.forEach((n) => {
+    for (const n of toDeleteAtEnd) {
       // parent of n may not be "root" in IE due to non-tree-shaped DOM (wtf)
       if (n.parentNode) n.parentNode.removeChild(n);
-    });
+    }
 
     // needed to stop chrome from breaking the ui when long strings without spaces are pasted
     if (scrollToTheLeftNeeded) {
@@ -1227,9 +1220,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   const insertDomLines = (nodeToAddAfter, infoStructs) => {
     let lastEntry;
     let lineStartOffset;
-    if (infoStructs.length < 1) return;
-
-    infoStructs.forEach((info) => {
+    for (const info of infoStructs) {
       const node = info.node;
       const key = uniqueId(node);
       let entry;
@@ -1259,7 +1250,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       nodeToAddAfter = node;
       info.notifyAdded();
       markNodeClean(node);
-    });
+    }
   };
 
   const isCaret = () => (rep.selStart && rep.selEnd &&
@@ -1422,10 +1413,10 @@ function Ace2Inner(editorInfo, cssManagers) {
 
       insertDomLines(nodeToAddAfter, lineEntries.map((entry) => entry.domInfo));
 
-      keysToDelete.forEach((k) => {
+      for (const k of keysToDelete) {
         const n = document.getElementById(k);
         n.parentNode.removeChild(n);
-      });
+      }
 
       if (
         (rep.selStart &&
@@ -1696,9 +1687,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   // Change the abstract representation of the document to have a different set of lines.
   // Must be called after rep.alltext is set.
   const doRepLineSplice = (startLine, deleteCount, newLineEntries) => {
-    newLineEntries.forEach((entry) => {
-      entry.width = entry.text.length + 1;
-    });
+    for (const entry of newLineEntries) entry.width = entry.text.length + 1;
 
     const startOldChar = rep.lines.offsetOfIndex(startLine);
     const endOldChar = rep.lines.offsetOfIndex(startLine + deleteCount);
@@ -2074,11 +2063,11 @@ function Ace2Inner(editorInfo, cssManagers) {
   const attribIsFormattingStyle = (attribName) => FORMATTING_STYLES.indexOf(attribName) !== -1;
 
   const selectFormattingButtonIfLineHasStyleApplied = (rep) => {
-    FORMATTING_STYLES.forEach((style) => {
+    for (const style of FORMATTING_STYLES) {
       const hasStyleOnRepSelection =
           documentAttributeManager.hasAttributeOnSelectionOrCaretPosition(style);
       updateStyleButtonState(style, hasStyleOnRepSelection);
-    });
+    }
   };
 
   const doCreateDomLine =
@@ -2096,9 +2085,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     ul: 1,
   };
 
-  hooks.callAll('aceRegisterBlockElements').forEach((element) => {
-    _blockElems[element] = 1;
-  });
+  for (const element of hooks.callAll('aceRegisterBlockElements')) _blockElems[element] = 1;
 
   const isBlockElement = (n) => !!_blockElems[(n.tagName || '').toLowerCase()];
   editorInfo.ace_isBlockElement = isBlockElement;
@@ -2469,9 +2456,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     }
 
-    mods.forEach((mod) => {
-      setLineListType(mod[0], mod[1]);
-    });
+    for (const mod of mods) setLineListType(mod[0], mod[1]);
     return true;
   };
   editorInfo.ace_doIndentOutdent = doIndentOutdent;
@@ -2689,8 +2674,8 @@ function Ace2Inner(editorInfo, cssManagers) {
             // Known authors info, both current and historical
             const padAuthors = parent.parent.pad.userList();
             let authorObj = {};
-            authors.forEach((authorId) => {
-              padAuthors.forEach((padAuthor) => {
+            for (const authorId of authors) {
+              for (const padAuthor of padAuthors) {
                 // If the person doing the lookup is the author..
                 if (padAuthor.userId === authorId) {
                   if (parent.parent.clientVars.userId === authorId) {
@@ -2701,15 +2686,15 @@ function Ace2Inner(editorInfo, cssManagers) {
                     authorObj = padAuthor;
                   }
                 }
-              });
+              }
               if (!authorObj) {
                 author = 'Unknown';
-                return;
+                continue;
               }
               author = authorObj.name;
               if (!author) author = 'Unknown';
               authorNames.push(author);
-            });
+            }
           }
           if (authors.length === 1) {
             authorString = `The author of this line is ${authorNames[0]}`;
@@ -3271,7 +3256,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const _teardownActions = [];
 
-  const teardown = () => _teardownActions.forEach((a) => a());
+  const teardown = () => { for (const a of _teardownActions) a(); };
 
   let inInternationalComposition = null;
   editorInfo.ace_getInInternationalComposition = () => inInternationalComposition;
@@ -3501,9 +3486,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     }
 
-    mods.forEach((mod) => {
-      setLineListType(mod[0], mod[1]);
-    });
+    for (const mod of mods) setLineListType(mod[0], mod[1]);
   };
 
   const doInsertUnorderedList = () => {
@@ -3537,10 +3520,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const innerdocbodyStyles = getComputedStyle(document.body);
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 
-    let docLine = document.body.firstElementChild;
-
-    // First loop to calculate the heights from doc body
-    while (docLine) {
+    for (const docLine of document.body.children) {
       let h;
       const nextDocLine = docLine.nextElementSibling;
       if (nextDocLine) {
@@ -3575,7 +3555,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       } else {
         lineHeights.push(defaultLineHeight);
       }
-      docLine = nextDocLine;
     }
 
     let newNumLines = rep.lines.length();

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -65,14 +65,15 @@ function Ace2Inner(editorInfo, cssManagers) {
   const sideDiv = outerDoc.getElementById('sidediv');
   const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
   const sideDivInner = outerDoc.getElementById('sidedivinner');
-  (() => {
+  const appendNewSideDivLine = () => {
     const lineDiv = outerDoc.createElement('div');
     sideDivInner.appendChild(lineDiv);
     const lineSpan = outerDoc.createElement('span');
     lineSpan.classList.add('line-number');
-    lineSpan.appendChild(outerDoc.createTextNode('1'));
+    lineSpan.appendChild(outerDoc.createTextNode(sideDivInner.children.length));
     lineDiv.appendChild(lineSpan);
-  })();
+  };
+  appendNewSideDivLine();
 
   const scroll = Scroll.init(outerWin);
 
@@ -3591,12 +3592,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     if (newNumLines < 1) newNumLines = 1;
 
     if (newNumLines !== sideDivInner.children.length) {
-      while (sideDivInner.children.length < newNumLines) {
-        const div = outerDoc.createElement('DIV');
-        sideDivInner.appendChild(div);
-        $(div).append($(`<span class='line-number'>${sideDivInner.children.length}</span>`));
-      }
-
+      while (sideDivInner.children.length < newNumLines) appendNewSideDivLine();
       // Remove extra lines
       while (sideDivInner.children.length > newNumLines) {
         sideDivInner.removeChild(sideDivInner.lastChild);

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3543,7 +3543,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     // but as it's non-text type the line-height/margins might not be present and it
     // could be that this breaks a theme that has a different default line height..
     // So instead of using an integer here we get the value from the Editor CSS.
-    const innerdocbody = document.querySelector('#innerdocbody');
+    const innerdocbody = document.body;
     const innerdocbodyStyles = getComputedStyle(innerdocbody);
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3543,8 +3543,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     // but as it's non-text type the line-height/margins might not be present and it
     // could be that this breaks a theme that has a different default line height..
     // So instead of using an integer here we get the value from the Editor CSS.
-    const innerdocbody = document.body;
-    const innerdocbodyStyles = getComputedStyle(innerdocbody);
+    const innerdocbodyStyles = getComputedStyle(document.body);
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 
     let docLine = document.body.firstChild;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -528,9 +528,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     performDocumentApplyChangeset(changeset);
 
     performSelectionChange(
-        [0, rep.lines.atIndex(0).lineMarker],
-        [0, rep.lines.atIndex(0).lineMarker]
-    );
+        [0, rep.lines.atIndex(0).lineMarker], [0, rep.lines.atIndex(0).lineMarker]);
 
     idleWorkTimer.atMost(100);
 
@@ -1129,10 +1127,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         splicesToDo.push([a + netNumLinesChangeSoFar, b - a, entries, lineAttribs, spliceHints]);
         netNumLinesChangeSoFar += (lines.length - (b - a));
       } else if (b > a) {
-        splicesToDo.push([a + netNumLinesChangeSoFar,
-          b - a,
-          [],
-          []]);
+        splicesToDo.push([a + netNumLinesChangeSoFar, b - a, [], []]);
       }
       i++;
     }
@@ -1271,12 +1266,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     });
   };
 
-  const isCaret = () => (
-    rep.selStart &&
-    rep.selEnd &&
-    rep.selStart[0] === rep.selEnd[0] &&
-    rep.selStart[1] === rep.selEnd[1]
-  );
+  const isCaret = () => (rep.selStart && rep.selEnd &&
+                         rep.selStart[0] === rep.selEnd[0] && rep.selStart[1] === rep.selEnd[1]);
   editorInfo.ace_isCaret = isCaret;
 
   // prereq: isCaret()
@@ -1473,12 +1464,9 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     if (requiredSelectionSetting) {
       performSelectionChange(
-          lineAndColumnFromChar(
-              requiredSelectionSetting[0]
-          ),
+          lineAndColumnFromChar(requiredSelectionSetting[0]),
           lineAndColumnFromChar(requiredSelectionSetting[1]),
-          requiredSelectionSetting[2]
-      );
+          requiredSelectionSetting[2]);
     }
   };
 
@@ -1553,8 +1541,8 @@ function Ace2Inner(editorInfo, cssManagers) {
         newText = newText.substring(0, newText.length - 1);
       }
     }
-    performDocumentReplaceRange(lineAndColumnFromChar(startChar),
-        lineAndColumnFromChar(endChar), newText);
+    performDocumentReplaceRange(
+        lineAndColumnFromChar(startChar), lineAndColumnFromChar(endChar), newText);
   };
 
   const performDocumentApplyAttributesToCharRange = (start, end, attribs) => {
@@ -1697,10 +1685,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     const attributeValue = selectionAllHasIt ? '' : 'true';
     documentAttributeManager.setAttributesOnRange(
-        rep.selStart,
-        rep.selEnd,
-        [[attributeName, attributeValue]]
-    );
+        rep.selStart, rep.selEnd, [[attributeName, attributeValue]]);
     if (attribIsFormattingStyle(attributeName)) {
       updateStyleButtonState(attributeName, !selectionAllHasIt); // italic, bold, ...
     }
@@ -1750,9 +1735,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     const oldText = rep.alltext.substring(startOldChar, endOldChar);
     const oldAttribs = rep.alines.slice(startLine, startLine + deleteCount).join('');
     const newAttribs = `${lineAttribs.join('|1+1')}|1+1`; // not valid in a changeset
-    const analysis = analyzeChange(
-        oldText, newText, oldAttribs, newAttribs, selStartHintChar, selEndHintChar
-    );
+    const analysis =
+        analyzeChange(oldText, newText, oldAttribs, newAttribs, selStartHintChar, selEndHintChar);
     const commonStart = analysis[0];
     let commonEnd = analysis[1];
     let shortOldText = oldText.substring(commonStart, oldText.length - commonEnd);
@@ -1837,9 +1821,7 @@ function Ace2Inner(editorInfo, cssManagers) {
                 return rep.apool.putAttrib([k, '']);
               }
               return false;
-            }
-            )
-        );
+            }));
 
         const builder1 = startBuilder();
         if (shiftFinalNewlineToBeforeNewText) {
@@ -2078,8 +2060,7 @@ function Ace2Inner(editorInfo, cssManagers) {
             isScrollableEditEvent(currentCallStack.type);
         const innerHeight = getInnerHeight();
         scroll.scrollWhenCaretIsInTheLastLineOfViewportWhenNecessary(
-            rep, isScrollableEvent, innerHeight * 2
-        );
+            rep, isScrollableEvent, innerHeight * 2);
       }
 
       return true;
@@ -2087,11 +2068,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     return false;
   };
 
-  const isPadLoading = (eventType) => (
-    eventType === 'setup') ||
-    (eventType === 'setBaseText') ||
-    (eventType === 'importText'
-    );
+  const isPadLoading = (t) => t === 'setup' || t === 'setBaseText' || t === 'importText';
 
   const updateStyleButtonState = (attribName, hasStyleOnRepSelection) => {
     const $formattingButton = parent.parent.$(`[data-key="${attribName}"]`).find('a');
@@ -2475,11 +2452,10 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const doIndentOutdent = (isOut) => {
     if (!((rep.selStart && rep.selEnd) ||
-        ((rep.selStart[0] === rep.selEnd[0]) &&
-        (rep.selStart[1] === rep.selEnd[1]) &&
-        rep.selEnd[1] > 1)) &&
-        (isOut !== true)
-    ) {
+          (rep.selStart[0] === rep.selEnd[0] &&
+           rep.selStart[1] === rep.selEnd[1] &&
+           rep.selEnd[1] > 1)) &&
+        isOut !== true) {
       return false;
     }
 
@@ -2553,9 +2529,7 @@ function Ace2Inner(editorInfo, cssManagers) {
               if (prevLineBlank && !prevLineListType) {
                 // previous line is blank, remove it
                 performDocumentReplaceRange(
-                    [theLine - 1, prevLineEntry.text.length],
-                    [theLine, 0], ''
-                );
+                    [theLine - 1, prevLineEntry.text.length], [theLine, 0], '');
               } else {
                 // delistify
                 performDocumentReplaceRange([theLine, 0], [theLine, lineEntry.lineMarker], '');
@@ -2563,15 +2537,11 @@ function Ace2Inner(editorInfo, cssManagers) {
             } else if (thisLineHasMarker && prevLineEntry) {
               // If the line has any attributes assigned, remove them by removing the marker '*'
               performDocumentReplaceRange(
-                  [theLine - 1, prevLineEntry.text.length],
-                  [theLine, lineEntry.lineMarker], ''
-              );
+                  [theLine - 1, prevLineEntry.text.length], [theLine, lineEntry.lineMarker], '');
             } else if (theLine > 0) {
               // remove newline
               performDocumentReplaceRange(
-                  [theLine - 1, prevLineEntry.text.length],
-                  [theLine, 0], ''
-              );
+                  [theLine - 1, prevLineEntry.text.length], [theLine, 0], '');
             }
           } else {
             const docChar = caretDocChar();
@@ -2624,29 +2594,24 @@ function Ace2Inner(editorInfo, cssManagers) {
     // 224 is the command-key under Mac Firefox.
     // 91 is the Windows key in IE; it is ASCII for open-bracket but isn't the keycode for that key
     // 20 is capslock in IE.
-    const isModKey = ((!charCode) &&
-    ((type === 'keyup') || (type === 'keydown')) &&
-    (
-      keyCode === 16 || keyCode === 17 || keyCode === 18 ||
-      keyCode === 20 || keyCode === 224 || keyCode === 91
-    ));
+    const isModKey = !charCode && (type === 'keyup' || type === 'keydown') &&
+        (keyCode === 16 || keyCode === 17 || keyCode === 18 ||
+         keyCode === 20 || keyCode === 224 || keyCode === 91);
     if (isModKey) return;
 
     // If the key is a keypress and the browser is opera and the key is enter,
     // do nothign at all as this fires twice.
-    if (keyCode === 13 && browser.opera && (type === 'keypress')) {
+    if (keyCode === 13 && browser.opera && type === 'keypress') {
       // This stops double enters in Opera but double Tabs still show on single
       // tab keypress, adding keyCode == 9 to this doesn't help as the event is fired twice
       return;
     }
     let specialHandled = false;
 
-    const isTypeForSpecialKey = ((browser.safari ||
-      browser.chrome ||
-      browser.firefox) ? (type === 'keydown') : (type === 'keypress'));
-    const isTypeForCmdKey = ((browser.safari ||
-      browser.chrome ||
-      browser.firefox) ? (type === 'keydown') : (type === 'keypress'));
+    const isTypeForSpecialKey = browser.safari || browser.chrome || browser.firefox
+      ? type === 'keydown' : type === 'keypress';
+    const isTypeForCmdKey = browser.safari || browser.chrome || browser.firefox
+      ? type === 'keydown' : type === 'keypress';
 
     let stopped = false;
 
@@ -2679,13 +2644,9 @@ function Ace2Inner(editorInfo, cssManagers) {
         }
 
         const padShortcutEnabled = parent.parent.clientVars.padShortcutEnabled;
-        if (
-          (!specialHandled) &&
-          altKey &&
-          isTypeForSpecialKey &&
-          keyCode === 120 &&
-          padShortcutEnabled.altF9
-        ) {
+        if (!specialHandled && isTypeForSpecialKey &&
+            altKey && keyCode === 120 &&
+            padShortcutEnabled.altF9) {
           // Alt F9 focuses on the File Menu and/or editbar.
           // Note that while most editors use Alt F10 this is not desirable
           // As ubuntu cannot use Alt F10....
@@ -2698,26 +2659,18 @@ function Ace2Inner(editorInfo, cssManagers) {
           firstEditbarElement.focus();
           evt.preventDefault();
         }
-        if (
-          (!specialHandled) &&
-          altKey && keyCode === 67 &&
-          type === 'keydown' &&
-          padShortcutEnabled.altC
-        ) {
+        if (!specialHandled && type === 'keydown' &&
+            altKey && keyCode === 67 &&
+            padShortcutEnabled.altC) {
           // Alt c focuses on the Chat window
           $(this).blur();
           parent.parent.chat.show();
           parent.parent.$('#chatinput').focus();
           evt.preventDefault();
         }
-        if (
-          (!specialHandled) &&
-          evt.ctrlKey &&
-          shiftKey &&
-          keyCode === 50 &&
-          type === 'keydown' &&
-          padShortcutEnabled.cmdShift2
-        ) {
+        if (!specialHandled && type === 'keydown' &&
+            evt.ctrlKey && shiftKey && keyCode === 50 &&
+            padShortcutEnabled.cmdShift2) {
           // Control-Shift-2 shows a gritter popup showing a line author
           const lineNumber = rep.selEnd[0];
           const alineAttrs = rep.alines[lineNumber];
@@ -2791,11 +2744,9 @@ function Ace2Inner(editorInfo, cssManagers) {
             time: '4000',
           });
         }
-        if ((!specialHandled) &&
-          isTypeForSpecialKey &&
-          keyCode === 8 &&
-          padShortcutEnabled.delete
-        ) {
+        if (!specialHandled && isTypeForSpecialKey &&
+            keyCode === 8 &&
+            padShortcutEnabled.delete) {
           // "delete" key; in mozilla, if we're at the beginning of a line, normalize now,
           // or else deleting a blank line can take two delete presses.
           // --
@@ -2808,11 +2759,9 @@ function Ace2Inner(editorInfo, cssManagers) {
           doDeleteKey(evt);
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          isTypeForSpecialKey &&
-          keyCode === 13 &&
-          padShortcutEnabled.return
-        ) {
+        if (!specialHandled && isTypeForSpecialKey &&
+            keyCode === 13 &&
+            padShortcutEnabled.return) {
           // return key, handle specially;
           // note that in mozilla we need to do an incorporation for proper return behavior anyway.
           fastIncorp(4);
@@ -2823,11 +2772,9 @@ function Ace2Inner(editorInfo, cssManagers) {
           }, 0);
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          isTypeForSpecialKey &&
-          keyCode === 27 &&
-          padShortcutEnabled.esc
-        ) {
+        if (!specialHandled && isTypeForSpecialKey &&
+            keyCode === 27 &&
+            padShortcutEnabled.esc) {
           // prevent esc key;
           // in mozilla versions 14-19 avoid reconnecting pad.
 
@@ -2838,15 +2785,11 @@ function Ace2Inner(editorInfo, cssManagers) {
           // close all gritters when the user hits escape key
           parent.parent.$.gritter.removeAll();
         }
-        if (
-          (!specialHandled) &&
-          /* Do a saved revision on ctrl S */
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 's' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          !evt.altKey &&
-          padShortcutEnabled.cmdS
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            /* Do a saved revision on ctrl S */
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 's' &&
+            !evt.altKey &&
+            padShortcutEnabled.cmdS) {
           evt.preventDefault();
           const originalBackground = parent.parent.$('#revisionlink').css('background');
           parent.parent.$('#revisionlink').css({background: 'lightyellow'});
@@ -2857,25 +2800,21 @@ function Ace2Inner(editorInfo, cssManagers) {
           parent.parent.pad.collabClient.sendMessage({type: 'SAVE_REVISION'});
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // tab
-          isTypeForSpecialKey &&
-          keyCode === 9 &&
-          !(evt.metaKey || evt.ctrlKey) &&
-          padShortcutEnabled.tab) {
+        if (!specialHandled && isTypeForSpecialKey &&
+            // tab
+            keyCode === 9 &&
+            !(evt.metaKey || evt.ctrlKey) &&
+            padShortcutEnabled.tab) {
           fastIncorp(5);
           evt.preventDefault();
           doTabKey(evt.shiftKey);
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-Z (undo)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'z' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          !evt.altKey &&
-          padShortcutEnabled.cmdZ
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-Z (undo)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'z' &&
+            !evt.altKey &&
+            padShortcutEnabled.cmdZ) {
           fastIncorp(6);
           evt.preventDefault();
           if (evt.shiftKey) {
@@ -2885,120 +2824,93 @@ function Ace2Inner(editorInfo, cssManagers) {
           }
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-        // cmd-Y (redo)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'y' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          padShortcutEnabled.cmdY
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-Y (redo)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'y' &&
+            padShortcutEnabled.cmdY) {
           fastIncorp(10);
           evt.preventDefault();
           doUndoRedo('redo');
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-B (bold)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'b' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          padShortcutEnabled.cmdB) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-B (bold)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'b' &&
+            padShortcutEnabled.cmdB) {
           fastIncorp(13);
           evt.preventDefault();
           toggleAttributeOnSelection('bold');
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-I (italic)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'i' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          padShortcutEnabled.cmdI
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-I (italic)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'i' &&
+            padShortcutEnabled.cmdI) {
           fastIncorp(14);
           evt.preventDefault();
           toggleAttributeOnSelection('italic');
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'u' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          padShortcutEnabled.cmdU
-        ) {
-          // cmd-U (underline)
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-U (underline)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'u' &&
+            padShortcutEnabled.cmdU) {
           fastIncorp(15);
           evt.preventDefault();
           toggleAttributeOnSelection('underline');
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-5 (strikethrough)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === '5' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          evt.altKey !== true &&
-          padShortcutEnabled.cmd5
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-5 (strikethrough)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === '5' &&
+            evt.altKey !== true &&
+            padShortcutEnabled.cmd5) {
           fastIncorp(13);
           evt.preventDefault();
           toggleAttributeOnSelection('strikethrough');
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-shift-L (unorderedlist)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'l' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          evt.shiftKey &&
-          padShortcutEnabled.cmdShiftL
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-shift-L (unorderedlist)
+            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'l' &&
+            evt.shiftKey &&
+            padShortcutEnabled.cmdShiftL) {
           fastIncorp(9);
           evt.preventDefault();
           doInsertUnorderedList();
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-shift-N and cmd-shift-1 (orderedlist)
-          isTypeForCmdKey &&
-          (
-            (String.fromCharCode(which).toLowerCase() === 'n' &&
-              padShortcutEnabled.cmdShiftN) || (String.fromCharCode(which) === '1' &&
-              padShortcutEnabled.cmdShift1)
-          ) && (evt.metaKey || evt.ctrlKey) &&
-            evt.shiftKey
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-shift-N and cmd-shift-1 (orderedlist)
+            (evt.metaKey || evt.ctrlKey) && evt.shiftKey &&
+            ((String.fromCharCode(which).toLowerCase() === 'n' && padShortcutEnabled.cmdShiftN) ||
+             (String.fromCharCode(which) === '1' && padShortcutEnabled.cmdShift1))) {
           fastIncorp(9);
           evt.preventDefault();
           doInsertOrderedList();
           specialHandled = true;
         }
-        if ((!specialHandled) &&
-          // cmd-shift-C (clearauthorship)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'c' &&
-          (evt.metaKey || evt.ctrlKey) &&
-          evt.shiftKey && padShortcutEnabled.cmdShiftC
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-shift-C (clearauthorship)
+            (evt.metaKey || evt.ctrlKey) && evt.shiftKey &&
+            String.fromCharCode(which).toLowerCase() === 'c' &&
+            padShortcutEnabled.cmdShiftC) {
           fastIncorp(9);
           evt.preventDefault();
           CMDS.clearauthorship();
         }
-        if ((!specialHandled) &&
-          // cmd-H (backspace)
-          isTypeForCmdKey &&
-          String.fromCharCode(which).toLowerCase() === 'h' &&
-          (evt.ctrlKey) &&
-          padShortcutEnabled.cmdH
-        ) {
+        if (!specialHandled && isTypeForCmdKey &&
+            // cmd-H (backspace)
+            (evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'h' &&
+            padShortcutEnabled.cmdH) {
           fastIncorp(20);
           evt.preventDefault();
           doDeleteKey();
           specialHandled = true;
         }
-        if ((evt.which === 36 && evt.ctrlKey === true) &&
-        // Control Home send to Y = 0
-        padShortcutEnabled.ctrlHome) {
+        if (evt.ctrlKey === true && evt.which === 36 &&
+            // Control Home send to Y = 0
+            padShortcutEnabled.ctrlHome) {
           scroll.setScrollY(0);
         }
         if ((evt.which === 33 || evt.which === 34) && type === 'keydown' && !evt.ctrlKey) {
@@ -3099,10 +3011,9 @@ function Ace2Inner(editorInfo, cssManagers) {
         thisKeyDoesntTriggerNormalize = true;
       }
 
-      if ((!specialHandled) && (!thisKeyDoesntTriggerNormalize) && (!inInternationalComposition)) {
-        if (type !== 'keyup') {
-          observeChangesAroundSelection();
-        }
+      if (!specialHandled && !thisKeyDoesntTriggerNormalize && !inInternationalComposition &&
+          type !== 'keyup') {
+        observeChangesAroundSelection();
       }
 
       if (type === 'keyup') {
@@ -3128,12 +3039,9 @@ function Ace2Inner(editorInfo, cssManagers) {
           }
           if (selectionInfo) {
             performSelectionChange(
-                lineAndColumnFromChar(
-                    selectionInfo.selStart
-                ),
+                lineAndColumnFromChar(selectionInfo.selStart),
                 lineAndColumnFromChar(selectionInfo.selEnd),
-                selectionInfo.selFocusAtStart
-            );
+                selectionInfo.selFocusAtStart);
           }
           const oldEvent = currentCallStack.startNewEvent(oldEventType, true);
           return oldEvent;
@@ -3173,15 +3081,13 @@ function Ace2Inner(editorInfo, cssManagers) {
         // with background doesn't seem to show up...
         if (isNodeText(p.node) && p.index === p.maxIndex) {
           let n = p.node;
-          while ((!n.nextSibling) && (n !== root) && (n.parentNode !== root)) {
+          while (!n.nextSibling && n !== root && n.parentNode !== root) {
             n = n.parentNode;
           }
-          if (
-            n.nextSibling &&
-            (!((typeof n.nextSibling.tagName) === 'string' &&
-              n.nextSibling.tagName.toLowerCase() === 'br')) &&
-              (n !== p.node) && (n !== root) && (n.parentNode !== root)
-          ) {
+          if (n.nextSibling &&
+              !(typeof n.nextSibling.tagName === 'string' &&
+                n.nextSibling.tagName.toLowerCase() === 'br') &&
+              n !== p.node && n !== root && n.parentNode !== root) {
             // found a parent, go to next node and dive in
             p.node = n.nextSibling;
             p.maxIndex = nodeMaxIndex(p.node);
@@ -3212,19 +3118,13 @@ function Ace2Inner(editorInfo, cssManagers) {
     if (browserSelection) {
       browserSelection.removeAllRanges();
       if (selection) {
-        isCollapsed = (
-          selection.startPoint.node === selection.endPoint.node &&
-          selection.startPoint.index === selection.endPoint.index
-        );
+        isCollapsed = (selection.startPoint.node === selection.endPoint.node &&
+                       selection.startPoint.index === selection.endPoint.index);
         const start = pointToRangeBound(selection.startPoint);
         const end = pointToRangeBound(selection.endPoint);
 
-        if (
-          (!isCollapsed) &&
-          selection.focusAtStart &&
-          browserSelection.collapse &&
-          browserSelection.extend
-        ) {
+        if (!isCollapsed && selection.focusAtStart &&
+            browserSelection.collapse && browserSelection.extend) {
           // can handle "backwards"-oriented selection, shift-arrow-keys move start
           // of selection
           browserSelection.collapse(end.container, end.offset);
@@ -3509,8 +3409,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       let charsToLeft = index;
       let charsToRight = node.nodeValue.length - index;
       let n;
-      for (n = node.previousSibling; n &&
-          isNodeText(n); n = n.previousSibling) {
+      for (n = node.previousSibling; n && isNodeText(n); n = n.previousSibling) {
         charsToLeft += n.nodeValue;
       }
       const leftEdge = (n ? rightOf(n) : leftOf(node.parentNode));
@@ -3560,9 +3459,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     if (!doesWrap) {
       const browserSelection = getSelection();
       if (browserSelection) {
-        const focusPoint = (
-          browserSelection.focusAtStart ? browserSelection.startPoint : browserSelection.endPoint
-        );
+        const focusPoint =
+            browserSelection.focusAtStart ? browserSelection.startPoint : browserSelection.endPoint;
         const selectionPointX = getSelectionPointX(focusPoint);
         scrollXHorizontallyIntoView(selectionPointX);
         fixView();
@@ -3681,8 +3579,7 @@ function Ace2Inner(editorInfo, cssManagers) {
           // extra margins/padding, but plugins might.
           h = docLine.nextSibling.offsetTop - parseInt(
               window.getComputedStyle(doc.body)
-                  .getPropertyValue('padding-top').split('px')[0]
-          );
+                  .getPropertyValue('padding-top').split('px')[0]);
         } else {
           h = docLine.nextSibling.offsetTop - docLine.offsetTop;
         }

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3589,9 +3589,21 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     let newNumLines = rep.lines.length();
     if (newNumLines < 1) newNumLines = 1;
-    let sidebarLine = sideDivInner.firstChild;
 
-    // Apply height to existing sidediv lines
+    if (newNumLines !== sideDivInner.children.length) {
+      while (sideDivInner.children.length < newNumLines) {
+        const div = outerDoc.createElement('DIV');
+        sideDivInner.appendChild(div);
+        $(div).append($(`<span class='line-number'>${sideDivInner.children.length}</span>`));
+      }
+
+      // Remove extra lines
+      while (sideDivInner.children.length > newNumLines) {
+        sideDivInner.removeChild(sideDivInner.lastChild);
+      }
+    }
+
+    let sidebarLine = sideDivInner.firstChild;
     currentLine = 0;
     while (sidebarLine && currentLine <= sideDivInner.children.length) {
       if (lineOffsets[currentLine] != null) {
@@ -3600,25 +3612,6 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
       sidebarLine = sidebarLine.nextSibling;
       currentLine++;
-    }
-
-    if (newNumLines !== sideDivInner.children.length) {
-      // Create missing line and apply height
-      while (sideDivInner.children.length < newNumLines) {
-        const div = outerDoc.createElement('DIV');
-        sideDivInner.appendChild(div);
-        if (lineOffsets[currentLine]) {
-          div.style.height = `${lineOffsets[currentLine]}px`;
-          div.style.lineHeight = `${lineHeights[currentLine]}px`;
-        }
-        $(div).append($(`<span class='line-number'>${sideDivInner.children.length}</span>`));
-        currentLine++;
-      }
-
-      // Remove extra lines
-      while (sideDivInner.children.length > newNumLines) {
-        sideDivInner.removeChild(sideDivInner.lastChild);
-      }
     }
   };
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -110,7 +110,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     undoModule.apool = rep.apool;
   }
 
-  let root, doc; // set in init()
   let isEditable = true;
   let doesWrap = true;
   let hasLineNumbers = true;
@@ -403,7 +402,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const setWraps = (newVal) => {
     doesWrap = newVal;
-    root.classList.toggle('doesWrap', doesWrap);
+    document.body.classList.toggle('doesWrap', doesWrap);
     scheduler.setTimeout(() => {
       inCallStackIfNecessary('setWraps', () => {
         fastIncorp(7);
@@ -433,7 +432,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const setTextFace = (face) => {
-    root.style.fontFamily = face;
+    document.body.style.fontFamily = face;
     lineMetricsDiv.style.fontFamily = face;
   };
 
@@ -444,8 +443,8 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const setEditable = (newVal) => {
     isEditable = newVal;
-    root.contentEditable = isEditable ? 'true' : 'false';
-    root.classList.toggle('static', !isEditable);
+    document.body.contentEditable = isEditable ? 'true' : 'false';
+    document.body.classList.toggle('static', !isEditable);
   };
 
   const enforceEditability = () => setEditable(isEditable);
@@ -628,8 +627,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     // These properties are exposed
     const setters = {
       wraps: setWraps,
-      showsauthorcolors: (val) => root.classList.toggle('authorColors', !!val),
-      showsuserselections: (val) => root.classList.toggle('userSelections', !!val),
+      showsauthorcolors: (val) => document.body.classList.toggle('authorColors', !!val),
+      showsuserselections: (val) => document.body.classList.toggle('userSelections', !!val),
       showslinenumbers: (value) => {
         hasLineNumbers = !!value;
         sideDiv.parentNode.classList.toggle('line-numbers-hidden', !hasLineNumbers);
@@ -642,8 +641,8 @@ function Ace2Inner(editorInfo, cssManagers) {
       styled: setStyled,
       textface: setTextFace,
       rtlistrue: (value) => {
-        root.classList.toggle('rtl', value);
-        root.classList.toggle('ltr', !value);
+        document.body.classList.toggle('rtl', value);
+        document.body.classList.toggle('ltr', !value);
         document.documentElement.dir = value ? 'rtl' : 'ltr';
       },
     };
@@ -681,7 +680,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   editorInfo.ace_getUnhandledErrors = () => caughtErrors.slice();
 
-  editorInfo.ace_getDocument = () => doc;
+  editorInfo.ace_getDocument = () => document;
 
   editorInfo.ace_getDebugProperty = (prop) => {
     if (prop === 'debugger') {
@@ -901,11 +900,11 @@ function Ace2Inner(editorInfo, cssManagers) {
   clearObservedChanges();
 
   const getCleanNodeByKey = (key) => {
-    let n = doc.getElementById(key);
+    let n = document.getElementById(key);
     // copying and pasting can lead to duplicate ids
     while (n && isNodeDirty(n)) {
       n.id = '';
-      n = doc.getElementById(key);
+      n = document.getElementById(key);
     }
     return n;
   };
@@ -987,11 +986,11 @@ function Ace2Inner(editorInfo, cssManagers) {
   const observeSuspiciousNodes = () => {
     // inspired by Firefox bug #473255, where pasting formatted text
     // causes the cursor to jump away, making the new HTML never found.
-    if (root.getElementsByTagName) {
-      const nds = root.getElementsByTagName('style');
+    if (document.body.getElementsByTagName) {
+      const nds = document.body.getElementsByTagName('style');
       for (let i = 0; i < nds.length; i++) {
         const n = topLevel(nds[i]);
-        if (n && n.parentNode === root) {
+        if (n && n.parentNode === document.body) {
           observeChangesAroundNode(n);
         }
       }
@@ -1006,8 +1005,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     if (DEBUG && window.DONT_INCORP || window.DEBUG_DONT_INCORP) return false;
 
     // returns true if dom changes were made
-    if (!root.firstChild) {
-      root.innerHTML = '<div><!-- --></div>';
+    if (!document.body.firstChild) {
+      document.body.innerHTML = '<div><!-- --></div>';
     }
 
     observeChangesAroundSelection();
@@ -1029,9 +1028,9 @@ function Ace2Inner(editorInfo, cssManagers) {
       j++;
     }
     if (!dirtyRangesCheckOut) {
-      const numBodyNodes = root.childNodes.length;
+      const numBodyNodes = document.body.childNodes.length;
       for (let k = 0; k < numBodyNodes; k++) {
-        const bodyNode = root.childNodes.item(k);
+        const bodyNode = document.body.childNodes.item(k);
         if ((bodyNode.tagName) && ((!bodyNode.id) || (!rep.lines.containsKey(bodyNode.id)))) {
           observeChangesAroundNode(bodyNode);
         }
@@ -1053,11 +1052,11 @@ function Ace2Inner(editorInfo, cssManagers) {
       const range = dirtyRanges[i];
       a = range[0];
       b = range[1];
-      let firstDirtyNode = (((a === 0) && root.firstChild) ||
+      let firstDirtyNode = (((a === 0) && document.body.firstChild) ||
           getCleanNodeByKey(rep.lines.atIndex(a - 1).key).nextSibling);
       firstDirtyNode = (firstDirtyNode && isNodeDirty(firstDirtyNode) && firstDirtyNode);
 
-      let lastDirtyNode = (((b === rep.lines.length()) && root.lastChild) ||
+      let lastDirtyNode = (((b === rep.lines.length()) && document.body.lastChild) ||
           getCleanNodeByKey(rep.lines.atIndex(b).key).previousSibling);
 
       lastDirtyNode = (lastDirtyNode && isNodeDirty(lastDirtyNode) && lastDirtyNode);
@@ -1159,7 +1158,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         callstack: currentCallStack,
         editorInfo,
         rep,
-        root,
+        root: document.body,
         point: selection.startPoint,
         documentAttributeManager,
       });
@@ -1171,7 +1170,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         callstack: currentCallStack,
         editorInfo,
         rep,
-        root,
+        root: document.body,
         point: selection.endPoint,
         documentAttributeManager,
       });
@@ -1253,9 +1252,9 @@ function Ace2Inner(editorInfo, cssManagers) {
       info.prepareForAdd();
       entry.lineMarker = info.lineMarker;
       if (!nodeToAddAfter) {
-        root.insertBefore(node, root.firstChild);
+        document.body.insertBefore(node, document.body.firstChild);
       } else {
-        root.insertBefore(node, nodeToAddAfter.nextSibling);
+        document.body.insertBefore(node, nodeToAddAfter.nextSibling);
       }
       nodeToAddAfter = node;
       info.notifyAdded();
@@ -1352,7 +1351,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     // Turn DOM node selection into [line,char] selection.
     // This method has to work when the DOM is not pristine,
     // assuming the point is not in a dirty node.
-    if (point.node === root) {
+    if (point.node === document.body) {
       if (point.index === 0) {
         return [0, 0];
       } else {
@@ -1371,7 +1370,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         col = nodeText(n).length;
       }
       let parNode, prevSib;
-      while ((parNode = n.parentNode) !== root) {
+      while ((parNode = n.parentNode) !== document.body) {
         if ((prevSib = n.previousSibling)) {
           n = prevSib;
           col += nodeText(n).length;
@@ -1424,7 +1423,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       insertDomLines(nodeToAddAfter, lineEntries.map((entry) => entry.domInfo));
 
       keysToDelete.forEach((k) => {
-        const n = doc.getElementById(k);
+        const n = document.getElementById(k);
         n.parentNode.removeChild(n);
       });
 
@@ -2082,7 +2081,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     });
   };
 
-  const doCreateDomLine = (nonEmpty) => domline.createDomLine(nonEmpty, doesWrap, browser, doc);
+  const doCreateDomLine =
+      (nonEmpty) => domline.createDomLine(nonEmpty, doesWrap, browser, document);
 
   const textify =
       (str) => str.replace(/[\n\r ]/g, ' ').replace(/\xa0/g, ' ').replace(/\t/g, '        ');
@@ -2141,7 +2141,7 @@ function Ace2Inner(editorInfo, cssManagers) {
           const a = cleanNodeForIndex(i - 1);
           const b = cleanNodeForIndex(i);
           if ((!a) || (!b)) return false; // violates precondition
-          if ((a === true) && (b === true)) return !root.firstChild;
+          if ((a === true) && (b === true)) return !document.body.firstChild;
           if ((a === true) && b.previousSibling) return false;
           if ((b === true) && a.nextSibling) return false;
           if ((a === true) || (b === true)) return true;
@@ -2294,7 +2294,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const isNodeDirty = (n) => {
-    if (n.parentNode !== root) return true;
+    if (n.parentNode !== document.body) return true;
     const data = getAssoc(n, 'dirtiness');
     if (!data) return true;
     if (n.id !== data.nodeId) return true;
@@ -3073,13 +3073,13 @@ function Ace2Inner(editorInfo, cssManagers) {
         // with background doesn't seem to show up...
         if (isNodeText(p.node) && p.index === p.maxIndex) {
           let n = p.node;
-          while (!n.nextSibling && n !== root && n.parentNode !== root) {
+          while (!n.nextSibling && n !== document.body && n.parentNode !== document.body) {
             n = n.parentNode;
           }
           if (n.nextSibling &&
               !(typeof n.nextSibling.tagName === 'string' &&
                 n.nextSibling.tagName.toLowerCase() === 'br') &&
-              n !== p.node && n !== root && n.parentNode !== root) {
+              n !== p.node && n !== document.body && n.parentNode !== document.body) {
             // found a parent, go to next node and dive in
             p.node = n.nextSibling;
             p.maxIndex = nodeMaxIndex(p.node);
@@ -3122,7 +3122,7 @@ function Ace2Inner(editorInfo, cssManagers) {
           browserSelection.collapse(end.container, end.offset);
           browserSelection.extend(start.container, start.offset);
         } else {
-          const range = doc.createRange();
+          const range = document.createRange();
           range.setStart(start.container, start.offset);
           range.setEnd(end.container, end.offset);
           browserSelection.removeAllRanges();
@@ -3199,7 +3199,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       if (!isInBody(container)) {
         // command-click in Firefox selects whole document, HEAD and BODY!
         return {
-          node: root,
+          node: document.body,
           index: 0,
           maxIndex: 1,
         };
@@ -3294,7 +3294,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     // If non-nullish, pasting on a link should be suppressed.
     let suppressPasteOnLink = null;
 
-    $(root).on('auxclick', (e) => {
+    $(document.body).on('auxclick', (e) => {
       if (e.originalEvent.button === 1 && (e.target.a || e.target.localName === 'a')) {
         // The user middle-clicked on a link. Usually users do this to open a link in a new tab, but
         // in X11 (Linux) this will instead paste the contents of the primary selection at the mouse
@@ -3316,7 +3316,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     });
 
-    $(root).on('paste', (e) => {
+    $(document.body).on('paste', (e) => {
       if (suppressPasteOnLink != null && (e.target.a || e.target.localName === 'a')) {
         scheduler.clearTimeout(suppressPasteOnLink);
         suppressPasteOnLink = null;
@@ -3378,8 +3378,8 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const topLevel = (n) => {
-    if ((!n) || n === root) return null;
-    while (n.parentNode !== root) {
+    if ((!n) || n === document.body) return null;
+    while (n.parentNode !== document.body) {
       n = n.parentNode;
     }
     return n;
@@ -3547,7 +3547,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const innerdocbodyStyles = getComputedStyle(innerdocbody);
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 
-    let docLine = doc.body.firstChild;
+    let docLine = document.body.firstChild;
     let currentLine = 0;
     let h = null;
 
@@ -3561,7 +3561,7 @@ function Ace2Inner(editorInfo, cssManagers) {
           // included on the first line. The default stylesheet doesn't add
           // extra margins/padding, but plugins might.
           h = docLine.nextSibling.offsetTop - parseInt(
-              window.getComputedStyle(doc.body)
+              window.getComputedStyle(document.body)
                   .getPropertyValue('padding-top').split('px')[0]);
         } else {
           h = docLine.nextSibling.offsetTop - docLine.offsetTop;
@@ -3639,19 +3639,16 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   this.init = async () => {
     await $.ready;
-    doc = document; // defined as a var in scope outside
     inCallStack('setup', () => {
-      const body = doc.getElementById('innerdocbody');
-      root = body; // defined as a var in scope outside
-      if (browser.firefox) $(root).addClass('mozilla');
-      if (browser.safari) $(root).addClass('safari');
-      root.classList.toggle('authorColors', true);
-      root.classList.toggle('doesWrap', doesWrap);
+      if (browser.firefox) $(document.body).addClass('mozilla');
+      if (browser.safari) $(document.body).addClass('safari');
+      document.body.classList.toggle('authorColors', true);
+      document.body.classList.toggle('doesWrap', doesWrap);
 
       enforceEditability();
 
       // set up dom and rep
-      while (root.firstChild) root.removeChild(root.firstChild);
+      while (document.body.firstChild) document.body.removeChild(document.body.firstChild);
       const oneEntry = createDomLineEntry('');
       doRepLineSplice(0, rep.lines.length(), [oneEntry]);
       insertDomLines(null, [oneEntry.domInfo]);

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -73,7 +73,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     lineSpan.appendChild(outerDoc.createTextNode('1'));
     lineDiv.appendChild(lineSpan);
   })();
-  let lineNumbersShown = 1;
 
   const scroll = Scroll.init(outerWin);
 
@@ -3594,7 +3593,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     // Apply height to existing sidediv lines
     currentLine = 0;
-    while (sidebarLine && currentLine <= lineNumbersShown) {
+    while (sidebarLine && currentLine <= sideDivInner.children.length) {
       if (lineOffsets[currentLine] != null) {
         sidebarLine.style.height = `${lineOffsets[currentLine]}px`;
         sidebarLine.style.lineHeight = `${lineHeights[currentLine]}px`;
@@ -3603,24 +3602,22 @@ function Ace2Inner(editorInfo, cssManagers) {
       currentLine++;
     }
 
-    if (newNumLines !== lineNumbersShown) {
+    if (newNumLines !== sideDivInner.children.length) {
       // Create missing line and apply height
-      while (lineNumbersShown < newNumLines) {
-        lineNumbersShown++;
+      while (sideDivInner.children.length < newNumLines) {
         const div = outerDoc.createElement('DIV');
+        sideDivInner.appendChild(div);
         if (lineOffsets[currentLine]) {
           div.style.height = `${lineOffsets[currentLine]}px`;
           div.style.lineHeight = `${lineHeights[currentLine]}px`;
         }
-        $(div).append($(`<span class='line-number'>${String(lineNumbersShown)}</span>`));
-        sideDivInner.appendChild(div);
+        $(div).append($(`<span class='line-number'>${sideDivInner.children.length}</span>`));
         currentLine++;
       }
 
       // Remove extra lines
-      while (lineNumbersShown > newNumLines) {
+      while (sideDivInner.children.length > newNumLines) {
         sideDivInner.removeChild(sideDivInner.lastChild);
-        lineNumbersShown--;
       }
     }
   };

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3543,14 +3543,13 @@ function Ace2Inner(editorInfo, cssManagers) {
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 
     let docLine = document.body.firstElementChild;
-    let currentLine = 0;
     let h = null;
 
     // First loop to calculate the heights from doc body
     while (docLine) {
       const nextDocLine = docLine.nextElementSibling;
       if (nextDocLine) {
-        if (currentLine === 0) {
+        if (lineOffsets.length === 0) {
           // It's the first line. For line number alignment purposes, its
           // height is taken to be the top offset of the next line. If we
           // didn't do this special case, we would miss out on any top margin
@@ -3582,7 +3581,6 @@ function Ace2Inner(editorInfo, cssManagers) {
         lineHeights.push(defaultLineHeight);
       }
       docLine = nextDocLine;
-      currentLine++;
     }
 
     let newNumLines = rep.lines.length();

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2162,16 +2162,13 @@ function Ace2Inner(editorInfo, cssManagers) {
       [-1, N + 1],
     ];
 
+    // returns index of cleanRange containing i, or -1 if none
     const rangeForLine = (i) => {
-      // returns index of cleanRange containing i, or -1 if none
-      let answer = -1;
-      cleanRanges.forEach((r, idx) => {
-        if (i >= r[1]) return false; // keep looking
-        if (i < r[0]) return true; // not found, stop looking
-        answer = idx;
-        return true; // found, stop looking
-      });
-      return answer;
+      for (const [idx, r] of cleanRanges.entries()) {
+        if (i < r[0]) return -1;
+        if (i < r[1]) return idx;
+      }
+      return -1;
     };
 
     const removeLineFromRange = (rng, line) => {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2579,12 +2579,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const handleKeyEvent = (evt) => {
     if (!isEditable) return;
-    const type = evt.type;
-    const charCode = evt.charCode;
-    const keyCode = evt.keyCode;
-    const which = evt.which;
-    const altKey = evt.altKey;
-    const shiftKey = evt.shiftKey;
+    const {type, charCode, keyCode, which, altKey, shiftKey} = evt;
 
     // Don't take action based on modifier keys going up and down.
     // Modifier keys do not generate "keypress" events.

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -1125,19 +1125,9 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     const domChanges = (splicesToDo.length > 0);
 
-    // update the representation
-    for (const splice of splicesToDo) {
-      doIncorpLineSplice(splice[0], splice[1], splice[2], splice[3], splice[4]);
-    }
-
-    // do DOM inserts
-    for (const ins of domInsertsNeeded) insertDomLines(ins[0], ins[1]);
-
-    // delete old dom nodes
-    for (const n of toDeleteAtEnd) {
-      // parent of n may not be "root" in IE due to non-tree-shaped DOM (wtf)
-      if (n.parentNode) n.parentNode.removeChild(n);
-    }
+    for (const splice of splicesToDo) doIncorpLineSplice(...splice);
+    for (const ins of domInsertsNeeded) insertDomLines(...ins);
+    for (const n of toDeleteAtEnd) n.remove();
 
     // needed to stop chrome from breaking the ui when long strings without spaces are pasted
     if (scrollToTheLeftNeeded) {
@@ -2269,10 +2259,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const markNodeClean = (n) => {
     // clean nodes have knownHTML that matches their innerHTML
-    const dirtiness = {};
-    dirtiness.nodeId = uniqueId(n);
-    dirtiness.knownHTML = n.innerHTML;
-    setAssoc(n, 'dirtiness', dirtiness);
+    setAssoc(n, 'dirtiness', {nodeId: uniqueId(n), knownHTML: n.innerHTML});
   };
 
   const isNodeDirty = (n) => {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3289,7 +3289,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     $(document).on('keyup', handleKeyEvent);
     $(document).on('click', handleClick);
     // dropdowns on edit bar need to be closed on clicks on both pad inner and pad outer
-    $(outerWin.document).on('click', hideEditBarDropdowns);
+    $(outerDoc).on('click', hideEditBarDropdowns);
 
     // If non-nullish, pasting on a link should be suppressed.
     let suppressPasteOnLink = null;
@@ -3414,11 +3414,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const getInnerHeight = () => {
-    const win = outerWin;
-    const odoc = win.document;
-    let h;
-    if (browser.opera) h = win.innerHeight;
-    else h = odoc.documentElement.clientHeight;
+    const h = browser.opera ? outerWin.innerHeight : outerDoc.documentElement.clientHeight;
     if (h) return h;
 
     // deal with case where iframe is hidden, hope that
@@ -3426,20 +3422,15 @@ function Ace2Inner(editorInfo, cssManagers) {
     return Number(editorInfo.frame.parentNode.style.height.replace(/[^0-9]/g, '') || 0);
   };
 
-  const getInnerWidth = () => {
-    const win = outerWin;
-    const odoc = win.document;
-    return odoc.documentElement.clientWidth;
-  };
+  const getInnerWidth = () => outerDoc.documentElement.clientWidth;
 
   const scrollXHorizontallyIntoView = (pixelX) => {
-    const win = outerWin;
-    const distInsideLeft = pixelX - win.scrollX;
-    const distInsideRight = win.scrollX + getInnerWidth() - pixelX;
+    const distInsideLeft = pixelX - outerWin.scrollX;
+    const distInsideRight = outerWin.scrollX + getInnerWidth() - pixelX;
     if (distInsideLeft < 0) {
-      win.scrollBy(distInsideLeft, 0);
+      outerWin.scrollBy(distInsideLeft, 0);
     } else if (distInsideRight < 0) {
-      win.scrollBy(-distInsideRight + 1, 0);
+      outerWin.scrollBy(-distInsideRight + 1, 0);
     }
   };
 
@@ -3615,13 +3606,12 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     if (newNumLines !== lineNumbersShown) {
       const container = sideDivInner;
-      const odoc = outerWin.document;
-      const fragment = odoc.createDocumentFragment();
+      const fragment = outerDoc.createDocumentFragment();
 
       // Create missing line and apply height
       while (lineNumbersShown < newNumLines) {
         lineNumbersShown++;
-        const div = odoc.createElement('DIV');
+        const div = outerDoc.createElement('DIV');
         if (lineOffsets[currentLine]) {
           div.style.height = `${lineOffsets[currentLine]}px`;
           div.style.lineHeight = `${lineHeights[currentLine]}px`;

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3604,8 +3604,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     }
 
     if (newNumLines !== lineNumbersShown) {
-      const fragment = outerDoc.createDocumentFragment();
-
       // Create missing line and apply height
       while (lineNumbersShown < newNumLines) {
         lineNumbersShown++;
@@ -3615,10 +3613,9 @@ function Ace2Inner(editorInfo, cssManagers) {
           div.style.lineHeight = `${lineHeights[currentLine]}px`;
         }
         $(div).append($(`<span class='line-number'>${String(lineNumbersShown)}</span>`));
-        fragment.appendChild(div);
+        sideDivInner.appendChild(div);
         currentLine++;
       }
-      sideDivInner.appendChild(fragment);
 
       // Remove extra lines
       while (lineNumbersShown > newNumLines) {

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3605,7 +3605,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     }
 
     if (newNumLines !== lineNumbersShown) {
-      const container = sideDivInner;
       const fragment = outerDoc.createDocumentFragment();
 
       // Create missing line and apply height
@@ -3620,11 +3619,11 @@ function Ace2Inner(editorInfo, cssManagers) {
         fragment.appendChild(div);
         currentLine++;
       }
-      container.appendChild(fragment);
+      sideDivInner.appendChild(fragment);
 
       // Remove extra lines
       while (lineNumbersShown > newNumLines) {
-        container.removeChild(container.lastChild);
+        sideDivInner.removeChild(sideDivInner.lastChild);
         lineNumbersShown--;
       }
     }

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3603,15 +3603,10 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     }
 
-    let sidebarLine = sideDivInner.firstChild;
-    currentLine = 0;
-    while (sidebarLine && currentLine <= sideDivInner.children.length) {
-      if (lineOffsets[currentLine] != null) {
-        sidebarLine.style.height = `${lineOffsets[currentLine]}px`;
-        sidebarLine.style.lineHeight = `${lineHeights[currentLine]}px`;
-      }
-      sidebarLine = sidebarLine.nextSibling;
-      currentLine++;
+    for (const [i, sideDivLine] of Array.prototype.entries.call(sideDivInner.children)) {
+      if (lineOffsets[i] == null) continue;
+      sideDivLine.style.height = `${lineOffsets[i]}px`;
+      sideDivLine.style.lineHeight = `${lineHeights[i]}px`;
     }
   };
 

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2330,9 +2330,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const hideEditBarDropdowns = () => {
-    if (window.parent.parent.padeditbar) { // required in case its in an iframe should probably use parent..  See Issue 327 https://github.com/ether/etherpad-lite/issues/327
-      window.parent.parent.padeditbar.toggleDropDown('none');
-    }
+    window.parent.parent.padeditbar.toggleDropDown('none');
   };
 
   const renumberList = (lineNum) => {
@@ -3525,8 +3523,6 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   // We apply the height of a line in the doc body, to the corresponding sidediv line number
   const updateLineNumbers = () => {
-    if (!currentCallStack || !currentCallStack.domClean) return;
-
     // Refs #4228, to avoid layout trashing, we need to first calculate all the heights,
     // and then apply at once all new height to div elements
     const lineOffsets = [];
@@ -3591,14 +3587,9 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     let newNumLines = rep.lines.length();
     if (newNumLines < 1) newNumLines = 1;
-
-    if (newNumLines !== sideDivInner.children.length) {
-      while (sideDivInner.children.length < newNumLines) appendNewSideDivLine();
-      while (sideDivInner.children.length > newNumLines) sideDivInner.lastElementChild.remove();
-    }
-
+    while (sideDivInner.children.length < newNumLines) appendNewSideDivLine();
+    while (sideDivInner.children.length > newNumLines) sideDivInner.lastElementChild.remove();
     for (const [i, sideDivLine] of Array.prototype.entries.call(sideDivInner.children)) {
-      if (lineOffsets[i] == null) continue;
       sideDivLine.style.height = `${lineOffsets[i]}px`;
       sideDivLine.style.lineHeight = `${lineHeights[i]}px`;
     }

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2263,13 +2263,11 @@ function Ace2Inner(editorInfo, cssManagers) {
       detectChangesAroundLine(0, 1);
       detectChangesAroundLine(N - 1, 1);
 
-      for (const k in observedChanges.cleanNodesNearChanges) {
-        if (observedChanges.cleanNodesNearChanges[k]) {
-          const key = k.substring(1);
-          if (rep.lines.containsKey(key)) {
-            const line = rep.lines.indexOfKey(key);
-            detectChangesAroundLine(line, 2);
-          }
+      for (const k of Object.keys(observedChanges.cleanNodesNearChanges)) {
+        const key = k.substring(1);
+        if (rep.lines.containsKey(key)) {
+          const line = rep.lines.indexOfKey(key);
+          detectChangesAroundLine(line, 2);
         }
       }
     }

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -3546,24 +3546,25 @@ function Ace2Inner(editorInfo, cssManagers) {
     const innerdocbodyStyles = getComputedStyle(document.body);
     const defaultLineHeight = parseInt(innerdocbodyStyles['line-height']);
 
-    let docLine = document.body.firstChild;
+    let docLine = document.body.firstElementChild;
     let currentLine = 0;
     let h = null;
 
     // First loop to calculate the heights from doc body
     while (docLine) {
-      if (docLine.nextSibling) {
+      const nextDocLine = docLine.nextElementSibling;
+      if (nextDocLine) {
         if (currentLine === 0) {
           // It's the first line. For line number alignment purposes, its
           // height is taken to be the top offset of the next line. If we
           // didn't do this special case, we would miss out on any top margin
           // included on the first line. The default stylesheet doesn't add
           // extra margins/padding, but plugins might.
-          h = docLine.nextSibling.offsetTop - parseInt(
+          h = nextDocLine.offsetTop - parseInt(
               window.getComputedStyle(document.body)
                   .getPropertyValue('padding-top').split('px')[0]);
         } else {
-          h = docLine.nextSibling.offsetTop - docLine.offsetTop;
+          h = nextDocLine.offsetTop - docLine.offsetTop;
         }
       } else {
         // last line
@@ -3584,7 +3585,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       } else {
         lineHeights.push(defaultLineHeight);
       }
-      docLine = docLine.nextSibling;
+      docLine = nextDocLine;
       currentLine++;
     }
 
@@ -3593,10 +3594,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     if (newNumLines !== sideDivInner.children.length) {
       while (sideDivInner.children.length < newNumLines) appendNewSideDivLine();
-      // Remove extra lines
-      while (sideDivInner.children.length > newNumLines) {
-        sideDivInner.removeChild(sideDivInner.lastChild);
-      }
+      while (sideDivInner.children.length > newNumLines) sideDivInner.lastElementChild.remove();
     }
 
     for (const [i, sideDivLine] of Array.prototype.entries.call(sideDivInner.children)) {


### PR DESCRIPTION
Multiple commits:
* ace2_inner: Formatting improvements
* ace2_inner: Delete redundant class assignment
* ace2_inner: Replace `initLineNumbers()` with an IIFE
* ace2_inner: Combine declaration and initialization
* ace2_inner: Build `sidedivinner` programmatically
* ace2_inner: Move `sidedivinner` creation to ace.js
* ace2_inner: Use destructuring assignment to simplify
* ace2_inner: Consistently use `outerWin` and `outerDoc`
* ace2_inner: Simplify document body selection
* ace2_inner: Delete unnecessary `doc` and `root` variables
* ace2_inner: Delete unnecessary `container` variable
* ace2_inner: Delete unnecessary `innerdocbody` variable
* ace2_inner: Add line number divs directly, not via fragment
* ace2_inner: Replace `lineNumbersShown` with number of children
* ace2_inner: Factor out duplicate line height application
* ace2_inner: Simplify iteration over line number divs
* ace2_inner: Factor out duplicate line number div creation
* ace2_inner: Operate on Elements, not Nodes
* ace2_inner: Delete unnecessary checks
* ace2_inner: Delete unnecessary `currentLine` variable
* ace2_inner: Move variable declarations to appropriate scope
* ace2_inner: Fix efficiency of `rangeForLine()`
* ace2_inner: Fix for..in iteration
* ace2_inner: Use for..of iteration to improve readability
* ace2_inner: Readability improvements
