### PR TITLE
Added support for installing a specific version of a plugin.

### DIFF
--- a/bin/installPlugins.ts
+++ b/bin/installPlugins.ts
@@ -39,6 +39,11 @@ const persistInstalledPlugins = async () => {
 async function run() {
   for (const plugin of registryPlugins) {
     console.log(`Installing plugin from registry: ${plugin}`)
+    if (plugin.includes('@')) {
+        const [name, version] = plugin.split('@');
+        await linkInstaller.installPlugin(name, version);
+        continue;
+    }
     await linkInstaller.installPlugin(plugin);
   }
 


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
You can now install specific versions of a plugin using: `pnpm run install-plugins ep_headings2@0.2.61`