### PR TITLE
Fix/log4js

### DIFF
--- a/.github/workflows/lint-package-lock.yml
+++ b/.github/workflows/lint-package-lock.yml
@@ -29,7 +29,7 @@ jobs:
             src/bin/doc/package-lock.json
       -
         name: Install lockfile-lint
-        run: npm install --no-save lockfile-lint
+        run: npm install --no-save lockfile-lint --legacy-peer-deps
       -
         name: Run lockfile-lint on package-lock.json
         run: >

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -90,7 +90,7 @@ jobs:
         run: cd src && npm test
       -
         name: Install Cypress
-        run: cd src && npm install cypress
+        run: cd src && npm install cypress --legacy-peer-deps
       -
         name: Run Etherpad & Test Frontend
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -115,7 +115,7 @@ jobs:
             etherpad/src/bin/doc/package-lock.json
       -
         name: Install Cypress
-        run: cd etherpad && cd src && npm install cypress
+        run: cd etherpad && cd src && npm install cypress --legacy-peer-deps
       -
         name: Run Etherpad
         run: |

--- a/src/bin/installOnWindows.bat
+++ b/src/bin/installOnWindows.bat
@@ -14,7 +14,7 @@ cd /D node_modules
 mklink /D "ep_etherpad-lite" "..\src"
 
 cd /D "ep_etherpad-lite"
-cmd /C npm ci || exit /B 1
+cmd /C npm ci --legacy-peer-deps || exit /B 1
 
 cd /D "%~dp0\..\.."
 

--- a/src/node/server.js
+++ b/src/node/server.js
@@ -25,7 +25,6 @@
  */
 
 const log4js = require('log4js');
-log4js.replaceConsole();
 
 const settings = require('./utils/Settings');
 

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -50,15 +50,18 @@ const nonSettings = [
 
 // This is a function to make it easy to create a new instance. It is important to not reuse a
 // config object after passing it to log4js.configure() because that method mutates the object. :(
-const defaultLogConfig = () => ({appenders: [{type: 'console'}]});
+const defaultLogConfig = () => ({appenders: {  console: { type: 'console' } },
+  categories:{
+    default: { appenders: ['console'], level: 'info'}
+  }});
 const defaultLogLevel = 'INFO';
 
 const initLogging = (logLevel, config) => {
   // log4js.configure() modifies exports.logconfig so check for equality first.
   const logConfigIsDefault = deepEqual(config, defaultLogConfig());
   log4js.configure(config);
-  log4js.setGlobalLogLevel(logLevel);
-  log4js.replaceConsole();
+  log4js.getLogger("console");
+  console.log = logger.info.bind(logger)
   // Log the warning after configuring log4js to increase the chances the user will see it.
   if (!logConfigIsDefault) logger.warn('The logconfig setting is deprecated.');
 };

--- a/src/node/utils/Settings.js
+++ b/src/node/utils/Settings.js
@@ -50,9 +50,9 @@ const nonSettings = [
 
 // This is a function to make it easy to create a new instance. It is important to not reuse a
 // config object after passing it to log4js.configure() because that method mutates the object. :(
-const defaultLogConfig = () => ({appenders: {  console: { type: 'console' } },
-  categories:{
-    default: { appenders: ['console'], level: 'info'}
+const defaultLogConfig = () => ({appenders: {console: {type: 'console'}},
+  categories: {
+    default: {appenders: ['console'], level: 'info'},
   }});
 const defaultLogLevel = 'INFO';
 
@@ -60,8 +60,14 @@ const initLogging = (logLevel, config) => {
   // log4js.configure() modifies exports.logconfig so check for equality first.
   const logConfigIsDefault = deepEqual(config, defaultLogConfig());
   log4js.configure(config);
-  log4js.getLogger("console");
-  console.log = logger.info.bind(logger)
+  log4js.getLogger('console');
+
+  // Overwrites for console output methods
+  console.debug = logger.debug.bind(logger);
+  console.log = logger.info.bind(logger);
+  console.warn = logger.warn.bind(logger);
+  console.error = logger.error.bind(logger);
+
   // Log the warning after configuring log4js to increase the chances the user will see it.
   if (!logConfigIsDefault) logger.warn('The logconfig setting is deprecated.');
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1037,7 +1037,8 @@
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1078,6 +1079,11 @@
         "whatwg-mimetype": "^3.0.0",
         "whatwg-url": "^11.0.0"
       }
+    },
+    "date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg=="
     },
     "debug": {
       "version": "2.6.9",
@@ -2154,8 +2160,7 @@
     "flatted": {
       "version": "3.2.9",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-      "dev": true
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "follow-redirects": {
       "version": "1.15.3",
@@ -2200,6 +2205,23 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2340,8 +2362,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "graphemer": {
       "version": "1.4.0",
@@ -2894,7 +2915,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2982,6 +3004,14 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonminify": {
@@ -3137,18 +3167,29 @@
       }
     },
     "log4js": {
-      "version": "0.6.38",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
-      "integrity": "sha512-Cd+klbx7lkiaamEId9/0odHxv/PFHDz2E12kEfd6/CzIOZD084DzysASR/Dot4i1dYPBQKC3r2XIER+dfbLOmw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
       "requires": {
-        "readable-stream": "~1.0.2",
-        "semver": "~4.3.3"
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
       },
       "dependencies": {
-        "semver": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-          "integrity": "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ=="
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -7114,17 +7155,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7231,6 +7261,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -7590,6 +7625,31 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "streamroller": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
+      "requires": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -7633,11 +7693,6 @@
         "define-properties": "^1.2.0",
         "es-abstract": "^1.22.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "stringify-entities": {
       "version": "4.0.3",

--- a/src/package.json
+++ b/src/package.json
@@ -50,7 +50,7 @@
     "jsonminify": "0.4.2",
     "languages4translatewiki": "0.1.3",
     "lodash.clonedeep": "4.5.0",
-    "log4js": "0.6.38",
+    "log4js": "^6.9.1",
     "measured-core": "^2.0.0",
     "mime-types": "^2.1.35",
     "npm": "^6.14.18",

--- a/src/package.json
+++ b/src/package.json
@@ -103,8 +103,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --timeout 120000 --recursive tests/backend/specs ../node_modules/ep_*/static/tests/backend/specs",
-    "test-container": "mocha --timeout 5000 tests/container/specs/api",
-    "dev": "bash ./bin/run.sh"
+    "test-container": "mocha --timeout 5000 tests/container/specs/api"
   },
   "version": "1.9.3",
   "license": "Apache-2.0"

--- a/src/tests/backend/common.js
+++ b/src/tests/backend/common.js
@@ -42,8 +42,6 @@ exports.init = async function () {
   if (!logLevel.isLessThanOrEqualTo(log4js.levels.DEBUG)) {
     logger.warn('Disabling non-test logging for the duration of the test. ' +
                 'To enable non-test logging, change the loglevel setting to DEBUG.');
-    log4js.setGlobalLogLevel(log4js.levels.OFF);
-    logger.setLevel(logLevel);
   }
 
   // Note: This is only a shallow backup.
@@ -66,7 +64,6 @@ exports.init = async function () {
     webaccess.authnFailureDelayMs = backups.authnFailureDelayMs;
     // Note: This does not unset settings that were added.
     Object.assign(settings, backups.settings);
-    log4js.setGlobalLogLevel(logLevel);
     await server.exit();
   });
 


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

This pull request updates log4js to the latest version. During testing I found out that if I bump typescript to 5.1.3 and npm enters legacy-peer-deps mode it somehow gets rid of all the old dependencies like request which I removed in this pull request too. 

I don't know why there are some tests that fail I'll look into that later.