### PR TITLE
Docker: Expose socketIo.maxHttpBufferSize and dumpOnUncleanExit settings as environment variables

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -211,7 +211,9 @@ For the editor container, you can also make it full width by adding `full-width-
 | `FOCUS_LINE_PERCENTAGE_ARROW_UP`  | Percentage of viewport height to be additionally scrolled when user presses arrow up in the line of the top of the viewport. Set to 0 to let the scroll to be handled as default by Etherpad           | `0`                |
 | `FOCUS_LINE_DURATION`             | Time (in milliseconds) used to animate the scroll transition. Set to 0 to disable animation                                                                                                            | `0`                |
 | `FOCUS_LINE_CARET_SCROLL`         | Flag to control if it should scroll when user places the caret in the last line of the viewport                                                                                                        | `false`            |
+| `SOCKETIO_MAX_HTTP_BUFFER_SIZE`   | The maximum size (in bytes) of a single message accepted via Socket.IO. If a client sends a larger message, its connection gets closed to prevent DoS (memory exhaustion) attacks.                     | `10000`            |
 | `LOAD_TEST`                       | Allow Load Testing tools to hit the Etherpad Instance. WARNING: this will disable security on the instance.                                                                                            | `false`            |
+| `DUMP_ON_UNCLEAN_EXIT`            | Enable dumping objects preventing a clean exit of Node.js. WARNING: this has a significant performance impact.                                                                                         | `false`            |
 | `EXPOSE_VERSION`                  | Expose Etherpad version in the web interface and in the Server http header. Do not enable on production machines.                                                                                      | `false`            |
 
 

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -482,7 +482,7 @@
      * value to work properly, but increasing the value increases susceptibility
      * to denial of service attacks (malicious clients can exhaust memory).
      */
-    "maxHttpBufferSize": 10000
+    "maxHttpBufferSize": "${SOCKETIO_MAX_HTTP_BUFFER_SIZE:10000}"
   },
 
   /*
@@ -495,7 +495,7 @@
   /**
   * Disable dump of objects preventing a clean exit
   */
-  "dumpOnUncleanExit": false,
+  "dumpOnUncleanExit": "${DUMP_ON_UNCLEAN_EXIT:false}",
 
   /*
    * Disable indentation on new line when previous line ends with some special


### PR DESCRIPTION
Unlike all other (simple) settings, these two were previously not available as environment variables. This change makes it possible to modify them without having to rebuild the image (cf. 85adaa44).