### PR TITLE
feat: Always install from path if the resolved URL does not include npm

### DIFF
--- a/src/static/js/pluginfw/installer.ts
+++ b/src/static/js/pluginfw/installer.ts
@@ -64,12 +64,12 @@ const migratePluginsFromNodeModules = async () => {
       .filter(([pkg, info]) => pkg.startsWith(plugins.prefix) && pkg !== 'ep_etherpad-lite')
       .map(async ([pkg, info]) => {
           const _info = info as PackageInfo
-          if (!_info.resolved) {
+          if (!_info.resolved|| !_info.resolved.includes('npm')) {
           // Install from node_modules directory
           await linkInstaller.installFromPath(`${findEtherpadRoot()}/node_modules/${pkg}`);
         } else {
-          await linkInstaller.installPlugin(pkg);
-        }
+            await linkInstaller.installPlugin(pkg, _info.version);
+          }
       }));
   await persistInstalledPlugins();
 };


### PR DESCRIPTION
Always install from local unless the resolved url is npmjs.
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
