### PR TITLE
Do not respond to right alt (Alt Gr) keyboard events.

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2526,7 +2526,15 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const handleKeyEvent = (evt) => {
     if (!isEditable) return;
-    const {type, charCode, keyCode, which, altKey, shiftKey} = evt;
+    const {type, charCode, keyCode, which, shiftKey} = evt;
+
+    // If DOM3 support exists, ensure that the left ALT key was pressed. This
+    // allows keyboard layouts with special meaning for right-alt-char to
+    // continue working on Firefox / macOS.
+    let altKey = evt.altKey;
+    if (evt.originalEvent.location !== undefined) {
+        altKey = altKey && evt.originalEvent.location === evt.originalEvent.DOM_KEY_LOCATION_LEFT;
+    }
 
     // Don't take action based on modifier keys going up and down.
     // Modifier keys do not generate "keypress" events.


### PR DESCRIPTION
On some keyboard layouts (eg. pl) the right alt key (a.k.a. Alt Gr) is used in combination with letters to type special characters, eg. AltGr-C makes a 'ć' on a pl keyboard layout.

At least on Firefox on macOS it seems like events that would otherwise result in a special character still get passed to keydown and friends. This means that if etherpad handles alt-c, it might swallow someone's intent to type in 'ć' and instead open up the chat window.

This could arguably be a bug in Firefox or macOS, as the same doesn't happen in Firefox on Linux/X11. But before I bring the discussion to a wider audience I'd like to at least make the issue go away at etherpad level.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
