### PR TITLE
Allow providing local plugins to Docker image

### DIFF
--- a/bin/installPlugins.ts
+++ b/bin/installPlugins.ts
@@ -10,17 +10,18 @@ if (process.argv.length === 2) {
   process.exit(1);
 }
 
-let plugins = process.argv.slice(2)
-let installFromPath = false;
+let args = process.argv.slice(2)
 
-const thirdOptPlug = plugins[0]
+let registryPlugins: string[] = [];
+let localPlugins: string[] = [];
 
-console.log("Third option: ", thirdOptPlug)
-if (thirdOptPlug && thirdOptPlug.includes('path')) {
-  installFromPath = true
-  plugins.splice(plugins.indexOf('--path'), 1);
+if (args.indexOf('--path') !== -1) {
+  const indexToSplit = args.indexOf('--path');
+  registryPlugins = args.slice(0, indexToSplit);
+  localPlugins = args.slice(indexToSplit + 1);
+} else {
+  registryPlugins = args;
 }
-
 
 const persistInstalledPlugins = async () => {
   const plugins:PackageData[] = []
@@ -36,14 +37,14 @@ const persistInstalledPlugins = async () => {
 };
 
 async function run() {
-  for (const plugin of plugins) {
-    if(installFromPath) {
-      console.log(`Installing plugin from path: ${plugin}`);
-        await linkInstaller.installFromPath(plugin);
-        continue;
-    }
+  for (const plugin of registryPlugins) {
     console.log(`Installing plugin from registry: ${plugin}`)
     await linkInstaller.installPlugin(plugin);
+  }
+
+  for (const plugin of localPlugins) {
+    console.log(`Installing plugin from path: ${plugin}`);
+    await linkInstaller.installFromPath(plugin);
   }
 }
 


### PR DESCRIPTION
Due to new changes in the version 2.0, it's no longer possible to specify local plugins when building a Docker image.

In my testing, executing `pnpm run install-plugins` (one for remote and one for local plugins via `--path`) made it so only the plugins specified in the latest command were loaded.

This PR changes that, so you can specify both remote and local plugins in one command: `pnpm run install-plugins ep_openid_connect --path ../ep_my_local_plugin`. It should still be possible to specify only remote or local plugins.

In addition, this PR introduces a new Dockerfile argument called `ETHERPAD_LOCAL_PLUGINS`, value of which gets passed to `install-plugins` script.

There is, however, one thing left to do, which is copying the plugins to the docker image. IIRC, before v.2.0 the root directory of the repo was copied over, but it's no longer a case and I'm not too sure how to tackle it.
One idea was that local plugins could be stored in a directory called `plugins`or `local_plugins` and copied over to `EP_DIR`in Docker image:

```
COPY --chown=etherpad:etherpad ./plugins/ ./
```