### PR TITLE
Fix comparison between `CustomError` and `string`

### DIFF
--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -255,7 +255,7 @@ const listSessionsWithDBKey = async (dbkey) => {
       const sessionInfo = await exports.getSessionInfo(sessionID);
       sessions[sessionID] = sessionInfo;
     } catch (err) {
-      if (err === 'apierror: sessionID does not exist') {
+      if (err.name === 'apierror') {
         console.warn(`Found bad session ${sessionID} in ${dbkey}`);
         sessions[sessionID] = null;
       } else {


### PR DESCRIPTION
This bug was introduced in #4667 where `==` was changed to `===`, resulting in a type comparison. However, the type of `err` is `CustomError`, not `string`. The comparison is therefore always false, resulting in the API error "sessionId does not exist" when `listSessionsWithDBKey` is called and some sessions do not exist instead of simply returning null for these sessions as was previously the case.