### PR TITLE
pad: Add `clientVars` to `postAceInit` hook context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
       [citizenos/ep_image_upload#49](https://github.com/citizenos/ep_image_upload/pull/49)
       for an example fix.
 
+### Notable enhancements
+
+* For plugin authors:
+  * `clientVars` was added to the context for the `postAceInit` client-side
+    hook. Plugins should use this instead of the `clientVars` global variable.
+
 # 1.8.14
 
 ### Security fixes

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -229,7 +229,10 @@ Called from: src/static/js/pad.js
 Things in context:
 
 1. ace - the ace object that is applied to this editor.
-2. pad - the pad object of the current pad.
+2. clientVars - Object containing client-side configuration such as author ID
+   and plugin settings. Your plugin can manipulate this object via the
+   `clientVars` server-side hook.
+3. pad - the pad object of the current pad.
 
 ## postToolbarInit
 

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -501,7 +501,7 @@ const pad = {
 
       $('#editorcontainer').addClass('initialized');
 
-      hooks.aCallAll('postAceInit', {ace: padeditor.ace, pad});
+      hooks.aCallAll('postAceInit', {ace: padeditor.ace, clientVars, pad});
     };
 
     // order of inits is important here:


### PR DESCRIPTION
This allows plugins to avoid the `clientVars` global variable.