### PR TITLE
tests: Run easysync tests with frontend tests

### DIFF
--- a/src/tests/frontend/specs/easysync.js
+++ b/src/tests/frontend/specs/easysync.js
@@ -29,33 +29,21 @@ const AttributePool = require('../../../static/js/AttributePool');
 const randInt = (maxValue) => Math.floor(Math.random() * maxValue);
 
 describe('easysync', function () {
-  const throughIterator = (opsStr) => {
-    const iter = Changeset.opIterator(opsStr);
-    const assem = Changeset.opAssembler();
-    while (iter.hasNext()) {
-      assem.append(iter.next());
-    }
-    return assem.toString();
-  };
-
-  const throughSmartAssembler = (opsStr) => {
-    const iter = Changeset.opIterator(opsStr);
-    const assem = Changeset.smartOpAssembler();
-    while (iter.hasNext()) {
-      assem.append(iter.next());
-    }
-    assem.endDocument();
-    return assem.toString();
-  };
-
   it('throughIterator', async function () {
     const x = '-c*3*4+6|3=az*asdf0*1*2*3+1=1-1+1*0+1=1-1+1|c=c-1';
-    expect(throughIterator(x)).to.equal(x);
+    const iter = Changeset.opIterator(x);
+    const assem = Changeset.opAssembler();
+    while (iter.hasNext()) assem.append(iter.next());
+    expect(assem.toString()).to.equal(x);
   });
 
   it('throughSmartAssembler', async function () {
     const x = '-c*3*4+6|3=az*asdf0*1*2*3+1=1-1+1*0+1=1-1+1|c=c-1';
-    expect(throughSmartAssembler(x)).to.equal(x);
+    const iter = Changeset.opIterator(x);
+    const assem = Changeset.smartOpAssembler();
+    while (iter.hasNext()) assem.append(iter.next());
+    assem.endDocument();
+    expect(assem.toString()).to.equal(x);
   });
 
   const applyMutations = (mu, arrayOfArrays) => {


### PR DESCRIPTION
Multiple commits:
* tests: easysync: Run with the frontend tests
* tests: easysync: Delete commented-out and unused code
* tests: easysync: Fix some ESLint errors
* tests: easysync: Remove unnecessary `Random` class
* tests: easysync: Use mocha `describe()` and `it()`
* tests: easysync: Use `expect.js` for checks
* tests: easysync: Inline some functions that are only used once

The easysync tests could be run with the backend tests, but the tested code is used in browsers so I put the tests with the frontend tests to get browser coverage.

Fixes #4190

cc @webzwo0i 