### PR TITLE
Fix: Plugin locales should overwrite core's locales

### DIFF
--- a/src/node/hooks/i18n.js
+++ b/src/node/hooks/i18n.js
@@ -41,6 +41,8 @@ const getAllLocales = () => {
 
   // add plugins languages (if any)
   for (const {package: {path: pluginPath}} of Object.values(pluginDefs.plugins)) {
+    // plugin locales should overwrite etherpad's core locales
+    if (pluginPath.endsWith('/ep_etherpad-lite') === true) continue;
     extractLangs(path.join(pluginPath, 'locales'));
   }
 


### PR DESCRIPTION
Fix for https://github.com/ether/etherpad-lite/issues/5628