### PR TITLE
On Ctrl+Click bring the window back to focus

### DIFF
--- a/src/static/js/ace2_inner.js
+++ b/src/static/js/ace2_inner.js
@@ -2248,7 +2248,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const isLink = (n) => (n.tagName || '').toLowerCase() === 'a' && n.href;
 
     // only want to catch left-click
-    if ((!evt.ctrlKey) && (evt.button !== 2) && (evt.button !== 3)) {
+    if ((evt.button !== 2) && (evt.button !== 3)) {
       // find A tag with HREF
       let n = evt.target;
       while (n && n.parentNode && !isLink(n)) {
@@ -2257,6 +2257,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       if (n && isLink(n)) {
         try {
           window.open(n.href, '_blank', 'noopener,noreferrer');
+          if (evt.ctrlKey) window.focus();
         } catch (e) {
           // absorb "user canceled" error in IE for certain prompts
         }


### PR DESCRIPTION
Fixes #4456

In case of a ctrl click what we can do to open in the background is keep the focus in the current one:
`if (evt.ctrlKey) window.focus();`

Here is a short video showing my testing on Chrome

https://github.com/ether/etherpad-lite/assets/545474/fdea80e8-8dbe-401c-b80e-9d501f924cb4

