### PR TITLE
ace2_inner.js: Do fn+delete customly

### DIFF
--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -150,6 +150,7 @@ exports.padShortcutEnabled = {
   altF9: true,
   altC: true,
   delete: true,
+  fnDelete: true,
   cmdShift2: true,
   return: true,
   esc: true,


### PR DESCRIPTION
'fn+delete' (or 'delete' in PCs) behaviour is inconsistent across browsers. In Chrome,
it might remove the class of the text in the line below when using
fn+delete to join lines. In this PR, we solve this issue by
doing 'fn+delete' customly, as we do 'delete' (or 'backspace' in PCs) customly.
Fixes: #5172.