### PR TITLE
feat(ace2_inner.js): Add keybinding meta-backspace to delete to beginning of line

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2482,7 +2482,11 @@ function Ace2Inner(editorInfo, cssManagers) {
         const lineEntry = rep.lines.atIndex(lineNum);
         const lineText = lineEntry.text;
         const lineMarker = lineEntry.lineMarker;
-        if (/^ +$/.exec(lineText.substring(lineMarker, col))) {
+        if (evt.metaKey && col > lineMarker) {
+          // cmd-backspace deletes to start of line (if not already at start)
+          performDocumentReplaceRange([lineNum, lineMarker], [lineNum, col], '');
+          handled = true;
+        } else if (/^ +$/.exec(lineText.substring(lineMarker, col))) {
           const col2 = col - lineMarker;
           const tabSize = THE_TAB.length;
           const toDelete = ((col2 - 1) % tabSize) + 1;


### PR DESCRIPTION
It would be more natural to add the new code inside the code that handles ctrl-backspace, but then this couldn't delete multiple "tabs" (which are actually 4 spaces).

It would be nice to have this feature on Windows too, but I don't know what keybinding it should have.  Maybe ctrl-shift-backspace?

Fixes https://github.com/ether/etherpad-lite/issues/440
