### PR TITLE
Added Progressive Web App support for Etherpad

### DIFF
--- a/src/ep.json
+++ b/src/ep.json
@@ -58,6 +58,12 @@
       }
     },
     {
+      "name": "pwa",
+      "hooks": {
+        "expressCreateServer": "ep_etherpad-lite/node/hooks/express/pwa"
+      }
+    },
+    {
       "name": "apicalls",
       "hooks": {
         "expressPreSession": "ep_etherpad-lite/node/hooks/express/apicalls"
@@ -111,12 +117,6 @@
       "name": "openapi",
       "hooks": {
         "expressPreSession": "ep_etherpad-lite/node/hooks/express/openapi"
-      }
-    },
-    {
-      "name": "ep_message_all",
-      "client_hooks": {
-        "handleClientMessage_shoutMessage": "ep_etherpad-lite/static/js/messageHandler"
       }
     }
   ]

--- a/src/node/hooks/express/pwa.ts
+++ b/src/node/hooks/express/pwa.ts
@@ -1,0 +1,32 @@
+import {ArgsExpressType} from "../../types/ArgsExpressType";
+const settings = require('../../utils/Settings');
+
+const pwa = {
+  name: settings.title || "Etherpad",
+  short_name: settings.title,
+  description: "A collaborative online editor",
+  icons: [
+    {
+      "src": "/static/skins/colibris/images/fond.jpg",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      type: "image/png"
+    }
+  ],
+  start_url: "/",
+  display: "fullscreen",
+  theme_color: "#0f775b",
+  background_color: "#0f775b"
+}
+
+exports.expressCreateServer = (hookName:string, args:ArgsExpressType, cb:Function) => {
+  args.app.get('/manifest.json', (req:any, res:any) => {
+    res.json(pwa);
+  });
+
+  return cb();
+}

--- a/src/templates/export_html.html
+++ b/src/templates/export_html.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
 <title><%- padId %></title>
-<meta name="generator" content="Etherpad"/>
+  <link rel="manifest" href="/manifest.json" />
+  <meta name="generator" content="Etherpad"/>
 <meta name="author" content="Etherpad"/>
 <meta name="changedby" content="Etherpad"/>
 <meta charset="utf-8"/>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -6,6 +6,7 @@
 
         <title><%=settings.title%></title>
         <meta charset="utf-8">
+        <link rel="manifest" href="/manifest.json" />
         <meta name="referrer" content="no-referrer">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
         <link rel="shortcut icon" href="favicon.ico">

--- a/src/templates/javascript.html
+++ b/src/templates/javascript.html
@@ -2,7 +2,8 @@
 <html>
     <head>
       <title>JavaScript license information</title>
-          <meta charset="utf-8">
+      <link rel="manifest" href="/manifest.json" />
+      <meta charset="utf-8">
           <meta name="robots" content="noindex, nofollow">
           <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
     </head>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -10,6 +10,7 @@
   <% e.begin_block("htmlHead"); %>
   <% e.end_block(); %>
   <title><%=settings.title%></title>
+  <link rel="manifest" href="/manifest.json" />
   <script>
     /*
     |@licstart  The following is the entire license notice for the

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -31,6 +31,7 @@
   </script>
   <script src="../../static/js/basic_error_handler.js?v=<%=settings.randomVersionString%>"></script>
   <meta charset="utf-8">
+  <link rel="manifest" href="/manifest.json" />
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

This pr adds progressive web app support to Etherpad. 
A progressive web app enables the Etherpad user to install a given Etherpad instance onto his desktop. That way users don't need to remember the instance url and just need to search their programs for Etherpad.


![image](https://github.com/ether/etherpad-lite/assets/40429738/a8e804f1-be02-48f7-ae96-e78fc61ff952)

