### PR TITLE
Feature: Docker build from behind a proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,15 @@
 FROM node:alpine as build
 LABEL maintainer="Etherpad team, https://github.com/ether/etherpad-lite"
 
+# Set these arguments when building the image from behind a proxy
+ARG http_proxy=
+ARG https_proxy=
+ARG no_proxy=
+
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
+ENV no_proxy=${no_proxy}
+
 ARG TIMEZONE=
 
 RUN \


### PR DESCRIPTION
## Problem

custom image cannot be built from behind a proxy

## Solution

- optionally set `http_proxy`, `https_proxy` and `no_proxy` as Docker build arguments to make the used package managers (`apk`, `npm`) work
- when the options are not provided, it's expected that the build works as before
- lowercase variables used as these work for both `apk` and `npm`