### PR TITLE
fix: Silent disconnect of pad

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -131,7 +131,8 @@
     "test-ui": "npx playwright test tests/frontend-new/specs",
     "test-ui:ui": "npx playwright test tests/frontend-new/specs --ui",
     "test-admin": "npx playwright test tests/frontend-new/admin-spec --workers 1",
-    "test-admin:ui": "npx playwright test tests/frontend-new/admin-spec --ui --workers 1"
+    "test-admin:ui": "npx playwright test tests/frontend-new/admin-spec --ui --workers 1",
+    "debug:socketio": "cross-env DEBUG=socket.io* node --require tsx/cjs node/server.ts"
   },
   "version": "2.1.0",
   "license": "Apache-2.0"

--- a/src/static/js/pad.js
+++ b/src/static/js/pad.js
@@ -230,7 +230,7 @@ const handshake = async () => {
     sendClientReady(false);
   });
 
-  socket.on('reconnect', () => {
+  socket.io.on('reconnect', () => {
     // pad.collabClient might be null if the hanshake failed (or it never got that far).
     if (pad.collabClient != null) {
       pad.collabClient.setChannelState('CONNECTED');
@@ -251,9 +251,8 @@ const handshake = async () => {
     // The socket.io client will automatically try to reconnect for all reasons other than "io
     // server disconnect".
     console.log(`Socket disconnected: ${reason}`)
-    if (reason !== 'io server disconnect' || reason !== 'ping timeout') return;
+    //if (reason !== 'io server disconnect' || reason !== 'ping timeout') return;
     socketReconnecting();
-    socket.connect();
   });
 
 
@@ -271,9 +270,9 @@ const handshake = async () => {
     }
   })
 
-  socket.on('reconnecting', socketReconnecting);
+  socket.io.on('reconnect_attempt', socketReconnecting);
 
-  socket.on('reconnect_failed', (error) => {
+  socket.io.on('reconnect_failed', (error) => {
     // pad.collabClient might be null if the hanshake failed (or it never got that far).
     if (pad.collabClient != null) {
       pad.collabClient.setChannelState('DISCONNECTED', 'reconnect_timeout');

--- a/src/static/js/socketio.js
+++ b/src/static/js/socketio.js
@@ -31,11 +31,11 @@ const connect = (etherpadBaseUrl, namespace = '/', options = {}) => {
 
   socket.on('connect_error', (error) => {
     console.log('Error connecting to pad', error);
-    if (socket.io.engine.transports.indexOf('polling') === -1) {
+    /*if (socket.io.engine.transports.indexOf('polling') === -1) {
       console.warn('WebSocket connection failed. Falling back to long-polling.');
-      socket.io.opts.transports = ['polling'];
+      socket.io.opts.transports = ['websocket','polling'];
       socket.io.engine.upgrade = false;
-    }
+    }*/
   });
 
   return socket;


### PR DESCRIPTION
Fixed silent disconnect of pad
- Errors were calling explicit socket.connect() even if this is now handled by socket io event loop
- Deprecated APIs: Some events like reconnect, reconnect_attempt were moved to the manager