### PR TITLE
Fix relative paths for template enrtypoints

### DIFF
--- a/src/node/hooks/express/specialpages.ts
+++ b/src/node/hooks/express/specialpages.ts
@@ -324,7 +324,7 @@ exports.expressCreateServer = async (hookName: string, args: any, cb: Function) 
 
     // serve index.html under /
     args.app.get('/', (req: any, res: any) => {
-      res.send(eejs.require('ep_etherpad-lite/templates/index.html', {req, settings, entrypoint: "/"+fileNameIndex}));
+      res.send(eejs.require('ep_etherpad-lite/templates/index.html', {req, settings, entrypoint: "./"+fileNameIndex}));
     });
 
 
@@ -342,7 +342,7 @@ exports.expressCreateServer = async (hookName: string, args: any, cb: Function) 
         req,
         toolbar,
         isReadOnly,
-        entrypoint: "../../"+fileNamePad
+        entrypoint: "../"+fileNamePad
       })
       res.send(content);
     });
@@ -356,7 +356,7 @@ exports.expressCreateServer = async (hookName: string, args: any, cb: Function) 
       res.send(eejs.require('ep_etherpad-lite/templates/timeslider.html', {
         req,
         toolbar,
-        entrypoint: "../../../"+fileNameTimeSlider
+        entrypoint: "../../"+fileNameTimeSlider
       }));
     });
   } else {


### PR DESCRIPTION
Fixes #6620 - Fixed relative path specifiers for template entrypoints.

The path prefixes have been modified for each page as follows:

- index(`/`) ... Modified to specify `. /` as the path prefix because the script appears to be in the same directory.
- pad(`/p/padname`) ... Modified to specify `../` as the path prefix because the script appears to be in the parent directory.
- history(`/p/padname/timeslider`) ... Modified to specify `../../` as the path prefix because the script appears to be in the parent's parent directory.