### PR TITLE
Fix interaction URL and diagnostics for subdirectory setup

### DIFF
--- a/src/node/hooks/express/apicalls.ts
+++ b/src/node/hooks/express/apicalls.ts
@@ -5,10 +5,13 @@ const clientLogger = log4js.getLogger('client');
 const {Formidable} = require('formidable');
 const apiHandler = require('../../handler/APIHandler');
 const util = require('util');
+const settings = require('ep_etherpad-lite/node/utils/Settings');
+
+const subdir = settings.subdirectory || '';
 
 exports.expressPreSession = async (hookName:string, {app}:any) => {
   // The Etherpad client side sends information about how a disconnect happened
-  app.post('/ep/pad/connection-diagnostic-info', async (req:any, res:any) => {
+  app.post(`${subdir}/ep/pad/connection-diagnostic-info`, async (req:any, res:any) => {
     const [fields, files] = await (new Formidable({})).parse(req);
     clientLogger.info(`DIAGNOSTIC-INFO: ${fields.diagnosticInfo}`);
     res.end('OK');
@@ -23,7 +26,7 @@ exports.expressPreSession = async (hookName:string, {app}:any) => {
   };
 
   // The Etherpad client side sends information about client side javscript errors
-  app.post('/jserror', (req:any, res:any, next:Function) => {
+  app.post(`${subdir}/jserror`, (req:any, res:any, next:Function) => {
     (async () => {
       const data = JSON.parse(await parseJserrorForm(req));
       clientLogger.warn(`${data.msg} --`, {
@@ -38,7 +41,7 @@ exports.expressPreSession = async (hookName:string, {app}:any) => {
   });
 
   // Provide a possibility to query the latest available API version
-  app.get('/api', (req:any, res:any) => {
+  app.get(`${subdir}/api`, (req:any, res:any) => {
     res.json({currentVersion: apiHandler.latestApiVersion});
   });
 };

--- a/ui/src/consent.ts
+++ b/ui/src/consent.ts
@@ -4,7 +4,8 @@ import "./style.css"
 const form = document.querySelector('form')!;
 const sessionId = new URLSearchParams(window.location.search).get('state');
 
-form.action = '/interaction/' + sessionId;
+const basePath = window.location.pathname.split('/interaction')[0];
+form.action = `${basePath}/interaction/${sessionId}`;
 
 /*form.addEventListener('submit', function (event) {
     event.preventDefault();

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -16,7 +16,8 @@ form.addEventListener('submit', function (event) {
     });
     const sessionId = new URLSearchParams(window.location.search).get('state');
 
-    fetch('/interaction/' + sessionId, {
+    const basePath = window.location.pathname.split('/interaction')[0];
+    fetch(`${basePath}/interaction/${sessionId}`, {    
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
What problem does this solve?

This fixes an issue where Etherpad's SSO interaction endpoint and diagnostic routes (e.g. `/ep/pad/connection-diagnostic-info`, `/jserror`, `/api`) fail to function when Etherpad is served from a subdirectory (like `/pad`).

Without this fix, form submissions and client-side error reporting do not reach the server when `settings.subdirectory` is set.

Current vs Desired Behavior

Current (broken):
  When deployed under a subdirectory, form submissions like `/pad/interaction/:sessionId` fail because the server expects the root path.

Desired (fixed):
  All client-side form actions and backend routes respect the `subdirectory` setting and continue working.


Screenshot / Visuals

Not applicable, routing logic fix.


- No breaking changes.
- Routes are conditionally prefixed using `settings.subdirectory || ''`.
- Frontend dynamically builds the form URL using `window.location.pathname`.

closes #4191
