### PR TITLE
Fix wrong link to error identifiers in documentation

### DIFF
--- a/doc/api/hooks_server-side.adoc
+++ b/doc/api/hooks_server-side.adoc
@@ -1049,8 +1049,7 @@ Context properties:
 * `srcFile`: The document to convert.
 * `ImportError`: Subclass of Error that can be thrown to provide a specific
   error message to the user. The constructor's first argument must be a string
-  matching one of the [known error
-  identifiers](https://github.com/ether/etherpad-lite/blob/1.8.16/src/static/js/pad_impexp.js==L80-L86).
+  matching one of the https://github.com/ether/etherpad-lite/blob/1.9.6/src/static/js/pad_impexp.js#L80-L86[known error identifiers].
 
 Example:
 


### PR DESCRIPTION
This PR fixes an incorrect link to 'known error identifiers' for `import` server side hook in documentation.