### PR TITLE
Don't install all dependencies from node_modules

### DIFF
--- a/src/static/js/pluginfw/installer.js
+++ b/src/static/js/pluginfw/installer.js
@@ -53,7 +53,7 @@ const migratePluginsFromNodeModules = async () => {
   await Promise.all(Object.entries(dependencies)
       .filter(([pkg, info]) => pkg.startsWith(plugins.prefix) && pkg !== 'ep_etherpad-lite')
       .map(async ([pkg, info]) => {
-        if (!info._resolved) {
+        if (!info.resolved) {
           // Install from node_modules directory
           await exports.manager.installFromPath(`${findEtherpadRoot()}/node_modules/${pkg}`);
         } else {


### PR DESCRIPTION
The output of `pnpm ls` command is different to the `npm ls` and forces live-plugin-manager to install all plugins from node_modules.

Here's an example of how the output looks like for pnpm:
```
ep_user_displayname: {
  from: 'ep_user_displayname',
  version: '1.0.4',
  resolved: 'https://registry.npmjs.org/ep_user_displayname/-/ep_user_displayname-1.0.4.tgz',
  description: "Etherpad plugin to set each user's display name via config or authentication plugin.",
  license: 'Apache-2.0',
  author: { name: 'Richard Hansen', email: 'rhansen@rhansen.org' },
  homepage: 'https://github.com/ether/ep_user_displayname#readme',
  repository: 'git+https://github.com/ether/ep_user_displayname.git',
  path: '/opt/etherpad-lite/node_modules/.pnpm/ep_user_displayname@1.0.4_ep_etherpad-lite@src/node_modules/ep_user_displayname'
}
```