### PR TITLE
Fix installation of local plugins (fixes #6912)

### DIFF
--- a/bin/installLocalPlugins.sh
+++ b/bin/installLocalPlugins.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+trim() {
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var#"${var%%[![:space:]]*}"}"
+    # remove trailing whitespace characters
+    var="${var%"${var##*[![:space:]]}"}"
+    printf '%s' "$var"
+}
+
+# Move to the Etherpad base directory.
+MY_DIR=$(cd "${0%/*}" && pwd -P) || exit 1
+cd "${MY_DIR}/.." || exit 1
+
+# Source constants and useful functions
+. bin/functions.sh
+
+PNPM_OPTIONS=
+if [ ! -z "${NODE_ENV-}"  ]; then
+  if [ "$NODE_ENV" == 'production' ]; then
+    PNPM_OPTIONS='--prod'
+  fi
+fi
+
+if [ ! -z "${ETHERPAD_LOCAL_PLUGINS_ENV-}"  ]; then
+  if [ "$ETHERPAD_LOCAL_PLUGINS_ENV" == 'production' ]; then
+    PNPM_OPTIONS='--prod'
+  elif [ "$ETHERPAD_LOCAL_PLUGINS_ENV" == 'development' ]; then
+    PNPM_OPTIONS='-D'
+  fi
+fi
+
+if [ ! -z "${ETHERPAD_LOCAL_PLUGINS}" ]; then
+  readarray -d ' ' plugins <<< "${ETHERPAD_LOCAL_PLUGINS}"
+  for plugin in "${plugins[@]}"; do
+    plugin=$(trim "$plugin")
+    if [ -d "local_plugins/${plugin}" ]; then
+      echo "Installing plugin: '${plugin}'"
+      pnpm install -w ${PNPM_OPTIONS:-} "local_plugins/${plugin}/"
+    else
+      ( echo "Error. Directory 'local_plugins/${plugin}' for local plugin " \
+             "'${plugin}' missing" >&2 )
+      exit 1
+    fi
+  done
+else
+  echo 'No local plugings to install.'
+fi

--- a/local_plugins/.gitignore
+++ b/local_plugins/.gitignore
@@ -1,0 +1,3 @@
+# ignore everything
+*
+!.gitignore


### PR DESCRIPTION
The background for this pull request is contained in #6912.

This pull request does 3 things:
1. creates a directory `local_plugins` in the root repository, with a `.gitignore` file that ignores all of its contents.
2. creates a script `bin/installLocalPlugins.sh`.
3. modifies the `Dockerfile` to change the installation process of local plugins:
   * copies the contents of the `local_plugins` directory into the container (if the directory does not exist, it skips it).
   * defines a new build arg variable `ETHERPAD_LOCAL_PLUGINS_ENV`
   * install the local plugins with the script `bin/installLocalPlugins.sh` (which uses `pnpm install -w "local_plugins/${plugin}/"`)

(**note:** I am not sure that the `pnpm -w install` command is the best way to install a plugin, I am not an expert node user.)

To install a plugin locally put the it inside the `local_plugins` directory and pass the name of the directory `ETHERPAD_LOCAL_PLUGINS`, like this (full log: [build-pr-1.log](https://github.com/user-attachments/files/19411423/build-pr-1.log)):
```
docker build --no-cache --progress=plain --target production --build-arg ETHERPAD_LOCAL_PLUGINS="ep_disable_reset_authorship_colours" -t cristiancantoro/etherpad-lite:2.2-fix6912 .
```
(I am using the [`ep_disable_reset_authorship_colours`](https://github.com/ether/ep_disable_reset_authorship_colours) as an example)

When running the container with the following command:
```
docker run -it -p 9001:9001 -v ./copy:/tmp/copy -e ADMIN_PASSWORD=foo cristiancantoro/etherpad-lite:2.2-fix6912
```

The log shows the following line:
```
[2025-03-23T19:41:57.719] [INFO] server - Installed plugins: ep_disable_reset_authorship_colours@0.0.25
```
(full log: [run-pr-1.log](https://github.com/user-attachments/files/19411424/run-pr-1.log))