### PR TITLE
fix "pnpm run plugins install ep_xxx"

### DIFF
--- a/bin/plugins.ts
+++ b/bin/plugins.ts
@@ -24,7 +24,7 @@ const possibleActions = [
 
 const install = ()=> {
   const argsAsString: string = args.join(" ");
-  const regexRegistryPlugins = /(?<=i\s)(.*?)(?=--github|--path|$)/;
+  const regexRegistryPlugins = /(?<=(?:i|install)\s)(.*?)(?=--github|--path|$)/;
   const regexLocalPlugins = /(?<=--path\s)(.*?)(?=--github|$)/;
   const regexGithubPlugins = /(?<=--github\s)(.*?)(?=--path|$)/;
   const registryPlugins = argsAsString.match(regexRegistryPlugins)?.[0]?.split(" ")?.filter(s => s) || [];


### PR DESCRIPTION
With previous code, "pnpm run plugins i ep_xxx" is working correctly, but "pnpm run plugins install ep_xxx" does not work correctly (since var `registryPlugins` is empty)

Either "pnpm run plugins install ep_xxx" should be disallowed (by removing `case "install"`) or this fix should be applied.
