### PR TITLE
GroupManager: Clean up any mappings when deleting a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Notable enhancements and fixes
 
 * Fixed a potential attribute pool corruption bug with `copyPadWithoutHistory`.
+* Mappings created by the `createGroupIfNotExistsFor` HTTP API are now removed
+  from the database when the group is deleted.
 
 #### For plugin authors
 


### PR DESCRIPTION
Thanks @timonegk for pointing out the oversight in https://github.com/ether/etherpad-lite/pull/5276#issuecomment-975600565.