### PR TITLE
API: `getText` with old revision should only return text, not atext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * `padOptions.showChat`
   * `padOptions.userColor`
   * `padOptions.userName`
+* Fixed the return value of the `getText` HTTP API when called with a specific
+  revision.
 * Fixed a potential attribute pool corruption bug with `copyPadWithoutHistory`.
 * Mappings created by the `createGroupIfNotExistsFor` HTTP API are now removed
   from the database when the group is deleted.

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -172,7 +172,9 @@ exports.getText = async (padID, rev) => {
     }
 
     // get the text of this revision
-    const text = await pad.getInternalRevisionAText(rev);
+    // getInternalRevisionAText() returns an atext object but we only want the .text inside it.
+    // Details at https://github.com/ether/etherpad-lite/issues/5073
+    const {text} = await pad.getInternalRevisionAText(rev);
     return {text};
   }
 

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -102,6 +102,7 @@ describe(__filename, function () {
                                 -> getLastEdited(padID) -- Should not be 0
                                 -> appendText(padID, "hello")
                                 -> getText(padID) -- Should be "hello worldhello"
+                                -> getText(padID, rev=2) - should return "hello world"
                                  -> setHTML(padID) -- Should fail on invalid HTML
                                   -> setHTML(padID) *3 -- Should fail on invalid HTML
                                    -> getHTML(padID) -- Should return HTML close to posted HTML
@@ -399,6 +400,22 @@ describe(__filename, function () {
           .expect('Content-Type', /json/);
       assert.equal(res.body.code, 0);
       assert.equal(res.body.data.text, `${text}hello\n`);
+    });
+
+    it('getText of old revision', async function () {
+      let res = await agent.get(`${endPoint('getRevisionsCount')}&padID=${testPadId}`)
+          .expect(200)
+          .expect('Content-Type', /json/);
+      assert.equal(res.body.code, 0);
+      const rev = res.body.data.revisions;
+      assert(rev != null);
+      assert(Number.isInteger(rev));
+      assert(rev > 0);
+      res = await agent.get(`${endPoint('getText')}&padID=${testPadId}&rev=${rev - 1}`)
+          .expect(200)
+          .expect('Content-Type', /json/);
+      assert.equal(res.body.code, 0);
+      assert.equal(res.body.data.text, `${text}\n`);
     });
 
     it('Sets the HTML of a Pad attempting to pass ugly HTML', async function () {


### PR DESCRIPTION
This is PR #5190 rebased and squashed. (I tried to reopen that PR but GitHub won't let you reopen a PR once its branch has been rebased, even if you undo the change by force-pushing the old revision.)

Fixes #5073