### PR TITLE
installDeps.sh improvements

### DIFF
--- a/src/bin/installDeps.sh
+++ b/src/bin/installDeps.sh
@@ -40,7 +40,7 @@ log "Installing dependencies..."
 (
   mkdir -p node_modules
   cd node_modules
-  [ -e ep_etherpad-lite ] || ln -s ../src ep_etherpad-lite
+  [ -d ep_etherpad-lite ] || ln -sf ../src ep_etherpad-lite
   cd ep_etherpad-lite
   npm ci --no-optional
 ) || {

--- a/src/bin/installDeps.sh
+++ b/src/bin/installDeps.sh
@@ -38,10 +38,10 @@ fi
 
 log "Installing dependencies..."
 (
-  mkdir -p node_modules
-  cd node_modules
-  [ -d ep_etherpad-lite ] || ln -sf ../src ep_etherpad-lite
-  cd ep_etherpad-lite
+  mkdir -p node_modules &&
+  cd node_modules &&
+  { [ -d ep_etherpad-lite ] || ln -sf ../src ep_etherpad-lite; } &&
+  cd ep_etherpad-lite &&
   npm ci --no-optional
 ) || {
   rm -rf src/node_modules

--- a/src/bin/installDeps.sh
+++ b/src/bin/installDeps.sh
@@ -34,7 +34,7 @@ if [ ! -f "$settings" ]; then
   cp settings.json.template "$settings" || exit 1
 fi
 
-log "Ensure that all dependencies are up to date...  If this is the first time you have run Etherpad please be patient."
+log "Installing dependencies..."
 (
   mkdir -p node_modules
   cd node_modules

--- a/src/bin/installDeps.sh
+++ b/src/bin/installDeps.sh
@@ -43,10 +43,7 @@ log "Installing dependencies..."
   { [ -d ep_etherpad-lite ] || ln -sf ../src ep_etherpad-lite; } &&
   cd ep_etherpad-lite &&
   npm ci --no-optional
-) || {
-  rm -rf src/node_modules
-  exit 1
-}
+) || exit 1
 
 # Remove all minified data to force node creating it new
 log "Clearing minified cache..."

--- a/src/bin/installDeps.sh
+++ b/src/bin/installDeps.sh
@@ -15,10 +15,12 @@ is_cmd node || fatal "Please install node.js ( https://nodejs.org )"
 is_cmd npm || fatal "Please install npm ( https://npmjs.org )"
 
 # Check npm version
-require_minimal_version "npm" $(get_program_version "npm") "$REQUIRED_NPM_MAJOR" "$REQUIRED_NPM_MINOR"
+require_minimal_version "npm" $(get_program_version "npm") \
+    "$REQUIRED_NPM_MAJOR" "$REQUIRED_NPM_MINOR"
 
 # Check node version
-require_minimal_version "nodejs" $(get_program_version "node") "$REQUIRED_NODE_MAJOR" "$REQUIRED_NODE_MINOR"
+require_minimal_version "nodejs" $(get_program_version "node") \
+    "$REQUIRED_NODE_MAJOR" "$REQUIRED_NODE_MINOR"
 
 # Get the name of the settings file
 settings="settings.json"

--- a/src/bin/installDeps.sh
+++ b/src/bin/installDeps.sh
@@ -15,11 +15,11 @@ is_cmd node || fatal "Please install node.js ( https://nodejs.org )"
 is_cmd npm || fatal "Please install npm ( https://npmjs.org )"
 
 # Check npm version
-require_minimal_version "npm" $(get_program_version "npm") \
+require_minimal_version "npm" "$(get_program_version "npm")" \
     "$REQUIRED_NPM_MAJOR" "$REQUIRED_NPM_MINOR"
 
 # Check node version
-require_minimal_version "nodejs" $(get_program_version "node") \
+require_minimal_version "nodejs" "$(get_program_version "node")" \
     "$REQUIRED_NODE_MAJOR" "$REQUIRED_NODE_MINOR"
 
 # Get the name of the settings file


### PR DESCRIPTION
Multiple commits:
* installDeps.sh: Simplify log message
* installDeps.sh: Wrap long lines
* installDeps.sh: Quote underquoted expansions
* installDeps.sh: Ensure that `ep_etherpad-lite` is a directory. This should avoid errors like #5165, or at least make them easier to troubleshoot.
* installDeps.sh: Handle errors
* installDeps.sh: Don't nuke `src/node_modules` on error

cc @sennewood