### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -3,6 +3,9 @@ name: "Backend tests"
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   withoutpluginsLinux:
     # run on pushes to any branch

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,8 +9,15 @@ on:
   schedule:
     - cron: '0 13 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
       - 'v?[0-9]+.[0-9]+.[0-9]+'
 env:
   TEST_TAG: etherpad/etherpad:test
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-package-lock.yml
+++ b/.github/workflows/lint-package-lock.yml
@@ -3,6 +3,9 @@ name: "Lint"
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint-package-lock:
     # run on pushes to any branch

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -3,6 +3,9 @@ name: "Loadtest"
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   withoutplugins:
     # run on pushes to any branch

--- a/.github/workflows/rate-limit.yml
+++ b/.github/workflows/rate-limit.yml
@@ -3,6 +3,9 @@ name: "rate limit"
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ratelimit:
     # run on pushes to any branch

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -3,6 +3,9 @@ name: "Upgrade from latest release"
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   withpluginsLinux:
     # run on pushes to any branch

--- a/.github/workflows/windows-zip.yml
+++ b/.github/workflows/windows-zip.yml
@@ -3,6 +3,9 @@ name: "Windows Zip"
 # any branch is useful for testing before a PR is submitted
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # run on pushes to any branch
@@ -52,6 +55,8 @@ jobs:
   deploy:
     # run on pushes to any branch
     # run on PRs from external forks
+    permissions:
+      contents: none
     if: |
       (github.event_name != 'pull_request')
       || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
