### PR TITLE
fix: ignore browser extension errors in Ace2Editor.init() and add screenreader accessibility

### DIFF
--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -29,7 +29,7 @@ const hooks = require('./pluginfw/hooks');
 const makeCSSManager = require('./cssmanager').makeCSSManager;
 const pluginUtils = require('./pluginfw/shared');
 const ace2_inner = require('ep_etherpad-lite/static/js/ace2_inner')
-const debugLog = (...args) => {};
+const debugLog = (...args) => { };
 const cl_plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins')
 const rJQuery = require('ep_etherpad-lite/static/js/rjquery')
 // The inner and outer iframe's locations are about:blank, so relative URLs are relative to that.
@@ -50,14 +50,19 @@ const eventFired = async (obj, event, cleanups = [], predicate = () => true) => 
       cleanup();
       resolve();
     };
-    const errorCb = () => {
+    const errorCb = (e) => {
+      // Ignore errors originating from browser extensions (e.g. BitWarden FIDO2).
+      // These are not Etherpad errors and should not block pad initialization. (Issue #6802)
+      const errorSource = (e instanceof ErrorEvent) ? (e.filename || '') : '';
+      if (/^(chrome|moz|safari)-extension:\/\//.test(errorSource)) return;
+      if (typeof obj?.src === 'string' && /^(chrome|moz|safari)-extension:\/\//.test(obj.src)) return;
       const err = new Error(`Ace2Editor.init() error event while waiting for ${event} event`);
       debugLog(`${err} on object`, obj);
       cleanup();
       reject(err);
     };
     cleanup = () => {
-      cleanup = () => {};
+      cleanup = () => { };
       obj.removeEventListener(event, successCb);
       obj.removeEventListener('error', errorCb);
     };
@@ -89,7 +94,7 @@ const frameReady = async (frame) => {
 };
 
 const Ace2Editor = function () {
-  let info = {editor: this};
+  let info = { editor: this };
   let loaded = false;
 
   let actionsPendingInit = [];
@@ -139,7 +144,7 @@ const Ace2Editor = function () {
   this.exportText = () => loaded ? info.ace_exportText() : '(awaiting init)\n';
 
   this.getInInternationalComposition =
-      () => loaded ? info.ace_getInInternationalComposition() : null;
+    () => loaded ? info.ace_getInInternationalComposition() : null;
 
   // prepareUserChangeset:
   // Returns null if no new changes or ACE not ready.  Otherwise, bundles up all user changes
@@ -175,8 +180,8 @@ const Ace2Editor = function () {
       `../static/css/iframe_editor.css?v=${clientVars.randomVersionString}`,
       `../static/css/pad.css?v=${clientVars.randomVersionString}`,
       ...hooks.callAll('aceEditorCSS').map(
-          // Allow urls to external CSS - http(s):// and //some/path.css
-          (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
+        // Allow urls to external CSS - http(s):// and //some/path.css
+        (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
       `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`,
     ];
 
@@ -185,7 +190,9 @@ const Ace2Editor = function () {
     const outerFrame = document.createElement('iframe');
     outerFrame.name = 'ace_outer';
     outerFrame.frameBorder = 0; // for IE
-    outerFrame.title = 'Ether';
+    outerFrame.title = 'Etherpad editor';
+    outerFrame.setAttribute('role', 'application');
+    outerFrame.setAttribute('aria-label', 'Etherpad editor');
     // Some browsers do strange things unless the iframe has a src or srcdoc property:
     //   - Firefox replaces the frame's contentWindow.document object with a different object after
     //     the frame is created. This can be worked around by waiting for the window's load event
@@ -224,6 +231,7 @@ const Ace2Editor = function () {
     const sideDiv = outerDocument.createElement('div');
     sideDiv.id = 'sidediv';
     sideDiv.classList.add('sidediv');
+    sideDiv.setAttribute('aria-hidden', 'true'); // Hide line numbers from screen readers (#7255)
     outerDocument.body.appendChild(sideDiv);
     const sideDivInner = outerDocument.createElement('div');
     sideDivInner.id = 'sidedivinner';
@@ -236,7 +244,9 @@ const Ace2Editor = function () {
 
     const innerFrame = outerDocument.createElement('iframe');
     innerFrame.name = 'ace_inner';
-    innerFrame.title = 'pad';
+    innerFrame.title = 'Pad content';
+    innerFrame.setAttribute('role', 'document');
+    innerFrame.setAttribute('aria-label', 'Pad content');
     innerFrame.scrolling = 'no';
     innerFrame.frameBorder = 0;
     innerFrame.allowTransparency = true; // for IE
@@ -262,7 +272,7 @@ const Ace2Editor = function () {
     //const requireKernel = innerDocument.createElement('script');
     //requireKernel.type = 'text/javascript';
     //requireKernel.src =
-     //   absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
+    //   absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
     //innerDocument.head.appendChild(requireKernel);
     // Pre-fetch modules to improve load performance.
     /*for (const module of ['ace2_inner', 'ace2_common']) {
@@ -277,24 +287,28 @@ const Ace2Editor = function () {
     innerStyle.title = 'dynamicsyntax';
     innerDocument.head.appendChild(innerStyle);
     const headLines = [];
-    hooks.callAll('aceInitInnerdocbodyHead', {iframeHTML: headLines});
+    hooks.callAll('aceInitInnerdocbodyHead', { iframeHTML: headLines });
     innerDocument.head.appendChild(
-        innerDocument.createRange().createContextualFragment(headLines.join('\n')));
+      innerDocument.createRange().createContextualFragment(headLines.join('\n')));
 
     // <body> tag
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
     innerDocument.body.setAttribute('spellcheck', 'false');
+    // Accessibility: mark the editor body as a multiline textbox for screen readers (#7255)
+    innerDocument.body.setAttribute('role', 'textbox');
+    innerDocument.body.setAttribute('aria-multiline', 'true');
+    innerDocument.body.setAttribute('aria-label', 'Pad content');
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
-/*
-    debugLog('Ace2Editor.init() waiting for require kernel load');
-    await eventFired(requireKernel, 'load');
-    debugLog('Ace2Editor.init() require kernel loaded');
-    const require = innerWindow.require;
-    require.setRootURI(absUrl('../javascripts/src'));
-    require.setLibraryURI(absUrl('../javascripts/lib'));
-    require.setGlobalKeyPath('require');
-*/
+    /*
+        debugLog('Ace2Editor.init() waiting for require kernel load');
+        await eventFired(requireKernel, 'load');
+        debugLog('Ace2Editor.init() require kernel loaded');
+        const require = innerWindow.require;
+        require.setRootURI(absUrl('../javascripts/src'));
+        require.setLibraryURI(absUrl('../javascripts/lib'));
+        require.setGlobalKeyPath('require');
+    */
     // intentially moved before requiring client_plugins to save a 307
     innerWindow.Ace2Inner = ace2_inner;
     innerWindow.plugins = cl_plugins;

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import {Builder} from "./Builder";
+import { Builder } from "./Builder";
 
 /**
  * Copyright 2009 Google Inc.
@@ -24,7 +24,7 @@ const browser = require('./vendors/browser');
 import padutils from './pad_utils'
 const Ace2Common = require('./ace2_common');
 const $ = require('./rjquery').$;
-import {characterRangeFollow, checkRep, cloneAText, compose, deserializeOps, filterAttribNumbers, inverse, isIdentity, makeAText, makeAttribution, mapAttribNumbers, moveOpsToNewPool, mutateAttributionLines, mutateTextLines, oldLen, opsFromAText, pack, splitAttributionLines} from './Changeset'
+import { characterRangeFollow, checkRep, cloneAText, compose, deserializeOps, filterAttribNumbers, inverse, isIdentity, makeAText, makeAttribution, mapAttribNumbers, moveOpsToNewPool, mutateAttributionLines, mutateTextLines, oldLen, opsFromAText, pack, splitAttributionLines } from './Changeset'
 
 
 const isNodeText = Ace2Common.isNodeText;
@@ -35,9 +35,9 @@ const hooks = require('./pluginfw/hooks');
 import SkipList from "./skiplist";
 import Scroll from './scroll'
 import AttribPool from './AttributePool'
-import {SmartOpAssembler} from "./SmartOpAssembler";
+import { SmartOpAssembler } from "./SmartOpAssembler";
 import Op from "./Op";
-import {buildKeepRange, buildKeepToStartOfRange, buildRemoveRange} from './ChangesetUtils'
+import { buildKeepRange, buildKeepToStartOfRange, buildRemoveRange } from './ChangesetUtils'
 
 function Ace2Inner(editorInfo, cssManagers) {
   const makeChangesetTracker = require('./changesettracker').makeChangesetTracker;
@@ -69,6 +69,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   const outerDoc = outerWin.contentWindow.document;
 
   const sideDiv = outerDoc.getElementById('sidediv');
+  sideDiv?.setAttribute('aria-hidden', 'true'); // Hide line numbers from screen readers (#7255)
   const lineMetricsDiv = outerDoc.getElementById('linemetricsdiv');
   const sideDivInner = outerDoc.getElementById('sidedivinner');
   const appendNewSideDivLine = () => {
@@ -193,19 +194,19 @@ function Ace2Inner(editorInfo, cssManagers) {
       inCallStackIfNecessary(operationName, () => {
         fastIncorp(1);
         f(
-            {
-              setDocumentAttributedText: (atext) => {
-                setDocAText(atext);
-              },
-              applyChangesetToDocument: (changeset, preferInsertionAfterCaret) => {
-                const oldEventType = currentCallStack.editEvent.eventType;
-                currentCallStack.startNewEvent('nonundoable');
+          {
+            setDocumentAttributedText: (atext) => {
+              setDocAText(atext);
+            },
+            applyChangesetToDocument: (changeset, preferInsertionAfterCaret) => {
+              const oldEventType = currentCallStack.editEvent.eventType;
+              currentCallStack.startNewEvent('nonundoable');
 
-                performDocumentApplyChangeset(changeset, preferInsertionAfterCaret);
+              performDocumentApplyChangeset(changeset, preferInsertionAfterCaret);
 
-                currentCallStack.startNewEvent(oldEventType);
-              },
-            });
+              currentCallStack.startNewEvent(oldEventType);
+            },
+          });
       });
     },
   });
@@ -240,7 +241,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         bgcolor = fadeColor(bgcolor, info.fade);
       }
       const textColor =
-          colorutils.textColorFromBackgroundColor(bgcolor, window.clientVars.skinName);
+        colorutils.textColorFromBackgroundColor(bgcolor, window.clientVars.skinName);
       const styles = [
         cssManagers.inner.selectorStyle(authorSelector),
         cssManagers.parent.selectorStyle(authorSelector),
@@ -541,11 +542,11 @@ function Ace2Inner(editorInfo, cssManagers) {
     for (const op of opsFromAText(atext)) assem.append(op);
     const newLen = oldLen + assem.getLengthChange();
     const changeset = checkRep(
-        pack(oldLen, newLen, assem.toString(), atext.text.slice(0, -1)));
+      pack(oldLen, newLen, assem.toString(), atext.text.slice(0, -1)));
     performDocumentApplyChangeset(changeset);
 
     performSelectionChange(
-        [0, rep.lines.atIndex(0).lineMarker], [0, rep.lines.atIndex(0).lineMarker]);
+      [0, rep.lines.atIndex(0).lineMarker], [0, rep.lines.atIndex(0).lineMarker]);
 
     idleWorkTimer.atMost(100);
 
@@ -852,7 +853,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       markNodeClean(lineEntry.lineNode);
 
       if (rep.selStart && rep.selStart[0] === lineIndex ||
-          rep.selEnd && rep.selEnd[0] === lineIndex) {
+        rep.selEnd && rep.selEnd[0] === lineIndex) {
         selectionNeedsResetting = true;
       }
 
@@ -880,14 +881,14 @@ function Ace2Inner(editorInfo, cssManagers) {
     if (text.length === 0) {
       // allow getLineStyleFilter to set line-div styles
       const func = linestylefilter.getLineStyleFilter(
-          0, '', textAndClassFunc, rep.apool);
+        0, '', textAndClassFunc, rep.apool);
       func('', '');
     } else {
       let filteredFunc = linestylefilter.getFilterStack(text, textAndClassFunc, browser);
       const lineNum = rep.lines.indexOfEntry(lineEntry);
       const aline = rep.alines[lineNum];
       filteredFunc = linestylefilter.getLineStyleFilter(
-          text.length, aline, filteredFunc, rep.apool);
+        text.length, aline, filteredFunc, rep.apool);
       filteredFunc(text, '');
     }
   };
@@ -923,7 +924,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       const prevSib = cleanNode.previousSibling;
       const nextSib = cleanNode.nextSibling;
       hasAdjacentDirtyness = ((prevSib && isNodeDirty(prevSib)) ||
-         (nextSib && isNodeDirty(nextSib)));
+        (nextSib && isNodeDirty(nextSib)));
     } else {
       // node is dirty, look for clean node above
       let upNode = node.previousSibling;
@@ -1023,7 +1024,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       a = dirtyRanges[j][0];
       b = dirtyRanges[j][1];
       if (!((a === 0 || getCleanNodeByKey(rep.lines.atIndex(a - 1).key)) &&
-          (b === rep.lines.length() || getCleanNodeByKey(rep.lines.atIndex(b).key)))) {
+        (b === rep.lines.length() || getCleanNodeByKey(rep.lines.atIndex(b).key)))) {
         dirtyRangesCheckOut = false;
         break;
       }
@@ -1053,11 +1054,11 @@ function Ace2Inner(editorInfo, cssManagers) {
       a = range[0];
       b = range[1];
       let firstDirtyNode = (((a === 0) && targetBody.firstChild) ||
-          getCleanNodeByKey(rep.lines.atIndex(a - 1).key).nextSibling);
+        getCleanNodeByKey(rep.lines.atIndex(a - 1).key).nextSibling);
       firstDirtyNode = (firstDirtyNode && isNodeDirty(firstDirtyNode) && firstDirtyNode);
 
       let lastDirtyNode = (((b === rep.lines.length()) && targetBody.lastChild) ||
-          getCleanNodeByKey(rep.lines.atIndex(b).key).previousSibling);
+        getCleanNodeByKey(rep.lines.atIndex(b).key).previousSibling);
 
       lastDirtyNode = (lastDirtyNode && isNodeDirty(lastDirtyNode) && lastDirtyNode);
       if (firstDirtyNode && lastDirtyNode) {
@@ -1065,7 +1066,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         cc.notifySelection(selection);
         const dirtyNodes = [];
         for (let n = firstDirtyNode; n &&
-            !(n.previousSibling && n.previousSibling === lastDirtyNode);
+          !(n.previousSibling && n.previousSibling === lastDirtyNode);
           n = n.nextSibling) {
           cc.collectContent(n);
           dirtyNodes.push(n);
@@ -1160,7 +1161,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         documentAttributeManager,
       });
       selEnd = (selEndFromHook == null ||
-         selEndFromHook.length === 0)
+        selEndFromHook.length === 0)
         ? getLineAndCharForPoint(selection.endPoint) : selEndFromHook;
     }
 
@@ -1207,7 +1208,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   const isStyleAttribute = (aname) => !!STYLE_ATTRIBS[aname];
 
   const isDefaultLineAttribute =
-      (aname) => AttributeManager.DEFAULT_LINE_ATTRIBUTES.indexOf(aname) !== -1;
+    (aname) => AttributeManager.DEFAULT_LINE_ATTRIBUTES.indexOf(aname) !== -1;
 
   const insertDomLines = (nodeToAddAfter, infoStructs) => {
     let lastEntry;
@@ -1246,7 +1247,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
 
   const isCaret = () => (rep.selStart && rep.selEnd &&
-                         rep.selStart[0] === rep.selEnd[0] && rep.selStart[1] === rep.selEnd[1]);
+    rep.selStart[0] === rep.selEnd[0] && rep.selStart[1] === rep.selEnd[1]);
   editorInfo.ace_isCaret = isCaret;
 
   // prereq: isCaret()
@@ -1275,10 +1276,10 @@ function Ace2Inner(editorInfo, cssManagers) {
         theIndent += THE_TAB;
       }
       const cs = new Builder(rep.lines.totalWidth()).keep(
-          rep.lines.offsetOfIndex(lineNum), lineNum).insert(
+        rep.lines.offsetOfIndex(lineNum), lineNum).insert(
           theIndent, [
-            ['author', thisAuthor],
-          ], rep.apool).toString();
+          ['author', thisAuthor],
+        ], rep.apool).toString();
       performDocumentApplyChangeset(cs);
       performSelectionChange([lineNum, theIndent.length], [lineNum, theIndent.length]);
     }
@@ -1414,7 +1415,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         (rep.selStart &&
           rep.selStart[0] >= startLine &&
           rep.selStart[0] <= startLine + deleteCount) ||
-         (rep.selEnd && rep.selEnd[0] >= startLine && rep.selEnd[0] <= startLine + deleteCount)) {
+        (rep.selEnd && rep.selEnd[0] >= startLine && rep.selEnd[0] <= startLine + deleteCount)) {
         currentCallStack.selectionAffected = true;
       }
     };
@@ -1426,7 +1427,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       const selStartChar = rep.lines.offsetOfIndex(rep.selStart[0]) + rep.selStart[1];
       const selEndChar = rep.lines.offsetOfIndex(rep.selEnd[0]) + rep.selEnd[1];
       const result =
-          characterRangeFollow(changes, selStartChar, selEndChar, insertsAfterSelection);
+        characterRangeFollow(changes, selStartChar, selEndChar, insertsAfterSelection);
       requiredSelectionSetting = [result[0], result[1], rep.selFocusAtStart];
     }
 
@@ -1442,9 +1443,9 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     if (requiredSelectionSetting) {
       performSelectionChange(
-          lineAndColumnFromChar(requiredSelectionSetting[0]),
-          lineAndColumnFromChar(requiredSelectionSetting[1]),
-          requiredSelectionSetting[2]);
+        lineAndColumnFromChar(requiredSelectionSetting[0]),
+        lineAndColumnFromChar(requiredSelectionSetting[1]),
+        requiredSelectionSetting[2]);
     }
   };
 
@@ -1518,17 +1519,17 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     }
     performDocumentReplaceRange(
-        lineAndColumnFromChar(startChar), lineAndColumnFromChar(endChar), newText);
+      lineAndColumnFromChar(startChar), lineAndColumnFromChar(endChar), newText);
   };
 
   const performDocumentApplyAttributesToCharRange = (start, end, attribs) => {
     end = Math.min(end, rep.alltext.length - 1);
     documentAttributeManager.setAttributesOnRange(
-        lineAndColumnFromChar(start), lineAndColumnFromChar(end), attribs);
+      lineAndColumnFromChar(start), lineAndColumnFromChar(end), attribs);
   };
 
   editorInfo.ace_performDocumentApplyAttributesToCharRange =
-      performDocumentApplyAttributesToCharRange;
+    performDocumentApplyAttributesToCharRange;
 
   const setAttributeOnSelection = (attributeName, attributeValue) => {
     if (!(rep.selStart && rep.selEnd)) return;
@@ -1564,7 +1565,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
         // from selStart to the end of the first line
         hasAttrib = hasAttrib &&
-            rangeHasAttrib(selStart, [selStart[0], rep.lines.atIndex(selStart[0]).text.length]);
+          rangeHasAttrib(selStart, [selStart[0], rep.lines.atIndex(selStart[0]).text.length]);
 
         // for all lines in between
         for (let n = selStart[0] + 1; n < selEnd[0]; n++) {
@@ -1650,7 +1651,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
     const attributeValue = selectionAllHasIt ? '' : 'true';
     documentAttributeManager.setAttributesOnRange(
-        rep.selStart, rep.selEnd, [[attributeName, attributeValue]]);
+      rep.selStart, rep.selEnd, [[attributeName, attributeValue]]);
     if (attribIsFormattingStyle(attributeName)) {
       updateStyleButtonState(attributeName, !selectionAllHasIt); // italic, bold, ...
     }
@@ -1676,7 +1677,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const newText = newLineEntries.map((e) => `${e.text}\n`).join('');
 
     rep.alltext = rep.alltext.substring(0, startOldChar) +
-       newText + rep.alltext.substring(endOldChar, rep.alltext.length);
+      newText + rep.alltext.substring(endOldChar, rep.alltext.length);
   };
 
   const doIncorpLineSplice = (startLine, deleteCount, newLineEntries, lineAttribs, hints) => {
@@ -1688,7 +1689,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     let selStartHintChar, selEndHintChar;
     if (hints && hints.selStart) {
       selStartHintChar =
-          rep.lines.offsetOfIndex(hints.selStart[0]) + hints.selStart[1] - oldRegionStart;
+        rep.lines.offsetOfIndex(hints.selStart[0]) + hints.selStart[1] - oldRegionStart;
     }
     if (hints && hints.selEnd) {
       selEndHintChar = rep.lines.offsetOfIndex(hints.selEnd[0]) + hints.selEnd[1] - oldRegionStart;
@@ -1699,7 +1700,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const oldAttribs = rep.alines.slice(startLine, startLine + deleteCount).join('');
     const newAttribs = `${lineAttribs.join('|1+1')}|1+1`; // not valid in a changeset
     const analysis =
-        analyzeChange(oldText, newText, oldAttribs, newAttribs, selStartHintChar, selEndHintChar);
+      analyzeChange(oldText, newText, oldAttribs, newAttribs, selStartHintChar, selEndHintChar);
     const commonStart = analysis[0];
     let commonEnd = analysis[1];
     let shortOldText = oldText.substring(commonStart, oldText.length - commonEnd);
@@ -1711,7 +1712,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     // adjust the splice to not involve the final newline of the document;
     // be very defensive
     if (shortOldText.charAt(shortOldText.length - 1) === '\n' &&
-        shortNewText.charAt(shortNewText.length - 1) === '\n') {
+      shortNewText.charAt(shortNewText.length - 1) === '\n') {
       // replacing text that ends in newline with text that also ends in newline
       // (still, after analysis, somehow)
       shortOldText = shortOldText.slice(0, -1);
@@ -1720,8 +1721,8 @@ function Ace2Inner(editorInfo, cssManagers) {
       commonEnd++;
     }
     if (shortOldText.length === 0 &&
-        spliceStart === rep.alltext.length &&
-        shortNewText.length > 0) {
+      spliceStart === rep.alltext.length &&
+      shortNewText.length > 0) {
       // inserting after final newline, bad
       spliceStart--;
       spliceEnd--;
@@ -1776,13 +1777,13 @@ function Ace2Inner(editorInfo, cssManagers) {
         // changeset the applies the styles found in the DOM.
         // This allows us to incorporate, e.g., Safari's native "unbold".
         const incorpedAttribClearer = cachedStrFunc(
-            (oldAtts) => mapAttribNumbers(oldAtts, (n) => {
-              const k = rep.apool.getAttribKey(n);
-              if (isStyleAttribute(k)) {
-                return rep.apool.putAttrib([k, '']);
-              }
-              return false;
-            }));
+          (oldAtts) => mapAttribNumbers(oldAtts, (n) => {
+            const k = rep.apool.getAttribKey(n);
+            if (isStyleAttribute(k)) {
+              return rep.apool.putAttrib([k, '']);
+            }
+            return false;
+          }));
 
         const builder1 = startBuilder();
         if (shiftFinalNewlineToBeforeNewText) {
@@ -1909,7 +1910,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     const newStartIter = attribIterator(newARuns, false);
     while (commonStart < minLen) {
       if (oldText.charAt(commonStart) === newText.charAt(commonStart) &&
-      oldStartIter() === newStartIter()) {
+        oldStartIter() === newStartIter()) {
         commonStart++;
       } else { break; }
     }
@@ -1925,7 +1926,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         commonEnd++;
       } else if (
         oldText.charAt(oldLen - 1 - commonEnd) === newText.charAt(newLen - 1 - commonEnd) &&
-          oldEndIter() === newEndIter()) {
+        oldEndIter() === newEndIter()) {
         commonEnd++;
       } else { break; }
     }
@@ -1983,13 +1984,13 @@ function Ace2Inner(editorInfo, cssManagers) {
     focusAtStart = !!focusAtStart;
 
     const newSelFocusAtStart = (focusAtStart && ((!selectStart) ||
-        (!selectEnd) ||
-        (selectStart[0] !== selectEnd[0]) ||
-        (selectStart[1] !== selectEnd[1])));
+      (!selectEnd) ||
+      (selectStart[0] !== selectEnd[0]) ||
+      (selectStart[1] !== selectEnd[1])));
 
     if ((!equalLineAndChars(rep.selStart, selectStart)) ||
-        (!equalLineAndChars(rep.selEnd, selectEnd)) ||
-        (rep.selFocusAtStart !== newSelFocusAtStart)) {
+      (!equalLineAndChars(rep.selEnd, selectEnd)) ||
+      (rep.selFocusAtStart !== newSelFocusAtStart)) {
       rep.selStart = selectStart;
       rep.selEnd = selectEnd;
       rep.selFocusAtStart = newSelFocusAtStart;
@@ -2009,10 +2010,10 @@ function Ace2Inner(editorInfo, cssManagers) {
       const docTextChanged = currentCallStack.docTextChanged;
       if (!docTextChanged) {
         const isScrollableEvent = !isPadLoading(currentCallStack.type) &&
-            isScrollableEditEvent(currentCallStack.type);
+          isScrollableEditEvent(currentCallStack.type);
         const innerHeight = getInnerHeight();
         scroll.scrollWhenCaretIsInTheLastLineOfViewportWhenNecessary(
-            rep, isScrollableEvent, innerHeight * 2);
+          rep, isScrollableEvent, innerHeight * 2);
       }
 
       return true;
@@ -2032,16 +2033,16 @@ function Ace2Inner(editorInfo, cssManagers) {
   const selectFormattingButtonIfLineHasStyleApplied = (rep) => {
     for (const style of FORMATTING_STYLES) {
       const hasStyleOnRepSelection =
-          documentAttributeManager.hasAttributeOnSelectionOrCaretPosition(style);
+        documentAttributeManager.hasAttributeOnSelectionOrCaretPosition(style);
       updateStyleButtonState(style, hasStyleOnRepSelection);
     }
   };
 
   const doCreateDomLine =
-      (nonEmpty) => domline.createDomLine(nonEmpty, doesWrap, browser, document);
+    (nonEmpty) => domline.createDomLine(nonEmpty, doesWrap, browser, document);
 
   const textify =
-      (str) => str.replace(/[\n\r ]/g, ' ').replace(/\xa0/g, ' ').replace(/\t/g, '        ');
+    (str) => str.replace(/[\n\r ]/g, ' ').replace(/\xa0/g, ' ').replace(/\t/g, '        ');
 
   const _blockElems = {
     div: 1,
@@ -2236,7 +2237,7 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const markNodeClean = (n) => {
     // clean nodes have knownHTML that matches their innerHTML
-    setAssoc(n, 'dirtiness', {nodeId: uniqueId(n), knownHTML: n.innerHTML});
+    setAssoc(n, 'dirtiness', { nodeId: uniqueId(n), knownHTML: n.innerHTML });
   };
 
   const isNodeDirty = (n) => {
@@ -2394,10 +2395,10 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const doIndentOutdent = (isOut) => {
     if (!((rep.selStart && rep.selEnd) ||
-          (rep.selStart[0] === rep.selEnd[0] &&
-           rep.selStart[1] === rep.selEnd[1] &&
-           rep.selEnd[1] > 1)) &&
-        isOut !== true) {
+      (rep.selStart[0] === rep.selEnd[0] &&
+        rep.selStart[1] === rep.selEnd[1] &&
+        rep.selEnd[1] > 1)) &&
+      isOut !== true) {
       return false;
     }
 
@@ -2464,7 +2465,7 @@ function Ace2Inner(editorInfo, cssManagers) {
             const thisLineListType = getLineListType(theLine);
             const prevLineEntry = (theLine > 0 && rep.lines.atIndex(theLine - 1));
             const prevLineBlank = (prevLineEntry &&
-                prevLineEntry.text.length === prevLineEntry.lineMarker);
+              prevLineEntry.text.length === prevLineEntry.lineMarker);
 
             const thisLineHasMarker = documentAttributeManager.lineHasMarker(theLine);
 
@@ -2473,7 +2474,7 @@ function Ace2Inner(editorInfo, cssManagers) {
               if (prevLineBlank && !prevLineListType) {
                 // previous line is blank, remove it
                 performDocumentReplaceRange(
-                    [theLine - 1, prevLineEntry.text.length], [theLine, 0], '');
+                  [theLine - 1, prevLineEntry.text.length], [theLine, 0], '');
               } else {
                 // delistify
                 performDocumentReplaceRange([theLine, 0], [theLine, lineEntry.lineMarker], '');
@@ -2481,11 +2482,11 @@ function Ace2Inner(editorInfo, cssManagers) {
             } else if (thisLineHasMarker && prevLineEntry) {
               // If the line has any attributes assigned, remove them by removing the marker '*'
               performDocumentReplaceRange(
-                  [theLine - 1, prevLineEntry.text.length], [theLine, lineEntry.lineMarker], '');
+                [theLine - 1, prevLineEntry.text.length], [theLine, lineEntry.lineMarker], '');
             } else if (theLine > 0) {
               // remove newline
               performDocumentReplaceRange(
-                  [theLine - 1, prevLineEntry.text.length], [theLine, 0], '');
+                [theLine - 1, prevLineEntry.text.length], [theLine, 0], '');
             }
           } else {
             const docChar = caretDocChar();
@@ -2526,14 +2527,14 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   const handleKeyEvent = (evt) => {
     if (!isEditable) return;
-    const {type, charCode, keyCode, which, shiftKey} = evt;
+    const { type, charCode, keyCode, which, shiftKey } = evt;
 
     // If DOM3 support exists, ensure that the left ALT key was pressed. This
     // allows keyboard layouts with special meaning for right-alt-char to
     // continue working on Firefox / macOS.
     let altKey = evt.altKey;
     if (evt.originalEvent.location !== undefined) {
-        altKey = altKey && evt.originalEvent.location === evt.originalEvent.DOM_KEY_LOCATION_LEFT;
+      altKey = altKey && evt.originalEvent.location === evt.originalEvent.DOM_KEY_LOCATION_LEFT;
     }
 
     // Don't take action based on modifier keys going up and down.
@@ -2542,8 +2543,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     // 91 is the Windows key in IE; it is ASCII for open-bracket but isn't the keycode for that key
     // 20 is capslock in IE.
     const isModKey = !charCode && (type === 'keyup' || type === 'keydown') &&
-        (keyCode === 16 || keyCode === 17 || keyCode === 18 ||
-         keyCode === 20 || keyCode === 224 || keyCode === 91);
+      (keyCode === 16 || keyCode === 17 || keyCode === 18 ||
+        keyCode === 20 || keyCode === 224 || keyCode === 91);
     if (isModKey) return;
 
     // If the key is a keypress and the browser is opera and the key is enter,
@@ -2592,23 +2593,23 @@ function Ace2Inner(editorInfo, cssManagers) {
 
         const padShortcutEnabled = window.clientVars.padShortcutEnabled;
         if (!specialHandled && isTypeForSpecialKey &&
-            altKey && keyCode === 120 &&
-            padShortcutEnabled.altF9) {
+          altKey && keyCode === 120 &&
+          padShortcutEnabled.altF9) {
           // Alt F9 focuses on the File Menu and/or editbar.
           // Note that while most editors use Alt F10 this is not desirable
           // As ubuntu cannot use Alt F10....
           // Focus on the editbar.
           // -- TODO: Move Focus back to previous state (we know it so we can use it)
           const firstEditbarElement = window.$('#editbar')
-              .children('ul').first().children().first()
-              .children().first().children().first();
+            .children('ul').first().children().first()
+            .children().first().children().first();
           $(this).trigger('blur');
           firstEditbarElement.trigger('focus');
           evt.preventDefault();
         }
         if (!specialHandled && type === 'keydown' &&
-            altKey && keyCode === 67 &&
-            padShortcutEnabled.altC) {
+          altKey && keyCode === 67 &&
+          padShortcutEnabled.altC) {
           // Alt c focuses on the Chat window
           $(this).trigger('blur');
           window.chat.show();
@@ -2616,8 +2617,8 @@ function Ace2Inner(editorInfo, cssManagers) {
           evt.preventDefault();
         }
         if (!specialHandled && type === 'keydown' &&
-            evt.ctrlKey && shiftKey && keyCode === 50 &&
-            padShortcutEnabled.cmdShift2) {
+          evt.ctrlKey && shiftKey && keyCode === 50 &&
+          padShortcutEnabled.cmdShift2) {
           // Control-Shift-2 shows a gritter popup showing a line author
           const lineNumber = rep.selEnd[0];
           const alineAttrs = rep.alines[lineNumber];
@@ -2637,21 +2638,21 @@ function Ace2Inner(editorInfo, cssManagers) {
           const idToName = new Map(window.pad.userList().map((a) => [a.userId, a.name]));
           const myId = window.clientVars.userId;
           const authors =
-              [...authorIds].map((id) => id === myId ? 'me' : idToName.get(id) || 'unknown');
+            [...authorIds].map((id) => id === myId ? 'me' : idToName.get(id) || 'unknown');
 
           window.$.gritter.add({
             title: 'Line Authors',
             text:
-                authors.length === 0 ? 'No author information is available'
+              authors.length === 0 ? 'No author information is available'
                 : authors.length === 1 ? `The author of this line is ${authors[0]}`
-                : `The authors of this line are ${authors.join(' & ')}`,
+                  : `The authors of this line are ${authors.join(' & ')}`,
             sticky: false,
             time: '4000',
           });
         }
         if (!specialHandled && isTypeForSpecialKey &&
-            keyCode === 8 &&
-            padShortcutEnabled.delete) {
+          keyCode === 8 &&
+          padShortcutEnabled.delete) {
           // "delete" key; in mozilla, if we're at the beginning of a line, normalize now,
           // or else deleting a blank line can take two delete presses.
           // --
@@ -2665,8 +2666,8 @@ function Ace2Inner(editorInfo, cssManagers) {
           specialHandled = true;
         }
         if (!specialHandled && isTypeForSpecialKey &&
-            keyCode === 13 &&
-            padShortcutEnabled.return) {
+          keyCode === 13 &&
+          padShortcutEnabled.return) {
           // return key, handle specially;
           // note that in mozilla we need to do an incorporation for proper return behavior anyway.
           fastIncorp(4);
@@ -2678,8 +2679,8 @@ function Ace2Inner(editorInfo, cssManagers) {
           specialHandled = true;
         }
         if (!specialHandled && isTypeForSpecialKey &&
-            keyCode === 27 &&
-            padShortcutEnabled.esc) {
+          keyCode === 27 &&
+          padShortcutEnabled.esc) {
           // prevent esc key;
           // in mozilla versions 14-19 avoid reconnecting pad.
 
@@ -2691,35 +2692,35 @@ function Ace2Inner(editorInfo, cssManagers) {
           window.$.gritter.removeAll();
         }
         if (!specialHandled && isTypeForCmdKey &&
-            /* Do a saved revision on ctrl S */
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 's' &&
-            !evt.altKey &&
-            padShortcutEnabled.cmdS) {
+          /* Do a saved revision on ctrl S */
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 's' &&
+          !evt.altKey &&
+          padShortcutEnabled.cmdS) {
           evt.preventDefault();
           const originalBackground = window.$('#revisionlink').css('background');
-          window.$('#revisionlink').css({background: 'lightyellow'});
+          window.$('#revisionlink').css({ background: 'lightyellow' });
           scheduler.setTimeout(() => {
-            window.$('#revisionlink').css({background: originalBackground});
+            window.$('#revisionlink').css({ background: originalBackground });
           }, 1000);
 
-          window.pad.collabClient.sendMessage({type: 'SAVE_REVISION'});
+          window.pad.collabClient.sendMessage({ type: 'SAVE_REVISION' });
           specialHandled = true;
         }
         if (!specialHandled && isTypeForSpecialKey &&
-            // tab
-            keyCode === 9 &&
-            !(evt.metaKey || evt.ctrlKey) &&
-            padShortcutEnabled.tab) {
+          // tab
+          keyCode === 9 &&
+          !(evt.metaKey || evt.ctrlKey) &&
+          padShortcutEnabled.tab) {
           fastIncorp(5);
           evt.preventDefault();
           doTabKey(evt.shiftKey);
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-Z (undo)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'z' &&
-            !evt.altKey &&
-            padShortcutEnabled.cmdZ) {
+          // cmd-Z (undo)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'z' &&
+          !evt.altKey &&
+          padShortcutEnabled.cmdZ) {
           fastIncorp(6);
           evt.preventDefault();
           if (evt.shiftKey) {
@@ -2730,92 +2731,92 @@ function Ace2Inner(editorInfo, cssManagers) {
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-Y (redo)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'y' &&
-            padShortcutEnabled.cmdY) {
+          // cmd-Y (redo)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'y' &&
+          padShortcutEnabled.cmdY) {
           fastIncorp(10);
           evt.preventDefault();
           doUndoRedo('redo');
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-B (bold)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'b' &&
-            padShortcutEnabled.cmdB) {
+          // cmd-B (bold)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'b' &&
+          padShortcutEnabled.cmdB) {
           fastIncorp(13);
           evt.preventDefault();
           toggleAttributeOnSelection('bold');
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-I (italic)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'i' &&
-            padShortcutEnabled.cmdI) {
+          // cmd-I (italic)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'i' &&
+          padShortcutEnabled.cmdI) {
           fastIncorp(14);
           evt.preventDefault();
           toggleAttributeOnSelection('italic');
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-U (underline)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'u' &&
-            padShortcutEnabled.cmdU) {
+          // cmd-U (underline)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'u' &&
+          padShortcutEnabled.cmdU) {
           fastIncorp(15);
           evt.preventDefault();
           toggleAttributeOnSelection('underline');
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-5 (strikethrough)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === '5' &&
-            evt.altKey !== true &&
-            padShortcutEnabled.cmd5) {
+          // cmd-5 (strikethrough)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === '5' &&
+          evt.altKey !== true &&
+          padShortcutEnabled.cmd5) {
           fastIncorp(13);
           evt.preventDefault();
           toggleAttributeOnSelection('strikethrough');
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-shift-L (unorderedlist)
-            (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'l' &&
-            evt.shiftKey &&
-            padShortcutEnabled.cmdShiftL) {
+          // cmd-shift-L (unorderedlist)
+          (evt.metaKey || evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'l' &&
+          evt.shiftKey &&
+          padShortcutEnabled.cmdShiftL) {
           fastIncorp(9);
           evt.preventDefault();
           doInsertUnorderedList();
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-shift-N and cmd-shift-1 (orderedlist)
-            (evt.metaKey || evt.ctrlKey) && evt.shiftKey &&
-            ((String.fromCharCode(which).toLowerCase() === 'n' && padShortcutEnabled.cmdShiftN) ||
-             (String.fromCharCode(which) === '1' && padShortcutEnabled.cmdShift1))) {
+          // cmd-shift-N and cmd-shift-1 (orderedlist)
+          (evt.metaKey || evt.ctrlKey) && evt.shiftKey &&
+          ((String.fromCharCode(which).toLowerCase() === 'n' && padShortcutEnabled.cmdShiftN) ||
+            (String.fromCharCode(which) === '1' && padShortcutEnabled.cmdShift1))) {
           fastIncorp(9);
           evt.preventDefault();
           doInsertOrderedList();
           specialHandled = true;
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-shift-C (clearauthorship)
-            (evt.metaKey || evt.ctrlKey) && evt.shiftKey &&
-            String.fromCharCode(which).toLowerCase() === 'c' &&
-            padShortcutEnabled.cmdShiftC) {
+          // cmd-shift-C (clearauthorship)
+          (evt.metaKey || evt.ctrlKey) && evt.shiftKey &&
+          String.fromCharCode(which).toLowerCase() === 'c' &&
+          padShortcutEnabled.cmdShiftC) {
           fastIncorp(9);
           evt.preventDefault();
           CMDS.clearauthorship();
         }
         if (!specialHandled && isTypeForCmdKey &&
-            // cmd-H (backspace)
-            (evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'h' &&
-            padShortcutEnabled.cmdH) {
+          // cmd-H (backspace)
+          (evt.ctrlKey) && String.fromCharCode(which).toLowerCase() === 'h' &&
+          padShortcutEnabled.cmdH) {
           fastIncorp(20);
           evt.preventDefault();
           doDeleteKey();
           specialHandled = true;
         }
         if (evt.ctrlKey === true && evt.which === 36 &&
-            // Control Home send to Y = 0
-            padShortcutEnabled.ctrlHome) {
+          // Control Home send to Y = 0
+          padShortcutEnabled.ctrlHome) {
           scroll.setScrollY(0);
         }
         if ((evt.which === 33 || evt.which === 34) && type === 'keydown' && !evt.ctrlKey) {
@@ -2875,7 +2876,7 @@ function Ace2Inner(editorInfo, cssManagers) {
             const myselection = targetDoc.getSelection();
             // get the carets selection offset in px IE 214
             let caretOffsetTop = myselection.focusNode.parentNode.offsetTop ||
-                myselection.focusNode.offsetTop;
+              myselection.focusNode.offsetTop;
 
             // sometimes the first selection is -1 which causes problems
             // (Especially with ep_page_view)
@@ -2904,11 +2905,11 @@ function Ace2Inner(editorInfo, cssManagers) {
 
       // Is part of multi-keystroke international character on Firefox Mac
       const isFirefoxHalfCharacter =
-          (browser.firefox && evt.altKey && charCode === 0 && keyCode === 0);
+        (browser.firefox && evt.altKey && charCode === 0 && keyCode === 0);
 
       // Is part of multi-keystroke international character on Safari Mac
       const isSafariHalfCharacter =
-          (browser.safari && evt.altKey && keyCode === 229);
+        (browser.safari && evt.altKey && keyCode === 229);
 
       if (thisKeyDoesntTriggerNormalize || isFirefoxHalfCharacter || isSafariHalfCharacter) {
         idleWorkTimer.atLeast(3000); // give user time to type
@@ -2917,7 +2918,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
 
       if (!specialHandled && !thisKeyDoesntTriggerNormalize && !inInternationalComposition &&
-          type !== 'keyup') {
+        type !== 'keyup') {
         observeChangesAroundSelection();
       }
 
@@ -2944,9 +2945,9 @@ function Ace2Inner(editorInfo, cssManagers) {
           }
           if (selectionInfo) {
             performSelectionChange(
-                lineAndColumnFromChar(selectionInfo.selStart),
-                lineAndColumnFromChar(selectionInfo.selEnd),
-                selectionInfo.selFocusAtStart);
+              lineAndColumnFromChar(selectionInfo.selStart),
+              lineAndColumnFromChar(selectionInfo.selEnd),
+              selectionInfo.selFocusAtStart);
           }
           const oldEvent = currentCallStack.startNewEvent(oldEventType, true);
           return oldEvent;
@@ -2990,9 +2991,9 @@ function Ace2Inner(editorInfo, cssManagers) {
             n = n.parentNode;
           }
           if (n.nextSibling &&
-              !(typeof n.nextSibling.tagName === 'string' &&
-                n.nextSibling.tagName.toLowerCase() === 'br') &&
-              n !== p.node && n !== targetBody && n.parentNode !== targetBody) {
+            !(typeof n.nextSibling.tagName === 'string' &&
+              n.nextSibling.tagName.toLowerCase() === 'br') &&
+            n !== p.node && n !== targetBody && n.parentNode !== targetBody) {
             // found a parent, go to next node and dive in
             p.node = n.nextSibling;
             p.maxIndex = nodeMaxIndex(p.node);
@@ -3024,12 +3025,12 @@ function Ace2Inner(editorInfo, cssManagers) {
       browserSelection.removeAllRanges();
       if (selection) {
         isCollapsed = (selection.startPoint.node === selection.endPoint.node &&
-                       selection.startPoint.index === selection.endPoint.index);
+          selection.startPoint.index === selection.endPoint.index);
         const start = pointToRangeBound(selection.startPoint);
         const end = pointToRangeBound(selection.endPoint);
 
         if (!isCollapsed && selection.focusAtStart &&
-            browserSelection.collapse && browserSelection.extend) {
+          browserSelection.collapse && browserSelection.extend) {
           // can handle "backwards"-oriented selection, shift-arrow-keys move start
           // of selection
           browserSelection.collapse(end.container, end.offset);
@@ -3096,7 +3097,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     // index is between 0 and maxIndex, inclusive.
     const browserSelection = targetDoc.getSelection();
     if (!browserSelection || browserSelection.type === 'None' ||
-        browserSelection.rangeCount === 0) {
+      browserSelection.rangeCount === 0) {
       return null;
     }
     const range = browserSelection.getRangeAt(0);
@@ -3131,9 +3132,9 @@ function Ace2Inner(editorInfo, cssManagers) {
           index: 0,
           maxIndex: 1,
         };
-      // treat point between two nodes as BEFORE the second (rather than after the first)
-      // if possible; this way point at end of a line block-element is treated as
-      // at beginning of next line
+        // treat point between two nodes as BEFORE the second (rather than after the first)
+        // if possible; this way point at end of a line block-element is treated as
+        // at beginning of next line
       } else if (offset === childCount) {
         const nd = n.childNodes.item(childCount - 1);
         const max = nodeMaxIndex(nd);
@@ -3156,10 +3157,10 @@ function Ace2Inner(editorInfo, cssManagers) {
       startPoint: pointFromRangeBound(range.startContainer, range.startOffset),
       endPoint: pointFromRangeBound(range.endContainer, range.endOffset),
       focusAtStart:
-          (range.startContainer !== range.endContainer || range.startOffset !== range.endOffset) &&
-          browserSelection.anchorNode &&
-          browserSelection.anchorNode === range.endContainer &&
-          browserSelection.anchorOffset === range.endOffset,
+        (range.startContainer !== range.endContainer || range.startOffset !== range.endOffset) &&
+        browserSelection.anchorNode &&
+        browserSelection.anchorNode === range.endContainer &&
+        browserSelection.anchorOffset === range.endOffset,
     };
 
     if (selection.startPoint.node.ownerDocument !== targetDoc) {
@@ -3356,7 +3357,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       const browserSelection = getSelection();
       if (browserSelection) {
         const focusPoint =
-            browserSelection.focusAtStart ? browserSelection.startPoint : browserSelection.endPoint;
+          browserSelection.focusAtStart ? browserSelection.startPoint : browserSelection.endPoint;
         const selectionPointX = getSelectionPointX(focusPoint);
         scrollXHorizontallyIntoView(selectionPointX);
         fixView();
@@ -3367,7 +3368,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   const listAttributeName = 'list';
 
   const getLineListType = (lineNum) => documentAttributeManager
-      .getAttributeOnLine(lineNum, listAttributeName);
+    .getAttributeOnLine(lineNum, listAttributeName);
   editorInfo.ace_getLineListType = getLineListType;
 
 
@@ -3466,8 +3467,8 @@ function Ace2Inner(editorInfo, cssManagers) {
           // included on the first line. The default stylesheet doesn't add
           // extra margins/padding, but plugins might.
           h = nextDocLine.offsetTop - parseInt(
-              window.getComputedStyle(targetBody)
-                  .getPropertyValue('padding-top').split('px')[0]);
+            window.getComputedStyle(targetBody)
+              .getPropertyValue('padding-top').split('px')[0]);
         } else {
           h = nextDocLine.offsetTop - docLine.offsetTop;
         }
@@ -3507,7 +3508,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   documentAttributeManager = new AttributeManager(rep, performDocumentApplyChangeset);
 
   editorInfo.ace_performDocumentApplyAttributesToRange =
-      (...args) => documentAttributeManager.setAttributesOnRange(...args);
+    (...args) => documentAttributeManager.setAttributesOnRange(...args);
 
   this.init = async () => {
     await $.ready;
@@ -3525,7 +3526,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       doRepLineSplice(0, rep.lines.length(), [oneEntry]);
       insertDomLines(null, [oneEntry.domInfo]);
       rep.alines = splitAttributionLines(
-          makeAttribution('\n'), '\n');
+        makeAttribution('\n'), '\n');
 
       bindTheEventHandlers();
     });

--- a/src/static/js/pad_utils.ts
+++ b/src/static/js/pad_utils.ts
@@ -6,7 +6,7 @@
  * TL;DR COMMENTS ON THIS FILE ARE HIGHLY APPRECIATED
  */
 
-import {binarySearch} from "./ace2_common";
+import { binarySearch } from "./ace2_common";
 
 /**
  * Copyright 2009 Google Inc.
@@ -25,7 +25,7 @@ import {binarySearch} from "./ace2_common";
  */
 
 const Security = require('security');
-import jsCookie, {CookiesStatic} from 'js-cookie'
+import jsCookie, { CookiesStatic } from 'js-cookie'
 
 /**
  * Generates a random String with the given length. Is needed to generate the Author, Group,
@@ -147,7 +147,7 @@ class PadUtils {
     if (typeof err.stack === 'string') {
       if (this.warnDeprecatedFlags._rl == null) {
         this.warnDeprecatedFlags._rl =
-          {prevs: new Map(), now: () => Date.now(), period: 10 * 60 * 1000};
+          { prevs: new Map(), now: () => Date.now(), period: 10 * 60 * 1000 };
       }
       const rl = this.warnDeprecatedFlags._rl;
       const now = rl.now();
@@ -217,12 +217,12 @@ class PadUtils {
     const urls = this.findURLs(text);
 
     const advanceTo = (i: number) => {
-        if (i > idx) {
-          pieces.push(Security.escapeHTML(text.substring(idx, i)));
-          idx = i;
-        }
+      if (i > idx) {
+        pieces.push(Security.escapeHTML(text.substring(idx, i)));
+        idx = i;
       }
-    ;
+    }
+      ;
     if (urls) {
       for (let j = 0; j < urls.length; j++) {
         const startIndex = urls[j][0];
@@ -273,10 +273,10 @@ class PadUtils {
   timediff = (d: number) => {
     const pad = require('./pad').pad; // Sidestep circular dependency
     const format = (n: number, word: string) => {
-        n = Math.round(n);
-        return (`${n} ${word}${n !== 1 ? 's' : ''} ago`);
-      }
-    ;
+      n = Math.round(n);
+      return (`${n} ${word}${n !== 1 ? 's' : ''} ago`);
+    }
+      ;
     d = Math.max(0, (+(new Date()) - (+d) - pad.clientTimeOffset) / 1000);
     if (d < 60) {
       return format(d, 'second');
@@ -317,7 +317,7 @@ class PadUtils {
           }, stepTime * stepsAtOnce);
         }
       };
-      return {scheduleAnimation};
+      return { scheduleAnimation };
     }
 
   makeFieldLabeledWhenEmpty
@@ -326,10 +326,10 @@ class PadUtils {
       field = $(field);
 
       const clear = () => {
-          field.addClass('editempty');
-          field.val(labelText);
-        }
-      ;
+        field.addClass('editempty');
+        field.val(labelText);
+      }
+        ;
       field.focus(() => {
         if (field.hasClass('editempty')) {
           field.val('');
@@ -398,17 +398,24 @@ class PadUtils {
   setupGlobalExceptionHandler = () => {
     if (this.globalExceptionHandler == null) {
       this.globalExceptionHandler = (e: any) => {
+        // Ignore errors originating from browser extensions (e.g. BitWarden FIDO2 scripts).
+        // These are not Etherpad errors and should not trigger the error modal. (Issue #6802)
+        const errorSource = (e instanceof ErrorEvent)
+          ? (e.filename || '')
+          : (e?.reason?.fileName || '');
+        if (/^(chrome|moz|safari)-extension:\/\//.test(errorSource)) return;
+
         let type;
         let err;
         let msg, url, linenumber;
         if (e instanceof ErrorEvent) {
           type = 'Uncaught exception';
           err = e.error || {};
-          ({message: msg, filename: url, lineno: linenumber} = e);
+          ({ message: msg, filename: url, lineno: linenumber } = e);
         } else if (e instanceof PromiseRejectionEvent) {
           type = 'Unhandled Promise rejection';
           err = e.reason || {};
-          ({message: msg = 'unknown', fileName: url = 'unknown', lineNumber: linenumber = -1} = err);
+          ({ message: msg = 'unknown', fileName: url = 'unknown', lineNumber: linenumber = -1 } = err);
         } else {
           throw new Error(`unknown event: ${e.toString()}`);
         }

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -1,461 +1,547 @@
-<%
-  var langs = require("ep_etherpad-lite/node/hooks/i18n").availableLangs
-    , pluginUtils = require('ep_etherpad-lite/static/js/pluginfw/shared')
-    ;
-%>
-<!doctype html>
-<html translate="no" class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
-<head>
-  <% e.begin_block("htmlHead"); %>
-  <% e.end_block(); %>
-  <title><%=settings.title%></title>
-  <link rel="manifest" href="../../manifest.json" />
-  <script>
-    /*
-    |@licstart  The following is the entire license notice for the
-    JavaScript code in this page.|
+<% var langs=require("ep_etherpad-lite/node/hooks/i18n").availableLangs ,
+  pluginUtils=require('ep_etherpad-lite/static/js/pluginfw/shared') ; %>
+  <!doctype html>
+  <html translate="no" class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
 
-    Copyright 2011 Peter Martischka, Primary Technology.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
-    |@licend  The above is the entire license notice
-    for the JavaScript code in this page.|
-    */
-  </script>
-
-  <meta charset="utf-8">
-  <meta name="robots" content="noindex, nofollow">
-  <meta name="referrer" content="no-referrer">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-  <link rel="shortcut icon" href="../favicon.ico">
-
-  <% e.begin_block("styles"); %>
-  <link href="../static/css/pad.css?v=<%=settings.randomVersionString%>" rel="stylesheet">
-
-  <% e.begin_block("customStyles"); %>
-  <link href="../static/skins/<%=encodeURI(settings.skinName)%>/pad.css?v=<%=settings.randomVersionString%>" rel="stylesheet">
-  <% e.end_block(); %>
-
-  <style title="dynamicsyntax"></style>
-  <% e.end_block(); %>
-
-  <link rel="localizations" type="application/l10n+json" href="../locales.json" />
-</head>
-<body>
-  <% e.begin_block("body"); %>
-
-  <!----------------------------->
-  <!--------- TOOLBAR ----------->
-  <!----------------------------->
-  <div id="editbar" class="toolbar">
-      <div id="toolbar-overlay"></div>
-
-      <ul class="menu_left" role="toolbar">
-          <% e.begin_block("editbarMenuLeft"); %>
-          <%- toolbar.menu(settings.toolbar.left, isReadOnly, 'left', 'pad') %>
-          <% e.end_block(); %>
-      </ul>
-      <ul class="menu_right" role="toolbar">
-          <% e.begin_block("editbarMenuRight"); %>
-          <%- toolbar.menu(settings.toolbar.right, isReadOnly, 'right', 'pad') %>
-          <% e.end_block(); %>
-      </ul>
-      <span class="show-more-icon-btn"></span> <!-- use on small screen to display hidden toolbar buttons -->
-  </div>
-
-  <% e.begin_block("afterEditbar"); %><% e.end_block(); %>
-
-  <div id="editorcontainerbox" class="flex-layout">
-
-      <% e.begin_block("editorContainerBox"); %>
-
-      <!----------------------------->
-      <!--- PAD EDITOR (in iframe) -->
-      <!----------------------------->
-
-      <div id="editorcontainer" class="editorcontainer"></div>
-
-      <div id="editorloadingbox">
-        <% e.begin_block("permissionDenied"); %>
-        <div id="permissionDenied">
-          <p data-l10n-id="pad.permissionDenied" class="editorloadingbox-message">
-            You do not have permission to access this pad
-          </p>
-        </div>
-        <% e.end_block(); %>
-        <% e.begin_block("loading"); %>
-        <p data-l10n-id="pad.loading" id="loading" class="editorloadingbox-message">
-          <img src='../static/img/brand.svg' class='etherpadBrand'><br/>
-          Loading...
-        </p>
-        <% e.end_block(); %>
-        <noscript>
-          <p class="editorloadingbox-message">
-            <strong>
-              Sorry, you have to enable Javascript in order to use this.
-            </strong>
-          </p>
-        </noscript>
-      </div>
-
-
-      <!------------------------------------------------------------->
-      <!-- SETTINGS POPUP (change font, language, chat parameters) -->
-      <!------------------------------------------------------------->
-
-      <div id="settings" class="popup"><div class="popup-content">
-          <h1 data-l10n-id="pad.settings.padSettings"></h1>
-          <% e.begin_block("mySettings"); %>
-          <h2 data-l10n-id="pad.settings.myView"></h2>
-          <p class="hide-for-mobile">
-              <input type="checkbox" id="options-stickychat">
-              <label for="options-stickychat" data-l10n-id="pad.settings.stickychat"></label>
-          </p>
-          <p class="hide-for-mobile">
-              <input type="checkbox" id="options-chatandusers" onClick="chat.chatAndUsers();">
-              <label for="options-chatandusers" data-l10n-id="pad.settings.chatandusers"></label>
-          </p>
-          <p>
-              <input type="checkbox" id="options-colorscheck">
-              <label for="options-colorscheck" data-l10n-id="pad.settings.colorcheck"></label>
-          </p>
-          <p>
-              <input type="checkbox" id="options-linenoscheck" checked>
-              <label for="options-linenoscheck" data-l10n-id="pad.settings.linenocheck"></label>
-          </p>
-          <p>
-              <input type="checkbox" id="options-rtlcheck">
-              <label for="options-rtlcheck" data-l10n-id="pad.settings.rtlcheck"></label>
-          </p>
-          <% e.end_block(); %>
-
-          <div class="dropdowns-container">
-            <% e.begin_block("mySettings.dropdowns"); %>
-            <p class="dropdown-line">
-              <label for="viewfontmenu" data-l10n-id="pad.settings.fontType">Font type:</label>
-              <select id="viewfontmenu">
-                <option value="" data-l10n-id="pad.settings.fontType.normal">Normal</option>
-                <%= fonts = ["Quicksand", "Roboto", "Alegreya", "PlayfairDisplay", "Montserrat", "OpenDyslexic", "RobotoMono"] %>
-                <% for(var i=0; i < fonts.length; i++) { %>
-                  <option value="<%=fonts[i]%>"><%=fonts[i]%></option>
-                <% } %>
-              </select>
-            </p>
-
-            <p class="dropdown-line">
-              <label for="languagemenu" data-l10n-id="pad.settings.language">Language:</label>
-              <select id="languagemenu">
-                  <% for (lang in langs) { %>
-                  <option value="<%=lang%>"><%=langs[lang].nativeName%></option>
-                  <% } %>
-              </select>
-            </p>
-            <% e.end_block(); %>
-          </div>
-          <button data-l10n-id="pad.settings.deletePad" id="delete-pad">Delete pad</button>
-        <div id="theme-switcher" style="display: none;">
-          <svg width="2rem" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
-          </svg>
-          <div>
-            <span aria-label="theme-switcher-knob"></span>
-          </div>
-          <svg width="2rem" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
-          </svg>
-        </div>
-
-
-        <h2 data-l10n-id="pad.settings.about">About</h2>
-          <span data-l10n-id="pad.settings.poweredBy">Powered by</span>
-          <a href="https://etherpad.org" target="_blank" referrerpolicy="no-referrer" rel="noopener">Etherpad</a>
-        <% if (settings.exposeVersion) { %>(commit <%= settings.gitVersion %>)<% } %>      </div></div>
-
-
-      <!------------------------->
-      <!-- IMPORT EXPORT POPUP -->
-      <!------------------------->
-
-      <div id="import_export" class="popup"><div class="popup-content">
-          <h1 data-l10n-id="pad.importExport.import_export"></h1>
-          <div class="acl-write">
-              <% e.begin_block("importColumn"); %>
-              <h2 data-l10n-id="pad.importExport.import"></h2>
-              <div class="importmessage" id="importmessageabiword" data-l10n-id="pad.importExport.abiword.innerHTML"></div><br>
-              <form id="importform" method="post" action="" target="importiframe" enctype="multipart/form-data">
-                  <div class="importformdiv" id="importformfilediv">
-                      <input type="file" name="file" size="10" id="importfileinput">
-                      <div class="importmessage" id="importmessagefail"></div>
-                  </div>
-                  <div id="import"></div>
-                  <div class="importmessage" id="importmessagesuccess" data-l10n-id="pad.importExport.importSuccessful"></div>
-                  <div class="importformdiv" id="importformsubmitdiv">
-                      <span class="nowrap">
-                          <input type="submit" class="btn btn-primary" name="submit" value="Import Now" disabled="disabled" id="importsubmitinput">
-                          <div alt="" id="importstatusball" class="loadingAnimation" align="top"></div>
-                      </span>
-                  </div>
-              </form>
-              <% e.end_block(); %>
-          </div>
-          <div id="exportColumn">
-              <h2 data-l10n-id="pad.importExport.export"></h2>
-              <% e.begin_block("exportColumn"); %>
-              <a id="exportetherpada" target="_blank" class="exportlink">
-                <span class="exporttype buttonicon buttonicon-file-powerpoint" id="exportetherpad" data-l10n-id="pad.importExport.exportetherpad"></span>
-              </a>
-              <a id="exporthtmla" target="_blank" class="exportlink">
-                <span class="exporttype buttonicon buttonicon-file-code" id="exporthtml" data-l10n-id="pad.importExport.exporthtml"></span>
-              </a>
-              <a id="exportplaina" target="_blank" class="exportlink">
-                <span class="exporttype buttonicon buttonicon-file" id="exportplain" data-l10n-id="pad.importExport.exportplain"></span>
-              </a>
-              <a id="exportworda" target="_blank" class="exportlink">
-                <span class="exporttype buttonicon buttonicon-file-word" id="exportword" data-l10n-id="pad.importExport.exportword"></span>
-              </a>
-              <a id="exportpdfa" target="_blank" class="exportlink">
-                <span class="exporttype buttonicon buttonicon-file-pdf" id="exportpdf" data-l10n-id="pad.importExport.exportpdf"></span>
-              </a>
-              <a id="exportopena" target="_blank" class="exportlink">
-                <span class="exporttype buttonicon buttonicon-file-alt" id="exportopen" data-l10n-id="pad.importExport.exportopen"></span>
-              </a>
-              <% e.end_block(); %>
-          </div>
-      </div></div>
-
-
-      <!---------------------------------------------------->
-      <!-- CONNECTIVITY POPUP (when you get disconnected) -->
-      <!---------------------------------------------------->
-
-      <div id="connectivity" class="popup"><div class="popup-content">
-          <% e.begin_block("modals"); %>
-          <div class="connected visible">
-            <h2 data-l10n-id="pad.modals.connected"></h2>
-          </div>
-          <div class="reconnecting">
-            <h1 data-l10n-id="pad.modals.reconnecting"></h1>
-            <i class='buttonicon buttonicon-spin5 icon-spin'>
-              <img src='../static/img/brand.svg' class='etherpadBrand'><br/>
-            </i>
-          </div>
-          <div class="userdup">
-            <h1 data-l10n-id="pad.modals.userdup"></h1>
-            <h2 data-l10n-id="pad.modals.userdup.explanation"></h2>
-            <p id="defaulttext" data-l10n-id="pad.modals.userdup.advice"></p>
-            <button id="forcereconnect" class="btn btn-primary" data-l10n-id="pad.modals.forcereconnect"></button>
-          </div>
-          <div class="unauth">
-            <h1 data-l10n-id="pad.modals.unauth"></h1>
-            <p id="defaulttext" data-l10n-id="pad.modals.unauth.explanation"></p>
-            <button id="forcereconnect" class="btn btn-primary" data-l10n-id="pad.modals.forcereconnect"></button>
-          </div>
-          <div class="looping">
-            <h1 data-l10n-id="pad.modals.disconnected"></h1>
-            <h2 data-l10n-id="pad.modals.looping.explanation"></h2>
-            <p data-l10n-id="pad.modals.looping.cause"></p>
-          </div>
-          <div class="initsocketfail">
-            <h1 data-l10n-id="pad.modals.initsocketfail"></h1>
-            <h2 data-l10n-id="pad.modals.initsocketfail.explanation"></h2>
-            <p data-l10n-id="pad.modals.initsocketfail.cause"></p>
-          </div>
-          <div class="slowcommit with_reconnect_timer">
-            <h1 data-l10n-id="pad.modals.disconnected"></h1>
-            <h2 data-l10n-id="pad.modals.slowcommit.explanation"></h2>
-            <p id="defaulttext" data-l10n-id="pad.modals.slowcommit.cause"></p>
-            <button id="forcereconnect" class="btn btn-primary" data-l10n-id="pad.modals.forcereconnect"></button>
-          </div>
-          <div class="badChangeset with_reconnect_timer">
-            <h1 data-l10n-id="pad.modals.disconnected"></h1>
-            <h2 data-l10n-id="pad.modals.badChangeset.explanation"></h2>
-            <p id="defaulttext" data-l10n-id="pad.modals.badChangeset.cause"></p>
-            <button id="forcereconnect" class="btn btn-primary" data-l10n-id="pad.modals.forcereconnect"></button>
-          </div>
-          <div class="corruptPad">
-            <h1 data-l10n-id="pad.modals.disconnected"></h1>
-            <h2 data-l10n-id="pad.modals.corruptPad.explanation"></h2>
-            <p data-l10n-id="pad.modals.corruptPad.cause"></p>
-          </div>
-          <div class="deleted">
-            <h1 data-l10n-id="pad.modals.deleted"></h1>
-            <p data-l10n-id="pad.modals.deleted.explanation"></p>
-          </div>
-          <div class="rateLimited">
-            <h1 data-l10n-id="pad.modals.rateLimited"></h1>
-            <p data-l10n-id="pad.modals.rateLimited.explanation"></p>
-          </div>
-          <div class="rejected">
-            <h1 data-l10n-id="pad.modals.disconnected"></h1>
-            <h2 data-l10n-id="pad.modals.rejected.explanation"></h2>
-            <p data-l10n-id="pad.modals.rejected.cause"></p>
-          </div>
-          <div class="disconnected with_reconnect_timer">
-            <% e.begin_block("disconnected"); %>
-            <h1 data-l10n-id="pad.modals.disconnected"></h1>
-            <h2 data-l10n-id="pad.modals.disconnected.explanation"></h2>
-            <p id="defaulttext" data-l10n-id="pad.modals.disconnected.cause"></p>
-            <button id="forcereconnect" class="btn btn-primary" data-l10n-id="pad.modals.forcereconnect"></button>
-            <% e.end_block(); %>
-          </div>
-          <form id="reconnectform" method="post" action="/ep/pad/reconnect" accept-charset="UTF-8" style="display: none;">
-              <input type="hidden" class="padId" name="padId">
-              <input type="hidden" class="diagnosticInfo" name="diagnosticInfo">
-              <input type="hidden" class="missedChanges" name="missedChanges">
-          </form>
-          <% e.end_block(); %>
-      </div></div>
-
-
-      <!-------------------------------->
-      <!-- EMBED POPUP (Share, embed) -->
-      <!-------------------------------->
-
-      <div id="embed" class="popup"><div class="popup-content">
-          <% e.begin_block("embedPopup"); %>
-          <h1 data-l10n-id="pad.share"></h1>
-          <div id="embedreadonly" class="acl-write">
-              <input type="checkbox" id="readonlyinput">
-              <label for="readonlyinput" data-l10n-id="pad.share.readonly"></label>
-          </div>
-          <div id="linkcode">
-              <h2 data-l10n-id="pad.share.link"></h2>
-              <input id="linkinput" type="text" value="" onclick="this.select()">
-          </div>
-          <div id="embedcode">
-              <h2 data-l10n-id="pad.share.emebdcode"></h2>
-              <input id="embedinput" type="text" value="" onclick="this.select()">
-          </div>
-          <% e.end_block(); %>
-      </div></div>
-
-      <div class="sticky-container">
-
-        <!---------------------------------------------------------------------->
-        <!-- USERS POPUP (set username, color, see other users names & color) -->
-        <!---------------------------------------------------------------------->
-
-        <div id="users" class="popup"><div class="popup-content">
-            <% e.begin_block("userlist"); %>
-            <div id="connectionstatus"></div>
-            <div id="myuser">
-                <div id="mycolorpicker" class="popup"><div class="popup-content">
-                    <div id="colorpicker"></div>
-                    <div class="btn-container">
-                      <button id="mycolorpickersave" data-l10n-id="pad.colorpicker.save" class="btn btn-primary"></button>
-                      <button id="mycolorpickercancel" data-l10n-id="pad.colorpicker.cancel" class="btn btn-default"></button>
-                      <span id="mycolorpickerpreview" class="myswatchboxhoverable"></span>
-                    </div>
-                </div></div>
-                <div id="myswatchbox"><div id="myswatch"></div></div>
-                <div id="myusernameform">
-                  <input type="text" id="myusernameedit" disabled="disabled" data-l10n-id="pad.userlist.entername">
-                </div>
-            </div>
-            <div id="otherusers" aria-role="document">
-                <table id="otheruserstable" cellspacing="0" cellpadding="0" border="0">
-                    <tr><td></td></tr>
-                </table>
-            </div>
-            <div id="userlistbuttonarea"></div>
-            <% e.end_block(); %>
-        </div></div>
-
-
-        <!----------------------------->
-        <!----------- CHAT ------------>
-        <!----------------------------->
-
-        <div id="chaticon" class="visible" onclick="chat.show();return false;" title="Chat (Alt C)">
-            <span id="chatlabel" data-l10n-id="pad.chat"></span>
-            <span class="buttonicon buttonicon-chat"></span>
-            <span id="chatcounter">0</span>
-        </div>
-
-        <div id="chatbox">
-          <div class="chat-content">
-            <div id="titlebar">
-              <h1 id ="titlelabel" data-l10n-id="pad.chat"></h1>
-              <a id="titlecross" class="hide-reduce-btn" onClick="chat.hide();return false;">-&nbsp;</a>
-              <a id="titlesticky" class="stick-to-screen-btn" onClick="chat.stickToScreen(true);return false;" data-l10n-id="pad.chat.stick.title">█&nbsp;&nbsp;</a>
-            </div>
-            <div id="chattext" class="thin-scrollbar" aria-live="polite" aria-relevant="additions removals text" role="log" aria-atomic="false">
-                <div alt="loading.." id="chatloadmessagesball" class="chatloadmessages loadingAnimation" align="top"></div>
-                <button id="chatloadmessagesbutton" class="chatloadmessages" data-l10n-id="pad.chat.loadmessages"></button>
-            </div>
-            <div id="chatinputbox">
-                <form>
-                    <textarea id="chatinput" maxlength="999" data-l10n-id="pad.chat.writeMessage.placeholder"></textarea>
-                </form>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!------------------------------------------------------------------>
-      <!-- SKIN VARIANTS BUILDER (Customize rendering, only for admins) -->
-      <!------------------------------------------------------------------>
-      <% if (settings.skinName == 'colibris') { %>
-      <div id="skin-variants" class="popup"><div class="popup-content">
-        <h1>Skin Builder</h1>
-
-        <div class="dropdowns-container">
-        <% containers = [ "toolbar", "background", "editor" ]; %>
-        <% for(var i=0; i < containers.length; i++) { %>
-          <p class="dropdown-line">
-            <label class="skin-variant-container"><%=containers[i]%></label>
-            <select class="skin-variant skin-variant-color" data-container="<%=containers[i]%>">
-              <option value="super-light">Super Light</option>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-              <option value="super-dark">Super Dark</option>
-            </select>
-          </p>
-        <% } %>
-        </div>
-
-        <p>
-            <input type="checkbox" id="skin-variant-full-width" class="skin-variant"/>
-            <label for="skin-variant-full-width">Full Width Editor</label>
-        </p>
-
-        <p>
-          <label>Result to copy in settings.json</label>
-          <input id="skin-variants-result" type="text" readonly class="disabled" />
-        </p>
-      </div></div>
-      <% } %>
-
+  <head>
+    <% e.begin_block("htmlHead"); %>
       <% e.end_block(); %>
+        <title>
+          <%=settings.title%>
+        </title>
+        <link rel="manifest" href="../../manifest.json" />
+        <script>
+          /*
+          |@licstart  The following is the entire license notice for the
+          JavaScript code in this page.|
+      
+          Copyright 2011 Peter Martischka, Primary Technology.
+      
+          Licensed under the Apache License, Version 2.0 (the "License");
+          you may not use this file except in compliance with the License.
+          You may obtain a copy of the License at
+      
+             http://www.apache.org/licenses/LICENSE-2.0
+      
+          Unless required by applicable law or agreed to in writing, software
+          distributed under the License is distributed on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          See the License for the specific language governing permissions and
+          limitations under the License.
+      
+          |@licend  The above is the entire license notice
+          for the JavaScript code in this page.|
+          */
+        </script>
 
-  </div> <!-- End of #editorcontainerbox -->
+        <meta charset="utf-8">
+        <meta name="robots" content="noindex, nofollow">
+        <meta name="referrer" content="no-referrer">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+        <link rel="shortcut icon" href="../favicon.ico">
 
-  <% e.end_block(); %>
+        <% e.begin_block("styles"); %>
+          <link href="../static/css/pad.css?v=<%=settings.randomVersionString%>" rel="stylesheet">
+
+          <% e.begin_block("customStyles"); %>
+            <link href="../static/skins/<%=encodeURI(settings.skinName)%>/pad.css?v=<%=settings.randomVersionString%>"
+              rel="stylesheet">
+            <% e.end_block(); %>
+
+              <style title="dynamicsyntax"></style>
+              <% e.end_block(); %>
+
+                <link rel="localizations" type="application/l10n+json" href="../locales.json" />
+  </head>
+
+  <body>
+    <% e.begin_block("body"); %>
+
+      <!-- Accessibility: Skip to content link for keyboard/screenreader users (#7255) -->
+      <style>
+        .skip-to-content {
+          position: absolute;
+          left: -9999px;
+          top: auto;
+          width: 1px;
+          height: 1px;
+          overflow: hidden;
+          z-index: 10000;
+        }
+
+        .skip-to-content:focus {
+          position: static;
+          width: auto;
+          height: auto;
+          overflow: visible;
+          padding: 8px 16px;
+          background: #0078d4;
+          color: #fff;
+          text-decoration: none;
+          font-weight: bold;
+        }
+      </style>
+      <a href="#editorcontainer" class="skip-to-content">Skip to content</a>
+
+      <!----------------------------->
+      <!--------- TOOLBAR ----------->
+      <!----------------------------->
+      <div id="editbar" class="toolbar">
+        <div id="toolbar-overlay"></div>
+
+        <ul class="menu_left" role="toolbar">
+          <% e.begin_block("editbarMenuLeft"); %>
+            <%- toolbar.menu(settings.toolbar.left, isReadOnly, 'left' , 'pad' ) %>
+              <% e.end_block(); %>
+        </ul>
+        <ul class="menu_right" role="toolbar">
+          <% e.begin_block("editbarMenuRight"); %>
+            <%- toolbar.menu(settings.toolbar.right, isReadOnly, 'right' , 'pad' ) %>
+              <% e.end_block(); %>
+        </ul>
+        <span class="show-more-icon-btn"></span> <!-- use on small screen to display hidden toolbar buttons -->
+      </div>
+
+      <% e.begin_block("afterEditbar"); %>
+        <% e.end_block(); %>
+
+          <div id="editorcontainerbox" class="flex-layout">
+
+            <% e.begin_block("editorContainerBox"); %>
+
+              <!----------------------------->
+              <!--- PAD EDITOR (in iframe) -->
+              <!----------------------------->
+
+              <div id="editorcontainer" class="editorcontainer"></div>
+
+              <div id="editorloadingbox">
+                <% e.begin_block("permissionDenied"); %>
+                  <div id="permissionDenied">
+                    <p data-l10n-id="pad.permissionDenied" class="editorloadingbox-message">
+                      You do not have permission to access this pad
+                    </p>
+                  </div>
+                  <% e.end_block(); %>
+                    <% e.begin_block("loading"); %>
+                      <p data-l10n-id="pad.loading" id="loading" class="editorloadingbox-message">
+                        <img src='../static/img/brand.svg' class='etherpadBrand'><br />
+                        Loading...
+                      </p>
+                      <% e.end_block(); %>
+                        <noscript>
+                          <p class="editorloadingbox-message">
+                            <strong>
+                              Sorry, you have to enable Javascript in order to use this.
+                            </strong>
+                          </p>
+                        </noscript>
+              </div>
 
 
-  <!----------------------------->
-  <!-------- JAVASCRIPT --------->
-  <!----------------------------->
+              <!------------------------------------------------------------->
+              <!-- SETTINGS POPUP (change font, language, chat parameters) -->
+              <!------------------------------------------------------------->
 
-  <% e.begin_block("scripts"); %>
+              <div id="settings" class="popup">
+                <div class="popup-content">
+                  <h1 data-l10n-id="pad.settings.padSettings"></h1>
+                  <% e.begin_block("mySettings"); %>
+                    <h2 data-l10n-id="pad.settings.myView"></h2>
+                    <p class="hide-for-mobile">
+                      <input type="checkbox" id="options-stickychat">
+                      <label for="options-stickychat" data-l10n-id="pad.settings.stickychat"></label>
+                    </p>
+                    <p class="hide-for-mobile">
+                      <input type="checkbox" id="options-chatandusers" onClick="chat.chatAndUsers();">
+                      <label for="options-chatandusers" data-l10n-id="pad.settings.chatandusers"></label>
+                    </p>
+                    <p>
+                      <input type="checkbox" id="options-colorscheck">
+                      <label for="options-colorscheck" data-l10n-id="pad.settings.colorcheck"></label>
+                    </p>
+                    <p>
+                      <input type="checkbox" id="options-linenoscheck" checked>
+                      <label for="options-linenoscheck" data-l10n-id="pad.settings.linenocheck"></label>
+                    </p>
+                    <p>
+                      <input type="checkbox" id="options-rtlcheck">
+                      <label for="options-rtlcheck" data-l10n-id="pad.settings.rtlcheck"></label>
+                    </p>
+                    <% e.end_block(); %>
 
-  <script src="<%=entrypoint%>"></script>
+                      <div class="dropdowns-container">
+                        <% e.begin_block("mySettings.dropdowns"); %>
+                          <p class="dropdown-line">
+                            <label for="viewfontmenu" data-l10n-id="pad.settings.fontType">Font type:</label>
+                            <select id="viewfontmenu">
+                              <option value="" data-l10n-id="pad.settings.fontType.normal">Normal</option>
+                              <%= fonts=["Quicksand", "Roboto" , "Alegreya" , "PlayfairDisplay" , "Montserrat"
+                                , "OpenDyslexic" , "RobotoMono" ] %>
+                                <% for(var i=0; i < fonts.length; i++) { %>
+                                  <option value="<%=fonts[i]%>">
+                                    <%=fonts[i]%>
+                                  </option>
+                                  <% } %>
+                            </select>
+                          </p>
 
-  <% e.begin_block("customScripts"); %>
-  <script type="text/javascript" src="../static/skins/<%=encodeURI(settings.skinName)%>/pad.js?v=<%=settings.randomVersionString%>"></script>
-  <% e.end_block(); %>
-  <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a></div>
-  <% e.end_block(); %>
-</body>
-</html>
+                          <p class="dropdown-line">
+                            <label for="languagemenu" data-l10n-id="pad.settings.language">Language:</label>
+                            <select id="languagemenu">
+                              <% for (lang in langs) { %>
+                                <option value="<%=lang%>">
+                                  <%=langs[lang].nativeName%>
+                                </option>
+                                <% } %>
+                            </select>
+                          </p>
+                          <% e.end_block(); %>
+                      </div>
+                      <button data-l10n-id="pad.settings.deletePad" id="delete-pad">Delete pad</button>
+                      <div id="theme-switcher" style="display: none;">
+                        <svg width="2rem" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                          stroke-width="1.5" stroke="currentColor" class="size-6">
+                          <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+                        </svg>
+                        <div>
+                          <span aria-label="theme-switcher-knob"></span>
+                        </div>
+                        <svg width="2rem" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                          stroke-width="1.5" stroke="currentColor" class="size-6">
+                          <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+                        </svg>
+                      </div>
+
+
+                      <h2 data-l10n-id="pad.settings.about">About</h2>
+                      <span data-l10n-id="pad.settings.poweredBy">Powered by</span>
+                      <a href="https://etherpad.org" target="_blank" referrerpolicy="no-referrer"
+                        rel="noopener">Etherpad</a>
+                      <% if (settings.exposeVersion) { %>(commit <%= settings.gitVersion %>)<% } %>
+                </div>
+              </div>
+
+
+              <!------------------------->
+              <!-- IMPORT EXPORT POPUP -->
+              <!------------------------->
+
+              <div id="import_export" class="popup">
+                <div class="popup-content">
+                  <h1 data-l10n-id="pad.importExport.import_export"></h1>
+                  <div class="acl-write">
+                    <% e.begin_block("importColumn"); %>
+                      <h2 data-l10n-id="pad.importExport.import"></h2>
+                      <div class="importmessage" id="importmessageabiword"
+                        data-l10n-id="pad.importExport.abiword.innerHTML"></div><br>
+                      <form id="importform" method="post" action="" target="importiframe" enctype="multipart/form-data">
+                        <div class="importformdiv" id="importformfilediv">
+                          <input type="file" name="file" size="10" id="importfileinput">
+                          <div class="importmessage" id="importmessagefail"></div>
+                        </div>
+                        <div id="import"></div>
+                        <div class="importmessage" id="importmessagesuccess"
+                          data-l10n-id="pad.importExport.importSuccessful"></div>
+                        <div class="importformdiv" id="importformsubmitdiv">
+                          <span class="nowrap">
+                            <input type="submit" class="btn btn-primary" name="submit" value="Import Now"
+                              disabled="disabled" id="importsubmitinput">
+                            <div alt="" id="importstatusball" class="loadingAnimation" align="top"></div>
+                          </span>
+                        </div>
+                      </form>
+                      <% e.end_block(); %>
+                  </div>
+                  <div id="exportColumn">
+                    <h2 data-l10n-id="pad.importExport.export"></h2>
+                    <% e.begin_block("exportColumn"); %>
+                      <a id="exportetherpada" target="_blank" class="exportlink">
+                        <span class="exporttype buttonicon buttonicon-file-powerpoint" id="exportetherpad"
+                          data-l10n-id="pad.importExport.exportetherpad"></span>
+                      </a>
+                      <a id="exporthtmla" target="_blank" class="exportlink">
+                        <span class="exporttype buttonicon buttonicon-file-code" id="exporthtml"
+                          data-l10n-id="pad.importExport.exporthtml"></span>
+                      </a>
+                      <a id="exportplaina" target="_blank" class="exportlink">
+                        <span class="exporttype buttonicon buttonicon-file" id="exportplain"
+                          data-l10n-id="pad.importExport.exportplain"></span>
+                      </a>
+                      <a id="exportworda" target="_blank" class="exportlink">
+                        <span class="exporttype buttonicon buttonicon-file-word" id="exportword"
+                          data-l10n-id="pad.importExport.exportword"></span>
+                      </a>
+                      <a id="exportpdfa" target="_blank" class="exportlink">
+                        <span class="exporttype buttonicon buttonicon-file-pdf" id="exportpdf"
+                          data-l10n-id="pad.importExport.exportpdf"></span>
+                      </a>
+                      <a id="exportopena" target="_blank" class="exportlink">
+                        <span class="exporttype buttonicon buttonicon-file-alt" id="exportopen"
+                          data-l10n-id="pad.importExport.exportopen"></span>
+                      </a>
+                      <% e.end_block(); %>
+                  </div>
+                </div>
+              </div>
+
+
+              <!---------------------------------------------------->
+              <!-- CONNECTIVITY POPUP (when you get disconnected) -->
+              <!---------------------------------------------------->
+
+              <div id="connectivity" class="popup">
+                <div class="popup-content">
+                  <% e.begin_block("modals"); %>
+                    <div class="connected visible">
+                      <h2 data-l10n-id="pad.modals.connected"></h2>
+                    </div>
+                    <div class="reconnecting">
+                      <h1 data-l10n-id="pad.modals.reconnecting"></h1>
+                      <i class='buttonicon buttonicon-spin5 icon-spin'>
+                        <img src='../static/img/brand.svg' class='etherpadBrand'><br />
+                      </i>
+                    </div>
+                    <div class="userdup">
+                      <h1 data-l10n-id="pad.modals.userdup"></h1>
+                      <h2 data-l10n-id="pad.modals.userdup.explanation"></h2>
+                      <p id="defaulttext" data-l10n-id="pad.modals.userdup.advice"></p>
+                      <button id="forcereconnect" class="btn btn-primary"
+                        data-l10n-id="pad.modals.forcereconnect"></button>
+                    </div>
+                    <div class="unauth">
+                      <h1 data-l10n-id="pad.modals.unauth"></h1>
+                      <p id="defaulttext" data-l10n-id="pad.modals.unauth.explanation"></p>
+                      <button id="forcereconnect" class="btn btn-primary"
+                        data-l10n-id="pad.modals.forcereconnect"></button>
+                    </div>
+                    <div class="looping">
+                      <h1 data-l10n-id="pad.modals.disconnected"></h1>
+                      <h2 data-l10n-id="pad.modals.looping.explanation"></h2>
+                      <p data-l10n-id="pad.modals.looping.cause"></p>
+                    </div>
+                    <div class="initsocketfail">
+                      <h1 data-l10n-id="pad.modals.initsocketfail"></h1>
+                      <h2 data-l10n-id="pad.modals.initsocketfail.explanation"></h2>
+                      <p data-l10n-id="pad.modals.initsocketfail.cause"></p>
+                    </div>
+                    <div class="slowcommit with_reconnect_timer">
+                      <h1 data-l10n-id="pad.modals.disconnected"></h1>
+                      <h2 data-l10n-id="pad.modals.slowcommit.explanation"></h2>
+                      <p id="defaulttext" data-l10n-id="pad.modals.slowcommit.cause"></p>
+                      <button id="forcereconnect" class="btn btn-primary"
+                        data-l10n-id="pad.modals.forcereconnect"></button>
+                    </div>
+                    <div class="badChangeset with_reconnect_timer">
+                      <h1 data-l10n-id="pad.modals.disconnected"></h1>
+                      <h2 data-l10n-id="pad.modals.badChangeset.explanation"></h2>
+                      <p id="defaulttext" data-l10n-id="pad.modals.badChangeset.cause"></p>
+                      <button id="forcereconnect" class="btn btn-primary"
+                        data-l10n-id="pad.modals.forcereconnect"></button>
+                    </div>
+                    <div class="corruptPad">
+                      <h1 data-l10n-id="pad.modals.disconnected"></h1>
+                      <h2 data-l10n-id="pad.modals.corruptPad.explanation"></h2>
+                      <p data-l10n-id="pad.modals.corruptPad.cause"></p>
+                    </div>
+                    <div class="deleted">
+                      <h1 data-l10n-id="pad.modals.deleted"></h1>
+                      <p data-l10n-id="pad.modals.deleted.explanation"></p>
+                    </div>
+                    <div class="rateLimited">
+                      <h1 data-l10n-id="pad.modals.rateLimited"></h1>
+                      <p data-l10n-id="pad.modals.rateLimited.explanation"></p>
+                    </div>
+                    <div class="rejected">
+                      <h1 data-l10n-id="pad.modals.disconnected"></h1>
+                      <h2 data-l10n-id="pad.modals.rejected.explanation"></h2>
+                      <p data-l10n-id="pad.modals.rejected.cause"></p>
+                    </div>
+                    <div class="disconnected with_reconnect_timer">
+                      <% e.begin_block("disconnected"); %>
+                        <h1 data-l10n-id="pad.modals.disconnected"></h1>
+                        <h2 data-l10n-id="pad.modals.disconnected.explanation"></h2>
+                        <p id="defaulttext" data-l10n-id="pad.modals.disconnected.cause"></p>
+                        <button id="forcereconnect" class="btn btn-primary"
+                          data-l10n-id="pad.modals.forcereconnect"></button>
+                        <% e.end_block(); %>
+                    </div>
+                    <form id="reconnectform" method="post" action="/ep/pad/reconnect" accept-charset="UTF-8"
+                      style="display: none;">
+                      <input type="hidden" class="padId" name="padId">
+                      <input type="hidden" class="diagnosticInfo" name="diagnosticInfo">
+                      <input type="hidden" class="missedChanges" name="missedChanges">
+                    </form>
+                    <% e.end_block(); %>
+                </div>
+              </div>
+
+
+              <!-------------------------------->
+              <!-- EMBED POPUP (Share, embed) -->
+              <!-------------------------------->
+
+              <div id="embed" class="popup">
+                <div class="popup-content">
+                  <% e.begin_block("embedPopup"); %>
+                    <h1 data-l10n-id="pad.share"></h1>
+                    <div id="embedreadonly" class="acl-write">
+                      <input type="checkbox" id="readonlyinput">
+                      <label for="readonlyinput" data-l10n-id="pad.share.readonly"></label>
+                    </div>
+                    <div id="linkcode">
+                      <h2 data-l10n-id="pad.share.link"></h2>
+                      <input id="linkinput" type="text" value="" onclick="this.select()">
+                    </div>
+                    <div id="embedcode">
+                      <h2 data-l10n-id="pad.share.emebdcode"></h2>
+                      <input id="embedinput" type="text" value="" onclick="this.select()">
+                    </div>
+                    <% e.end_block(); %>
+                </div>
+              </div>
+
+              <div class="sticky-container">
+
+                <!---------------------------------------------------------------------->
+                <!-- USERS POPUP (set username, color, see other users names & color) -->
+                <!---------------------------------------------------------------------->
+
+                <div id="users" class="popup">
+                  <div class="popup-content">
+                    <% e.begin_block("userlist"); %>
+                      <div id="connectionstatus"></div>
+                      <div id="myuser">
+                        <div id="mycolorpicker" class="popup">
+                          <div class="popup-content">
+                            <div id="colorpicker"></div>
+                            <div class="btn-container">
+                              <button id="mycolorpickersave" data-l10n-id="pad.colorpicker.save"
+                                class="btn btn-primary"></button>
+                              <button id="mycolorpickercancel" data-l10n-id="pad.colorpicker.cancel"
+                                class="btn btn-default"></button>
+                              <span id="mycolorpickerpreview" class="myswatchboxhoverable"></span>
+                            </div>
+                          </div>
+                        </div>
+                        <div id="myswatchbox">
+                          <div id="myswatch"></div>
+                        </div>
+                        <div id="myusernameform">
+                          <input type="text" id="myusernameedit" disabled="disabled"
+                            data-l10n-id="pad.userlist.entername">
+                        </div>
+                      </div>
+                      <div id="otherusers" aria-role="document">
+                        <table id="otheruserstable" cellspacing="0" cellpadding="0" border="0">
+                          <tr>
+                            <td></td>
+                          </tr>
+                        </table>
+                      </div>
+                      <div id="userlistbuttonarea"></div>
+                      <% e.end_block(); %>
+                  </div>
+                </div>
+
+
+                <!----------------------------->
+                <!----------- CHAT ------------>
+                <!----------------------------->
+
+                <div id="chaticon" class="visible" onclick="chat.show();return false;" title="Chat (Alt C)">
+                  <span id="chatlabel" data-l10n-id="pad.chat"></span>
+                  <span class="buttonicon buttonicon-chat"></span>
+                  <span id="chatcounter">0</span>
+                </div>
+
+                <div id="chatbox">
+                  <div class="chat-content">
+                    <div id="titlebar">
+                      <h1 id="titlelabel" data-l10n-id="pad.chat"></h1>
+                      <a id="titlecross" class="hide-reduce-btn" onClick="chat.hide();return false;">-&nbsp;</a>
+                      <a id="titlesticky" class="stick-to-screen-btn" onClick="chat.stickToScreen(true);return false;"
+                        data-l10n-id="pad.chat.stick.title">█&nbsp;&nbsp;</a>
+                    </div>
+                    <div id="chattext" class="thin-scrollbar" aria-live="polite" aria-relevant="additions removals text"
+                      role="log" aria-atomic="false">
+                      <div alt="loading.." id="chatloadmessagesball" class="chatloadmessages loadingAnimation"
+                        align="top"></div>
+                      <button id="chatloadmessagesbutton" class="chatloadmessages"
+                        data-l10n-id="pad.chat.loadmessages"></button>
+                    </div>
+                    <div id="chatinputbox">
+                      <form>
+                        <textarea id="chatinput" maxlength="999"
+                          data-l10n-id="pad.chat.writeMessage.placeholder"></textarea>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!------------------------------------------------------------------>
+              <!-- SKIN VARIANTS BUILDER (Customize rendering, only for admins) -->
+              <!------------------------------------------------------------------>
+              <% if (settings.skinName=='colibris' ) { %>
+                <div id="skin-variants" class="popup">
+                  <div class="popup-content">
+                    <h1>Skin Builder</h1>
+
+                    <div class="dropdowns-container">
+                      <% containers=[ "toolbar" , "background" , "editor" ]; %>
+                        <% for(var i=0; i < containers.length; i++) { %>
+                          <p class="dropdown-line">
+                            <label class="skin-variant-container">
+                              <%=containers[i]%>
+                            </label>
+                            <select class="skin-variant skin-variant-color" data-container="<%=containers[i]%>">
+                              <option value="super-light">Super Light</option>
+                              <option value="light">Light</option>
+                              <option value="dark">Dark</option>
+                              <option value="super-dark">Super Dark</option>
+                            </select>
+                          </p>
+                          <% } %>
+                    </div>
+
+                    <p>
+                      <input type="checkbox" id="skin-variant-full-width" class="skin-variant" />
+                      <label for="skin-variant-full-width">Full Width Editor</label>
+                    </p>
+
+                    <p>
+                      <label>Result to copy in settings.json</label>
+                      <input id="skin-variants-result" type="text" readonly class="disabled" />
+                    </p>
+                  </div>
+                </div>
+                <% } %>
+
+                  <% e.end_block(); %>
+
+          </div> <!-- End of #editorcontainerbox -->
+
+          <% e.end_block(); %>
+
+
+            <!----------------------------->
+            <!-------- JAVASCRIPT --------->
+            <!----------------------------->
+
+            <% e.begin_block("scripts"); %>
+
+              <script src="<%=entrypoint%>"></script>
+
+              <% e.begin_block("customScripts"); %>
+                <script type="text/javascript"
+                  src="../static/skins/<%=encodeURI(settings.skinName)%>/pad.js?v=<%=settings.randomVersionString%>"></script>
+                <% e.end_block(); %>
+                  <div style="display:none"><a href="/javascript" data-jslicense="1">JavaScript license information</a>
+                  </div>
+                  <% e.end_block(); %>
+  </body>
+
+  </html>


### PR DESCRIPTION
## Summary

This PR fixes two open issues:

### Issue #6802: globalExceptionHandler catching unrelated errors around Ace2Editor.init()

**Problem:** Browser extensions (e.g., BitWarden FIDO2 script) inject code that throws errors inside the editor iframes. The eventFired() function catches these and crashes the entire pad load with a misleading error.

**Fix:** Filter out errors originating from chrome-extension://, moz-extension://, and safari-extension:// URLs in both:

- eventFired() in ace.ts (prevents Promise rejection during init)
- setupGlobalExceptionHandler() in pad_utils.ts (prevents misleading error modal)

### Issue #7255: Inaccessibility to screenreaders

**Problem:** Screen readers can only cycle through line numbers with no way to read actual pad content.

**Fix:**

- Added role and aria-label to the outer iframe
- Added role and aria-label to the inner iframe
- Added role=textbox, aria-multiline=true, aria-label to the editor body (innerdocbody)
- Added aria-hidden=true to the sidediv (line numbers) in both ace.ts and ace2_inner.ts
- Added a Skip to content link in pad.html for keyboard/screenreader users

Closes #6802
Closes #7255
