### PR TITLE
Fix #5200, Windows Installer and back-end tests  

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -116,9 +116,7 @@ jobs:
         node-version: 12
 
     - name: Install all dependencies and symlink for ep_etherpad-lite
-      run: |
-            cd src
-            npm ci --no-optional
+      run: src/bin/installOnWindows.bat
 
     - name:  Fix up the settings.json
       run: |
@@ -172,9 +170,7 @@ jobs:
     # if npm correctly hoists the dependencies, the hoisting seems to confuse
     # tools such as `npm outdated`, `npm update`, and some ESLint rules.
     - name: Install all dependencies and symlink for ep_etherpad-lite
-      run: |
-            cd src
-            npm ci --no-optional
+      run: src/bin/installOnWindows.bat
 
     - name:  Fix up the settings.json
       run: |

--- a/src/bin/installOnWindows.bat
+++ b/src/bin/installOnWindows.bat
@@ -1,7 +1,7 @@
 @echo off
 
 :: Change directory to etherpad-lite root
-cd /D "%~dp0\.."
+cd /D "%~dp0\..\.."
 
 :: Is node installed?
 cmd /C node -e "" || ( echo "Please install node.js ( https://nodejs.org )" && exit /B 1 )
@@ -16,7 +16,7 @@ mklink /D "ep_etherpad-lite" "..\src"
 cd /D "ep_etherpad-lite"
 cmd /C npm ci || exit /B 1
 
-cd /D "%~dp0\.."
+cd /D "%~dp0\..\.."
 
 echo _
 echo Clearing cache...


### PR DESCRIPTION
Changing directory on [`installOnWindows.bat`](https://github.com/ether/etherpad-lite/blob/develop/src/bin/installOnWindows.bat) file in lines [4](https://github.com/ether/etherpad-lite/blob/4d2839457a903d210e9790e43e0b353fa9e1eb6c/src/bin/installOnWindows.bat#L4) and [19](https://github.com/ether/etherpad-lite/blob/4d2839457a903d210e9790e43e0b353fa9e1eb6c/src/bin/installOnWindows.bat#L19) are wrong!

**[Reason/Solution]:** we need to go back one more directory to reach etherpad-lite root.

**Also,**

It's better to change the Github action flow in [`backend-tests.yml`](https://github.com/ether/etherpad-lite/blob/develop/.github/workflows/backend-tests.yml) on lines [119 ](https://github.com/ether/etherpad-lite/blob/4d2839457a903d210e9790e43e0b353fa9e1eb6c/.github/workflows/backend-tests.yml#L119)&[175 ](https://github.com/ether/etherpad-lite/blob/4d2839457a903d210e9790e43e0b353fa9e1eb6c/.github/workflows/backend-tests.yml#L175)and use `installOnWindows.bat` to install all dependencies and symlink.
