### PR TITLE
Prevent infinite loop when exiting

### DIFF
--- a/src/node/server.js
+++ b/src/node/server.js
@@ -107,7 +107,14 @@ exports.start = async () => {
 
     process.on('uncaughtException', (err) => {
       logger.debug(`uncaught exception: ${err.stack || err}`);
-      exports.exit(err);
+
+      // eslint-disable-next-line promise/no-promise-in-callback
+      exports.exit(err)
+          .catch((err) => {
+            logger.error('Error in process exit', err);
+            // eslint-disable-next-line n/no-process-exit
+            process.exit(1);
+          });
     });
     // As of v14, Node.js does not exit when there is an unhandled Promise rejection. Convert an
     // unhandled rejection into an uncaught exception, which does cause Node.js to exit.


### PR DESCRIPTION
When exiting, the process can be stuck if the `exit` function throws an error.

Prevent this behaviour by catching the error and hard exiting.
