### PR TITLE
After delete the user will now redirected to home page

### DIFF
--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -86,6 +86,8 @@ const padeditor = (() => {
       $('#delete-pad').on('click', () => {
         if (window.confirm(html10n.get('pad.delete.confirm'))) {
           pad.collabClient.sendMessage({type: 'PAD_DELETE', data:{padId: pad.getPadId()}});
+          // redirect to home page after deletion  
+          window.location.href = '/';
         }
       })
 


### PR DESCRIPTION
<!--

This is a small improvement on issue #6758  

Now the user does not get stuck after clicking on the delete pad; rather, they get redirected to the Home page.


-->
