### PR TITLE
New attributes processing library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
   (low-level API) and `ep_etherpad-lite/static/js/AttributeMap` (high-level
   API).
 
+### Compatibility changes
+
+#### For plugin authors
+
+* Changes to the `src/static/js/Changeset.js` library:
+  * The following attribute processing functions are deprecated (use the new
+    attribute APIs instead):
+    * `attribsAttributeValue()`
+    * `eachAttribNumber()`
+    * `makeAttribsString()`
+    * `opAttributeValue()`
+
 # 1.8.15
 
 ### Security fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.9.0 (not yet released)
+
+### Notable enhancements
+
+#### For plugin authors
+
+* New APIs for processing attributes: `ep_etherpad-lite/static/js/attributes`
+  (low-level API) and `ep_etherpad-lite/static/js/AttributeMap` (high-level
+  API).
+
 # 1.8.15
 
 ### Security fixes

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -665,6 +665,7 @@ Context properties:
 Example:
 
 ```javascript
+const AttributeMap = require('ep_etherpad-lite/static/js/AttributeMap');
 const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 
 exports.getLineHTMLForExport = async (hookName, context) => {
@@ -672,7 +673,7 @@ exports.getLineHTMLForExport = async (hookName, context) => {
   const opIter = Changeset.opIterator(context.attribLine);
   if (!opIter.hasNext()) return;
   const op = opIter.next();
-  const heading = Changeset.opAttributeValue(op, 'heading', apool);
+  const heading = AttributeMap.fromString(op.attribs, context.apool).get('heading');
   if (!heading) return;
   context.lineContent = `<${heading}>${context.lineContent}</${heading}>`;
 };

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -646,39 +646,36 @@ exports.clientVars = (hookName, context, callback) => {
 };
 ```
 
-## getLineHTMLForExport
-Called from: src/node/utils/ExportHtml.js
+## `getLineHTMLForExport`
 
-Things in context:
+Called from: `src/node/utils/ExportHtml.js`
 
-1. apool - pool object
-2. attribLine - line attributes
-3. text - line text
+This hook will allow a plug-in developer to re-write each line when exporting to
+HTML.
 
-This hook will allow a plug-in developer to re-write each line when exporting to HTML.
+Context properties:
+
+* `apool`: Pool object.
+* `attribLine`: Line attributes.
+* `line`:
+* `lineContent`:
+* `text`: Line text.
+* `padId`: Writable (not read-only) pad identifier.
 
 Example:
-```
-var Changeset = require("ep_etherpad-lite/static/js/Changeset");
 
-exports.getLineHTMLForExport = function (hook, context) {
-  var header = _analyzeLine(context.attribLine, context.apool);
-  if (header) {
-    return "<" + header + ">" + context.lineContent + "</" + header + ">";
-  }
-}
+```javascript
+const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 
-function _analyzeLine(alineAttrs, apool) {
-  var header = null;
-  if (alineAttrs) {
-    var opIter = Changeset.opIterator(alineAttrs);
-    if (opIter.hasNext()) {
-      var op = opIter.next();
-      header = Changeset.opAttributeValue(op, 'heading', apool);
-    }
-  }
-  return header;
-}
+exports.getLineHTMLForExport = async (hookName, context) => {
+  if (!context.attribLine) return;
+  const opIter = Changeset.opIterator(context.attribLine);
+  if (!opIter.hasNext()) return;
+  const op = opIter.next();
+  const heading = Changeset.opAttributeValue(op, 'heading', apool);
+  if (!heading) return;
+  context.lineContent = `<${heading}>${context.lineContent}</${heading}>`;
+};
 ```
 
 ## exportHTMLAdditionalContent

--- a/src/node/utils/ExportHelper.js
+++ b/src/node/utils/ExportHelper.js
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+const AttributeMap = require('../../static/js/AttributeMap');
 const Changeset = require('../../static/js/Changeset');
 
 exports.getPadPlainText = (pad, revNum) => {
@@ -54,7 +55,8 @@ exports._analyzeLine = (text, aline, apool) => {
     const opIter = Changeset.opIterator(aline);
     if (opIter.hasNext()) {
       const op = opIter.next();
-      let listType = Changeset.opAttributeValue(op, 'list', apool);
+      const attribs = AttributeMap.fromString(op.attribs, apool);
+      let listType = attribs.get('list');
       if (listType) {
         lineMarker = 1;
         listType = /([a-z]+)([0-9]+)/.exec(listType);
@@ -63,7 +65,7 @@ exports._analyzeLine = (text, aline, apool) => {
           line.listLevel = Number(listType[2]);
         }
       }
-      const start = Changeset.opAttributeValue(op, 'start', apool);
+      const start = attribs.get('start');
       if (start) {
         line.start = start;
       }

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -16,6 +16,7 @@
  */
 
 const Changeset = require('../../static/js/Changeset');
+const attributes = require('../../static/js/attributes');
 const padManager = require('../db/PadManager');
 const _ = require('underscore');
 const Security = require('../../static/js/security');
@@ -206,11 +207,11 @@ const getHTMLFromAtext = async (pad, atext, authorColors) => {
         const usedAttribs = [];
 
         // mark all attribs as used
-        Changeset.eachAttribNumber(o.attribs, (a) => {
+        for (const a of attributes.decodeAttribString(o.attribs)) {
           if (a in anumMap) {
             usedAttribs.push(anumMap[a]); // i = 0 => bold, etc.
           }
-        });
+        }
         let outermostTag = -1;
         // find the outer most open tag that is no longer used
         for (let i = openTags.length - 1; i >= 0; i--) {

--- a/src/node/utils/ExportTxt.js
+++ b/src/node/utils/ExportTxt.js
@@ -20,6 +20,7 @@
  */
 
 const Changeset = require('../../static/js/Changeset');
+const attributes = require('../../static/js/attributes');
 const padManager = require('../db/PadManager');
 const _analyzeLine = require('./ExportHelper')._analyzeLine;
 
@@ -82,7 +83,7 @@ const getTXTFromAtext = (pad, atext, authorColors) => {
         const o = iter.next();
         let propChanged = false;
 
-        Changeset.eachAttribNumber(o.attribs, (a) => {
+        for (const a of attributes.decodeAttribString(o.attribs)) {
           if (a in anumMap) {
             const i = anumMap[a]; // i = 0 => bold, etc.
 
@@ -93,7 +94,7 @@ const getTXTFromAtext = (pad, atext, authorColors) => {
               propVals[i] = STAY;
             }
           }
-        });
+        }
 
         for (let i = 0; i < propVals.length; i++) {
           if (propVals[i] === true) {

--- a/src/node/utils/padDiff.js
+++ b/src/node/utils/padDiff.js
@@ -364,9 +364,6 @@ PadDiff.prototype._createDeletionChangeset = function (cs, startAText, apool) {
     };
   };
 
-  const attribKeys = [];
-  const attribValues = [];
-
   // iterate over all operators of this changeset
   while (csIter.hasNext()) {
     const csOp = csIter.next();
@@ -381,28 +378,17 @@ PadDiff.prototype._createDeletionChangeset = function (cs, startAText, apool) {
       if (csOp.attribs && textBank !== '*') {
         const deletedAttrib = apool.putAttrib(['removed', true]);
         let authorAttrib = apool.putAttrib(['author', '']);
-
-        attribKeys.length = 0;
-        attribValues.length = 0;
+        const attribs = [];
         Changeset.eachAttribNumber(csOp.attribs, (n) => {
-          attribKeys.push(apool.getAttribKey(n));
-          attribValues.push(apool.getAttribValue(n));
-
-          if (apool.getAttribKey(n) === 'author') {
-            authorAttrib = n;
-          }
+          const attrib = apool.getAttrib(n);
+          attribs.push(attrib);
+          if (attrib[0] === 'author') authorAttrib = n;
         });
-
-        const undoBackToAttribs = cachedStrFunc((attribs) => {
+        const undoBackToAttribs = cachedStrFunc((oldAttribsStr) => {
           const backAttribs = [];
-          for (let i = 0; i < attribKeys.length; i++) {
-            const appliedKey = attribKeys[i];
-            const appliedValue = attribValues[i];
-            const oldValue = Changeset.attribsAttributeValue(attribs, appliedKey, apool);
-
-            if (appliedValue !== oldValue) {
-              backAttribs.push([appliedKey, oldValue]);
-            }
+          for (const [key, value] of attribs) {
+            const oldValue = Changeset.attribsAttributeValue(oldAttribsStr, key, apool);
+            if (oldValue !== value) backAttribs.push([key, oldValue])
           }
 
           return Changeset.makeAttribsString('=', backAttribs, apool);

--- a/src/node/utils/padDiff.js
+++ b/src/node/utils/padDiff.js
@@ -383,6 +383,8 @@ PadDiff.prototype._createDeletionChangeset = function (cs, startAText, apool) {
             const oldValue = oldAttribs.get(key);
             if (oldValue !== value) backAttribs.set(key, oldValue);
           }
+          // TODO: backAttribs does not restore removed attributes (it is missing attributes that
+          // are in oldAttribs but not in attribs). I don't know if that is intentional.
           return backAttribs.toString();
         });
 

--- a/src/node/utils/tar.json
+++ b/src/node/utils/tar.json
@@ -54,6 +54,8 @@
   , "broadcast_revisions.js"
   , "socketio.js"
   , "AttributeManager.js"
+  , "AttributeMap.js"
+  , "attributes.js"
   , "ChangesetUtils.js"
   ]
 , "ace2_inner.js": [
@@ -71,6 +73,8 @@
   , "linestylefilter.js"
   , "domline.js"
   , "AttributeManager.js"
+  , "AttributeMap.js"
+  , "attributes.js"
   , "scroll.js"
   , "caretPosition.js"
   , "pad_utils.js"

--- a/src/static/js/AttributeManager.js
+++ b/src/static/js/AttributeManager.js
@@ -166,9 +166,7 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
     const op = opIter.next();
     if (!op.attribs) return [];
     const attributes = [];
-    Changeset.eachAttribNumber(op.attribs, (n) => {
-      attributes.push([this.rep.apool.getAttribKey(n), this.rep.apool.getAttribValue(n)]);
-    });
+    Changeset.eachAttribNumber(op.attribs, (n) => attributes.push(this.rep.apool.getAttrib(n)));
     return attributes;
   },
 
@@ -277,12 +275,8 @@ AttributeManager.prototype = _(AttributeManager.prototype).extend({
       currentPointer += currentOperation.chars;
       if (currentPointer <= column) continue;
       const attributes = [];
-      Changeset.eachAttribNumber(currentOperation.attribs, (n) => {
-        attributes.push([
-          this.rep.apool.getAttribKey(n),
-          this.rep.apool.getAttribValue(n),
-        ]);
-      });
+      Changeset.eachAttribNumber(
+          currentOperation.attribs, (n) => attributes.push(this.rep.apool.getAttrib(n)));
       return attributes;
     }
     return [];

--- a/src/static/js/AttributeMap.js
+++ b/src/static/js/AttributeMap.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const attributes = require('./attributes');
+
+/**
+ * A `[key, value]` pair of strings describing a text attribute.
+ *
+ * @typedef {[string, string]} Attribute
+ */
+
+/**
+ * A concatenated sequence of zero or more attribute identifiers, each one represented by an
+ * asterisk followed by a base-36 encoded attribute number.
+ *
+ * Examples: '', '*0', '*3*j*z*1q'
+ *
+ * @typedef {string} AttributeString
+ */
+
+/**
+ * Convenience class to convert an Op's attribute string to/from a Map of key, value pairs.
+ */
+class AttributeMap extends Map {
+  /**
+   * Converts an attribute string into an AttributeMap.
+   *
+   * @param {AttributeString} str - The attribute string to convert into an AttributeMap.
+   * @param {AttributePool} pool - Attribute pool.
+   * @returns {AttributeMap}
+   */
+  static fromString(str, pool) {
+    return new AttributeMap(pool).updateFromString(str);
+  }
+
+  /**
+   * @param {AttributePool} pool - Attribute pool.
+   */
+  constructor(pool) {
+    super();
+    /** @public */
+    this.pool = pool;
+  }
+
+  /**
+   * @param {string} k - Attribute name.
+   * @param {string} v - Attribute value.
+   * @returns {AttributeMap} `this` (for chaining).
+   */
+  set(k, v) {
+    k = k == null ? '' : String(k);
+    v = v == null ? '' : String(v);
+    this.pool.putAttrib([k, v]);
+    return super.set(k, v);
+  }
+
+  toString() {
+    return attributes.attribsToString(attributes.sort([...this]), this.pool);
+  }
+
+  /**
+   * @param {Iterable<Attribute>} entries - [key, value] pairs to insert into this map.
+   * @param {boolean} [emptyValueIsDelete] - If true and an entry's value is the empty string, the
+   *     key is removed from this map (if present).
+   * @returns {AttributeMap} `this` (for chaining).
+   */
+  update(entries, emptyValueIsDelete = false) {
+    for (let [k, v] of entries) {
+      k = k == null ? '' : String(k);
+      v = v == null ? '' : String(v);
+      if (!v && emptyValueIsDelete) {
+        this.delete(k);
+      } else {
+        this.set(k, v);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * @param {AttributeString} str - The attribute string identifying the attributes to insert into
+   *     this map.
+   * @param {boolean} [emptyValueIsDelete] - If true and an entry's value is the empty string, the
+   *     key is removed from this map (if present).
+   * @returns {AttributeMap} `this` (for chaining).
+   */
+  updateFromString(str, emptyValueIsDelete = false) {
+    return this.update(attributes.attribsFromString(str, this.pool), emptyValueIsDelete);
+  }
+}
+
+module.exports = AttributeMap;

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -2098,6 +2098,8 @@ exports.inverse = (cs, lines, alines, pool) => {
             const oldValue = oldAttribs.get(key) || '';
             if (oldValue !== value) backAttribs.set(key, oldValue);
           }
+          // TODO: backAttribs does not restore removed attributes (it is missing attributes that
+          // are in oldAttribs but not in attribs). I don't know if that is intentional.
           return backAttribs.toString();
         });
         consumeAttribRuns(csOp.chars, (len, attribs, endsLine) => {

--- a/src/static/js/Changeset.js
+++ b/src/static/js/Changeset.js
@@ -1905,25 +1905,24 @@ exports.builder = (oldLen) => {
   return self;
 };
 
+/**
+ * Constructs an attribute string from a sequence of attributes.
+ *
+ * @param {string} opcode - The opcode for the Op that will get the resulting attribute string.
+ * @param {?(Attribute[]|AttributeString)} attribs - The attributes to insert into the pool
+ *     (if necessary) and encode. If an attribute string, no checking is performed to ensure that
+ *     the attributes exist in the pool, are in the canonical order, and contain no duplicate keys.
+ *     If this is an iterable of attributes, `pool` must be non-null.
+ * @param {AttributePool} pool - Attribute pool. Required if `attribs` is an iterable of attributes,
+ *     ignored if `attribs` is an attribute string.
+ * @returns {AttributeString}
+ */
 exports.makeAttribsString = (opcode, attribs, pool) => {
-  // makeAttribsString(opcode, '*3') or makeAttribsString(opcode, [['foo','bar']], myPool) work
-  if (!attribs) {
-    return '';
-  } else if ((typeof attribs) === 'string') {
-    return attribs;
-  } else if (pool && attribs.length) {
-    if (attribs.length > 1) {
-      attribs = attribs.slice();
-      sortAttribs(attribs);
-    }
-    const result = [];
-    for (const pair of attribs) {
-      if (opcode === '=' || (opcode === '+' && pair[1])) {
-        result.push(`*${exports.numToString(pool.putAttrib(pair))}`);
-      }
-    }
-    return result.join('');
-  }
+  if (!attribs || !['=', '+'].includes(opcode)) return '';
+  if (typeof attribs === 'string') return attribs;
+  return sortAttribs(attribs.filter(([k, v]) => v || opcode === '='))
+      .map((a) => `*${exports.numToString(pool.putAttrib(a))}`)
+      .join('');
 };
 
 /**

--- a/src/static/js/attributes.js
+++ b/src/static/js/attributes.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// Low-level utilities for manipulating attribute strings. For a high-level API, see AttributeMap.
+
+/**
+ * A `[key, value]` pair of strings describing a text attribute.
+ *
+ * @typedef {[string, string]} Attribute
+ */
+
+/**
+ * A concatenated sequence of zero or more attribute identifiers, each one represented by an
+ * asterisk followed by a base-36 encoded attribute number.
+ *
+ * Examples: '', '*0', '*3*j*z*1q'
+ *
+ * @typedef {string} AttributeString
+ */
+
+/**
+ * Converts an attribute string into a sequence of attribute identifier numbers.
+ *
+ * WARNING: This only works on attribute strings. It does NOT work on serialized operations or
+ * changesets.
+ *
+ * @param {AttributeString} str - Attribute string.
+ * @yields {number} The attribute numbers (to look up in the associated pool), in the order they
+ *     appear in `str`.
+ * @returns {Generator<number>}
+ */
+exports.decodeAttribString = function* (str) {
+  const re = /\*([0-9a-z]+)|./gy;
+  let match;
+  while ((match = re.exec(str)) != null) {
+    const [m, n] = match;
+    if (n == null) throw new Error(`invalid character in attribute string: ${m}`);
+    yield Number.parseInt(n, 36);
+  }
+};
+
+const checkAttribNum = (n) => {
+  if (typeof n !== 'number') throw new TypeError(`not a number: ${n}`);
+  if (n < 0) throw new Error(`attribute number is negative: ${n}`);
+  if (n !== Math.trunc(n)) throw new Error(`attribute number is not an integer: ${n}`);
+};
+
+/**
+ * Inverse of `decodeAttribString`.
+ *
+ * @param {Iterable<number>} attribNums - Sequence of attribute numbers.
+ * @returns {AttributeString}
+ */
+exports.encodeAttribString = (attribNums) => {
+  let str = '';
+  for (const n of attribNums) {
+    checkAttribNum(n);
+    str += `*${n.toString(36).toLowerCase()}`;
+  }
+  return str;
+};
+
+/**
+ * Converts a sequence of attribute numbers into a sequence of attributes.
+ *
+ * @param {Iterable<number>} attribNums - Attribute numbers to look up in the pool.
+ * @param {AttributePool} pool - Attribute pool.
+ * @yields {Attribute} The identified attributes, in the same order as `attribNums`.
+ * @returns {Generator<Attribute>}
+ */
+exports.attribsFromNums = function* (attribNums, pool) {
+  for (const n of attribNums) {
+    checkAttribNum(n);
+    const attrib = pool.getAttrib(n);
+    if (attrib == null) throw new Error(`attribute ${n} does not exist in pool`);
+    yield attrib;
+  }
+};
+
+/**
+ * Inverse of `attribsFromNums`.
+ *
+ * @param {Iterable<Attribute>} attribs - Attributes. Any attributes not already in `pool` are
+ *     inserted into `pool`. No checking is performed to ensure that the attributes are in the
+ *     canonical order and that there are no duplicate keys. (Use an AttributeMap and/or `sort()` if
+ *     required.)
+ * @param {AttributePool} pool - Attribute pool.
+ * @yields {number} The attribute number of each attribute in `attribs`, in order.
+ * @returns {Generator<number>}
+ */
+exports.attribsToNums = function* (attribs, pool) {
+  for (const attrib of attribs) yield pool.putAttrib(attrib);
+};
+
+/**
+ * Convenience function that is equivalent to `attribsFromNums(decodeAttribString(str), pool)`.
+ *
+ * WARNING: This only works on attribute strings. It does NOT work on serialized operations or
+ * changesets.
+ *
+ * @param {AttributeString} str - Attribute string.
+ * @param {AttributePool} pool - Attribute pool.
+ * @yields {Attribute} The attributes identified in `str`, in order.
+ * @returns {Generator<Attribute>}
+ */
+exports.attribsFromString = function* (str, pool) {
+  yield* exports.attribsFromNums(exports.decodeAttribString(str), pool);
+};
+
+/**
+ * Inverse of `attribsFromString`.
+ *
+ * @param {Iterable<Attribute>} attribs - Attributes. The attributes to insert into the pool (if
+ *     necessary) and encode. No checking is performed to ensure that the attributes are in the
+ *     canonical order and that there are no duplicate keys. (Use an AttributeMap and/or `sort()` if
+ *     required.)
+ * @param {AttributePool} pool - Attribute pool.
+ * @returns {AttributeString}
+ */
+exports.attribsToString =
+    (attribs, pool) => exports.encodeAttribString(exports.attribsToNums(attribs, pool));
+
+/**
+ * Sorts the attributes in canonical order. The order of entries with the same attribute name is
+ * unspecified.
+ *
+ * @param {Attribute[]} attribs - Attributes to sort in place.
+ * @returns {Attribute[]} `attribs` (for chaining).
+ */
+exports.sort =
+    (attribs) => attribs.sort(([keyA], [keyB]) => (keyA > keyB ? 1 : 0) - (keyA < keyB ? 1 : 0));

--- a/src/static/js/broadcast.js
+++ b/src/static/js/broadcast.js
@@ -26,6 +26,7 @@ const makeCSSManager = require('./cssmanager').makeCSSManager;
 const domline = require('./domline').domline;
 const AttribPool = require('./AttributePool');
 const Changeset = require('./Changeset');
+const attributes = require('./attributes');
 const linestylefilter = require('./linestylefilter').linestylefilter;
 const colorutils = require('./colorutils').colorutils;
 const _ = require('./underscore');
@@ -114,20 +115,18 @@ const loadBroadcastJS = (socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, Bro
     },
 
     getActiveAuthors() {
-      const authors = [];
-      const seenNums = {};
-      const alines = this.alines;
-      for (let i = 0; i < alines.length; i++) {
-        Changeset.eachAttribNumber(alines[i], (n) => {
-          if (seenNums[n]) return;
-          seenNums[n] = true;
-          if (this.apool.getAttribKey(n) !== 'author') return;
-          const a = this.apool.getAttribValue(n);
-          if (a) authors.push(a);
-        });
+      const authorIds = new Set();
+      for (const aline of this.alines) {
+        const opIter = Changeset.opIterator(aline);
+        while (opIter.hasNext()) {
+          const op = opIter.next();
+          for (const [k, v] of attributes.attribsFromString(op.attribs, this.apool)) {
+            if (k !== 'author') continue;
+            if (v) authorIds.add(v);
+          }
+        }
       }
-      authors.sort();
-      return authors;
+      return [...authorIds].sort();
     },
   };
 

--- a/src/static/js/broadcast.js
+++ b/src/static/js/broadcast.js
@@ -119,15 +119,11 @@ const loadBroadcastJS = (socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, Bro
       const alines = this.alines;
       for (let i = 0; i < alines.length; i++) {
         Changeset.eachAttribNumber(alines[i], (n) => {
-          if (!seenNums[n]) {
-            seenNums[n] = true;
-            if (this.apool.getAttribKey(n) === 'author') {
-              const a = this.apool.getAttribValue(n);
-              if (a) {
-                authors.push(a);
-              }
-            }
-          }
+          if (seenNums[n]) return;
+          seenNums[n] = true;
+          if (this.apool.getAttribKey(n) !== 'author') return;
+          const a = this.apool.getAttribValue(n);
+          if (a) authors.push(a);
         });
       }
       authors.sort();

--- a/src/static/js/changesettracker.js
+++ b/src/static/js/changesettracker.js
@@ -139,18 +139,9 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         // Get my authorID
         const authorId = parent.parent.pad.myUserInfo.userId;
 
-        // Sanitize authorship
-        // We need to replace all author attribs with thisSession.author,
-        // in case they copy/pasted or otherwise inserted other peoples changes
-        let authorAttr;
-        for (const attr in apool.numToAttrib) {
-          if (apool.numToAttrib[attr][0] === 'author' &&
-              apool.numToAttrib[attr][1] === authorId) {
-            authorAttr = Number(attr).toString(36);
-          }
-        }
-
-        // Replace all added 'author' attribs with the value of the current user
+        // Sanitize authorship: Replace all author attributes with this user's author ID in case the
+        // text was copied from another author.
+        const authorAttr = Changeset.numToString(apool.putAttrib(['author', authorId]));
         const cs = Changeset.unpack(userChangeset);
         const iterator = Changeset.opIterator(cs.ops);
         let op;

--- a/src/static/js/changesettracker.js
+++ b/src/static/js/changesettracker.js
@@ -142,43 +142,42 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         // Sanitize authorship
         // We need to replace all author attribs with thisSession.author,
         // in case they copy/pasted or otherwise inserted other peoples changes
-        if (apool.numToAttrib) {
-          let authorAttr;
-          for (const attr in apool.numToAttrib) {
-            if (apool.numToAttrib[attr][0] === 'author' &&
-                apool.numToAttrib[attr][1] === authorId) {
-              authorAttr = Number(attr).toString(36);
-            }
+        let authorAttr;
+        for (const attr in apool.numToAttrib) {
+          if (apool.numToAttrib[attr][0] === 'author' &&
+              apool.numToAttrib[attr][1] === authorId) {
+            authorAttr = Number(attr).toString(36);
           }
-
-          // Replace all added 'author' attribs with the value of the current user
-          const cs = Changeset.unpack(userChangeset);
-          const iterator = Changeset.opIterator(cs.ops);
-          let op;
-          const assem = Changeset.mergingOpAssembler();
-
-          while (iterator.hasNext()) {
-            op = iterator.next();
-            if (op.opcode === '+') {
-              let newAttrs = '';
-
-              op.attribs.split('*').forEach((attrNum) => {
-                if (!attrNum) return;
-                const attr = apool.getAttrib(parseInt(attrNum, 36));
-                if (!attr) return;
-                if ('author' === attr[0]) {
-                  // replace that author with the current one
-                  newAttrs += `*${authorAttr}`;
-                } else { newAttrs += `*${attrNum}`; } // overtake all other attribs as is
-              });
-              op.attribs = newAttrs;
-            }
-            assem.append(op);
-          }
-          assem.endDocument();
-          userChangeset = Changeset.pack(cs.oldLen, cs.newLen, assem.toString(), cs.charBank);
-          Changeset.checkRep(userChangeset);
         }
+
+        // Replace all added 'author' attribs with the value of the current user
+        const cs = Changeset.unpack(userChangeset);
+        const iterator = Changeset.opIterator(cs.ops);
+        let op;
+        const assem = Changeset.mergingOpAssembler();
+
+        while (iterator.hasNext()) {
+          op = iterator.next();
+          if (op.opcode === '+') {
+            let newAttrs = '';
+
+            op.attribs.split('*').forEach((attrNum) => {
+              if (!attrNum) return;
+              const attr = apool.getAttrib(parseInt(attrNum, 36));
+              if (!attr) return;
+              if ('author' === attr[0]) {
+                // replace that author with the current one
+                newAttrs += `*${authorAttr}`;
+              } else { newAttrs += `*${attrNum}`; } // overtake all other attribs as is
+            });
+            op.attribs = newAttrs;
+          }
+          assem.append(op);
+        }
+        assem.endDocument();
+        userChangeset = Changeset.pack(cs.oldLen, cs.newLen, assem.toString(), cs.charBank);
+        Changeset.checkRep(userChangeset);
+
         if (Changeset.isIdentity(userChangeset)) toSubmit = null;
         else toSubmit = userChangeset;
       }

--- a/src/static/js/contentcollector.js
+++ b/src/static/js/contentcollector.js
@@ -235,6 +235,9 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
       // to enable the content collector to store key-value attributes
       // see https://github.com/ether/etherpad-lite/issues/2567 for more information
       // in long term the contentcollector should be refactored to get rid of this workaround
+      //
+      // TODO: This approach doesn't support changing existing values: if both 'foo::bar' and
+      // 'foo::baz' are in state.attribs then the last one encountered while iterating will win.
       const ATTRIBUTE_SPLIT_STRING = '::';
 
       // see if attributeString is splittable
@@ -265,6 +268,9 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
     const attribs = new AttributeMap(apool)
         .set('lmkr', '1')
         .set('insertorder', 'first')
+        // TODO: Converting all falsy values in state.lineAttributes into removals is awkward.
+        // Better would be to never add 0, false, null, or undefined to state.lineAttributes in the
+        // first place (I'm looking at you, state.lineAttributes.start).
         .update(Object.entries(state.lineAttributes).map(([k, v]) => [k, v || '']), true);
     lines.appendText('*', attribs.toString());
   };

--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -75,11 +75,8 @@ linestylefilter.getLineStyleFilter = (lineLength, aline, textAndClassFunc, apool
 
       // For each attribute number
       Changeset.eachAttribNumber(attribs, (n) => {
-        // Give us this attributes key
-        const key = apool.getAttribKey(n);
-        if (!key) return;
-        const value = apool.getAttribValue(n);
-        if (!value) return;
+        const [key, value] = apool.getAttrib(n);
+        if (!key || !value) return;
         if (!isLineAttribMarker && AttributeManager.lineAttributes.indexOf(key) >= 0) {
           isLineAttribMarker = true;
         }

--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -77,26 +77,24 @@ linestylefilter.getLineStyleFilter = (lineLength, aline, textAndClassFunc, apool
       Changeset.eachAttribNumber(attribs, (n) => {
         // Give us this attributes key
         const key = apool.getAttribKey(n);
-        if (key) {
-          const value = apool.getAttribValue(n);
-          if (value) {
-            if (!isLineAttribMarker && AttributeManager.lineAttributes.indexOf(key) >= 0) {
-              isLineAttribMarker = true;
-            }
-            if (key === 'author') {
-              classes += ` ${linestylefilter.getAuthorClassName(value)}`;
-            } else if (key === 'list') {
-              classes += ` list:${value}`;
-            } else if (key === 'start') {
-              // Needed to introduce the correct Ordered list item start number on import
-              classes += ` start:${value}`;
-            } else if (linestylefilter.ATTRIB_CLASSES[key]) {
-              classes += ` ${linestylefilter.ATTRIB_CLASSES[key]}`;
-            } else {
-              const results = hooks.callAll('aceAttribsToClasses', {linestylefilter, key, value});
-              classes += ` ${results.join(' ')}`;
-            }
-          }
+        if (!key) return;
+        const value = apool.getAttribValue(n);
+        if (!value) return;
+        if (!isLineAttribMarker && AttributeManager.lineAttributes.indexOf(key) >= 0) {
+          isLineAttribMarker = true;
+        }
+        if (key === 'author') {
+          classes += ` ${linestylefilter.getAuthorClassName(value)}`;
+        } else if (key === 'list') {
+          classes += ` list:${value}`;
+        } else if (key === 'start') {
+          // Needed to introduce the correct Ordered list item start number on import
+          classes += ` start:${value}`;
+        } else if (linestylefilter.ATTRIB_CLASSES[key]) {
+          classes += ` ${linestylefilter.ATTRIB_CLASSES[key]}`;
+        } else {
+          const results = hooks.callAll('aceAttribsToClasses', {linestylefilter, key, value});
+          classes += ` ${results.join(' ')}`;
         }
       });
 

--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -31,6 +31,7 @@
 // requires: undefined
 
 const Changeset = require('./Changeset');
+const attributes = require('./attributes');
 const hooks = require('./pluginfw/hooks');
 const linestylefilter = {};
 const AttributeManager = require('./AttributeManager');
@@ -73,10 +74,8 @@ linestylefilter.getLineStyleFilter = (lineLength, aline, textAndClassFunc, apool
       let classes = '';
       let isLineAttribMarker = false;
 
-      // For each attribute number
-      Changeset.eachAttribNumber(attribs, (n) => {
-        const [key, value] = apool.getAttrib(n);
-        if (!key || !value) return;
+      for (const [key, value] of attributes.attribsFromString(attribs, apool)) {
+        if (!key || !value) continue;
         if (!isLineAttribMarker && AttributeManager.lineAttributes.indexOf(key) >= 0) {
           isLineAttribMarker = true;
         }
@@ -93,7 +92,7 @@ linestylefilter.getLineStyleFilter = (lineLength, aline, textAndClassFunc, apool
           const results = hooks.callAll('aceAttribsToClasses', {linestylefilter, key, value});
           classes += ` ${results.join(' ')}`;
         }
-      });
+      }
 
       if (isLineAttribMarker) classes += ` ${lineAttributeMarker}`;
       return classes.substring(1);

--- a/src/tests/backend/specs/contentcollector.js
+++ b/src/tests/backend/specs/contentcollector.js
@@ -10,35 +10,64 @@
  */
 
 const AttributePool = require('../../../static/js/AttributePool');
+const Changeset = require('../../../static/js/Changeset');
 const assert = require('assert').strict;
 const contentcollector = require('../../../static/js/contentcollector');
 const jsdom = require('jsdom');
 
-const tests = {
-  nestedLi: {
+// All test case `wantAlines` values must only refer to attributes in this list so that the
+// attribute numbers do not change due to changes in pool insertion order.
+const knownAttribs = [
+  ['insertorder', 'first'],
+  ['italic', 'true'],
+  ['list', 'bullet1'],
+  ['list', 'bullet2'],
+  ['list', 'number1'],
+  ['list', 'number2'],
+  ['lmkr', '1'],
+  ['start', '1'],
+  ['start', '2'],
+];
+
+const testCases = [
+  {
+    description: 'Simple',
+    html: '<html><body><p>foo</p></body></html>',
+    wantAlines: ['+3'],
+    wantText: ['foo'],
+  },
+  {
+    description: 'Line starts with asterisk',
+    html: '<html><body><p>*foo</p></body></html>',
+    wantAlines: ['+4'],
+    wantText: ['*foo'],
+  },
+  {
     description: 'Complex nested Li',
     html: '<!doctype html><html><body><ol><li>one</li><li><ol><li>1.1</li></ol></li><li>two</li></ol></body></html>',
-    wantLineAttribs: [
-      '*0*1*2*3+1+3', '*0*4*2*5+1+3', '*0*1*2*5+1+3',
+    wantAlines: [
+      '*0*4*6*7+1+3',
+      '*0*5*6*8+1+3',
+      '*0*4*6*8+1+3',
     ],
     wantText: [
       '*one', '*1.1', '*two',
     ],
   },
-  complexNest: {
+  {
     description: 'Complex list of different types',
     html: '<!doctype html><html><body><ul class="bullet"><li>one</li><li>two</li><li>0</li><li>1</li><li>2<ul class="bullet"><li>3</li><li>4</li></ul></li></ul><ol class="number"><li>item<ol class="number"><li>item1</li><li>item2</li></ol></li></ol></body></html>',
-    wantLineAttribs: [
-      '*0*1*2+1+3',
-      '*0*1*2+1+3',
-      '*0*1*2+1+1',
-      '*0*1*2+1+1',
-      '*0*1*2+1+1',
-      '*0*3*2+1+1',
-      '*0*3*2+1+1',
-      '*0*4*2*5+1+4',
-      '*0*6*2*7+1+5',
-      '*0*6*2*7+1+5',
+    wantAlines: [
+      '*0*2*6+1+3',
+      '*0*2*6+1+3',
+      '*0*2*6+1+1',
+      '*0*2*6+1+1',
+      '*0*2*6+1+1',
+      '*0*3*6+1+1',
+      '*0*3*6+1+1',
+      '*0*4*6*7+1+4',
+      '*0*5*6*8+1+5',
+      '*0*5*6*8+1+5',
     ],
     wantText: [
       '*one',
@@ -53,147 +82,174 @@ const tests = {
       '*item2',
     ],
   },
-  ul: {
+  {
     description: 'Tests if uls properly get attributes',
     html: '<html><body><ul><li>a</li><li>b</li></ul><div>div</div><p>foo</p></body></html>',
-    wantLineAttribs: ['*0*1*2+1+1', '*0*1*2+1+1', '+3', '+3'],
+    wantAlines: [
+      '*0*2*6+1+1',
+      '*0*2*6+1+1',
+      '+3',
+      '+3',
+    ],
     wantText: ['*a', '*b', 'div', 'foo'],
   },
-  ulIndented: {
+  {
     description: 'Tests if indented uls properly get attributes',
     html: '<html><body><ul><li>a</li><ul><li>b</li></ul><li>a</li></ul><p>foo</p></body></html>',
-    wantLineAttribs: ['*0*1*2+1+1', '*0*3*2+1+1', '*0*1*2+1+1', '+3'],
+    wantAlines: [
+      '*0*2*6+1+1',
+      '*0*3*6+1+1',
+      '*0*2*6+1+1',
+      '+3',
+    ],
     wantText: ['*a', '*b', '*a', 'foo'],
   },
-  ol: {
+  {
     description: 'Tests if ols properly get line numbers when in a normal OL',
     html: '<html><body><ol><li>a</li><li>b</li><li>c</li></ol><p>test</p></body></html>',
-    wantLineAttribs: ['*0*1*2*3+1+1', '*0*1*2*3+1+1', '*0*1*2*3+1+1', '+4'],
+    wantAlines: [
+      '*0*4*6*7+1+1',
+      '*0*4*6*7+1+1',
+      '*0*4*6*7+1+1',
+      '+4',
+    ],
     wantText: ['*a', '*b', '*c', 'test'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
   },
-  lineDoBreakInOl: {
+  {
     description: 'A single completely empty line break within an ol should reset count if OL is closed off..',
     html: '<html><body><ol><li>should be 1</li></ol><p>hello</p><ol><li>should be 1</li><li>should be 2</li></ol><p></p></body></html>',
-    wantLineAttribs: ['*0*1*2*3+1+b', '+5', '*0*1*2*4+1+b', '*0*1*2*4+1+b', ''],
+    wantAlines: [
+      '*0*4*6*7+1+b',
+      '+5',
+      '*0*4*6*8+1+b',
+      '*0*4*6*8+1+b',
+      '',
+    ],
     wantText: ['*should be 1', 'hello', '*should be 1', '*should be 2', ''],
     noteToSelf: "Shouldn't include attribute marker in the <p> line",
   },
-  testP: {
+  {
     description: 'A single <p></p> should create a new line',
     html: '<html><body><p></p><p></p></body></html>',
-    wantLineAttribs: ['', ''],
+    wantAlines: ['', ''],
     wantText: ['', ''],
     noteToSelf: '<p></p>should create a line break but not break numbering',
   },
-  nestedOl: {
-    description: 'Tests if ols properly get line numbers when in a normal OL',
+  {
+    description: 'Tests if ols properly get line numbers when in a normal OL #2',
     html: '<html><body>a<ol><li>b<ol><li>c</li></ol></ol>notlist<p>foo</p></body></html>',
-    wantLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1', '+7', '+3'],
+    wantAlines: [
+      '+1',
+      '*0*4*6*7+1+1',
+      '*0*5*6*8+1+1',
+      '+7',
+      '+3',
+    ],
     wantText: ['a', '*b', '*c', 'notlist', 'foo'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
   },
-  nestedOl2: {
+  {
     description: 'First item being an UL then subsequent being OL will fail',
     html: '<html><body><ul><li>a<ol><li>b</li><li>c</li></ol></li></ul></body></html>',
-    wantLineAttribs: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1'],
+    wantAlines: ['+1', '*0*1*2*3+1+1', '*0*4*2*5+1+1'],
     wantText: ['a', '*b', '*c'],
     noteToSelf: 'Ensure empty P does not induce line attribute marker, wont this break the editor?',
     disabled: true,
   },
-  lineDontBreakOL: {
+  {
     description: 'A single completely empty line break within an ol should NOT reset count',
     html: '<html><body><ol><li>should be 1</li><p></p><li>should be 2</li><li>should be 3</li></ol><p></p></body></html>',
-    wantLineAttribs: [],
+    wantAlines: [],
     wantText: ['*should be 1', '*should be 2', '*should be 3'],
     noteToSelf: "<p></p>should create a line break but not break numbering -- This is what I can't get working!",
     disabled: true,
   },
-  ignoreAnyTagsOutsideBody: {
+  {
     description: 'Content outside body should be ignored',
     html: '<html><head><title>title</title><style></style></head><body>empty<br></body></html>',
-    wantLineAttribs: ['+5'],
+    wantAlines: ['+5'],
     wantText: ['empty'],
   },
-  lineWithMultipleSpaces: {
+  {
     description: 'Multiple spaces should be preserved',
     html: '<html><body>Text with  more   than    one space.<br></body></html>',
-    wantLineAttribs: ['+10'],
+    wantAlines: ['+10'],
     wantText: ['Text with  more   than    one space.'],
   },
-  lineWithMultipleNonBreakingAndNormalSpaces: {
+  {
     description: 'non-breaking and normal space should be preserved',
     html: '<html><body>Text&nbsp;with&nbsp; more&nbsp;&nbsp;&nbsp;than   &nbsp;one space.<br></body></html>',
-    wantLineAttribs: ['+10'],
+    wantAlines: ['+10'],
     wantText: ['Text with  more   than    one space.'],
   },
-  multiplenbsp: {
+  {
     description: 'Multiple nbsp should be preserved',
     html: '<html><body>&nbsp;&nbsp;<br></body></html>',
-    wantLineAttribs: ['+2'],
+    wantAlines: ['+2'],
     wantText: ['  '],
   },
-  multipleNonBreakingSpaceBetweenWords: {
+  {
     description: 'Multiple nbsp between words ',
     html: '<html><body>&nbsp;&nbsp;word1&nbsp;&nbsp;word2&nbsp;&nbsp;&nbsp;word3<br></body></html>',
-    wantLineAttribs: ['+m'],
+    wantAlines: ['+m'],
     wantText: ['  word1  word2   word3'],
   },
-  nonBreakingSpacePreceededBySpaceBetweenWords: {
+  {
     description: 'A non-breaking space preceded by a normal space',
     html: '<html><body> &nbsp;word1 &nbsp;word2 &nbsp;word3<br></body></html>',
-    wantLineAttribs: ['+l'],
+    wantAlines: ['+l'],
     wantText: ['  word1  word2  word3'],
   },
-  nonBreakingSpaceFollowededBySpaceBetweenWords: {
+  {
     description: 'A non-breaking space followed by a normal space',
     html: '<html><body>&nbsp; word1&nbsp; word2&nbsp; word3<br></body></html>',
-    wantLineAttribs: ['+l'],
+    wantAlines: ['+l'],
     wantText: ['  word1  word2  word3'],
   },
-  spacesAfterNewline: {
+  {
     description: 'Don\'t collapse spaces that follow a newline',
     html: '<!doctype html><html><body>something<br>             something<br></body></html>',
-    wantLineAttribs: ['+9', '+m'],
+    wantAlines: ['+9', '+m'],
     wantText: ['something', '             something'],
   },
-  spacesAfterNewlineP: {
+  {
     description: 'Don\'t collapse spaces that follow a empty paragraph',
     html: '<!doctype html><html><body>something<p></p>             something<br></body></html>',
-    wantLineAttribs: ['+9', '', '+m'],
+    wantAlines: ['+9', '', '+m'],
     wantText: ['something', '', '             something'],
   },
-  spacesAtEndOfLine: {
+  {
     description: 'Don\'t collapse spaces that preceed/follow a newline',
     html: '<html><body>something            <br>             something<br></body></html>',
-    wantLineAttribs: ['+l', '+m'],
+    wantAlines: ['+l', '+m'],
     wantText: ['something            ', '             something'],
   },
-  spacesAtEndOfLineP: {
+  {
     description: 'Don\'t collapse spaces that preceed/follow a empty paragraph',
     html: '<html><body>something            <p></p>             something<br></body></html>',
-    wantLineAttribs: ['+l', '', '+m'],
+    wantAlines: ['+l', '', '+m'],
     wantText: ['something            ', '', '             something'],
   },
-  nonBreakingSpacesAfterNewlines: {
+  {
     description: 'Don\'t collapse non-breaking spaces that follow a newline',
     html: '<html><body>something<br>&nbsp;&nbsp;&nbsp;something<br></body></html>',
-    wantLineAttribs: ['+9', '+c'],
+    wantAlines: ['+9', '+c'],
     wantText: ['something', '   something'],
   },
-  nonBreakingSpacesAfterNewlinesP: {
+  {
     description: 'Don\'t collapse non-breaking spaces that follow a paragraph',
     html: '<html><body>something<p></p>&nbsp;&nbsp;&nbsp;something<br></body></html>',
-    wantLineAttribs: ['+9', '', '+c'],
+    wantAlines: ['+9', '', '+c'],
     wantText: ['something', '', '   something'],
   },
-  preserveSpacesInsideElements: {
+  {
     description: 'Preserve all spaces when multiple are present',
     html: '<html><body>Need <span> more </span> space<i>  s </i> !<br></body></html>',
-    wantLineAttribs: ['+h*0+4+2'],
+    wantAlines: ['+h*1+4+2'],
     wantText: ['Need  more  space  s  !'],
   },
-  preserveSpacesAcrossNewlines: {
+  {
     description: 'Newlines and multiple spaces across newlines should be preserved',
     html: `
       <html><body>Need
@@ -201,25 +257,25 @@ const tests = {
           space
           <i>  s </i>
           !<br></body></html>`,
-    wantLineAttribs: ['+19*0+4+b'],
+    wantAlines: ['+19*1+4+b'],
     wantText: ['Need           more           space            s           !'],
   },
-  multipleNewLinesAtBeginning: {
+  {
     description: 'Multiple new lines at the beginning should be preserved',
     html: '<html><body><br><br><p></p><p></p>first line<br><br>second line<br></body></html>',
-    wantLineAttribs: ['', '', '', '', '+a', '', '+b'],
+    wantAlines: ['', '', '', '', '+a', '', '+b'],
     wantText: ['', '', '', '', 'first line', '', 'second line'],
   },
-  multiLineParagraph: {
+  {
     description: 'A paragraph with multiple lines should not loose spaces when lines are combined',
     html: `<html><body><p>
 а б в г ґ д е є ж з и і ї й к л м н о
 п р с т у ф х ц ч ш щ ю я ь</p>
 </body></html>`,
-    wantLineAttribs: ['+1t'],
+    wantAlines: ['+1t'],
     wantText: ['а б в г ґ д е є ж з и і ї й к л м н о п р с т у ф х ц ч ш щ ю я ь'],
   },
-  multiLineParagraphWithPre: {
+  {
     description: 'lines in preformatted text should be kept intact',
     html: `<html><body><p>
 а б в г ґ д е є ж з и і ї й к л м н о</p><pre>multiple
@@ -229,7 +285,7 @@ pre
 </pre><p>п р с т у ф х ц ч ш щ ю я
 ь</p>
 </body></html>`,
-    wantLineAttribs: ['+11', '+8', '+5', '+2', '+3', '+r'],
+    wantAlines: ['+11', '+8', '+5', '+2', '+3', '+r'],
     wantText: [
       'а б в г ґ д е є ж з и і ї й к л м н о',
       'multiple',
@@ -239,85 +295,100 @@ pre
       'п р с т у ф х ц ч ш щ ю я ь',
     ],
   },
-  preIntroducesASpace: {
+  {
     description: 'pre should be on a new line not preceded by a space',
     html: `<html><body><p>
     1
 </p><pre>preline
 </pre></body></html>`,
-    wantLineAttribs: ['+6', '+7'],
+    wantAlines: ['+6', '+7'],
     wantText: ['    1 ', 'preline'],
   },
-  dontDeleteSpaceInsideElements: {
+  {
     description: 'Preserve spaces on the beginning and end of a element',
     html: '<html><body>Need<span> more </span>space<i> s </i>!<br></body></html>',
-    wantLineAttribs: ['+f*0+3+1'],
+    wantAlines: ['+f*1+3+1'],
     wantText: ['Need more space s !'],
   },
-  dontDeleteSpaceOutsideElements: {
+  {
     description: 'Preserve spaces outside elements',
     html: '<html><body>Need <span>more</span> space <i>s</i> !<br></body></html>',
-    wantLineAttribs: ['+g*0+1+2'],
+    wantAlines: ['+g*1+1+2'],
     wantText: ['Need more space s !'],
   },
-  dontDeleteSpaceAtEndOfElement: {
+  {
     description: 'Preserve spaces at the end of an element',
     html: '<html><body>Need <span>more </span>space <i>s </i>!<br></body></html>',
-    wantLineAttribs: ['+g*0+2+1'],
+    wantAlines: ['+g*1+2+1'],
     wantText: ['Need more space s !'],
   },
-  dontDeleteSpaceAtBeginOfElements: {
+  {
     description: 'Preserve spaces at the start of an element',
     html: '<html><body>Need<span> more</span> space<i> s</i> !<br></body></html>',
-    wantLineAttribs: ['+f*0+2+2'],
+    wantAlines: ['+f*1+2+2'],
     wantText: ['Need more space s !'],
   },
-};
+];
 
 describe(__filename, function () {
-  for (const test of Object.keys(tests)) {
-    const testObj = tests[test];
-    describe(test, function () {
-      if (testObj.disabled) {
-        return xit('DISABLED:', test, function (done) {
-          done();
-        });
-      }
+  for (const tc of testCases) {
+    describe(tc.description, function () {
+      let apool;
+      let result;
 
-      it(testObj.description, async function () {
-        const {window: {document}} = new jsdom.JSDOM(testObj.html);
-        // Create an empty attribute pool
-        const apool = new AttributePool();
-        // Convert a dom tree into a list of lines and attribute liens
-        // using the content collector object
+      before(async function () {
+        if (tc.disabled) return this.skip();
+        const {window: {document}} = new jsdom.JSDOM(tc.html);
+        apool = new AttributePool();
+        // To reduce test fragility, the attribute pool is seeded with `knownAttribs`, and all
+        // attributes in `tc.wantAlines` must be in `knownAttribs`. (This guarantees that attribute
+        // numbers do not change if the attribute processing code changes.)
+        for (const attrib of knownAttribs) apool.putAttrib(attrib);
+        for (const aline of tc.wantAlines) {
+          const opIter = Changeset.opIterator(aline);
+          while (opIter.hasNext()) {
+            const op = opIter.next();
+            Changeset.eachAttribNumber(op.attribs, (n) => assert(n < knownAttribs.length));
+          }
+        }
         const cc = contentcollector.makeContentCollector(true, null, apool);
         cc.collectContent(document.body);
-        const result = cc.finish();
-        const gotAttributes = result.lineAttribs;
-        const wantAttributes = testObj.wantLineAttribs;
-        const gotText = new Array(result.lines);
-        const wantText = testObj.wantText;
+        result = cc.finish();
+      });
 
-        assert.deepEqual(gotText[0], wantText);
-        assert.deepEqual(gotAttributes, wantAttributes);
+      it('text matches', async function () {
+        assert.deepEqual(result.lines, tc.wantText);
+      });
+
+      it('alines match', async function () {
+        assert.deepEqual(result.lineAttribs, tc.wantAlines);
+      });
+
+      it('attributes are sorted in canonical order', async function () {
+        const gotAttribs = [];
+        const wantAttribs = [];
+        for (const aline of result.lineAttribs) {
+          const gotAlineAttribs = [];
+          gotAttribs.push(gotAlineAttribs);
+          const wantAlineAttribs = [];
+          wantAttribs.push(wantAlineAttribs);
+          const opIter = Changeset.opIterator(aline);
+          while (opIter.hasNext()) {
+            const op = opIter.next();
+            const gotOpAttribs = [];
+            gotAlineAttribs.push(gotOpAttribs);
+            const wantOpAttribs = [];
+            wantAlineAttribs.push(wantOpAttribs);
+            Changeset.eachAttribNumber(op.attribs, (n) => {
+              const attrib = apool.getAttrib(n);
+              gotOpAttribs.push(attrib);
+              wantOpAttribs.push(attrib);
+            });
+            wantOpAttribs.sort(([keyA], [keyB]) => (keyA > keyB ? 1 : 0) - (keyA < keyB ? 1 : 0));
+          }
+        }
+        assert.deepEqual(gotAttribs, wantAttribs);
       });
     });
   }
 });
-
-
-function arraysEqual(a, b) {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (a.length !== b.length) return false;
-
-  // If you don't care about the order of the elements inside
-  // the array, you should sort both arrays here.
-  // Please note that calling sort on an array will modify that array.
-  // you might want to clone your array first.
-
-  for (let i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}

--- a/src/tests/backend/specs/contentcollector.js
+++ b/src/tests/backend/specs/contentcollector.js
@@ -12,6 +12,7 @@
 const AttributePool = require('../../../static/js/AttributePool');
 const Changeset = require('../../../static/js/Changeset');
 const assert = require('assert').strict;
+const attributes = require('../../../static/js/attributes');
 const contentcollector = require('../../../static/js/contentcollector');
 const jsdom = require('jsdom');
 
@@ -348,7 +349,9 @@ describe(__filename, function () {
           const opIter = Changeset.opIterator(aline);
           while (opIter.hasNext()) {
             const op = opIter.next();
-            Changeset.eachAttribNumber(op.attribs, (n) => assert(n < knownAttribs.length));
+            for (const n of attributes.decodeAttribString(op.attribs)) {
+              assert(n < knownAttribs.length);
+            }
           }
         }
         const cc = contentcollector.makeContentCollector(true, null, apool);
@@ -375,16 +378,9 @@ describe(__filename, function () {
           const opIter = Changeset.opIterator(aline);
           while (opIter.hasNext()) {
             const op = opIter.next();
-            const gotOpAttribs = [];
+            const gotOpAttribs = [...attributes.attribsFromString(op.attribs, apool)];
             gotAlineAttribs.push(gotOpAttribs);
-            const wantOpAttribs = [];
-            wantAlineAttribs.push(wantOpAttribs);
-            Changeset.eachAttribNumber(op.attribs, (n) => {
-              const attrib = apool.getAttrib(n);
-              gotOpAttribs.push(attrib);
-              wantOpAttribs.push(attrib);
-            });
-            wantOpAttribs.sort(([keyA], [keyB]) => (keyA > keyB ? 1 : 0) - (keyA < keyB ? 1 : 0));
+            wantAlineAttribs.push(attributes.sort([...gotOpAttribs]));
           }
         }
         assert.deepEqual(gotAttribs, wantAttribs);

--- a/src/tests/frontend/specs/AttributeMap.js
+++ b/src/tests/frontend/specs/AttributeMap.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const AttributeMap = require('../../../static/js/AttributeMap');
+const AttributePool = require('../../../static/js/AttributePool');
+const attributes = require('../../../static/js/attributes');
+
+describe('AttributeMap', function () {
+  const attribs = [
+    ['foo', 'bar'],
+    ['baz', 'bif'],
+    ['emptyValue', ''],
+  ];
+  let pool;
+
+  const getPoolSize = () => {
+    let n = 0;
+    pool.eachAttrib(() => ++n);
+    return n;
+  };
+
+  beforeEach(async function () {
+    pool = new AttributePool();
+    for (let i = 0; i < attribs.length; ++i) expect(pool.putAttrib(attribs[i])).to.equal(i);
+  });
+
+  it('fromString works', async function () {
+    const got = AttributeMap.fromString('*0*1*2', pool);
+    for (const [k, v] of attribs) expect(got.get(k)).to.equal(v);
+    // Maps iterate in insertion order, so [...got] should be in the same order as attribs.
+    expect(JSON.stringify([...got])).to.equal(JSON.stringify(attribs));
+  });
+
+  describe('set', function () {
+    it('stores the value', async function () {
+      const m = new AttributeMap(pool);
+      expect(m.size).to.equal(0);
+      m.set('k', 'v');
+      expect(m.size).to.equal(1);
+      expect(m.get('k')).to.equal('v');
+    });
+
+    it('reuses attributes in the pool', async function () {
+      expect(getPoolSize()).to.equal(attribs.length);
+      const m = new AttributeMap(pool);
+      const [k0, v0] = attribs[0];
+      m.set(k0, v0);
+      expect(getPoolSize()).to.equal(attribs.length);
+      expect(m.size).to.equal(1);
+      expect(m.toString()).to.equal('*0');
+    });
+
+    it('inserts new attributes into the pool', async function () {
+      const m = new AttributeMap(pool);
+      expect(getPoolSize()).to.equal(attribs.length);
+      m.set('k', 'v');
+      expect(getPoolSize()).to.equal(attribs.length + 1);
+      expect(JSON.stringify(pool.getAttrib(attribs.length))).to.equal(JSON.stringify(['k', 'v']));
+    });
+
+    describe('coerces key and value to string', function () {
+      const testCases = [
+        ['object (with toString)', {toString: () => 'obj'}, 'obj'],
+        ['undefined', undefined, ''],
+        ['null', null, ''],
+        ['boolean', true, 'true'],
+        ['number', 1, '1'],
+      ];
+      for (const [desc, input, want] of testCases) {
+        describe(desc, function () {
+          it('key is coerced to string', async function () {
+            const m = new AttributeMap(pool);
+            m.set(input, 'value');
+            expect(m.get(want)).to.equal('value');
+          });
+
+          it('value is coerced to string', async function () {
+            const m = new AttributeMap(pool);
+            m.set('key', input);
+            expect(m.get('key')).to.equal(want);
+          });
+        });
+      }
+    });
+
+    it('returns the map', async function () {
+      const m = new AttributeMap(pool);
+      expect(m.set('k', 'v')).to.equal(m);
+    });
+  });
+
+  describe('toString', function () {
+    it('sorts attributes', async function () {
+      const m = new AttributeMap(pool).update(attribs);
+      const got = [...attributes.attribsFromString(m.toString(), pool)];
+      const want = attributes.sort([...attribs]);
+      // Verify that attribs is not already sorted so that this test doesn't accidentally pass.
+      expect(JSON.stringify(want)).to.not.equal(JSON.stringify(attribs));
+      expect(JSON.stringify(got)).to.equal(JSON.stringify(want));
+    });
+
+    it('returns all entries', async function () {
+      const m = new AttributeMap(pool);
+      expect(m.toString()).to.equal('');
+      m.set(...attribs[0]);
+      expect(m.toString()).to.equal('*0');
+      m.delete(attribs[0][0]);
+      expect(m.toString()).to.equal('');
+      m.set(...attribs[1]);
+      expect(m.toString()).to.equal('*1');
+      m.set(attribs[1][0], 'new value');
+      expect(m.toString()).to.equal(attributes.encodeAttribString([attribs.length]));
+      m.set(...attribs[2]);
+      expect(m.toString()).to.equal(attributes.attribsToString(
+          attributes.sort([attribs[2], [attribs[1][0], 'new value']]), pool));
+    });
+  });
+
+  for (const funcName of ['update', 'updateFromString']) {
+    const callUpdateFn = (m, ...args) => {
+      if (funcName === 'updateFromString') {
+        args[0] = attributes.attribsToString(attributes.sort([...args[0]]), pool);
+      }
+      return AttributeMap.prototype[funcName].call(m, ...args);
+    };
+
+    describe(funcName, function () {
+      it('works', async function () {
+        const m = new AttributeMap(pool);
+        m.set(attribs[2][0], 'value to be overwritten');
+        callUpdateFn(m, attribs);
+        for (const [k, v] of attribs) expect(m.get(k)).to.equal(v);
+        expect(m.size).to.equal(attribs.length);
+        const wantStr = attributes.attribsToString(attributes.sort([...attribs]), pool);
+        expect(m.toString()).to.equal(wantStr);
+        callUpdateFn(m, []);
+        expect(m.toString()).to.equal(wantStr);
+      });
+
+      it('inserts new attributes into the pool', async function () {
+        const m = new AttributeMap(pool);
+        callUpdateFn(m, [['k', 'v']]);
+        expect(m.size).to.equal(1);
+        expect(m.get('k')).to.equal('v');
+        expect(getPoolSize()).to.equal(attribs.length + 1);
+        expect(m.toString()).to.equal(attributes.encodeAttribString([attribs.length]));
+      });
+
+      it('returns the map', async function () {
+        const m = new AttributeMap(pool);
+        expect(callUpdateFn(m, [])).to.equal(m);
+      });
+
+      describe('emptyValueIsDelete=false inserts empty values', function () {
+        for (const emptyVal of ['', null, undefined]) {
+          it(emptyVal == null ? String(emptyVal) : JSON.stringify(emptyVal), async function () {
+            const m = new AttributeMap(pool);
+            m.set('k', 'v');
+            callUpdateFn(m, [['k', emptyVal]]);
+            expect(m.size).to.equal(1);
+            expect(m.toString()).to.equal(attributes.attribsToString([['k', '']], pool));
+          });
+        }
+      });
+
+      describe('emptyValueIsDelete=true deletes entries', function () {
+        for (const emptyVal of ['', null, undefined]) {
+          it(emptyVal == null ? String(emptyVal) : JSON.stringify(emptyVal), async function () {
+            const m = new AttributeMap(pool);
+            m.set('k', 'v');
+            callUpdateFn(m, [['k', emptyVal]], true);
+            expect(m.size).to.equal(0);
+            expect(m.toString()).to.equal('');
+          });
+        }
+      });
+    });
+  }
+});

--- a/src/tests/frontend/specs/attributes.js
+++ b/src/tests/frontend/specs/attributes.js
@@ -1,0 +1,343 @@
+'use strict';
+
+const AttributePool = require('../../../static/js/AttributePool');
+const attributes = require('../../../static/js/attributes');
+
+describe('attributes', function () {
+  const attribs = [['foo', 'bar'], ['baz', 'bif']];
+  let pool;
+
+  beforeEach(async function () {
+    pool = new AttributePool();
+    for (let i = 0; i < attribs.length; ++i) expect(pool.putAttrib(attribs[i])).to.equal(i);
+  });
+
+  describe('decodeAttribString', function () {
+    it('is a generator function', async function () {
+      expect(attributes.decodeAttribString).to.be.a((function* () {}).constructor);
+    });
+
+    describe('rejects invalid attribute strings', function () {
+      const testCases = ['x', '*0+1', '*A', '*0$', '*', '0', '*-1'];
+      for (const tc of testCases) {
+        it(JSON.stringify(tc), async function () {
+          expect(() => [...attributes.decodeAttribString(tc)])
+              .to.throwException(/invalid character/);
+        });
+      }
+    });
+
+    describe('accepts valid attribute strings', function () {
+      const testCases = [
+        ['', []],
+        ['*0', [0]],
+        ['*a', [10]],
+        ['*z', [35]],
+        ['*10', [36]],
+        [
+          '*0*1*2*3*4*5*6*7*8*9*a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*10',
+          [...Array(37).keys()],
+        ],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const got = [...attributes.decodeAttribString(input)];
+          expect(JSON.stringify(got)).to.equal(JSON.stringify(want));
+        });
+      }
+    });
+  });
+
+  describe('encodeAttribString', function () {
+    describe('accepts any kind of iterable', function () {
+      const testCases = [
+        ['generator', (function* () { yield 0; yield 1; })()],
+        ['list', [0, 1]],
+        ['set', new Set([0, 1])],
+      ];
+      for (const [desc, input] of testCases) {
+        it(desc, async function () {
+          expect(attributes.encodeAttribString(input)).to.equal('*0*1');
+        });
+      }
+    });
+
+    describe('rejects invalid inputs', function () {
+      const testCases = [
+        [null, /.*/], // Different browsers may have different error messages.
+        [[-1], /is negative/],
+        [['0'], /not a number/],
+        [[null], /not a number/],
+        [[0.5], /not an integer/],
+        [[{}], /not a number/],
+        [[true], /not a number/],
+      ];
+      for (const [input, wantErr] of testCases) {
+        it(JSON.stringify(input), async function () {
+          expect(() => attributes.encodeAttribString(input)).to.throwException(wantErr);
+        });
+      }
+    });
+
+    describe('accepts valid inputs', function () {
+      const testCases = [
+        [[], ''],
+        [[0], '*0'],
+        [[10], '*a'],
+        [[35], '*z'],
+        [[36], '*10'],
+        [
+          [...Array(37).keys()],
+          '*0*1*2*3*4*5*6*7*8*9*a*b*c*d*e*f*g*h*i*j*k*l*m*n*o*p*q*r*s*t*u*v*w*x*y*z*10',
+        ],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          expect(attributes.encodeAttribString(input)).to.equal(want);
+        });
+      }
+    });
+  });
+
+  describe('attribsFromNums', function () {
+    it('is a generator function', async function () {
+      expect(attributes.attribsFromNums).to.be.a((function* () {}).constructor);
+    });
+
+    describe('accepts any kind of iterable', function () {
+      const testCases = [
+        ['generator', (function* () { yield 0; yield 1; })()],
+        ['list', [0, 1]],
+        ['set', new Set([0, 1])],
+      ];
+
+      for (const [desc, input] of testCases) {
+        it(desc, async function () {
+          const gotAttribs = [...attributes.attribsFromNums(input, pool)];
+          expect(JSON.stringify(gotAttribs)).to.equal(JSON.stringify(attribs));
+        });
+      }
+    });
+
+    describe('rejects invalid inputs', function () {
+      const testCases = [
+        [null, /.*/], // Different browsers may have different error messages.
+        [[-1], /is negative/],
+        [['0'], /not a number/],
+        [[null], /not a number/],
+        [[0.5], /not an integer/],
+        [[{}], /not a number/],
+        [[true], /not a number/],
+        [[9999], /does not exist in pool/],
+      ];
+      for (const [input, wantErr] of testCases) {
+        it(JSON.stringify(input), async function () {
+          expect(() => [...attributes.attribsFromNums(input, pool)]).to.throwException(wantErr);
+        });
+      }
+    });
+
+    describe('accepts valid inputs', function () {
+      const testCases = [
+        [[], []],
+        [[0], [attribs[0]]],
+        [[1], [attribs[1]]],
+        [[0, 1], [attribs[0], attribs[1]]],
+        [[1, 0], [attribs[1], attribs[0]]],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const gotAttribs = [...attributes.attribsFromNums(input, pool)];
+          expect(JSON.stringify(gotAttribs)).to.equal(JSON.stringify(want));
+        });
+      }
+    });
+  });
+
+  describe('attribsToNums', function () {
+    it('is a generator function', async function () {
+      expect(attributes.attribsToNums).to.be.a((function* () {}).constructor);
+    });
+
+    describe('accepts any kind of iterable', function () {
+      const testCases = [
+        ['generator', (function* () { yield attribs[0]; yield attribs[1]; })()],
+        ['list', [attribs[0], attribs[1]]],
+        ['set', new Set([attribs[0], attribs[1]])],
+      ];
+
+      for (const [desc, input] of testCases) {
+        it(desc, async function () {
+          const gotNums = [...attributes.attribsToNums(input, pool)];
+          expect(JSON.stringify(gotNums)).to.equal(JSON.stringify([0, 1]));
+        });
+      }
+    });
+
+    describe('rejects invalid inputs', function () {
+      const testCases = [null, [null]];
+      for (const input of testCases) {
+        it(JSON.stringify(input), async function () {
+          expect(() => [...attributes.attribsToNums(input, pool)]).to.throwException();
+        });
+      }
+    });
+
+    describe('reuses existing pool entries', function () {
+      const testCases = [
+        [[], []],
+        [[attribs[0]], [0]],
+        [[attribs[1]], [1]],
+        [[attribs[0], attribs[1]], [0, 1]],
+        [[attribs[1], attribs[0]], [1, 0]],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const got = [...attributes.attribsToNums(input, pool)];
+          expect(JSON.stringify(got)).to.equal(JSON.stringify(want));
+        });
+      }
+    });
+
+    describe('inserts new attributes into the pool', function () {
+      const testCases = [
+        [[['k', 'v']], [attribs.length]],
+        [[attribs[0], ['k', 'v']], [0, attribs.length]],
+        [[['k', 'v'], attribs[0]], [attribs.length, 0]],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const got = [...attributes.attribsToNums(input, pool)];
+          expect(JSON.stringify(got)).to.equal(JSON.stringify(want));
+          expect(JSON.stringify(pool.getAttrib(attribs.length)))
+              .to.equal(JSON.stringify(['k', 'v']));
+        });
+      }
+    });
+
+    describe('coerces key and value to string', function () {
+      const testCases = [
+        ['object (with toString)', {toString: () => 'obj'}, 'obj'],
+        ['undefined', undefined, ''],
+        ['null', null, ''],
+        ['boolean', true, 'true'],
+        ['number', 1, '1'],
+      ];
+      for (const [desc, inputVal, wantVal] of testCases) {
+        describe(desc, function () {
+          for (const [desc, inputAttribs, wantAttribs] of [
+            ['key is coerced to string', [[inputVal, 'value']], [[wantVal, 'value']]],
+            ['value is coerced to string', [['key', inputVal]], [['key', wantVal]]],
+          ]) {
+            it(desc, async function () {
+              const gotNums = [...attributes.attribsToNums(inputAttribs, pool)];
+              // Each attrib in inputAttribs is expected to be new to the pool.
+              const wantNums = [...Array(attribs.length + 1).keys()].slice(attribs.length);
+              expect(JSON.stringify(gotNums)).to.equal(JSON.stringify(wantNums));
+              const gotAttribs = gotNums.map((n) => pool.getAttrib(n));
+              expect(JSON.stringify(gotAttribs)).to.equal(JSON.stringify(wantAttribs));
+            });
+          }
+        });
+      }
+    });
+  });
+
+  describe('attribsFromString', function () {
+    it('is a generator function', async function () {
+      expect(attributes.attribsFromString).to.be.a((function* () {}).constructor);
+    });
+
+    describe('rejects invalid attribute strings', function () {
+      const testCases = [
+        ['x', /invalid character/],
+        ['*0+1', /invalid character/],
+        ['*A', /invalid character/],
+        ['*0$', /invalid character/],
+        ['*', /invalid character/],
+        ['0', /invalid character/],
+        ['*-1', /invalid character/],
+        ['*9999', /does not exist in pool/],
+      ];
+      for (const [input, wantErr] of testCases) {
+        it(JSON.stringify(input), async function () {
+          expect(() => [...attributes.attribsFromString(input, pool)]).to.throwException(wantErr);
+        });
+      }
+    });
+
+    describe('accepts valid inputs', function () {
+      const testCases = [
+        ['', []],
+        ['*0', [attribs[0]]],
+        ['*1', [attribs[1]]],
+        ['*0*1', [attribs[0], attribs[1]]],
+        ['*1*0', [attribs[1], attribs[0]]],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const gotAttribs = [...attributes.attribsFromString(input, pool)];
+          expect(JSON.stringify(gotAttribs)).to.equal(JSON.stringify(want));
+        });
+      }
+    });
+  });
+
+  describe('attribsToString', function () {
+    describe('accepts any kind of iterable', function () {
+      const testCases = [
+        ['generator', (function* () { yield attribs[0]; yield attribs[1]; })()],
+        ['list', [attribs[0], attribs[1]]],
+        ['set', new Set([attribs[0], attribs[1]])],
+      ];
+
+      for (const [desc, input] of testCases) {
+        it(desc, async function () {
+          const got = attributes.attribsToString(input, pool);
+          expect(got).to.equal('*0*1');
+        });
+      }
+    });
+
+    describe('rejects invalid inputs', function () {
+      const testCases = [null, [null]];
+      for (const input of testCases) {
+        it(JSON.stringify(input), async function () {
+          expect(() => attributes.attribsToString(input, pool)).to.throwException();
+        });
+      }
+    });
+
+    describe('reuses existing pool entries', function () {
+      const testCases = [
+        [[], ''],
+        [[attribs[0]], '*0'],
+        [[attribs[1]], '*1'],
+        [[attribs[0], attribs[1]], '*0*1'],
+        [[attribs[1], attribs[0]], '*1*0'],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const got = attributes.attribsToString(input, pool);
+          expect(got).to.equal(want);
+        });
+      }
+    });
+
+    describe('inserts new attributes into the pool', function () {
+      const testCases = [
+        [[['k', 'v']], `*${attribs.length}`],
+        [[attribs[0], ['k', 'v']], `*0*${attribs.length}`],
+        [[['k', 'v'], attribs[0]], `*${attribs.length}*0`],
+      ];
+      for (const [input, want] of testCases) {
+        it(`${JSON.stringify(input)} -> ${JSON.stringify(want)}`, async function () {
+          const got = attributes.attribsToString(input, pool);
+          expect(got).to.equal(want);
+          expect(JSON.stringify(pool.getAttrib(attribs.length)))
+              .to.equal(JSON.stringify(['k', 'v']));
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Multiple commits; please do not squash.

The existing code to manipulate attributes was awkward. This PR introduces a new AttributeMap class that subclasses Map and has easy conversion to/from attribute strings.

I think we should bump the Etherpad minor version to 1.9.0 so that plugins can easily depend on the new class.

This PR is some yak shaving required to move import processing to a worker thread. (cc @packardone)