### PR TITLE
Call exports.start() for Phusion Passenger

### DIFF
--- a/src/node/server.js
+++ b/src/node/server.js
@@ -276,3 +276,4 @@ exports.exit = async (err = null) => {
 };
 
 if (require.main === module) exports.start();
+if (typeof(PhusionPassenger) !== 'undefined') exports.start();


### PR DESCRIPTION
Now `exports.start()` is called only for cli: `if (require.main === module) exports.start();`
To run etherpad-lite also with Passenger it is needed to call `exports.start();` too.

fixes #5683