### PR TITLE
Prevent pad translation and crash

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -5,7 +5,7 @@
     ;
 %>
 <!doctype html>
-<html class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
+<html translate="no" class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
 <head>
   <% e.begin_block("htmlHead"); %>
   <% e.end_block(); %>

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -3,7 +3,7 @@
     , langs = require("ep_etherpad-lite/node/hooks/i18n").availableLangs
 %>
 <!doctype html>
-<html class="pad <%=settings.skinVariants%>">
+<html translate="no" class="pad <%=settings.skinVariants%>">
 <head>
   <title data-l10n-id="timeslider.pageTitle" data-l10n-args='{ "appTitle": "<%=settings.title%>" }'><%=settings.title%> Timeslider</title>
   <script>


### PR DESCRIPTION
Prevent "TypeError: Cannot read properties of null (reading 'sheet')" exception leading to a crash

Google chrome can translate `<style type="text/css" title="dynamicsyntax"></style>` title attribute. So https://github.com/ether/etherpad-lite/blob/develop/src/static/js/ace.js#L310 will throw.

It also disables pad content translation.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
