### PR TITLE
Correct Node.js install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ We're looking for maintainers and have some funding available.  Please contact J
 
 #### Quick install on Debian/Ubuntu
 
+Install the latest Node.js LTS per [official install instructions](https://github.com/nodesource/distributions#installation-instructions), then:
 ```sh
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-sudo apt install -y nodejs
 git clone --branch master https://github.com/ether/etherpad-lite.git &&
 cd etherpad-lite &&
 src/bin/run.sh


### PR DESCRIPTION
This is a followup to #6067.
This corrects the install instructions for Node.js. Node.js 14 is EOL for very long now and the current version of Etherpad does not even work with it.
As per the [release notes](https://github.com/ether/etherpad-lite/releases/tag/v1.9.5) and the [requirements](https://github.com/ether/etherpad-lite#requirements) in the README, at least Node.js 18.x is required and Node.js 20 is recommended.

This also reduces the maintenance effort, as duplicating these third-party install instructions does not provide additional value.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
