### PR TITLE
Pad: Don't create no-op revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fixed a potential attribute pool corruption bug with `copyPadWithoutHistory`.
 * Mappings created by the `createGroupIfNotExistsFor` HTTP API are now removed
   from the database when the group is deleted.
+* Fixed race conditions in the `setText`, `appendText`, and `restoreRevision`
+  functions (HTTP API).
 
 #### For plugin authors
 

--- a/src/node/db/API.js
+++ b/src/node/db/API.js
@@ -201,10 +201,8 @@ exports.setText = async (padID, text) => {
   // get the pad
   const pad = await getPadSafe(padID, true);
 
-  await Promise.all([
-    pad.setText(text),
-    padMessageHandler.updatePadClients(pad),
-  ]);
+  await pad.setText(text);
+  await padMessageHandler.updatePadClients(pad);
 };
 
 /**
@@ -223,10 +221,8 @@ exports.appendText = async (padID, text) => {
   }
 
   const pad = await getPadSafe(padID, true);
-  await Promise.all([
-    pad.appendText(text),
-    padMessageHandler.updatePadClients(pad),
-  ]);
+  await pad.appendText(text);
+  await padMessageHandler.updatePadClients(pad);
 };
 
 /**
@@ -559,10 +555,8 @@ exports.restoreRevision = async (padID, rev) => {
 
   const changeset = builder.toString();
 
-  await Promise.all([
-    pad.appendRevision(changeset),
-    padMessageHandler.updatePadClients(pad),
-  ]);
+  await pad.appendRevision(changeset);
+  await padMessageHandler.updatePadClients(pad);
 };
 
 /**

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -82,6 +82,9 @@ Pad.prototype.appendRevision = async function (aChangeset, author) {
   }
 
   const newAText = Changeset.applyToAText(aChangeset, this.atext, this.pool);
+  if (newAText.text === this.atext.text && newAText.attribs === this.atext.attribs) {
+    return this.head;
+  }
   Changeset.copyAText(newAText, this.atext);
 
   const newRev = ++this.head;
@@ -268,8 +271,7 @@ Pad.prototype.setText = async function (newText) {
     changeset = Changeset.makeSplice(oldText, 0, oldText.length - 1, newText);
   }
 
-  // append the changeset
-  if (newText !== oldText) await this.appendRevision(changeset);
+  await this.appendRevision(changeset);
 };
 
 Pad.prototype.appendText = async function (newText) {

--- a/src/node/db/Pad.js
+++ b/src/node/db/Pad.js
@@ -119,6 +119,7 @@ Pad.prototype.appendRevision = async function (aChangeset, author) {
   }
 
   await Promise.all(p);
+  return newRev;
 };
 
 // save all attributes to the database

--- a/src/node/handler/PadMessageHandler.js
+++ b/src/node/handler/PadMessageHandler.js
@@ -640,7 +640,9 @@ const handleUserChanges = async (socket, message) => {
     }
 
     const newRev = await pad.appendRevision(rebasedChangeset, thisSession.author);
-    assert.equal(newRev, r + 1);
+    // The head revision will either stay the same or increase by 1 depending on whether the
+    // changeset has a net effect.
+    assert([r, r + 1].includes(newRev));
 
     const correctionChangeset = _correctMarkersInPad(pad.atext, pad.pool);
     if (correctionChangeset) {
@@ -658,7 +660,7 @@ const handleUserChanges = async (socket, message) => {
     assert.equal(thisSession.rev, r);
     socket.json.send({type: 'COLLABROOM', data: {type: 'ACCEPT_COMMIT', newRev}});
     thisSession.rev = newRev;
-    thisSession.time = await pad.getRevisionDate(newRev);
+    if (newRev !== r) thisSession.time = await pad.getRevisionDate(newRev);
     await exports.updatePadClients(pad);
   } catch (err) {
     socket.json.send({disconnect: 'badChangeset'});

--- a/src/node/utils/ImportHtml.js
+++ b/src/node/utils/ImportHtml.js
@@ -85,5 +85,5 @@ exports.setPadHTML = async (pad, html) => {
 
   apiLogger.debug(`The changeset: ${theChangeset}`);
   await pad.setText('\n');
-  if (!Changeset.isIdentity(theChangeset)) await pad.appendRevision(theChangeset);
+  await pad.appendRevision(theChangeset);
 };

--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -208,8 +208,9 @@ const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad)
     } else if (msg.type === 'ACCEPT_COMMIT') {
       serverMessageTaskQueue.enqueue(() => {
         const {newRev} = msg;
-        // newRev will equal rev if the changeset has no net effect (identity changeset, or removing
-        // and re-adding the same characters with the same attributes).
+        // newRev will equal rev if the changeset has no net effect (identity changeset, removing
+        // and re-adding the same characters with the same attributes, or retransmission of an
+        // already applied changeset).
         if (![rev, rev + 1].includes(newRev)) {
           window.console.warn(`bad message revision on ACCEPT_COMMIT: ${newRev} not ${rev + 1}`);
           // setChannelState("DISCONNECTED", "badmessage_acceptcommit");

--- a/src/static/js/collab_client.js
+++ b/src/static/js/collab_client.js
@@ -207,8 +207,10 @@ const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad)
       });
     } else if (msg.type === 'ACCEPT_COMMIT') {
       serverMessageTaskQueue.enqueue(() => {
-        const newRev = msg.newRev;
-        if (newRev !== (rev + 1)) {
+        const {newRev} = msg;
+        // newRev will equal rev if the changeset has no net effect (identity changeset, or removing
+        // and re-adding the same characters with the same attributes).
+        if (![rev, rev + 1].includes(newRev)) {
           window.console.warn(`bad message revision on ACCEPT_COMMIT: ${newRev} not ${rev + 1}`);
           // setChannelState("DISCONNECTED", "badmessage_acceptcommit");
           return;

--- a/src/tests/backend/common.js
+++ b/src/tests/backend/common.js
@@ -184,3 +184,18 @@ exports.handshake = async (socket, padId) => {
   logger.debug('received CLIENT_VARS message');
   return msg;
 };
+
+const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Generates a random string.
+ *
+ * @param {number} [len] - The desired length of the generated string.
+ * @param {string} [charset] - Characters to pick from.
+ * @returns {string}
+ */
+exports.randomString = (len = 10, charset = `${alphabet}${alphabet.toUpperCase()}0123456789`) => {
+  let ret = '';
+  while (ret.length < len) ret += charset[Math.floor(Math.random() * charset.length)];
+  return ret;
+};

--- a/src/tests/backend/specs/api/pad.js
+++ b/src/tests/backend/specs/api/pad.js
@@ -278,7 +278,7 @@ describe(__filename, function () {
       const res = await agent.post(endPoint('setText'))
           .send({
             padID: testPadId,
-            text: 'testTextTwo',
+            text: 'testTextThree',
           })
           .expect(200)
           .expect('Content-Type', /json/);

--- a/src/tests/backend/specs/messages.js
+++ b/src/tests/backend/specs/messages.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const AttributePool = require('../../../static/js/AttributePool');
+const assert = require('assert').strict;
+const common = require('../common');
+const padManager = require('../../../node/db/PadManager');
+
+describe(__filename, function () {
+  let agent;
+  let pad;
+  let padId;
+  let rev;
+  let socket;
+
+  before(async function () {
+    agent = await common.init();
+  });
+
+  beforeEach(async function () {
+    padId = common.randomString();
+    assert(!await padManager.doesPadExist(padId));
+    pad = await padManager.getPad(padId, '');
+    assert.equal(pad.text(), '\n');
+    const res = await agent.get(`/p/${padId}`).expect(200);
+    socket = await common.connect(res);
+    const {type, data: clientVars} = await common.handshake(socket, padId);
+    assert.equal(type, 'CLIENT_VARS');
+    rev = clientVars.collab_client_vars.rev;
+  });
+
+  afterEach(async function () {
+    if (socket != null) socket.close();
+    socket = null;
+    if (pad != null) await pad.remove();
+    pad = null;
+  });
+
+  describe('USER_CHANGES', function () {
+    const sendUserChanges = (changeset, apool = new AttributePool()) => {
+      socket.json.send({
+        type: 'COLLABROOM',
+        component: 'pad',
+        data: {
+          type: 'USER_CHANGES',
+          baseRev: rev,
+          changeset,
+          apool: new AttributePool(),
+        },
+      });
+    };
+    const assertAccepted = async (wantRev) => {
+      const msg = await common.waitForSocketEvent(socket, 'message');
+      assert.deepEqual(msg, {
+        type: 'COLLABROOM',
+        data: {
+          type: 'ACCEPT_COMMIT',
+          newRev: wantRev,
+        },
+      });
+      rev = wantRev;
+    };
+    const assertRejected = async () => {
+      const msg = await common.waitForSocketEvent(socket, 'message');
+      assert.deepEqual(msg, {disconnect: 'badChangeset'});
+    };
+
+    it('changes are applied', async function () {
+      sendUserChanges('Z:1>5+5$hello');
+      await assertAccepted(rev + 1);
+      assert.equal(pad.text(), 'hello\n');
+    });
+
+    it('bad changeset is rejected', async function () {
+      sendUserChanges('this is not a valid changeset');
+      await assertRejected();
+    });
+
+    it('retransmission is rejected', async function () {
+      sendUserChanges('Z:1>5+5$hello');
+      await assertAccepted(rev + 1);
+      --rev;
+      sendUserChanges('Z:1>5+5$hello');
+      await assertRejected();
+      assert.equal(pad.text(), 'hello\n');
+    });
+
+    it('identity changeset is accepted', async function () {
+      sendUserChanges('Z:1>5+5$hello');
+      await assertAccepted(rev + 1);
+      sendUserChanges('Z:6>0$');
+      await assertAccepted(rev + 1);
+      assert.equal(pad.text(), 'hello\n');
+    });
+
+    it('non-identity changeset with no net change is accepted', async function () {
+      sendUserChanges('Z:1>5+5$hello');
+      await assertAccepted(rev + 1);
+      sendUserChanges('Z:6>0-5+5$hello');
+      await assertAccepted(rev + 1);
+      assert.equal(pad.text(), 'hello\n');
+    });
+  });
+});

--- a/src/tests/backend/specs/messages.js
+++ b/src/tests/backend/specs/messages.js
@@ -84,19 +84,19 @@ describe(__filename, function () {
       assert.equal(pad.text(), 'hello\n');
     });
 
-    it('identity changeset is accepted', async function () {
+    it('identity changeset is accepted, has no effect', async function () {
       sendUserChanges('Z:1>5+5$hello');
       await assertAccepted(rev + 1);
       sendUserChanges('Z:6>0$');
-      await assertAccepted(rev + 1);
+      await assertAccepted(rev);
       assert.equal(pad.text(), 'hello\n');
     });
 
-    it('non-identity changeset with no net change is accepted', async function () {
+    it('non-identity changeset with no net change is accepted, has no effect', async function () {
       sendUserChanges('Z:1>5+5$hello');
       await assertAccepted(rev + 1);
       sendUserChanges('Z:6>0-5+5$hello');
-      await assertAccepted(rev + 1);
+      await assertAccepted(rev);
       assert.equal(pad.text(), 'hello\n');
     });
   });

--- a/src/tests/backend/specs/messages.js
+++ b/src/tests/backend/specs/messages.js
@@ -75,12 +75,12 @@ describe(__filename, function () {
       await assertRejected();
     });
 
-    it('retransmission is rejected', async function () {
+    it('retransmission is accepted, has no effect', async function () {
       sendUserChanges('Z:1>5+5$hello');
       await assertAccepted(rev + 1);
       --rev;
       sendUserChanges('Z:1>5+5$hello');
-      await assertRejected();
+      await assertAccepted(rev + 1);
       assert.equal(pad.text(), 'hello\n');
     });
 


### PR DESCRIPTION
Also:

* Accept `USER_CHANGES` retransmissions. (Currently the client doesn't ever retransmit, but accepting retransmissions removes an awkward exception in the server code and opens the door to future protocol improvements.)
* Fix race conditions in the `setText`, `appendText`, `restoreRevision` HTTP API functions.