### PR TITLE
Move away from using toast in the plugin search

### DIFF
--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -93,25 +93,20 @@ export const HomePage = () => {
         if (!pluginsSocket) {
             return
         }
-
         pluginsSocket?.emit('search', searchParams)
-
-
         pluginsSocket!.on('results:search', (data: {
             results: PluginDef[]
         }) => {
-            if (Array.isArray(data.results) && data.results.length > 0) {
-                setPlugins(data.results)
-            } else {
-                useStore.getState().setToastState({
-                    open: true,
-                    title: "Error retrieving plugins",
-                    success: false
-                })
-            }
+            setPlugins(data.results)
         })
-
-
+        pluginsSocket!.on('results:searcherror', (data: {error: string}) => {
+            console.log(data.error)
+            useStore.getState().setToastState({
+                open: true,
+                title: "Error retrieving plugins",
+                success: false
+            })
+        })
     }, [searchParams, pluginsSocket]);
 
     const uninstallPlugin  = (pluginName: string)=>{
@@ -124,7 +119,6 @@ export const HomePage = () => {
         pluginsSocket!.emit('install', pluginName);
         setPlugins(plugins.filter(plugin=>plugin.name !== pluginName))
     }
-
 
     useDebounce(()=>{
         setSearchParams({
@@ -161,12 +155,12 @@ export const HomePage = () => {
                     </td>
                         </tr>
                     })}
-                </tbody>
-            </table>
+            </tbody>
+        </table>
 
 
-                <h2><Trans i18nKey="admin_plugins.available"/></h2>
-                <SearchField onChange={v=>{setSearchTerm(v.target.value)}} placeholder={t('admin_plugins.available_search.placeholder')} value={searchTerm}/>
+        <h2><Trans i18nKey="admin_plugins.available"/></h2>
+        <SearchField onChange={v=>{setSearchTerm(v.target.value)}} placeholder={t('admin_plugins.available_search.placeholder')} value={searchTerm}/>
 
         <table id="available-plugins">
             <thead>
@@ -179,17 +173,21 @@ export const HomePage = () => {
             </tr>
             </thead>
             <tbody style={{overflow: 'auto'}}>
-            {plugins.map((plugin) => {
-                return <tr key={plugin.name}>
-                    <td><a rel="noopener noreferrer" href={`https://npmjs.com/${plugin.name}`} target="_blank">{plugin.name}</a></td>
-                    <td>{plugin.description}</td>
-                    <td>{plugin.version}</td>
-                    <td>{plugin.time}</td>
-                    <td>
-                        <IconButton icon={<Download/>} onClick={() => installPlugin(plugin.name)} title={<Trans i18nKey="admin_plugins.available_install.value"/>}/>
-                    </td>
-                </tr>
-            })}
+            {(plugins.length > 0) ?
+                    plugins.map((plugin) => {
+                        return <tr key={plugin.name}>
+                            <td><a rel="noopener noreferrer" href={`https://npmjs.com/${plugin.name}`} target="_blank">{plugin.name}</a></td>
+                            <td>{plugin.description}</td>
+                            <td>{plugin.version}</td>
+                            <td>{plugin.time}</td>
+                            <td>
+                                <IconButton icon={<Download/>} onClick={() => installPlugin(plugin.name)} title={<Trans i18nKey="admin_plugins.available_install.value"/>}/>
+                            </td>
+                        </tr>
+                    })
+                :
+                <tr><td colSpan={5}>{searchTerm == '' ? <Trans i18nKey="pad.loading"/>: <Trans i18nKey="admin_plugins.available_not-found"/>}</td></tr>
+            }
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
Fixes #6440

Refactor the plugin search behavior in the `HomePage.tsx` instead of using the toast with the message:
`Error retrieving plugins`

we will now show a much softer message in the table letting the user that no plugins are found, it also uses the correct language messages instead of the hardcoded english in the toast  

https://github.com/ether/etherpad-lite/assets/545474/c166d9f2-e690-4454-b55a-9ac372e9534e

____

Add 'results:searcherror' event to truly show errors in the search
Also add logger to the adminPlugins  

![Screenshot from 2024-06-09 11-44-03](https://github.com/ether/etherpad-lite/assets/545474/0d01dc7f-26e3-4c91-ad93-1dfe078c26b4)
