### PR TITLE
bugfix: ensure getText only includes text when a revision is specified.

### DIFF
--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -171,8 +171,8 @@ exports.getText = async (padID, rev) => {
     }
 
     // get the text of this revision
-    // getInternalRevisionAText method returns a text.text and attribs so we ensure we only
-    // return the text - details at https://github.com/ether/etherpad-lite/issues/5073
+    // getInternalRevisionAText() returns an atext object but we only want the .text inside it.
+    // Details at https://github.com/ether/etherpad-lite/issues/5073
     const {text} = await pad.getInternalRevisionAText(rev);
     return {text};
   }

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -173,10 +173,8 @@ exports.getText = async (padID, rev) => {
     // get the text of this revision
     // getInternalRevisionAText method returns a text.text and attribs so we ensure we only
     // return the text - details at https://github.com/ether/etherpad-lite/issues/5073
-    const text = await pad.getInternalRevisionAText(rev);
-    return {
-      text: text.text
-    };
+    const {text} = await pad.getInternalRevisionAText(rev);
+    return {text};
   }
 
   // the client wants the latest text, lets return it to him

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -171,8 +171,12 @@ exports.getText = async (padID, rev) => {
     }
 
     // get the text of this revision
+    // getInternalRevisionAText method returns a text.text and attribs so we ensure we only
+    // return the text - details at https://github.com/ether/etherpad-lite/issues/5073
     const text = await pad.getInternalRevisionAText(rev);
-    return {text};
+    return {
+      text: text.text
+    };
   }
 
   // the client wants the latest text, lets return it to him

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -114,10 +114,13 @@ describe(__filename, function () {
                                 -> getLastEdited(padID) -- Should not be 0
                                 -> appendText(padID, "hello")
                                 -> getText(padID) -- Should be "hello worldhello"
+                                -> getText(padID, rev) -- Should be "hello world
                                  -> setHTML(padID) -- Should fail on invalid HTML
                                   -> setHTML(padID) *3 -- Should fail on invalid HTML
                                    -> getHTML(padID) -- Should return HTML close to posted HTML
                                     -> createPad -- Tries to create pads with bad url characters
+
+
 
   */
 
@@ -586,6 +589,31 @@ describe(__filename, function () {
     });
   });
 
+  describe('appendText', function () {
+    it('Append text to a pad Id', function (done) {
+      agent.get(`${endPoint('appendText', '1.2.13')}&padID=${testPadId}&text=hello`)
+          .expect((res) => {
+            if (res.body.code !== 0) throw new Error('Pad Append Text failed');
+          })
+          .expect('Content-Type', /json/)
+          .expect(200, done);
+    });
+  });
+
+
+  describe('getText', function () {
+    it('Gets text on a pad Id at a given revision', function (done) {
+      agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=3`)
+          .expect((res) => {
+            if (res.body.code !== 0) throw new Error('Pad Get Text failed');
+            if (res.body.data.text !== `${text}hello\n`) {
+              throw new Error('getText Revision not returning correct contents');
+            }
+          })
+          .expect('Content-Type', /json/)
+          .expect(200, done);
+    });
+  });
 
   describe('setHTML', function () {
     it('Sets the HTML of a Pad attempting to pass ugly HTML', function (done) {

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -114,13 +114,12 @@ describe(__filename, function () {
                                 -> getLastEdited(padID) -- Should not be 0
                                 -> appendText(padID, "hello")
                                 -> getText(padID) -- Should be "hello worldhello"
-                                -> getText(padID, rev) -- Should be "hello world
+                                -> appendText(padID, "hello")
+                                -> getText(padID, rev) - should return "hello worldhello"
                                  -> setHTML(padID) -- Should fail on invalid HTML
                                   -> setHTML(padID) *3 -- Should fail on invalid HTML
                                    -> getHTML(padID) -- Should return HTML close to posted HTML
                                     -> createPad -- Tries to create pads with bad url characters
-
-
 
   */
 

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -589,13 +589,11 @@ describe(__filename, function () {
   });
 
   describe('appendText', function () {
-    it('Append text to a pad Id', function (done) {
-      agent.get(`${endPoint('appendText', '1.2.13')}&padID=${testPadId}&text=hello`)
-          .expect((res) => {
-            if (res.body.code !== 0) throw new Error('Pad Append Text failed');
-          })
-          .expect('Content-Type', /json/)
-          .expect(200, done);
+    it('Append text to a pad Id', async function () {
+      const res = await agent.get(`${endPoint('appendText', '1.2.13')}&padID=${testPadId}&text=hello`)
+          .expect(200)
+          .expect('Content-Type', /json/);
+      assert.equal(res.body.code, 0);
     });
   });
 

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -114,8 +114,7 @@ describe(__filename, function () {
                                 -> getLastEdited(padID) -- Should not be 0
                                 -> appendText(padID, "hello")
                                 -> getText(padID) -- Should be "hello worldhello"
-                                -> appendText(padID, "hello")
-                                -> getText(padID, rev) - should return "hello worldhello"
+                                -> getText(padID, rev=2) - should return "hello world"
                                  -> setHTML(padID) -- Should fail on invalid HTML
                                   -> setHTML(padID) *3 -- Should fail on invalid HTML
                                    -> getHTML(padID) -- Should return HTML close to posted HTML
@@ -588,23 +587,13 @@ describe(__filename, function () {
     });
   });
 
-  describe('appendText again', function () {
-    it('Append text to a pad Id', async function () {
-      const res = await agent.get(`${endPoint('appendText', '1.2.13')}&padID=${testPadId}&text=hello`)
-          .expect(200)
-          .expect('Content-Type', /json/);
-      assert.equal(res.body.code, 0);
-    });
-  });
-
-
   describe('getText of old revision', function () {
     it('Gets text on a pad Id at a given revision', async function () {
-      const res = await agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=3`)
+      const res = await agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=2`)
           .expect(200)
           .expect('Content-Type', /json/);
       assert.equal(res.body.code, 0);
-      assert.equal(res.body.data.text, `${text}hello\n`);
+      assert.equal(res.body.data.text, `${text}\n`);
     });
   });
 

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -598,7 +598,7 @@ describe(__filename, function () {
   });
 
 
-  describe('getText', function () {
+  describe('getText of old revision', function () {
     it('Gets text on a pad Id at a given revision', async function () {
       const res = await agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=3`)
           .expect(200)

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -588,7 +588,7 @@ describe(__filename, function () {
     });
   });
 
-  describe('appendText', function () {
+  describe('appendText again', function () {
     it('Append text to a pad Id', async function () {
       const res = await agent.get(`${endPoint('appendText', '1.2.13')}&padID=${testPadId}&text=hello`)
           .expect(200)

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -599,16 +599,12 @@ describe(__filename, function () {
 
 
   describe('getText', function () {
-    it('Gets text on a pad Id at a given revision', function (done) {
-      agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=3`)
-          .expect((res) => {
-            if (res.body.code !== 0) throw new Error('Pad Get Text failed');
-            if (res.body.data.text !== `${text}hello\n`) {
-              throw new Error('getText Revision not returning correct contents');
-            }
-          })
-          .expect('Content-Type', /json/)
-          .expect(200, done);
+    it('Gets text on a pad Id at a given revision', async function () {
+      const res = await agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=3`)
+          .expect(200)
+          .expect('Content-Type', /json/);
+      assert.equal(res.body.code, 0);
+      assert.equal(res.body.data.text, `${text}hello\n`);
     });
   });
 


### PR DESCRIPTION
Fix for https://github.com/ether/etherpad-lite/issues/5073

Note that if people have been using ``getText`` with revision set before this would be a breaking change.  I imagine most people can adapt their environments to use this function as per the docs.

I included tests too.