### PR TITLE
fix: Ensure ETHERPAD_PLUGINS ARG is recognized in all stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,10 @@ FROM build AS build_copy
 
 FROM build_${BUILD_ENV} AS development
 
+ARG ETHERPAD_PLUGINS=
+ARG ETHERPAD_LOCAL_PLUGINS=
+ARG ETHERPAD_GITHUB_PLUGINS=
+
 COPY --chown=etherpad:etherpad ./src/ ./src/
 COPY --chown=etherpad:etherpad --from=adminbuild /opt/etherpad-lite/src/ templates/admin./src/templates/admin
 COPY --chown=etherpad:etherpad --from=adminbuild /opt/etherpad-lite/src/static/oidc ./src/static/oidc
@@ -143,6 +147,10 @@ RUN bin/installDeps.sh && \
 
 
 FROM build_${BUILD_ENV} AS production
+
+ARG ETHERPAD_PLUGINS=
+ARG ETHERPAD_LOCAL_PLUGINS=
+ARG ETHERPAD_GITHUB_PLUGINS=
 
 ENV NODE_ENV=production
 ENV ETHERPAD_PRODUCTION=true


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
 - 
This pull request includes updates to the `Dockerfile` to introduce new build arguments for Etherpad plugins. These changes aim to enhance the flexibility and configurability of the Docker build process.

Enhancements to Docker build process:

* Added new build arguments `ETHERPAD_PLUGINS`, `ETHERPAD_LOCAL_PLUGINS`, and `ETHERPAD_GITHUB_PLUGINS` to the development stage.
* Added new build arguments `ETHERPAD_PLUGINS`, `ETHERPAD_LOCAL_PLUGINS`, and `ETHERPAD_GITHUB_PLUGINS` to the production stage.Declared ARG ETHERPAD_PLUGINS in build, development, and production stages to ensure it is recognized and used correctly throughout the build process.
- This resolves the issue of the ETHERPAD_PLUGINS argument appearing empty during the build process.