### PR TITLE
Add docker & npm ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
   - package-ecosystem: "npm"
     directory: "/src"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/src/bin/doc"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/src"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I already use Dependabot for many projects. With Dependabot it is relatively easy to stay up to date with the dependencies and packages used. Instead of always checking for updates manually, you can e.g. use the dependabot.yml configuration to tell Dependabot to check the project once a week for new releases of the npm packages that are used. If there are new updates, a new pull request is automatically created for them.

Since this procedure takes at least some work off my hands over at my projects, I wanted to ask if you would be up to using it for npm as well.