### PR TITLE
Delete session after corresponding group2session and author2session entries

### DIFF
--- a/src/node/db/SessionManager.js
+++ b/src/node/db/SessionManager.js
@@ -204,9 +204,6 @@ exports.deleteSession = async (sessionID) => {
   const group2sessions = await db.get(`group2sessions:${groupID}`);
   const author2sessions = await db.get(`author2sessions:${authorID}`);
 
-  // remove the session
-  await db.remove(`session:${sessionID}`);
-
   // remove session from group2sessions
   if (group2sessions != null) { // Maybe the group was already deleted
     delete group2sessions.sessionIDs[sessionID];
@@ -218,6 +215,9 @@ exports.deleteSession = async (sessionID) => {
     delete author2sessions.sessionIDs[sessionID];
     await db.set(`author2sessions:${authorID}`, author2sessions);
   }
+
+  // remove the session
+  await db.remove(`session:${sessionID}`);
 };
 
 exports.listSessionsOfGroup = async (groupID) => {


### PR DESCRIPTION
Currently, when a session is deleted, the session itself is removed before the session entries are removed from `group2sessions` and `author2sessions`. This leads to an unclean state when the application is killed or an error occurs after the session was deleted but before all references are deleted because sessions that do not exist are still referenced. This pull request changes the order to delete the references first.