### PR TITLE
CI: add --omit=dev and --only=prod flags to npm to work around bug with

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -78,8 +78,10 @@ jobs:
         name: Install Etherpad plugins
         # The --legacy-peer-deps flag is required to work around a bug in npm v7:
         # https://github.com/npm/cli/issues/2199
+        # npm v8: --omit=dev
+        # npm v6: --only=prod # can be dropped when support for v12/v14 is no longer needed
         run: >
-          npm install --no-save --legacy-peer-deps
+          npm install --no-save --legacy-peer-deps --only=prod --omit=dev
           ep_align
           ep_author_hover
           ep_cursortrace
@@ -166,8 +168,10 @@ jobs:
         name: Install Etherpad plugins
         # The --legacy-peer-deps flag is required to work around a bug in npm
         # v7: https://github.com/npm/cli/issues/2199
+        # npm v8: --omit=dev
+        # npm v6: --only=prod # can be dropped when support for v12/v14 is no longer needed
         run: >
-          npm install --no-save --legacy-peer-deps
+          npm install --no-save --legacy-peer-deps --only=prod --omit=dev
           ep_align
           ep_author_hover
           ep_cursortrace

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -64,10 +64,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          cache: 'npm'
-          cache-dependency-path: |
-            src/package-lock.json
-            src/bin/doc/package-lock.json
       -
         name: Install libreoffice
         run: |

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -47,7 +47,9 @@ jobs:
         # We intentionally install an old ep_align version to test upgrades to
         # the minor version number. The --legacy-peer-deps flag is required to
         # work around a bug in npm v7: https://github.com/npm/cli/issues/2199
-        run: npm install --no-save --legacy-peer-deps ep_align@0.2.27
+        # npm v8: --omit=dev
+        # npm v6: --only=prod # can be dropped when support for v12/v14 is no longer needed
+        run: npm install --no-save --legacy-peer-deps ep_align@0.2.27 --omit=dev --only=prod
       # Etherpad core dependencies must be installed after installing the
       # plugin's dependencies, otherwise npm will try to hoist common
       # dependencies by removing them from src/node_modules and installing them

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -37,8 +37,10 @@ jobs:
         name: Install Etherpad plugins
         # The --legacy-peer-deps flag is required to work around a bug in npm
         # v7: https://github.com/npm/cli/issues/2199
+        # npm v8: --omit=dev
+        # npm v6: --only=prod # can be dropped when support for v12/v14 is no longer needed
         run: >
-          npm install --no-save --legacy-peer-deps
+          npm install --no-save --legacy-peer-deps --omit=dev --only=prod
           ep_align
           ep_author_hover
           ep_cursortrace


### PR DESCRIPTION
hanging `git ls-remote`
A better solution is needed. The bug only affects node v12 and v14