### PR TITLE
Docker: use buildx to build amd64 and arm64 images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ jobs:
         name: Check out
         uses: actions/checkout@v3
       -
+        name: Set up QEMU
+        if: github.event_name == 'push'
+        uses: docker/setup-qemu-action@v1
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -78,6 +82,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add github action tasks to build for `amd64` and `arm64` platform.

`arm64` is now widely used: Raspberry PI, Docker for Mac (on Apple Silicon) and AWS Graviton.

Tested a docker building locally using the Dockerfile on an `arm64` system without issue.
Don't expect any issues with the same on Github Actions