### PR TITLE
fix(frontend): add timesliderBootstrap to static resources

### DIFF
--- a/src/node/hooks/express/webaccess.ts
+++ b/src/node/hooks/express/webaccess.ts
@@ -51,6 +51,7 @@ exports.authnFailureDelayMs = 1000;
 
 const staticResources = [
   /^\/padbootstrap-[a-zA-Z0-9]+\.min\.js$/,
+  /^\/timeSliderBootstrap-[a-zA-Z0-9]+\.min\.js$/,
   /^\/manifest.json$/
 ]
 


### PR DESCRIPTION
Basically the same thing as I reported in https://github.com/ether/etherpad-lite/issues/6893, except it's the timeslider. Since it's not loaded when accessing a pad, I missed it in my initial report.

Also I'm not sure but looking at the `src/node/hook/express/specialpages.ts` maybe a entry should be added for indexBootstrap ? I wasn't able to find where it is used so that's why I didn't include it in this PR.