### PR TITLE
Fix document not scrolling in iOS (all browsers)

### DIFF
--- a/src/static/skins/colibris/src/layout.css
+++ b/src/static/skins/colibris/src/layout.css
@@ -1,3 +1,18 @@
+.scroll-wrapper { 
+  display: flex;
+  min-width: 100vw;
+}
+
+@supports (-webkit-touch-callout: none)  {
+  .scroll-wrapper {
+    -webkit-overflow-scrolling: touch;
+    overflow-y: scroll;
+  }                      
+                       
+  .scroll-wrapper iframe {}
+                      
+}
+
 #outerdocbody {
   margin: 0 auto;
   padding-top: 20px;

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -80,7 +80,9 @@
 
   <% e.begin_block("afterEditbar"); %><% e.end_block(); %>
 
-  <div id="editorcontainerbox" class="flex-layout">
+      <div class="scroll-wrapper">
+          <div id="editorcontainerbox" class="flex-layout">
+      </div>
 
       <% e.begin_block("editorContainerBox"); %>
 


### PR DESCRIPTION
This patches a bug where users cannot scroll a document on iOS, because iOS does not allow iframes to be scrolled.

See https://davidwalsh.name/scroll-iframes-ios for details.

This is purely a cosmetic change, so a frontend test is not applicable for it.

Tested on iOS 12