### PR TITLE
fix: Always install npm@6 for correct package-lock.json version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN  \
     mkdir -p /usr/share/man/man1 && \
+    npm install npm@6 -g  && \
     apk update && apk upgrade && \
     apk add  \
         ca-certificates \
@@ -100,7 +101,6 @@ COPY --chown=etherpad:etherpad ./ ./
 # rules.
 RUN { [ -z "${ETHERPAD_PLUGINS}" ] || \
       npm install --no-save --legacy-peer-deps ${ETHERPAD_PLUGINS}; } && \
-    npm install npm@6 -g \
     src/bin/installDeps.sh && \
     rm -rf ~/.npm
 


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

Closes ##6072