### PR TITLE
Rename token transfer cookies to Etherpad-specific names to avoid conflicts

### DIFF
--- a/src/node/hooks/express/tokenTransfer.ts
+++ b/src/node/hooks/express/tokenTransfer.ts
@@ -1,45 +1,51 @@
 import {ArgsExpressType} from "../../types/ArgsExpressType";
-const db = require('../../db/DB');
-import crypto from 'crypto'
-
+const db = require("../../db/DB");
+import crypto from "crypto";
 
 type TokenTransferRequest = {
   token: string;
-  prefsHttp: string,
+  prefsHttp: string;
   createdAt?: number;
-}
+};
 
 const tokenTransferKey = "tokenTransfer:";
 
-export const expressCreateServer =  (hookName:string, {app}:ArgsExpressType) => {
-  app.post('/tokenTransfer', async (req, res) => {
+export const expressCreateServer = (hookName: string, {app}: ArgsExpressType) => {
+  app.post("/tokenTransfer", async (req, res) => {
     const token = req.body as TokenTransferRequest;
     if (!token || !token.token) {
-      return res.status(400).send({error: 'Invalid request'});
+      return res.status(400).send({error: "Invalid request"});
     }
 
-    const id = crypto.randomUUID()
+    const id = crypto.randomUUID();
     token.createdAt = Date.now();
 
-    await db.set(`${tokenTransferKey}:${id}`, token)
+    await db.set(`${tokenTransferKey}:${id}`, token);
     res.send({id});
-  })
+  });
 
-  app.get('/tokenTransfer/:token', async (req, res) => {
+  app.get("/tokenTransfer/:token", async (req, res) => {
     const id = req.params.token;
     if (!id) {
-      return res.status(400).send({error: 'Invalid request'});
+      return res.status(400).send({error: "Invalid request"});
     }
 
     const tokenData = await db.get(`${tokenTransferKey}:${id}`);
     if (!tokenData) {
-      return res.status(404).send({error: 'Token not found'});
+      return res.status(404).send({error: "Token not found"});
     }
 
-    const token = await db.get(`${tokenTransferKey}:${id}`)
+    const token = await db.get(`${tokenTransferKey}:${id}`);
 
-    res.cookie('token', tokenData.token, {path: '/', maxAge: 1000*60*60*24*365});
-    res.cookie('prefsHttp', tokenData.prefsHttp, {path: '/', maxAge: 1000*60*60*24*365});
+    res.cookie("epToken", tokenData.token, {
+      path: "/",
+      maxAge: 1000 * 60 * 60 * 24 * 365,
+    });
+    res.cookie("epPrefsHttp", tokenData.prefsHttp, {
+      path: "/",
+      maxAge: 1000 * 60 * 60 * 24 * 365,
+    });
+
     res.send(token);
-  })
-}
+  });
+};


### PR DESCRIPTION
This change updates the cookies set by the /tokenTransfer/:token endpoint to use Etherpad‑specific names:

token → epToken

prefsHttp → epPrefsHttp

Using generic cookie names like token can easily collide with existing session or auth cookies used by apps that embed Etherpad under the same parent domain (for example, sessionID, token, etc.). Renaming these cookies to Etherpad‑specific names improves interoperability and avoids unexpected overwrites while keeping the current behavior intact.

Implementation details:

The persistence format in the database (tokenTransfer:<id>) and the response payload remain unchanged.

Cookie options (path: "/" and one‑year maxAge) are preserved so existing clients can migrate by simply reading the new cookie names.

The change is limited to the token transfer Express hook and does not modify any other cookies or session logic.