### PR TITLE
Potential fix for code scanning alert no. 110: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releaseEtherpad.yaml.yml
+++ b/.github/workflows/releaseEtherpad.yaml.yml
@@ -1,4 +1,6 @@
 name: releaseEtherpad.yaml
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/ether/etherpad-lite/security/code-scanning/110](https://github.com/ether/etherpad-lite/security/code-scanning/110)

To fix the problem, you should explicitly set the `permissions` key that restricts the GitHub Actions token's access according to the principle of least privilege. Given the context, most steps like checkout, cache, setup, and install only require read access to repository contents. The publish step does not require modification of GitHub repository content, but it interacts with npm using a secret, so the permission for secrets is managed through the workflow but doesn’t require additional repository writes. Therefore, the lowest sufficient privilege for GitHub-related actions is `contents: read`. This should be set at the root (top-level) of the workflow so it applies to the entire workflow, ensuring no job will be granted more permission than necessary unless specifically overridden.

The explicit addition should be at the top, after the workflow name and before the `on:` block. No imports, definitions, or further code edits are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
