### PR TITLE
plugins: Give each plugin a plugin-specific logger object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
   and whether the user only has read-only access.
 * The `handleMessageSecurity` server-side hook can now be used to grant write
   access for the current message only.
+* The `init_<pluginName>` server-side hooks have a new `logger` context
+  property that plugins can use to log messages.
 
 ### Compatibility changes
 

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -56,7 +56,10 @@ Called from: `src/static/js/pluginfw/plugins.js`
 
 Run during startup after the named plugin is initialized.
 
-Context properties: None
+Context properties:
+
+  * `logger`: An object with the following `console`-like methods: `debug`,
+    `info`, `log`, `warn`, `error`.
 
 ## `expressPreSession`
 

--- a/src/static/js/pluginfw/plugins.js
+++ b/src/static/js/pluginfw/plugins.js
@@ -98,7 +98,10 @@ exports.update = async () => {
   defs.parts = sortParts(parts);
   defs.hooks = pluginUtils.extractHooks(defs.parts, 'hooks', exports.pathNormalization);
   defs.loaded = true;
-  await Promise.all(Object.keys(defs.plugins).map((p) => hooks.aCallAll(`init_${p}`, {})));
+  await Promise.all(Object.keys(defs.plugins).map(async (p) => {
+    const logger = log4js.getLogger(`plugin:${p}`);
+    await hooks.aCallAll(`init_${p}`, {logger});
+  }));
 };
 
 exports.getPackages = async () => {


### PR DESCRIPTION
This makes it possible for plugins to stop assuming that log4js is available at `ep_etherpad-lite/node_modules/log4js`.