### PR TITLE
Potential fix for code scanning alert no. 107: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Release etherpad
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ether/etherpad-lite/security/code-scanning/107](https://github.com/ether/etherpad-lite/security/code-scanning/107)

To fix the problem, explicitly set the `permissions` key in your GitHub Actions workflow. This can be placed at the workflow root (applies to all jobs), or at the job level if different jobs need different scopes (not the case here: there is only one job). The minimal permissions for most CI/CD jobs are `contents: read`, which blocks write and admin access by default but allows the workflow to read the repo contents. If the workflow requires more privileges (e.g., to create releases, push tags, comment on issues or PRs), then those should be added explicitly, but from the code provided it seems only read access is needed for GITHUB_TOKEN. All write operations seem to be using an external custom token.

Edit `.github/workflows/release.yml` to add a top-level `permissions:` block just beneath the workflow `name:` and above `on:` (for workflow-scope) or at the job level (beneath `releases:`). The workflow-scope is preferred for single-job workflows for clarity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
