### PR TITLE
LoginScreen.tsx -> Passwort -> Password

### DIFF
--- a/admin/src/pages/LoginScreen.tsx
+++ b/admin/src/pages/LoginScreen.tsx
@@ -46,7 +46,7 @@ export const LoginScreen = ()=>{
                 <input {...register('username', {
                     required: true
                 })} className="login-textinput input-control" type="text" placeholder="Username"/>
-                <div>Passwort</div>
+                <div>Password</div>
                 <span className="icon-input">
                         <input {...register('password', {
                             required: true


### PR DESCRIPTION
Found a typo in LoginScreen where is says Passwort instead of Password.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
