### PR TITLE
Fixed session key rotation problem with a default empty array on null value.

### DIFF
--- a/src/node/security/SecretRotator.js
+++ b/src/node/security/SecretRotator.js
@@ -160,7 +160,7 @@ class SecretRotator {
     // TODO: This is racy. If two instances start up at the same time and there are no existing
     // matching publications, each will generate and publish their own paramters. In practice this
     // is unlikely to happen, and if it does it can be fixed by restarting both Etherpad instances.
-    const dbKeys = await db.findKeys(`${this._dbPrefix}:*`, null);
+    const dbKeys = await db.findKeys(`${this._dbPrefix}:*`, null) || [];
     let currentParams = null;
     let currentId = null;
     const dbWrites = [];


### PR DESCRIPTION


<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
