### PR TITLE
timeslider scrollTo: fixes wrong line number calculation

### DIFF
--- a/src/static/js/broadcast.js
+++ b/src/static/js/broadcast.js
@@ -164,10 +164,16 @@ const loadBroadcastJS = (socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, Bro
           return true; // break
         }
       });
-      // deal with someone is the author of a line and changes one character,
-      // so the alines won't change
+      // some chars are replaced (no attributes change and no length change)
+      // test if there are keep ops at the start of the cs
       if (lineChanged === undefined) {
-        lineChanged = Changeset.opIterator(Changeset.unpack(changeset).ops).next().lines;
+        lineChanged = 0;
+        const opIter = Changeset.opIterator(Changeset.unpack(changeset).ops);
+
+        if (opIter.hasNext()) {
+          const op = opIter.next();
+          if (op.opcode === '=') lineChanged += op.lines;
+        }
       }
 
       const goToLineNumber = (lineNumber) => {


### PR DESCRIPTION
Fixes the "Uncaught TypeError: $(...)[0] is undefined." error of https://github.com/ether/etherpad-lite/issues/5213 (not the curSplice error!)

In case there are no attribute changes and no length change, the alines before and after applying a changeset are identical. The identity changeset is the only exception, in all other cases, we can find the first changed line by looking at the first changeset op:
- if it's an insert, the first changed line is 0
- if it's a deletion, the first changed line is 0
- if it's a keep, the first changed line is either 0 (if no lines are skipped) or `op.lines` if lines are skipped.