### PR TITLE
Fixed favicon not being loaded from url.

### DIFF
--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -46,7 +46,7 @@ exports.expressPreSession = async (hookName, {app}) => {
       /*
         If this is a url we simply redirect to that one.
        */
-      if (settings.favicon.startsWith('http')) {
+      if (settings.favicon && settings.favicon.startsWith('http')) {
         res.redirect(settings.favicon);
         res.send();
         return;

--- a/src/node/hooks/express/specialpages.js
+++ b/src/node/hooks/express/specialpages.js
@@ -43,6 +43,16 @@ exports.expressPreSession = async (hookName, {app}) => {
 
   app.get('/favicon.ico', (req, res, next) => {
     (async () => {
+      /*
+        If this is a url we simply redirect to that one.
+       */
+      if (settings.favicon.startsWith('http')) {
+        res.redirect(settings.favicon);
+        res.send();
+        return;
+      }
+
+
       const fns = [
         ...(settings.favicon ? [path.resolve(settings.root, settings.favicon)] : []),
         path.join(settings.root, 'src', 'static', 'skins', settings.skinName, 'favicon.ico'),

--- a/src/tests/backend/specs/favicon.js
+++ b/src/tests/backend/specs/favicon.js
@@ -51,6 +51,12 @@ describe(__filename, function () {
     assert(gotIcon.equals(wantCustomIcon));
   });
 
+  it('uses custom favicon from url', async function () {
+    settings.favicon = 'https://etherpad.org/favicon.ico';
+    await agent.get('/favicon.ico')
+        .expect(302);
+  });
+
   it('uses custom favicon if set (absolute pathname)', async function () {
     settings.favicon = path.join(__dirname, 'favicon-test-custom.png');
     assert(path.isAbsolute(settings.favicon));


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->


This pull request fixes the favicon issues related to urls. If a url is entered in the settings.json etherpad will redirect the favicon request to the url in settings.json. That way we can load images from any source in the internet and are not dependent from rebuilding a docker image.

Closes #3392