### PR TITLE
Added hostrequire undefined to always install all subdependencies.

### DIFF
--- a/src/static/js/pluginfw/LinkInstaller.ts
+++ b/src/static/js/pluginfw/LinkInstaller.ts
@@ -19,6 +19,7 @@ export class LinkInstaller {
     constructor() {
         this.livePluginManager = new PluginManager({
             pluginsPath: pluginInstallPath,
+            hostRequire: undefined,
             cwd: path.join(settings.root, 'src')
         });
         this.dependenciesMap = new Map();


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

Due to an issue in the configuration of the live plugin manager subdependencies were not installed in some cases. This fixes the issue that the manager assumes a package is already installed while it is not. Thanks to @dhalenok for the fix.