### PR TITLE
chore: bump live-plugin-manager to 0.20.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,8 @@ importers:
         specifier: 0.1.3
         version: 0.1.3
       live-plugin-manager:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.20.0
+        version: 0.20.0
       lodash.clonedeep:
         specifier: 4.5.0
         version: 4.5.0
@@ -2471,8 +2471,8 @@ packages:
       '@types/superagent': 8.1.3
     dev: true
 
-  /@types/tar@6.1.11:
-    resolution: {integrity: sha512-ThA1WD8aDdVU4VLuyq5NEqriwXErF5gEIJeyT6gHBWU7JtSmW2a5qjNv3/vR82O20mW+1vhmeZJfBQPT3HCugg==}
+  /@types/tar@6.1.13:
+    resolution: {integrity: sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==}
     dependencies:
       '@types/node': 20.12.7
       minipass: 4.2.8
@@ -2490,8 +2490,8 @@ packages:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: false
 
-  /@types/url-join@4.0.1:
-    resolution: {integrity: sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==}
+  /@types/url-join@4.0.3:
+    resolution: {integrity: sha512-3l1qMm3wqO0iyC5gkADzT95UVW7C/XXcdvUcShOideKF0ddgVRErEQQJXBd2kvQm+aSgqhBGHGB38TgMeT57Ww==}
     dev: false
 
   /@types/web-bluetooth@0.0.20:
@@ -5453,23 +5453,23 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
-  /live-plugin-manager@0.19.0:
-    resolution: {integrity: sha512-qvgGHkDIRCg89WFB6wi8LDyrmSdSr2372+1lF68RJfOiXfXZPV4EKwYTM64M/k+H3Y4u4USR8BsvSyuHHqbLtw==}
+  /live-plugin-manager@0.20.0:
+    resolution: {integrity: sha512-b8qcfHQNe3SgVKNZv/AUfOIpAUz/7VmNw/wcFyljN4toeSfXmatlHIUTvHhmknw7zMbXNFMGcWtk2Tw8y35Z7Q==}
     dependencies:
       '@types/debug': 4.1.12
       '@types/fs-extra': 9.0.13
       '@types/lockfile': 1.0.4
       '@types/node-fetch': 2.6.11
       '@types/semver': 7.5.8
-      '@types/tar': 6.1.11
-      '@types/url-join': 4.0.1
+      '@types/tar': 6.1.13
+      '@types/url-join': 4.0.3
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 10.1.0
       lockfile: 1.0.4
       node-fetch: 2.7.0
       proxy-agent: 6.4.0
       semver: 7.6.0
-      tar: 6.2.0
+      tar: 6.2.1
       url-join: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -6095,7 +6095,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.0
+      agent-base: 7.1.1
       debug: 4.3.4(supports-color@8.1.1)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
@@ -6239,7 +6239,7 @@ packages:
     resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
     engines: {node: '>= 14'}
     dependencies:
-      agent-base: 7.1.0
+      agent-base: 7.1.1
       debug: 4.3.4(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4
@@ -7016,8 +7016,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /tar@6.2.0:
-    resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
+  /tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     dependencies:
       chownr: 2.0.0

--- a/src/package.json
+++ b/src/package.json
@@ -51,7 +51,7 @@
     "jsonminify": "0.4.2",
     "jsonwebtoken": "^9.0.2",
     "languages4translatewiki": "0.1.3",
-    "live-plugin-manager": "^0.19.0",
+    "live-plugin-manager": "^0.20.0",
     "lodash.clonedeep": "4.5.0",
     "log4js": "^6.9.1",
     "measured-core": "^2.0.0",


### PR DESCRIPTION
This version updates several super outdated dependencies, see https://github.com/davideicardi/live-plugin-manager/pull/88.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)

