### PR TITLE
plugins: Don't create `.ep_initialized` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ var/dirty.db
 *.patch
 npm-debug.log
 *.DS_Store
-.ep_initialized
 *.crt
 *.key
 credentials.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
       for an example fix.
   * The `clientReady` server-side hook is deprecated; use the new `userJoin`
     hook instead.
+  * The `init_<pluginName>` server-side hooks are now run every time Etherpad
+    starts up, not just the first time after the named plugin is installed.
   * The `userLeave` server-side hook's context properties have changed:
     * `auth`: Deprecated.
     * `author`: Deprecated; use the new `authorId` property instead.

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -50,12 +50,13 @@ Things in context:
 
 If this hook returns an error, the callback to the install function gets an error, too. This seems useful for adding in features when a particular plugin is installed.
 
-## init_`<plugin name>`
-Called from: src/static/js/pluginfw/plugins.js
+## `init_<plugin name>`
 
-Things in context: None
+Called from: `src/static/js/pluginfw/plugins.js`
 
-This function is called after a specific plugin is initialized. This would probably be more useful than the previous two functions if you only wanted to add in features to one specific plugin.
+Run during startup after the named plugin is initialized.
+
+Context properties: None
 
 ## expressConfigure
 Called from: src/node/hooks/express.js

--- a/src/bin/plugins/lib/gitignore
+++ b/src/bin/plugins/lib/gitignore
@@ -1,5 +1,3 @@
-.ep_initialized
 .DS_Store
 node_modules/
-node_modules
 npm-debug.log

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -72,19 +72,6 @@ exports.formatHooks = (hookSetName, html) => {
   return lines.join('\n');
 };
 
-const callInit = async () => {
-  await Promise.all(Object.keys(defs.plugins).map(async (pluginName) => {
-    const plugin = defs.plugins[pluginName];
-    const epInit = path.join(plugin.package.path, '.ep_initialized');
-    try {
-      await fs.stat(epInit);
-    } catch (err) {
-      await fs.writeFile(epInit, 'done');
-      await hooks.aCallAll(`init_${pluginName}`, {});
-    }
-  }));
-};
-
 exports.pathNormalization = (part, hookFnName, hookName) => {
   const tmp = hookFnName.split(':'); // hookFnName might be something like 'C:\\foo.js:myFunc'.
   // If there is a single colon assume it's 'filename:funcname' not 'C:\\filename'.
@@ -111,7 +98,7 @@ exports.update = async () => {
   defs.parts = sortParts(parts);
   defs.hooks = pluginUtils.extractHooks(defs.parts, 'hooks', exports.pathNormalization);
   defs.loaded = true;
-  await callInit();
+  await Promise.all(Object.keys(defs.plugins).map((p) => hooks.aCallAll(`init_${p}`, {})));
 };
 
 exports.getPackages = async () => {


### PR DESCRIPTION
These files cause problems with Docker images and read-only directories/mounts, and they have dubious value (any install-time setup should instead be done at startup).

Fixes #2683