### PR TITLE
SocketIORouter: Add acknowledgement support

### DIFF
--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -78,7 +78,11 @@ exports.setSocketIO = (_io) => {
         return;
       }
       logger.debug(`from ${socket.id}: ${JSON.stringify(message)}`);
-      await components[message.component].handleMessage(socket, message);
+      try {
+        await components[message.component].handleMessage(socket, message);
+      } catch (err) {
+        logger.error(`Error while handling message from ${socket.id}: ${err.stack || err}`);
+      }
     });
 
     socket.on('disconnect', (reason) => {

--- a/src/node/handler/SocketIORouter.js
+++ b/src/node/handler/SocketIORouter.js
@@ -39,10 +39,12 @@ let io;
  * adds a component
  */
 exports.addComponent = (moduleName, module) => {
-  // save the component
+  if (module == null) return exports.deleteComponent(moduleName);
   components[moduleName] = module;
   module.setSocketIO(io);
 };
+
+exports.deleteComponent = (moduleName) => { delete components[moduleName]; };
 
 /**
  * sets the socket.io and adds event functions for routing


### PR DESCRIPTION
Multiple commits:
* SocketIORouter: Rename variables to improve readability
* SocketIORouter: Logging improvements
* SocketIORouter: Add ability to unregister handler
* SocketIORouter: Add unit tests
* SocketIORouter: Don't crash if message handler throws
* SocketIORouter: Add acknowledgement support

There are two main goals of this PR:
  1. Stop the server from crashing if a socket.io message handler throws. This will make it easier to resolve the feedback for PR #5106 (cc @webzwo0i).
  2. Make it possible for a future PR to improve UX when the client sends a bad message.