### PR TITLE
Changeset: Improved operation iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
     * `eachAttribNumber()`
     * `makeAttribsString()`
     * `opAttributeValue()`
+  * `opIterator()`: Deprecated in favor of the new `deserializeOps()` generator
+    function.
   * `appendATextToAssembler()`: Deprecated in favor of the new `opsFromAText()`
     generator function.
   * `newOp()`: Deprecated in favor of the new `Op` class.

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -670,9 +670,8 @@ const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 
 exports.getLineHTMLForExport = async (hookName, context) => {
   if (!context.attribLine) return;
-  const opIter = Changeset.opIterator(context.attribLine);
-  if (!opIter.hasNext()) return;
-  const op = opIter.next();
+  const [op] = Changeset.deserializeOps(context.attribLine);
+  if (op == null) return;
   const heading = AttributeMap.fromString(op.attribs, context.apool).get('heading');
   if (!heading) return;
   context.lineContent = `<${heading}>${context.lineContent}</${heading}>`;

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -527,12 +527,10 @@ exports.restoreRevision = async (padID, rev) => {
   atext.text += '\n';
 
   const eachAttribRun = (attribs, func) => {
-    const attribsIter = Changeset.opIterator(attribs);
     let textIndex = 0;
     const newTextStart = 0;
     const newTextEnd = atext.text.length;
-    while (attribsIter.hasNext()) {
-      const op = attribsIter.next();
+    for (const op of Changeset.deserializeOps(attribs)) {
       const nextIndex = textIndex + op.chars;
       if (!(nextIndex <= newTextStart || textIndex >= newTextEnd)) {
         func(Math.max(newTextStart, textIndex), Math.min(newTextEnd, nextIndex), op.attribs);

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -586,12 +586,7 @@ const handleUserChanges = async (socket, message) => {
     Changeset.checkRep(changeset);
 
     // Validate all added 'author' attribs to be the same value as the current user
-    const iterator = Changeset.opIterator(Changeset.unpack(changeset).ops);
-    let op;
-
-    while (iterator.hasNext()) {
-      op = iterator.next();
-
+    for (const op of Changeset.deserializeOps(Changeset.unpack(changeset).ops)) {
       // + can add text with attribs
       // = can change or add attribs
       // - can have attribs, but they are discarded and don't show up in the attribs -
@@ -741,10 +736,8 @@ const _correctMarkersInPad = (atext, apool) => {
   // collect char positions of line markers (e.g. bullets) in new atext
   // that aren't at the start of a line
   const badMarkers = [];
-  const iter = Changeset.opIterator(atext.attribs);
   let offset = 0;
-  while (iter.hasNext()) {
-    const op = iter.next();
+  for (const op of Changeset.deserializeOps(atext.attribs)) {
     const attribs = AttributeMap.fromString(op.attribs, apool);
     const hasMarker = AttributeManager.lineAttributes.some((a) => attribs.has(a));
     if (hasMarker) {

--- a/src/node/utils/ExportHelper.js
+++ b/src/node/utils/ExportHelper.js
@@ -52,9 +52,8 @@ exports._analyzeLine = (text, aline, apool) => {
   let lineMarker = 0;
   line.listLevel = 0;
   if (aline) {
-    const opIter = Changeset.opIterator(aline);
-    if (opIter.hasNext()) {
-      const op = opIter.next();
+    const [op] = Changeset.deserializeOps(aline);
+    if (op != null) {
       const attribs = AttributeMap.fromString(op.attribs, apool);
       let listType = attribs.get('list');
       if (listType) {

--- a/src/node/utils/ExportHtml.js
+++ b/src/node/utils/ExportHtml.js
@@ -197,13 +197,12 @@ const getHTMLFromAtext = async (pad, atext, authorColors) => {
         return;
       }
 
-      const iter = Changeset.opIterator(Changeset.subattribution(attribs, idx, idx + numChars));
+      const ops = Changeset.deserializeOps(Changeset.subattribution(attribs, idx, idx + numChars));
       idx += numChars;
 
       // this iterates over every op string and decides which tags to open or to close
       // based on the attribs used
-      while (iter.hasNext()) {
-        const o = iter.next();
+      for (const o of ops) {
         const usedAttribs = [];
 
         // mark all attribs as used

--- a/src/node/utils/ExportTxt.js
+++ b/src/node/utils/ExportTxt.js
@@ -76,11 +76,10 @@ const getTXTFromAtext = (pad, atext, authorColors) => {
         return;
       }
 
-      const iter = Changeset.opIterator(Changeset.subattribution(attribs, idx, idx + numChars));
+      const ops = Changeset.deserializeOps(Changeset.subattribution(attribs, idx, idx + numChars));
       idx += numChars;
 
-      while (iter.hasNext()) {
-        const o = iter.next();
+      for (const o of ops) {
         let propChanged = false;
 
         for (const a of attributes.decodeAttribString(o.attribs)) {

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -67,12 +67,10 @@ exports.setPadHTML = async (pad, html) => {
   const builder = Changeset.builder(1);
 
   // assemble each line into the builder
-  const attribsIter = Changeset.opIterator(newAttribs);
   let textIndex = 0;
   const newTextStart = 0;
   const newTextEnd = newText.length;
-  while (attribsIter.hasNext()) {
-    const op = attribsIter.next();
+  for (const op of Changeset.deserializeOps(newAttribs)) {
     const nextIndex = textIndex + op.chars;
     if (!(nextIndex <= newTextStart || textIndex >= newTextEnd)) {
       const start = Math.max(newTextStart, textIndex);

--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -1576,13 +1576,8 @@ function Ace2Inner(editorInfo, cssManagers) {
       const end = selEnd[1];
       let hasAttrib = true;
 
-      // Iterate over attribs on this line
-
-      const opIter = Changeset.opIterator(rep.alines[lineNum]);
       let indexIntoLine = 0;
-
-      while (opIter.hasNext()) {
-        const op = opIter.next();
+      for (const op of Changeset.deserializeOps(rep.alines[lineNum])) {
         const opStartInLine = indexIntoLine;
         const opEndInLine = opStartInLine + op.chars;
         if (!hasIt(op.attribs)) {
@@ -1615,7 +1610,6 @@ function Ace2Inner(editorInfo, cssManagers) {
     const selStartLine = rep.selStart[0];
     const selEndLine = rep.selEnd[0];
     for (let n = selStartLine; n <= selEndLine; n++) {
-      const opIter = Changeset.opIterator(rep.alines[n]);
       let indexIntoLine = 0;
       let selectionStartInLine = 0;
       if (documentAttributeManager.lineHasMarker(n)) {
@@ -1628,8 +1622,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       if (n === selEndLine) {
         selectionEndInLine = rep.selEnd[1];
       }
-      while (opIter.hasNext()) {
-        const op = opIter.next();
+      for (const op of Changeset.deserializeOps(rep.alines[n])) {
         const opStartInLine = indexIntoLine;
         const opEndInLine = opStartInLine + op.chars;
         if (!hasIt(op.attribs)) {
@@ -1754,12 +1747,10 @@ function Ace2Inner(editorInfo, cssManagers) {
       };
 
       const eachAttribRun = (attribs, func /* (startInNewText, endInNewText, attribs)*/) => {
-        const attribsIter = Changeset.opIterator(attribs);
         let textIndex = 0;
         const newTextStart = commonStart;
         const newTextEnd = newText.length - commonEnd - (shiftFinalNewlineToBeforeNewText ? 1 : 0);
-        while (attribsIter.hasNext()) {
-          const op = attribsIter.next();
+        for (const op of Changeset.deserializeOps(attribs)) {
           const nextIndex = textIndex + op.chars;
           if (!(nextIndex <= newTextStart || textIndex >= newTextEnd)) {
             func(Math.max(newTextStart, textIndex), Math.min(newTextEnd, nextIndex), op.attribs);
@@ -1873,9 +1864,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const attribRuns = (attribs) => {
       const lengs = [];
       const atts = [];
-      const iter = Changeset.opIterator(attribs);
-      while (iter.hasNext()) {
-        const op = iter.next();
+      for (const op of Changeset.deserializeOps(attribs)) {
         lengs.push(op.chars);
         atts.push(op.attribs);
       }
@@ -2619,9 +2608,7 @@ function Ace2Inner(editorInfo, cssManagers) {
           // TODO: There appears to be a race condition or so.
           const authorIds = new Set();
           if (alineAttrs) {
-            const opIter = Changeset.opIterator(alineAttrs);
-            while (opIter.hasNext()) {
-              const op = opIter.next();
+            for (const op of Changeset.deserializeOps(alineAttrs)) {
               const authorId = AttributeMap.fromString(op.attribs, apool).get('author');
               if (authorId) authorIds.add(authorId);
             }

--- a/src/static/js/broadcast.js
+++ b/src/static/js/broadcast.js
@@ -162,13 +162,8 @@ const loadBroadcastJS = (socket, sendSocketMsg, fireWhenAllScriptsAreLoaded, Bro
       // some chars are replaced (no attributes change and no length change)
       // test if there are keep ops at the start of the cs
       if (lineChanged === undefined) {
-        lineChanged = 0;
-        const opIter = Changeset.opIterator(Changeset.unpack(changeset).ops);
-
-        if (opIter.hasNext()) {
-          const op = opIter.next();
-          if (op.opcode === '=') lineChanged += op.lines;
-        }
+        const [op] = Changeset.deserializeOps(Changeset.unpack(changeset).ops);
+        lineChanged = op != null && op.opcode === '=' ? op.lines : 0;
       }
 
       const goToLineNumber = (lineNumber) => {

--- a/src/static/js/changesettracker.js
+++ b/src/static/js/changesettracker.js
@@ -143,12 +143,9 @@ const makeChangesetTracker = (scheduler, apool, aceCallbacksProvider) => {
         // Sanitize authorship: Replace all author attributes with this user's author ID in case the
         // text was copied from another author.
         const cs = Changeset.unpack(userChangeset);
-        const iterator = Changeset.opIterator(cs.ops);
-        let op;
         const assem = Changeset.mergingOpAssembler();
 
-        while (iterator.hasNext()) {
-          op = iterator.next();
+        for (const op of Changeset.deserializeOps(cs.ops)) {
           if (op.opcode === '+') {
             const attribs = AttributeMap.fromString(op.attribs, apool);
             const oldAuthorId = attribs.get('author');

--- a/src/static/js/linestylefilter.js
+++ b/src/static/js/linestylefilter.js
@@ -98,11 +98,13 @@ linestylefilter.getLineStyleFilter = (lineLength, aline, textAndClassFunc, apool
       return classes.substring(1);
     };
 
-    const attributionIter = Changeset.opIterator(aline);
+    const attrOps = Changeset.deserializeOps(aline);
+    let attrOpsNext = attrOps.next();
     let nextOp, nextOpClasses;
 
     const goNextOp = () => {
-      nextOp = attributionIter.hasNext() ? attributionIter.next() : new Changeset.Op();
+      nextOp = attrOpsNext.done ? new Changeset.Op() : attrOpsNext.value;
+      if (!attrOpsNext.done) attrOpsNext = attrOps.next();
       nextOpClasses = (nextOp.opcode && attribsToClasses(nextOp.attribs));
     };
     goNextOp();

--- a/src/tests/frontend/specs/easysync.js
+++ b/src/tests/frontend/specs/easysync.js
@@ -31,17 +31,15 @@ const randInt = (maxValue) => Math.floor(Math.random() * maxValue);
 describe('easysync', function () {
   it('throughIterator', async function () {
     const x = '-c*3*4+6|3=az*asdf0*1*2*3+1=1-1+1*0+1=1-1+1|c=c-1';
-    const iter = Changeset.opIterator(x);
     const assem = Changeset.opAssembler();
-    while (iter.hasNext()) assem.append(iter.next());
+    for (const op of Changeset.deserializeOps(x)) assem.append(op);
     expect(assem.toString()).to.equal(x);
   });
 
   it('throughSmartAssembler', async function () {
     const x = '-c*3*4+6|3=az*asdf0*1*2*3+1=1-1+1*0+1=1-1+1|c=c-1';
-    const iter = Changeset.opIterator(x);
     const assem = Changeset.smartOpAssembler();
-    while (iter.hasNext()) assem.append(iter.next());
+    for (const op of Changeset.deserializeOps(x)) assem.append(op);
     assem.endDocument();
     expect(assem.toString()).to.equal(x);
   });
@@ -730,7 +728,7 @@ describe('easysync', function () {
     p.putAttrib(['name', 'david']);
     p.putAttrib(['color', 'green']);
 
-    const stringOp = (str) => Changeset.opIterator(str).next();
+    const stringOp = (str) => Changeset.deserializeOps(str).next().value;
 
     expect(Changeset.opAttributeValue(stringOp('*0*1+1'), 'name', p)).to.equal('david');
     expect(Changeset.opAttributeValue(stringOp('*0+1'), 'name', p)).to.equal('david');


### PR DESCRIPTION
New `deserializeOps()` generator function to replace the `OpIter` class. This makes it possible to use `for..of` iteration to iterate over operations.

This is the next batch from PR #5233.