### PR TITLE
Don't access jQuery through `parent.parent`

### DIFF
--- a/src/static/js/pad_editbar.js
+++ b/src/static/js/pad_editbar.js
@@ -318,7 +318,7 @@ exports.padeditbar = new class {
         }
       } else {
         // Focus on the editbar :)
-        const firstEditbarElement = parent.parent.$('#editbar button').first();
+        const firstEditbarElement = $('#editbar button').first();
 
         $(evt.currentTarget).trigger('blur');
         firstEditbarElement.trigger('focus');


### PR DESCRIPTION
When Etherpad is hosted on a different domain and the iframe is violating the same-origin policy, trying to close Import/Export window via Escape key results in an error:

<img width="1367" alt="Screenshot 2023-09-21 at 10 27 09" src="https://github.com/ether/etherpad-lite/assets/3399445/87832061-143a-41cd-8fd7-75b08bffdccd">

This PR fixes that by removing the reference to `parent.parent` when accessing the jQuery ($).