### PR TITLE
Added proxy support for axios.

### DIFF
--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -100,7 +100,15 @@ export const HomePage = () => {
         pluginsSocket!.on('results:search', (data: {
             results: PluginDef[]
         }) => {
-            setPlugins(data.results)
+            if (Array.isArray(data.results) && data.results.length === 0) {
+                setPlugins(data.results)
+            } else {
+                useStore.getState().setToastState({
+                    open: true,
+                    title: "Error retrieving plugins",
+                    success: false
+                })
+            }
         })
 
 

--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -27,6 +27,7 @@ import {ErrorCaused} from "./types/ErrorCaused";
 import log4js from 'log4js';
 import pkg from '../package.json';
 import {checkForMigration} from "../static/js/pluginfw/installer";
+import axios from "axios";
 
 const settings = require('./utils/Settings');
 
@@ -36,6 +37,28 @@ if (settings.dumpOnUncleanExit) {
   // it should be above everything else so that it can hook in before resources are used.
   wtfnode = require('wtfnode');
 }
+
+
+const addProxyToAxios = (url: URL) => {
+  axios.defaults.proxy = {
+    host: url.hostname,
+    port: Number(url.port),
+    protocol: url.protocol,
+  }
+}
+
+if(process.env['http_proxy']) {
+  console.log("Using proxy: " + process.env['http_proxy'])
+  addProxyToAxios(new URL(process.env['http_proxy']));
+}
+
+
+if (process.env['https_proxy']) {
+  console.log("Using proxy: " + process.env['https_proxy'])
+  addProxyToAxios(new URL(process.env['https_proxy']));
+}
+
+
 
 /*
  * early check for version compatibility before calling


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

You can now use http_proxy and https_proxy and specify an axios proxy server that is used for retrieving Etherpad's latest version and also the plugins list
