### PR TITLE
Chat hook improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
     * The `chatNewMessage` client-side hook context has new properties:
       * `message`: Provides access to the raw message object so that plugins can
         see the original unprocessed message text and any added metadata.
+      * `rendered`: Allows plugins to completely override how the message is
+        rendered in the UI.
 
 # 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
         see the original unprocessed message text and any added metadata.
       * `rendered`: Allows plugins to completely override how the message is
         rendered in the UI.
+    * New `chatSendMessage` client-side hook that enables plugins to process the
+      text before sending it to the server or augment the message object with
+      custom metadata.
 
 # 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
   * The `helper.aNewPad()` function (accessible to client-side tests) now
     accepts hook functions to inject when opening a pad. This can be used to
     test any new client-side hooks your plugin provides.
+  * Chat improvements:
+    * The `chatNewMessage` client-side hook context has new properties:
+      * `message`: Provides access to the raw message object so that plugins can
+        see the original unprocessed message text and any added metadata.
 
 # 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
     * New `chatSendMessage` client-side hook that enables plugins to process the
       text before sending it to the server or augment the message object with
       custom metadata.
+    * New `chatNewMessage` server-side hook to process new chat messages before
+      they are saved to the database and relayed to users.
 
 # 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
     hook. Plugins should use this instead of the `clientVars` global variable.
   * New `userJoin` server-side hook.
   * The `userLeave` server-side hook has a new `socket` context property.
+  * The `helper.aNewPad()` function (accessible to client-side tests) now
+    accepts hook functions to inject when opening a pad. This can be used to
+    test any new client-side hooks your plugin provides.
 
 # 1.8.14
 

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -299,7 +299,7 @@ Context properties:
   href="url">url</a>`. (Note that `message.text` is not sanitized or processed
   in any way.)
 * `message`: The raw message object as received from the server, except with
-  time correction and a default `userId` property if missing. Plugins must not
+  time correction and a default `authorId` property if missing. Plugins must not
   modify this object. Warning: Unlike `text`, `message.text` is not
   pre-sanitized or processed in any way.
 * `rendered` - Used to override the default message rendering. Initially set to

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -296,7 +296,12 @@ Context properties:
 * `authorName`: The display name of the user that wrote the message.
 * `author`: The author ID of the user that wrote the message.
 * `text`: Sanitized message HTML, with URLs wrapped like `<a
-  href="url">url</a>`.
+  href="url">url</a>`. (Note that `message.text` is not sanitized or processed
+  in any way.)
+* `message`: The raw message object as received from the server, except with
+  time correction and a default `userId` property if missing. Plugins must not
+  modify this object. Warning: Unlike `text`, `message.text` is not
+  pre-sanitized or processed in any way.
 * `sticky` (boolean): Whether the gritter notification should fade out on its
   own or just sit there until manually closed.
 * `timestamp`: When the chat message was sent (milliseconds since epoch),

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -279,29 +279,31 @@ Things in context:
 This hook is called on the client side whenever a user joins or changes. This
 can be used to create notifications or an alternate user list.
 
-## chatNewMessage
+## `chatNewMessage`
 
-Called from: src/static/js/chat.js
+Called from: `src/static/js/chat.js`
 
-Things in context:
-
-1. authorName - The user that wrote this message
-2. author - The authorID of the user that wrote the message
-3. text - the message text
-4. sticky (boolean) - if you want the gritter notification bubble to fade out on
-   its own or just sit there
-5. timestamp - the timestamp of the chat message
-6. timeStr - the timestamp as a formatted string
-7. duration - for how long in milliseconds should the gritter notification
-   appear (0 to disable)
-
-This hook is called on the client side whenever a chat message is received from
-the server. It can be used to create different notifications for chat messages.
-Hoook functions can modify the `author`, `authorName`, `duration`, `sticky`,
-`text`, and `timeStr` context properties to change how the message is processed.
-The `text` and `timeStr` properties may contain HTML, but plugins should be
-careful to sanitize any added user input to avoid introducing an XSS
+This hook runs on the client side whenever a chat message is received from the
+server. It can be used to create different notifications for chat messages. Hook
+functions can modify the `author`, `authorName`, `duration`, `sticky`, `text`,
+and `timeStr` context properties to change how the message is processed. The
+`text` and `timeStr` properties may contain HTML and come pre-sanitized; plugins
+should be careful to sanitize any added user input to avoid introducing an XSS
 vulnerability.
+
+Context properties:
+
+* `authorName`: The display name of the user that wrote the message.
+* `author`: The author ID of the user that wrote the message.
+* `text`: Sanitized message HTML, with URLs wrapped like `<a
+  href="url">url</a>`.
+* `sticky` (boolean): Whether the gritter notification should fade out on its
+  own or just sit there until manually closed.
+* `timestamp`: When the chat message was sent (milliseconds since epoch),
+  corrected using the difference between the local clock and the server's clock.
+* `timeStr`: The message timestamp as a formatted string.
+* `duration`: How long (in milliseconds) to display the gritter notification (0
+  to disable).
 
 ## collectContentPre
 

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -315,6 +315,18 @@ Context properties:
 * `duration`: How long (in milliseconds) to display the gritter notification (0
   to disable).
 
+## `chatSendMessage`
+
+Called from: `src/static/js/chat.js`
+
+This hook runs on the client side whenever the user sends a new chat message.
+Plugins can mutate the message object to change the message text or add metadata
+to control how the message will be rendered by the `chatNewMessage` hook.
+
+Context properties:
+
+* `message`: The message object that will be sent to the Etherpad server.
+
 ## collectContentPre
 
 Called from: src/static/js/contentcollector.js

--- a/doc/api/hooks_client-side.md
+++ b/doc/api/hooks_client-side.md
@@ -285,11 +285,11 @@ Called from: `src/static/js/chat.js`
 
 This hook runs on the client side whenever a chat message is received from the
 server. It can be used to create different notifications for chat messages. Hook
-functions can modify the `author`, `authorName`, `duration`, `sticky`, `text`,
-and `timeStr` context properties to change how the message is processed. The
-`text` and `timeStr` properties may contain HTML and come pre-sanitized; plugins
-should be careful to sanitize any added user input to avoid introducing an XSS
-vulnerability.
+functions can modify the `author`, `authorName`, `duration`, `rendered`,
+`sticky`, `text`, and `timeStr` context properties to change how the message is
+processed. The `text` and `timeStr` properties may contain HTML and come
+pre-sanitized; plugins should be careful to sanitize any added user input to
+avoid introducing an XSS vulnerability.
 
 Context properties:
 
@@ -302,6 +302,11 @@ Context properties:
   time correction and a default `userId` property if missing. Plugins must not
   modify this object. Warning: Unlike `text`, `message.text` is not
   pre-sanitized or processed in any way.
+* `rendered` - Used to override the default message rendering. Initially set to
+  `null`. If the hook function sets this to a DOM element object or a jQuery
+  object, then that object will be used as the rendered message UI. Otherwise,
+  if this is set to `null`, then Etherpad will render a default UI for the
+  message using the other context properties.
 * `sticky` (boolean): Whether the gritter notification should fade out on its
   own or just sit there until manually closed.
 * `timestamp`: When the chat message was sent (milliseconds since epoch),

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -853,3 +853,20 @@ exports.userLeave = async (hookName, {author, padId}) => {
   console.log(`${author} left pad ${padId}`);
 };
 ```
+
+## `chatNewMessage`
+
+Called from: `src/node/handler/PadMessageHandler.js`
+
+Called when a user (or plugin) generates a new chat message, just before it is
+saved to the pad and relayed to all connected users.
+
+Context properties:
+
+* `message`: The chat message object. Plugins can mutate this object to change
+  the message text or add custom metadata to control how the message will be
+  rendered by the `chatNewMessage` client-side hook. The message's `authorId`
+  property can be trusted (the server overwrites any client-provided author ID
+  value with the user's actual author ID before this hook runs).
+* `padId`: The pad's real (not read-only) identifier.
+* `pad`: The pad's Pad object.

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -20,6 +20,7 @@
  */
 
 const Changeset = require('../../static/js/Changeset');
+const ChatMessage = require('../../static/js/ChatMessage');
 const CustomError = require('../utils/customError');
 const padManager = require('./PadManager');
 const padMessageHandler = require('../handler/PadMessageHandler');
@@ -364,7 +365,7 @@ exports.appendChatMessage = async (padID, text, authorID, time) => {
   // @TODO - missing getPadSafe() call ?
 
   // save chat message to database and send message to all connected clients
-  await padMessageHandler.sendChatMessageToPadClients(time, authorID, text, padID);
+  await padMessageHandler.sendChatMessageToPadClients(new ChatMessage(text, authorID, time), padID);
 };
 
 /* ***************

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -280,19 +280,19 @@ Pad.prototype.appendText = async function (newText) {
  *
  * @param {(ChatMessage|string)} msgOrText - Either a chat message object (recommended) or a string
  *     containing the raw text of the user's chat message (deprecated).
- * @param {?string} [userId] - The user's author ID. Deprecated; use `msgOrText.userId` instead.
+ * @param {?string} [authorId] - The user's author ID. Deprecated; use `msgOrText.authorId` instead.
  * @param {?number} [time] - Message timestamp (milliseconds since epoch). Deprecated; use
  *     `msgOrText.time` instead.
  */
-Pad.prototype.appendChatMessage = async function (msgOrText, userId = null, time = null) {
+Pad.prototype.appendChatMessage = async function (msgOrText, authorId = null, time = null) {
   const msg =
-      msgOrText instanceof ChatMessage ? msgOrText : new ChatMessage(msgOrText, userId, time);
+      msgOrText instanceof ChatMessage ? msgOrText : new ChatMessage(msgOrText, authorId, time);
   this.chatHead++;
   await Promise.all([
     // Don't save the display name in the database because the user can change it at any time. The
-    // `userName` property will be populated with the current value when the message is read from
+    // `displayName` property will be populated with the current value when the message is read from
     // the database.
-    db.set(`pad:${this.id}:chat:${this.chatHead}`, {...msg, userName: undefined}),
+    db.set(`pad:${this.id}:chat:${this.chatHead}`, {...msg, displayName: undefined}),
     this.saveToDatabase(),
   ]);
 };
@@ -305,7 +305,7 @@ Pad.prototype.getChatMessage = async function (entryNum) {
   const entry = await db.get(`pad:${this.id}:chat:${entryNum}`);
   if (entry == null) return null;
   const message = ChatMessage.fromObject(entry);
-  message.userName = await authorManager.getAuthorName(message.userId);
+  message.displayName = await authorManager.getAuthorName(message.authorId);
   return message;
 };
 

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -364,6 +364,7 @@ exports.sendChatMessageToPadClients = async (mt, puId, text = null, padId = null
   const message = mt instanceof ChatMessage ? mt : new ChatMessage(text, puId, mt);
   padId = mt instanceof ChatMessage ? puId : padId;
   const pad = await padManager.getPad(padId);
+  await hooks.aCallAll('chatNewMessage', {message, pad, padId});
   // pad.appendChatMessage() ignores the displayName property so we don't need to wait for
   // authorManager.getAuthorName() to resolve before saving the message to the database.
   const promise = pad.appendChatMessage(message);

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -345,7 +345,7 @@ const handleChatMessage = async (socket, message) => {
   const {padId, author: authorId} = sessioninfos[socket.id];
   // Don't trust the user-supplied values.
   chatMessage.time = Date.now();
-  chatMessage.userId = authorId;
+  chatMessage.authorId = authorId;
   await exports.sendChatMessageToPadClients(chatMessage, padId);
 };
 
@@ -364,10 +364,10 @@ exports.sendChatMessageToPadClients = async (mt, puId, text = null, padId = null
   const message = mt instanceof ChatMessage ? mt : new ChatMessage(text, puId, mt);
   padId = mt instanceof ChatMessage ? puId : padId;
   const pad = await padManager.getPad(padId);
-  // pad.appendChatMessage() ignores the userName property so we don't need to wait for
+  // pad.appendChatMessage() ignores the displayName property so we don't need to wait for
   // authorManager.getAuthorName() to resolve before saving the message to the database.
   const promise = pad.appendChatMessage(message);
-  message.userName = await authorManager.getAuthorName(message.userId);
+  message.displayName = await authorManager.getAuthorName(message.userId);
   socketio.sockets.in(padId).json.send({
     type: 'COLLABROOM',
     data: {type: 'CHAT_MESSAGE', message},

--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -19,6 +19,7 @@
   , "pad_impexp.js"
   , "pad_savedrevs.js"
   , "pad_connectionstatus.js"
+  , "ChatMessage.js"
   , "chat.js"
   , "vendors/gritter.js"
   , "$js-cookie/dist/js.cookie.js"

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -98,7 +98,12 @@
 #chattext .time {
   float: right;
   font-style: italic;
-  font-size: .85rem;
+  /*
+   * 'smaller' is relative to the parent element, so if the parent has its own
+   * 'font-size: smaller' rule then the timestamp will become even smaller (as
+   * desired).
+   */
+  font-size: smaller;
   opacity: .8;
   margin-left: 3px;
   margin-right: 2px;

--- a/src/static/js/ChatMessage.js
+++ b/src/static/js/ChatMessage.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Represents a chat message stored in the database and transmitted among users. Plugins can extend
+ * the object with additional properties.
+ *
+ * Supports serialization to JSON.
+ */
+class ChatMessage {
+  static fromObject(obj) {
+    return Object.assign(new ChatMessage(), obj);
+  }
+
+  /**
+   * @param {?string} [text] - Initial value of the `text` property.
+   * @param {?string} [userId] - Initial value of the `userId` property.
+   * @param {?number} [time] - Initial value of the `time` property.
+   */
+  constructor(text = null, userId = null, time = null) {
+    /**
+     * The raw text of the user's chat message (before any rendering or processing).
+     *
+     * @type {?string}
+     */
+    this.text = text;
+
+    /**
+     * The user's author ID.
+     *
+     * @type {?string}
+     */
+    this.userId = userId;
+
+    /**
+     * The message's timestamp, as milliseconds since epoch.
+     *
+     * @type {?number}
+     */
+    this.time = time;
+
+    /**
+     * The user's display name.
+     *
+     * @type {?string}
+     */
+    this.userName = null;
+  }
+}
+
+module.exports = ChatMessage;

--- a/src/static/js/ChatMessage.js
+++ b/src/static/js/ChatMessage.js
@@ -13,10 +13,10 @@ class ChatMessage {
 
   /**
    * @param {?string} [text] - Initial value of the `text` property.
-   * @param {?string} [userId] - Initial value of the `userId` property.
+   * @param {?string} [authorId] - Initial value of the `authorId` property.
    * @param {?number} [time] - Initial value of the `time` property.
    */
-  constructor(text = null, userId = null, time = null) {
+  constructor(text = null, authorId = null, time = null) {
     /**
      * The raw text of the user's chat message (before any rendering or processing).
      *
@@ -29,7 +29,7 @@ class ChatMessage {
      *
      * @type {?string}
      */
-    this.userId = userId;
+    this.authorId = authorId;
 
     /**
      * The message's timestamp, as milliseconds since epoch.
@@ -43,7 +43,37 @@ class ChatMessage {
      *
      * @type {?string}
      */
-    this.userName = null;
+    this.displayName = null;
+  }
+
+  /**
+   * Alias of `authorId`, for compatibility with old plugins.
+   *
+   * @deprecated Use `authorId` instead.
+   * @type {string}
+   */
+  get userId() { return this.authorId; }
+  set userId(val) { this.authorId = val; }
+
+  /**
+   * Alias of `displayName`, for compatibility with old plugins.
+   *
+   * @deprecated Use `displayName` instead.
+   * @type {string}
+   */
+  get userName() { return this.displayName; }
+  set userName(val) { this.displayName = val; }
+
+  // TODO: Delete this method once users are unlikely to roll back to a version of Etherpad that
+  // doesn't support authorId and displayName.
+  toJSON() {
+    return {
+      ...this,
+      authorId: undefined,
+      displayName: undefined,
+      userId: this.authorId,
+      userName: this.displayName,
+    };
   }
 }
 

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+const ChatMessage = require('./ChatMessage');
 const padutils = require('./pad_utils').padutils;
 const padcookie = require('./pad_cookie').padcookie;
 const Tinycon = require('tinycon/tinycon');
@@ -102,10 +103,11 @@ exports.chat = (() => {
     send() {
       const text = $('#chatinput').val();
       if (text.replace(/\s+/, '').length === 0) return;
-      this._pad.collabClient.sendMessage({type: 'CHAT_MESSAGE', text});
+      this._pad.collabClient.sendMessage({type: 'CHAT_MESSAGE', message: new ChatMessage(text)});
       $('#chatinput').val('');
     },
     async addMessage(msg, increment, isHistoryAdd) {
+      msg = ChatMessage.fromObject(msg);
       // correct the time
       msg.time += this._pad.clientTimeOffset;
 

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -131,6 +131,7 @@ exports.chat = (() => {
         authorName: msg.userName != null ? msg.userName : html10n.get('pad.userlist.unnamed'),
         author: msg.userId,
         text: padutils.escapeHtmlWithClickableLinks(msg.text, '_blank'),
+        message: msg,
         sticky: false,
         timestamp: msg.time,
         timeStr: (() => {

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -22,6 +22,9 @@ const Tinycon = require('tinycon/tinycon');
 const hooks = require('./pluginfw/hooks');
 const padeditor = require('./pad_editor').padeditor;
 
+// Removes diacritics and lower-cases letters. https://stackoverflow.com/a/37511463
+const normalize = (s) => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+
 exports.chat = (() => {
   let isStuck = false;
   let userAndChat = false;
@@ -155,10 +158,11 @@ exports.chat = (() => {
       // does the user already have the chatbox open?
       const chatOpen = $('#chatbox').hasClass('visible');
 
-      // does this message contain this user's name? (is the curretn user mentioned?)
-      const myName = $('#myusernameedit').val();
+      // does this message contain this user's name? (is the current user mentioned?)
       const wasMentioned =
-          ctx.text.toLowerCase().indexOf(myName.toLowerCase()) !== -1 && myName !== 'undefined';
+          msg.authorId !== window.clientVars.userId &&
+          ctx.authorName !== html10n.get('pad.userlist.unnamed') &&
+          normalize(ctx.text).includes(normalize(ctx.authorName));
 
       // If the user was mentioned, make the message sticky
       if (wasMentioned && !alreadyFocused && !isHistoryAdd && !chatOpen) {

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -205,7 +205,7 @@ exports.chat = (() => {
                 // to not introduce an XSS vulnerability by adding unescaped user input.
                 .append($('<div>').html(ctx.text).contents()),
             sticky: ctx.sticky,
-            time: 5000,
+            time: ctx.duration,
             position: 'bottom',
             class_name: 'chat-gritter-msg',
           });

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -132,6 +132,7 @@ exports.chat = (() => {
         author: msg.userId,
         text: padutils.escapeHtmlWithClickableLinks(msg.text, '_blank'),
         message: msg,
+        rendered: null,
         sticky: false,
         timestamp: msg.time,
         timeStr: (() => {
@@ -164,7 +165,7 @@ exports.chat = (() => {
 
       await hooks.aCallAll('chatNewMessage', ctx);
       const cls = authorClass(ctx.author);
-      const chatMsg = $('<p>')
+      const chatMsg = ctx.rendered != null ? $(ctx.rendered) : $('<p>')
           .attr('data-authorId', ctx.author)
           .addClass(cls)
           .append($('<b>').text(`${ctx.authorName}:`))

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -189,6 +189,7 @@ exports.chat = (() => {
           .append($('<div>').html(ctx.text).contents());
       if (isHistoryAdd) chatMsg.insertAfter('#chatloadmessagesbutton');
       else $('#chattext').append(chatMsg);
+      chatMsg.each((i, e) => html10n.translateElement(html10n.translations, e));
 
       // should we increment the counter??
       if (increment && !isHistoryAdd) {
@@ -198,12 +199,14 @@ exports.chat = (() => {
         $('#chatcounter').text(count);
 
         if (!chatOpen && ctx.duration > 0) {
+          const text = $('<p>')
+              .append($('<span>').addClass('author-name').text(ctx.authorName))
+              // ctx.text was HTML-escaped before calling the hook. Hook functions are trusted
+              // to not introduce an XSS vulnerability by adding unescaped user input.
+              .append($('<div>').html(ctx.text).contents());
+          text.each((i, e) => html10n.translateElement(html10n.translations, e));
           $.gritter.add({
-            text: $('<p>')
-                .append($('<span>').addClass('author-name').text(ctx.authorName))
-                // ctx.text was HTML-escaped before calling the hook. Hook functions are trusted
-                // to not introduce an XSS vulnerability by adding unescaped user input.
-                .append($('<div>').html(ctx.text).contents()),
+            text,
             sticky: ctx.sticky,
             time: ctx.duration,
             position: 'bottom',

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -111,15 +111,15 @@ exports.chat = (() => {
       // correct the time
       msg.time += this._pad.clientTimeOffset;
 
-      if (!msg.userId) {
+      if (!msg.authorId) {
         /*
          * If, for a bug or a database corruption, the message coming from the
-         * server does not contain the userId field (see for example #3731),
+         * server does not contain the authorId field (see for example #3731),
          * let's be defensive and replace it with "unknown".
          */
-        msg.userId = 'unknown';
+        msg.authorId = 'unknown';
         console.warn(
-            'The "userId" field of a chat message coming from the server was not present. ' +
+            'The "authorId" field of a chat message coming from the server was not present. ' +
             'Replacing with "unknown". This may be a bug or a database corruption.');
       }
 
@@ -130,8 +130,8 @@ exports.chat = (() => {
 
       // the hook args
       const ctx = {
-        authorName: msg.userName != null ? msg.userName : html10n.get('pad.userlist.unnamed'),
-        author: msg.userId,
+        authorName: msg.displayName != null ? msg.displayName : html10n.get('pad.userlist.unnamed'),
+        author: msg.authorId,
         text: padutils.escapeHtmlWithClickableLinks(msg.text, '_blank'),
         message: msg,
         rendered: null,

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -203,12 +203,6 @@ exports.chat = (() => {
           }
         }
       });
-
-      // Clear the chat mentions when the user clicks on the chat input box
-      $('#chatinput').click(() => {
-        chatMentions = 0;
-        Tinycon.setBubble(0);
-      });
       if (!isHistoryAdd) this.scrollDown();
     },
     init(pad) {
@@ -223,6 +217,11 @@ exports.chat = (() => {
           evt.preventDefault();
           return false;
         }
+      });
+      // Clear the chat mentions when the user clicks on the chat input box
+      $('#chatinput').click(() => {
+        chatMentions = 0;
+        Tinycon.setBubble(0);
       });
 
       const self = this;

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -100,10 +100,12 @@ exports.chat = (() => {
         }
       }
     },
-    send() {
+    async send() {
       const text = $('#chatinput').val();
       if (text.replace(/\s+/, '').length === 0) return;
-      this._pad.collabClient.sendMessage({type: 'CHAT_MESSAGE', message: new ChatMessage(text)});
+      const message = new ChatMessage(text);
+      await hooks.aCallAll('chatSendMessage', Object.freeze({message}));
+      this._pad.collabClient.sendMessage({type: 'CHAT_MESSAGE', message});
       $('#chatinput').val('');
     },
     async addMessage(msg, increment, isHistoryAdd) {

--- a/src/static/js/chat.js
+++ b/src/static/js/chat.js
@@ -202,8 +202,8 @@ exports.chat = (() => {
             });
           }
         }
+        if (!isHistoryAdd) this.scrollDown();
       });
-      if (!isHistoryAdd) this.scrollDown();
     },
     init(pad) {
       this._pad = pad;

--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -272,7 +272,7 @@ const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad)
     } else if (msg.type === 'CLIENT_MESSAGE') {
       callbacks.onClientMessage(msg.payload);
     } else if (msg.type === 'CHAT_MESSAGE') {
-      chat.addMessage(msg, true, false);
+      chat.addMessage(msg.message, true, false);
     } else if (msg.type === 'CHAT_MESSAGES') {
       for (let i = msg.messages.length - 1; i >= 0; i--) {
         chat.addMessage(msg.messages[i], true, true);

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -311,14 +311,21 @@ const handshake = async () => {
     }
   });
 
-  await new Promise((resolve) => {
-    const h = (obj) => {
-      if (obj.accessStatus || obj.type !== 'CLIENT_VARS') return;
-      socket.off('message', h);
-      resolve();
-    };
-    socket.on('message', h);
-  });
+  await Promise.all([
+    new Promise((resolve) => {
+      const h = (obj) => {
+        if (obj.accessStatus || obj.type !== 'CLIENT_VARS') return;
+        socket.off('message', h);
+        resolve();
+      };
+      socket.on('message', h);
+    }),
+    // This hook is only intended to be used by test code. If a plugin would like to use this hook,
+    // the hook must first be promoted to officially supported by deleting the leading underscore
+    // from the name, adding documentation to `doc/api/hooks_client-side.md`, and deleting this
+    // comment.
+    hooks.aCallAll('_socketCreated', {socket}),
+  ]);
 };
 
 /** Defers message handling until setCollabClient() is called with a non-null value. */

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -478,6 +478,10 @@
 
         plugins.baseURL = baseURL;
         plugins.update(function () {
+          // Mechanism for tests to register hook functions (install fake plugins).
+          window._postPluginUpdateForTestingDone = false;
+          if (window._postPluginUpdateForTesting != null) window._postPluginUpdateForTesting();
+          window._postPluginUpdateForTestingDone = true;
           // Call documentReady hook
           $(function() {
             hooks.aCallAll('documentReady');

--- a/src/tests/backend/common.js
+++ b/src/tests/backend/common.js
@@ -17,7 +17,8 @@ exports.baseUrl = null;
 exports.httpServer = null;
 exports.logger = log4js.getLogger('test');
 
-const logLevel = exports.logger.level;
+const logger = exports.logger;
+const logLevel = logger.level;
 
 // Mocha doesn't monitor unhandled Promise rejections, so convert them to uncaught exceptions.
 // https://github.com/mochajs/mocha/issues/2640
@@ -34,10 +35,10 @@ exports.init = async function () {
   agentPromise = new Promise((resolve) => { agentResolve = resolve; });
 
   if (!logLevel.isLessThanOrEqualTo(log4js.levels.DEBUG)) {
-    exports.logger.warn('Disabling non-test logging for the duration of the test. ' +
-                        'To enable non-test logging, change the loglevel setting to DEBUG.');
+    logger.warn('Disabling non-test logging for the duration of the test. ' +
+                'To enable non-test logging, change the loglevel setting to DEBUG.');
     log4js.setGlobalLogLevel(log4js.levels.OFF);
-    exports.logger.setLevel(logLevel);
+    logger.setLevel(logLevel);
   }
 
   // Note: This is only a shallow backup.
@@ -49,7 +50,7 @@ exports.init = async function () {
   settings.commitRateLimiting = {duration: 0.001, points: 1e6};
   exports.httpServer = await server.start();
   exports.baseUrl = `http://localhost:${exports.httpServer.address().port}`;
-  exports.logger.debug(`HTTP server at ${exports.baseUrl}`);
+  logger.debug(`HTTP server at ${exports.baseUrl}`);
   // Create a supertest user agent for the HTTP server.
   exports.agent = supertest(exports.baseUrl);
   // Speed up authn tests.

--- a/src/tests/backend/common.js
+++ b/src/tests/backend/common.js
@@ -79,7 +79,7 @@ exports.init = async function () {
  * @param {string} event - The socket.io Socket event to listen for.
  * @returns The argument(s) passed to the event handler.
  */
-exports.getSocketEvent = async (socket, event) => {
+exports.waitForSocketEvent = async (socket, event) => {
   const errorEvents = [
     'error',
     'connect_error',
@@ -137,7 +137,7 @@ exports.connect = async (res = null) => {
     query: {cookie: reqCookieHdr, padId},
   });
   try {
-    await exports.getSocketEvent(socket, 'connect');
+    await exports.waitForSocketEvent(socket, 'connect');
   } catch (e) {
     socket.close();
     throw e;
@@ -164,7 +164,7 @@ exports.handshake = async (socket, padId) => {
     token: 't.12345',
   });
   logger.debug('waiting for CLIENT_VARS response...');
-  const msg = await exports.getSocketEvent(socket, 'message');
+  const msg = await exports.waitForSocketEvent(socket, 'message');
   logger.debug('received CLIENT_VARS message');
   return msg;
 };

--- a/src/tests/backend/specs/chat.js
+++ b/src/tests/backend/specs/chat.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const ChatMessage = require('../../../static/js/ChatMessage');
+const {Pad} = require('../../../node/db/Pad');
+const assert = require('assert').strict;
+const common = require('../common');
+const padManager = require('../../../node/db/PadManager');
+const pluginDefs = require('../../../static/js/pluginfw/plugin_defs');
+
+const logger = common.logger;
+
+const checkHook = async (hookName, checkFn) => {
+  if (pluginDefs.hooks[hookName] == null) pluginDefs.hooks[hookName] = [];
+  await new Promise((resolve, reject) => {
+    pluginDefs.hooks[hookName].push({
+      hook_fn: async (hookName, context) => {
+        if (checkFn == null) return;
+        logger.debug(`hook ${hookName} invoked`);
+        try {
+          // Make sure checkFn is called only once.
+          const _checkFn = checkFn;
+          checkFn = null;
+          await _checkFn(context);
+        } catch (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      },
+    });
+  });
+};
+
+const sendMessage = (socket, data) => {
+  socket.send({
+    type: 'COLLABROOM',
+    component: 'pad',
+    data,
+  });
+};
+
+const sendChat = (socket, message) => sendMessage(socket, {type: 'CHAT_MESSAGE', message});
+
+describe(__filename, function () {
+  const padId = 'testChatPad';
+  const hooksBackup = {};
+
+  before(async function () {
+    for (const [name, defs] of Object.entries(pluginDefs.hooks)) {
+      if (defs == null) continue;
+      hooksBackup[name] = defs;
+    }
+  });
+
+  beforeEach(async function () {
+    for (const [name, defs] of Object.entries(hooksBackup)) pluginDefs.hooks[name] = [...defs];
+    for (const name of Object.keys(pluginDefs.hooks)) {
+      if (hooksBackup[name] == null) delete pluginDefs.hooks[name];
+    }
+    if (await padManager.doesPadExist(padId)) {
+      const pad = await padManager.getPad(padId);
+      await pad.remove();
+    }
+  });
+
+  after(async function () {
+    Object.assign(pluginDefs.hooks, hooksBackup);
+    for (const name of Object.keys(pluginDefs.hooks)) {
+      if (hooksBackup[name] == null) delete pluginDefs.hooks[name];
+    }
+  });
+
+  describe('chatNewMessage hook', function () {
+    let authorId;
+    let socket;
+
+    beforeEach(async function () {
+      socket = await common.connect();
+      const {data: clientVars} = await common.handshake(socket, padId);
+      authorId = clientVars.userId;
+    });
+
+    afterEach(async function () {
+      socket.close();
+    });
+
+    it('message', async function () {
+      const start = Date.now();
+      await Promise.all([
+        checkHook('chatNewMessage', ({message}) => {
+          assert(message != null);
+          assert(message instanceof ChatMessage);
+          assert.equal(message.authorId, authorId);
+          assert.equal(message.text, this.test.title);
+          assert(message.time >= start);
+          assert(message.time <= Date.now());
+        }),
+        sendChat(socket, {text: this.test.title}),
+      ]);
+    });
+
+    it('pad', async function () {
+      await Promise.all([
+        checkHook('chatNewMessage', ({pad}) => {
+          assert(pad != null);
+          assert(pad instanceof Pad);
+          assert.equal(pad.id, padId);
+        }),
+        sendChat(socket, {text: this.test.title}),
+      ]);
+    });
+
+    it('padId', async function () {
+      await Promise.all([
+        checkHook('chatNewMessage', (context) => {
+          assert.equal(context.padId, padId);
+        }),
+        sendChat(socket, {text: this.test.title}),
+      ]);
+    });
+
+    it('mutations propagate', async function () {
+      const listen = async (type) => await new Promise((resolve) => {
+        const handler = (msg) => {
+          if (msg.type !== 'COLLABROOM') return;
+          if (msg.data == null || msg.data.type !== type) return;
+          resolve(msg.data);
+          socket.off('message', handler);
+        };
+        socket.on('message', handler);
+      });
+
+      const modifiedText = `${this.test.title} <added changes>`;
+      const customMetadata = {foo: this.test.title};
+      await Promise.all([
+        checkHook('chatNewMessage', ({message}) => {
+          message.text = modifiedText;
+          message.customMetadata = customMetadata;
+        }),
+        (async () => {
+          const {message} = await listen('CHAT_MESSAGE');
+          assert(message != null);
+          assert.equal(message.text, modifiedText);
+          assert.deepEqual(message.customMetadata, customMetadata);
+        })(),
+        sendChat(socket, {text: this.test.title}),
+      ]);
+      // Simulate fetch of historical chat messages when a pad is first loaded.
+      await Promise.all([
+        (async () => {
+          const {messages: [message]} = await listen('CHAT_MESSAGES');
+          assert(message != null);
+          assert.equal(message.text, modifiedText);
+          assert.deepEqual(message.customMetadata, customMetadata);
+        })(),
+        sendMessage(socket, {type: 'GET_CHAT_MESSAGES', start: 0, end: 0}),
+      ]);
+    });
+  });
+});

--- a/src/tests/backend/specs/socketio.js
+++ b/src/tests/backend/specs/socketio.js
@@ -2,96 +2,11 @@
 
 const assert = require('assert').strict;
 const common = require('../common');
-const io = require('socket.io-client');
 const padManager = require('../../../node/db/PadManager');
 const plugins = require('../../../static/js/pluginfw/plugin_defs');
 const readOnlyManager = require('../../../node/db/ReadOnlyManager');
-const setCookieParser = require('set-cookie-parser');
 const settings = require('../../../node/utils/Settings');
 const socketIoRouter = require('../../../node/handler/SocketIORouter');
-
-const logger = common.logger;
-
-// Waits for and returns the next named socket.io event. Rejects if there is any error while waiting
-// (unless waiting for that error event).
-const getSocketEvent = async (socket, event) => {
-  const errorEvents = [
-    'error',
-    'connect_error',
-    'connect_timeout',
-    'reconnect_error',
-    'reconnect_failed',
-  ];
-  const handlers = {};
-  let timeoutId;
-  return new Promise((resolve, reject) => {
-    timeoutId = setTimeout(() => reject(new Error(`timed out waiting for ${event} event`)), 1000);
-    for (const event of errorEvents) {
-      handlers[event] = (errorString) => {
-        logger.debug(`socket.io ${event} event: ${errorString}`);
-        reject(new Error(errorString));
-      };
-    }
-    // This will overwrite one of the above handlers if the user is waiting for an error event.
-    handlers[event] = (...args) => {
-      logger.debug(`socket.io ${event} event`);
-      if (args.length > 1) return resolve(args);
-      resolve(args[0]);
-    };
-    Object.entries(handlers).forEach(([event, handler]) => socket.on(event, handler));
-  }).finally(() => {
-    clearTimeout(timeoutId);
-    Object.entries(handlers).forEach(([event, handler]) => socket.off(event, handler));
-  });
-};
-
-// Establishes a new socket.io connection. Passes the cookies from the `set-cookie` header(s) in
-// `res` (which may be nullish) to the server. Returns a socket.io Socket object.
-const connect = async (res) => {
-  // Convert the `set-cookie` header(s) into a `cookie` header.
-  const resCookies = (res == null) ? {} : setCookieParser.parse(res, {map: true});
-  const reqCookieHdr = Object.entries(resCookies).map(
-      ([name, cookie]) => `${name}=${encodeURIComponent(cookie.value)}`).join('; ');
-
-  logger.debug('socket.io connecting...');
-  let padId = null;
-  if (res) {
-    padId = res.req.path.split('/p/')[1];
-  }
-  const socket = io(`${common.baseUrl}/`, {
-    forceNew: true, // Different tests will have different query parameters.
-    path: '/socket.io',
-    // socketio.js-client on node.js doesn't support cookies (see https://git.io/JU8u9), so the
-    // express_sid cookie must be passed as a query parameter.
-    query: {cookie: reqCookieHdr, padId},
-  });
-  try {
-    await getSocketEvent(socket, 'connect');
-  } catch (e) {
-    socket.close();
-    throw e;
-  }
-  logger.debug('socket.io connected');
-
-  return socket;
-};
-
-// Helper function to exchange CLIENT_READY+CLIENT_VARS messages for the named pad.
-// Returns the CLIENT_VARS message from the server.
-const handshake = async (socket, padID) => {
-  logger.debug('sending CLIENT_READY...');
-  socket.send({
-    component: 'pad',
-    type: 'CLIENT_READY',
-    padId: padID,
-    sessionID: null,
-    token: 't.12345',
-  });
-  logger.debug('waiting for CLIENT_VARS response...');
-  const msg = await getSocketEvent(socket, 'message');
-  logger.debug('received CLIENT_VARS message');
-  return msg;
-};
 
 describe(__filename, function () {
   this.timeout(30000);
@@ -143,26 +58,26 @@ describe(__filename, function () {
   describe('Normal accesses', function () {
     it('!authn anonymous cookie /p/pad -> 200, ok', async function () {
       const res = await agent.get('/p/pad').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
     });
     it('!authn !cookie -> ok', async function () {
-      socket = await connect(null);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(null);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
     });
     it('!authn user /p/pad -> 200, ok', async function () {
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
     });
     it('authn user /p/pad -> 200, ok', async function () {
       settings.requireAuthentication = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
     });
 
@@ -176,16 +91,16 @@ describe(__filename, function () {
         };
         settings.requireAuthentication = authn;
         let res = await get('/p/pad');
-        socket = await connect(res);
-        let clientVars = await handshake(socket, 'pad');
+        socket = await common.connect(res);
+        let clientVars = await common.handshake(socket, 'pad');
         assert.equal(clientVars.type, 'CLIENT_VARS');
         assert.equal(clientVars.data.readonly, false);
         const readOnlyId = clientVars.data.readOnlyId;
         assert(readOnlyManager.isReadOnlyId(readOnlyId));
         socket.close();
         res = await get(`/p/${readOnlyId}`);
-        socket = await connect(res);
-        clientVars = await handshake(socket, readOnlyId);
+        socket = await common.connect(res);
+        clientVars = await common.handshake(socket, readOnlyId);
         assert.equal(clientVars.type, 'CLIENT_VARS');
         assert.equal(clientVars.data.readonly, true);
       });
@@ -195,8 +110,8 @@ describe(__filename, function () {
       settings.requireAuthentication = true;
       settings.requireAuthorization = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
     });
     it('supports pad names with characters that must be percent-encoded', async function () {
@@ -208,8 +123,8 @@ describe(__filename, function () {
       settings.requireAuthorization = true;
       const encodedPadId = encodeURIComponent('päd');
       const res = await agent.get(`/p/${encodedPadId}`).auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'päd');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'päd');
       assert.equal(clientVars.type, 'CLIENT_VARS');
     });
   });
@@ -219,31 +134,31 @@ describe(__filename, function () {
       settings.requireAuthentication = true;
       const res = await agent.get('/p/pad').expect(401);
       // Despite the 401, try to create the pad via a socket.io connection anyway.
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
 
     it('authn anonymous read-only /p/pad -> 401, error', async function () {
       settings.requireAuthentication = true;
       let res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       const readOnlyId = clientVars.data.readOnlyId;
       assert(readOnlyManager.isReadOnlyId(readOnlyId));
       socket.close();
       res = await agent.get(`/p/${readOnlyId}`).expect(401);
       // Despite the 401, try to read the pad via a socket.io connection anyway.
-      socket = await connect(res);
-      const message = await handshake(socket, readOnlyId);
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, readOnlyId);
       assert.equal(message.accessStatus, 'deny');
     });
 
     it('authn !cookie -> error', async function () {
       settings.requireAuthentication = true;
-      socket = await connect(null);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(null);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it('authorization bypass attempt -> error', async function () {
@@ -253,9 +168,9 @@ describe(__filename, function () {
       settings.requireAuthorization = true;
       // First authenticate and establish a session.
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
+      socket = await common.connect(res);
       // Accessing /p/other-pad should fail, despite the successful fetch of /p/pad.
-      const message = await handshake(socket, 'other-pad');
+      const message = await common.handshake(socket, 'other-pad');
       assert.equal(message.accessStatus, 'deny');
     });
   });
@@ -269,16 +184,16 @@ describe(__filename, function () {
     it("level='create' -> can create", async function () {
       authorize = () => 'create';
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, false);
     });
     it('level=true -> can create', async function () {
       authorize = () => true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, false);
     });
@@ -286,8 +201,8 @@ describe(__filename, function () {
       await padManager.getPad('pad'); // Create the pad.
       authorize = () => 'modify';
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, false);
     });
@@ -295,31 +210,31 @@ describe(__filename, function () {
       authorize = () => 'create';
       settings.editOnly = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it("level='modify' settings.editOnly=false -> unable to create", async function () {
       authorize = () => 'modify';
       settings.editOnly = false;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it("level='readOnly' -> unable to create", async function () {
       authorize = () => 'readOnly';
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it("level='readOnly' -> unable to modify", async function () {
       await padManager.getPad('pad'); // Create the pad.
       authorize = () => 'readOnly';
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, true);
     });
@@ -333,39 +248,39 @@ describe(__filename, function () {
     it('user.canCreate = true -> can create and modify', async function () {
       settings.users.user.canCreate = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, false);
     });
     it('user.canCreate = false -> unable to create', async function () {
       settings.users.user.canCreate = false;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it('user.readOnly = true -> unable to create', async function () {
       settings.users.user.readOnly = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it('user.readOnly = true -> unable to modify', async function () {
       await padManager.getPad('pad'); // Create the pad.
       settings.users.user.readOnly = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, true);
     });
     it('user.readOnly = false -> can create and modify', async function () {
       settings.users.user.readOnly = false;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const clientVars = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const clientVars = await common.handshake(socket, 'pad');
       assert.equal(clientVars.type, 'CLIENT_VARS');
       assert.equal(clientVars.data.readonly, false);
     });
@@ -373,8 +288,8 @@ describe(__filename, function () {
       settings.users.user.canCreate = true;
       settings.users.user.readOnly = true;
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
   });
@@ -389,8 +304,8 @@ describe(__filename, function () {
       settings.users.user.readOnly = true;
       authorize = () => 'create';
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
     it('user settings does not elevate level from authorize hook', async function () {
@@ -398,8 +313,8 @@ describe(__filename, function () {
       settings.users.user.canCreate = true;
       authorize = () => 'readOnly';
       const res = await agent.get('/p/pad').auth('user', 'user-password').expect(200);
-      socket = await connect(res);
-      const message = await handshake(socket, 'pad');
+      socket = await common.connect(res);
+      const message = await common.handshake(socket, 'pad');
       assert.equal(message.accessStatus, 'deny');
     });
   });
@@ -430,7 +345,7 @@ describe(__filename, function () {
       socketIoRouter.addComponent(this.test.fullTitle(), new class extends Module {
         handleConnect(socket) { serverSocket = socket; }
       }());
-      socket = await connect();
+      socket = await common.connect();
       assert(serverSocket != null);
     });
 
@@ -452,7 +367,7 @@ describe(__filename, function () {
           resolveDisconnected();
         }
       }());
-      socket = await connect();
+      socket = await common.connect();
       await connected;
       socket.close();
       socket = null;
@@ -474,7 +389,7 @@ describe(__filename, function () {
       socketIoRouter.addComponent(`${this.test.fullTitle()} #2`, new class extends Module {
         handleMessage(socket, message) { assert.fail('wrong handler called'); }
       }());
-      socket = await connect();
+      socket = await common.connect();
       socket.send(want);
       assert.deepEqual(await got, want);
     });
@@ -492,7 +407,7 @@ describe(__filename, function () {
       socketIoRouter.addComponent(this.test.fullTitle(), new class extends Module {
         handleMessage(socket, msg) { return want; }
       }());
-      socket = await connect();
+      socket = await common.connect();
       const got = await tx(socket, {component: this.test.fullTitle()});
       assert.equal(got, want);
     });
@@ -504,7 +419,7 @@ describe(__filename, function () {
       socketIoRouter.addComponent(this.test.fullTitle(), new class extends Module {
         handleMessage(socket, msg) { throw new InjectedError(); }
       }());
-      socket = await connect();
+      socket = await common.connect();
       await assert.rejects(tx(socket, {component: this.test.fullTitle()}), new InjectedError());
     });
   });

--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -99,6 +99,16 @@ const helper = {};
       hookFns: {},
     }, opts);
 
+    // Set up socket.io spying as early as possible.
+    /** chat messages received */
+    helper.chatMessages = [];
+    /** changeset commits from the server */
+    helper.commits = [];
+    /** userInfo messages from the server */
+    helper.userInfos = [];
+    if (opts.hookFns._socketCreated == null) opts.hookFns._socketCreated = [];
+    opts.hookFns._socketCreated.unshift(() => helper.spyOnSocketIO());
+
     // if opts.params is set we manipulate the URL to include URL parameters IE ?foo=Bah.
     let encodedParams;
     if (opts.params) {
@@ -170,27 +180,6 @@ const helper = {};
     helper.padChrome$.fx.off = true;
     helper.padOuter$.fx.off = true;
     helper.padInner$.fx.off = true;
-
-    /*
-     * chat messages received
-     * @type {Array}
-     */
-    helper.chatMessages = [];
-
-    /*
-     * changeset commits from the server
-     * @type {Array}
-     */
-    helper.commits = [];
-
-    /*
-     * userInfo messages from the server
-     * @type {Array}
-     */
-    helper.userInfos = [];
-
-    // listen for server messages
-    helper.spyOnSocketIO();
 
     return opts.id;
   };

--- a/src/tests/frontend/helper.js
+++ b/src/tests/frontend/helper.js
@@ -96,6 +96,7 @@ const helper = {};
       _retry: 0,
       clearCookies: true,
       id: `FRONTEND_TEST_${helper.randomString(20)}`,
+      hookFns: {},
     }, opts);
 
     // if opts.params is set we manipulate the URL to include URL parameters IE ?foo=Bah.
@@ -122,7 +123,26 @@ const helper = {};
     $('#iframe-container iframe').remove();
     // set new iframe
     $('#iframe-container').append($iframe);
-    await new Promise((resolve) => $iframe.one('load', resolve));
+    await Promise.all([
+      new Promise((resolve) => $iframe.one('load', resolve)),
+      // Install the hook functions as early as possible because some of them fire right away.
+      new Promise((resolve, reject) => {
+        if ($iframe[0].contentWindow._postPluginUpdateForTestingDone) {
+          return reject(new Error(
+              'failed to set _postPluginUpdateForTesting before it would have been called'));
+        }
+        $iframe[0].contentWindow._postPluginUpdateForTesting = () => {
+          const {hooks} =
+                $iframe[0].contentWindow.require('ep_etherpad-lite/static/js/pluginfw/plugin_defs');
+          for (const [hookName, hookFns] of Object.entries(opts.hookFns)) {
+            if (hooks[hookName] == null) hooks[hookName] = [];
+            hooks[hookName].push(
+                ...hookFns.map((hookFn) => ({hook_name: hookName, hook_fn: hookFn})));
+          }
+          resolve();
+        };
+      }),
+    ]);
     helper.padChrome$ = await helper.getFrameJQuery($('#iframe-container iframe'), true);
     helper.padChrome$.padeditor =
         helper.padChrome$.window.require('ep_etherpad-lite/static/js/pad_editor').padeditor;

--- a/src/tests/frontend/helper/methods.js
+++ b/src/tests/frontend/helper/methods.js
@@ -12,7 +12,7 @@ helper.spyOnSocketIO = () => {
     } else if (msg.data.type === 'USER_NEWINFO') {
       helper.userInfos.push(msg);
     } else if (msg.data.type === 'CHAT_MESSAGE') {
-      helper.chatMessages.push(msg.data);
+      helper.chatMessages.push(msg.data.message);
     } else if (msg.data.type === 'CHAT_MESSAGES') {
       helper.chatMessages.push(...msg.data.messages);
     }

--- a/src/tests/frontend/helper/methods.js
+++ b/src/tests/frontend/helper/methods.js
@@ -12,7 +12,7 @@ helper.spyOnSocketIO = () => {
     } else if (msg.data.type === 'USER_NEWINFO') {
       helper.userInfos.push(msg);
     } else if (msg.data.type === 'CHAT_MESSAGE') {
-      helper.chatMessages.push(msg);
+      helper.chatMessages.push(msg.data);
     }
   });
 };

--- a/src/tests/frontend/helper/methods.js
+++ b/src/tests/frontend/helper/methods.js
@@ -13,6 +13,8 @@ helper.spyOnSocketIO = () => {
       helper.userInfos.push(msg);
     } else if (msg.data.type === 'CHAT_MESSAGE') {
       helper.chatMessages.push(msg.data);
+    } else if (msg.data.type === 'CHAT_MESSAGES') {
+      helper.chatMessages.push(...msg.data.messages);
     }
   });
 };

--- a/src/tests/frontend/runner.js
+++ b/src/tests/frontend/runner.js
@@ -214,7 +214,7 @@ $(() => (async () => {
       const [origDefs] = args;
       const defs = {};
       for (const [path, origDef] of Object.entries(origDefs)) {
-        defs[path] = function (require, exports, module) {
+        defs[path] = origDef == null ? origDef : function (require, exports, module) {
           const calls = [];
           mochaCalls.set(module.id.replace(/\.js$/, ''), calls);
           // Backup Mocha functions. Note that because modules can require other modules, these

--- a/src/tests/frontend/specs/chat_hooks.js
+++ b/src/tests/frontend/specs/chat_hooks.js
@@ -79,5 +79,18 @@ describe('chat hooks', function () {
         helper.sendChatMessage(`${msg}{enter}`),
       ]);
     });
+
+    it('`rendered` overrides default rendering', async function () {
+      let rendered;
+      await Promise.all([
+        checkHook('chatNewMessage', (context) => {
+          expect(context.rendered == null).to.be.ok();
+          rendered = context.rendered = helper.padChrome$.document.createElement('p');
+          rendered.append('message rendering overridden');
+        }),
+        helper.sendChatMessage(`${this.test.title}{enter}`),
+      ]);
+      expect(helper.chatTextParagraphs().last()[0]).to.be(rendered);
+    });
   });
 });

--- a/src/tests/frontend/specs/chat_hooks.js
+++ b/src/tests/frontend/specs/chat_hooks.js
@@ -60,5 +60,24 @@ describe('chat hooks', function () {
         ]);
       });
     }
+
+    it('message is an object', async function () {
+      await Promise.all([
+        checkHook('chatNewMessage', ({message}) => {
+          expect(message).to.be.an('object');
+        }),
+        helper.sendChatMessage(`${this.test.title}{enter}`),
+      ]);
+    });
+
+    it('message.text is not processed', async function () {
+      const msg = '<script>alert("foo");</script> https://etherpad.org';
+      await Promise.all([
+        checkHook('chatNewMessage', ({message: {text}}) => {
+          expect(text).to.equal(`${msg}\n`);
+        }),
+        helper.sendChatMessage(`${msg}{enter}`),
+      ]);
+    });
   });
 });

--- a/src/tests/frontend/specs/chat_hooks.js
+++ b/src/tests/frontend/specs/chat_hooks.js
@@ -1,11 +1,13 @@
 'use strict';
 
 describe('chat hooks', function () {
+  let ChatMessage;
   let hooks;
   const hooksBackup = {};
 
   const loadPad = async (opts = {}) => {
     await helper.aNewPad(opts);
+    ChatMessage = helper.padChrome$.window.require('ep_etherpad-lite/static/js/ChatMessage');
     ({hooks} = helper.padChrome$.window.require('ep_etherpad-lite/static/js/pluginfw/plugin_defs'));
     for (const [name, defs] of Object.entries(hooks)) {
       hooksBackup[name] = defs;
@@ -61,10 +63,10 @@ describe('chat hooks', function () {
       });
     }
 
-    it('message is an object', async function () {
+    it('message is a ChatMessage object', async function () {
       await Promise.all([
         checkHook('chatNewMessage', ({message}) => {
-          expect(message).to.be.an('object');
+          expect(message).to.be.a(ChatMessage);
         }),
         helper.sendChatMessage(`${this.test.title}{enter}`),
       ]);

--- a/src/tests/frontend/specs/chat_hooks.js
+++ b/src/tests/frontend/specs/chat_hooks.js
@@ -1,0 +1,64 @@
+'use strict';
+
+describe('chat hooks', function () {
+  let hooks;
+  const hooksBackup = {};
+
+  const loadPad = async (opts = {}) => {
+    await helper.aNewPad(opts);
+    ({hooks} = helper.padChrome$.window.require('ep_etherpad-lite/static/js/pluginfw/plugin_defs'));
+    for (const [name, defs] of Object.entries(hooks)) {
+      hooksBackup[name] = defs;
+      hooks[name] = [...defs];
+    }
+    await helper.showChat();
+  };
+
+  before(async function () {
+    await loadPad();
+  });
+
+  afterEach(async function () {
+    for (const [name, defs] of Object.entries(hooksBackup)) hooks[name] = [...defs];
+    for (const name of Object.keys(hooks)) {
+      if (hooksBackup[name] == null) delete hooks[name];
+    }
+  });
+
+  const checkHook = async (hookName, checkFn) => {
+    if (hooks[hookName] == null) hooks[hookName] = [];
+    await new Promise((resolve, reject) => {
+      hooks[hookName].push({
+        hook_fn: async (hookName, context) => {
+          if (checkFn == null) return;
+          try {
+            // Make sure checkFn is called only once.
+            const _checkFn = checkFn;
+            checkFn = null;
+            await _checkFn(context);
+          } catch (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        },
+      });
+    });
+  };
+
+  describe('chatNewMessage', function () {
+    for (const [desc, msg, wantRegEx] of [
+      ['HTML is escaped', '<script>alert("foo");</script>', /^[^<]*$/],
+      ['URL becomes a link', 'https://etherpad.org', /<a [^>]*href/],
+    ]) {
+      it(`text processing: ${desc}`, async function () {
+        await Promise.all([
+          checkHook('chatNewMessage', ({text}) => {
+            expect(text).to.match(wantRegEx);
+          }),
+          helper.sendChatMessage(`${msg}{enter}`),
+        ]);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Multiple commits, do not squash.

Plugins can now access the raw chat message object (to set and get custom metadata) and can completely override the rendering of any chat message. This can be used to add user joined/left notices or IRC-like "/me \<message\>" commands.

cc @packardone