### PR TITLE
Fix german translation for pad.settings.poweredBy

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -98,7 +98,7 @@
 	"pad.settings.deletePad": "Pad löschen",
 	"pad.delete.confirm": "Möchtest du dieses Pad wirklich löschen?",
 	"pad.settings.about": "Über",
-	"pad.settings.poweredBy": "Betrieben von",
+	"pad.settings.poweredBy": "Betrieben mit",
 	"pad.importExport.import_export": "Import/Export",
 	"pad.importExport.import": "Textdatei oder Dokument hochladen",
 	"pad.importExport.importSuccessful": "Erfolgreich!",


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

Fixes the german translation for "Powered by": 
Current "Betrieben von" translates to "Operated by" or "Hosted by", which is misleading. 

"Betrieben mit" translates to "Being run with" / "Operated with", which is IMHO the closest to "Powered by".

Another option would be "Bereitgestellt von", which translates somewhere between "Provided by" and "Powered by" and is therefore more ambigious, as it could refer to either the software or the host. 