### PR TITLE
Make repairPad.js more verbose

### DIFF
--- a/src/bin/repairPad.js
+++ b/src/bin/repairPad.js
@@ -43,7 +43,9 @@ let valueCount = 0;
     neededDBValues.push(`pad:${padId}:chat:${chat}`);
   }
   // now fetch and reinsert every key
+  console.log('Fetch and reinsert every key');
   for (const key of neededDBValues) {
+    if (valueCount % 100 === 0) console.log(valueCount + "/" + neededDBValues.length);
     const value = await db.get(key);
     // if it isn't a globalAuthor value which we want to ignore..
     // console.log(`Key: ${key}, value: ${JSON.stringify(value)}`);


### PR DESCRIPTION
The current version of the script may take hours for some pads. This PR adds some output so that the user can have an idea of the progress. 

The new output looks like this:

```console
$ node bin/repairPad2.js some-pad
WARNING: This script must not be used while etherpad is running!
[2024-01-24T15:45:53.790] [INFO] settings - All relative paths will be interpreted relative to the identified Etherpad base dir: /opt/etherpad-lite
[2024-01-24T15:45:53.806] [INFO] settings - settings loaded from: /opt/etherpad-lite/settings.json
[2024-01-24T15:45:53.807] [INFO] settings - No credentials file found in /opt/etherpad-lite/credentials.json. Ignoring.
[2024-01-24T15:45:53.807] [INFO] settings - Using skin "colibris" in dir: /opt/etherpad-lite/src/static/skins/colibris
[2024-01-24T15:45:53.808] [INFO] settings - Random string used for versioning assets: 82608b8a
[2024-01-24T15:45:54.327] [INFO] settings - Fetch and reinsert every key
[2024-01-24T15:45:54.328] [INFO] settings - 0/303751
[2024-01-24T15:46:14.272] [INFO] settings - 100/303751
[2024-01-24T15:46:34.298] [INFO] settings - 200/303751
[2024-01-24T15:46:54.326] [INFO] settings - 300/303751
[2024-01-24T15:47:14.348] [INFO] settings - 400/303751
[2024-01-24T15:47:34.379] [INFO] settings - 500/303751
```