### PR TITLE
fix: ignore browser extension errors in Ace2Editor.init()

### DIFF
--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -29,7 +29,7 @@ const hooks = require('./pluginfw/hooks');
 const makeCSSManager = require('./cssmanager').makeCSSManager;
 const pluginUtils = require('./pluginfw/shared');
 const ace2_inner = require('ep_etherpad-lite/static/js/ace2_inner')
-const debugLog = (...args) => {};
+const debugLog = (...args) => { };
 const cl_plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins')
 const rJQuery = require('ep_etherpad-lite/static/js/rjquery')
 // The inner and outer iframe's locations are about:blank, so relative URLs are relative to that.
@@ -50,14 +50,19 @@ const eventFired = async (obj, event, cleanups = [], predicate = () => true) => 
       cleanup();
       resolve();
     };
-    const errorCb = () => {
+    const errorCb = (e) => {
+      // Ignore errors originating from browser extensions (e.g. BitWarden FIDO2).
+      // These are not Etherpad errors and should not block pad initialization. (Issue #6802)
+      const errorSource = (e instanceof ErrorEvent) ? (e.filename || '') : '';
+      if (/^(chrome|moz|safari)-extension:\/\//.test(errorSource)) return;
+      if (typeof obj?.src === 'string' && /^(chrome|moz|safari)-extension:\/\//.test(obj.src)) return;
       const err = new Error(`Ace2Editor.init() error event while waiting for ${event} event`);
       debugLog(`${err} on object`, obj);
       cleanup();
       reject(err);
     };
     cleanup = () => {
-      cleanup = () => {};
+      cleanup = () => { };
       obj.removeEventListener(event, successCb);
       obj.removeEventListener('error', errorCb);
     };
@@ -89,7 +94,7 @@ const frameReady = async (frame) => {
 };
 
 const Ace2Editor = function () {
-  let info = {editor: this};
+  let info = { editor: this };
   let loaded = false;
 
   let actionsPendingInit = [];
@@ -139,7 +144,7 @@ const Ace2Editor = function () {
   this.exportText = () => loaded ? info.ace_exportText() : '(awaiting init)\n';
 
   this.getInInternationalComposition =
-      () => loaded ? info.ace_getInInternationalComposition() : null;
+    () => loaded ? info.ace_getInInternationalComposition() : null;
 
   // prepareUserChangeset:
   // Returns null if no new changes or ACE not ready.  Otherwise, bundles up all user changes
@@ -175,8 +180,8 @@ const Ace2Editor = function () {
       `../static/css/iframe_editor.css?v=${clientVars.randomVersionString}`,
       `../static/css/pad.css?v=${clientVars.randomVersionString}`,
       ...hooks.callAll('aceEditorCSS').map(
-          // Allow urls to external CSS - http(s):// and //some/path.css
-          (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
+        // Allow urls to external CSS - http(s):// and //some/path.css
+        (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
       `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`,
     ];
 
@@ -262,7 +267,7 @@ const Ace2Editor = function () {
     //const requireKernel = innerDocument.createElement('script');
     //requireKernel.type = 'text/javascript';
     //requireKernel.src =
-     //   absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
+    //   absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
     //innerDocument.head.appendChild(requireKernel);
     // Pre-fetch modules to improve load performance.
     /*for (const module of ['ace2_inner', 'ace2_common']) {
@@ -277,24 +282,24 @@ const Ace2Editor = function () {
     innerStyle.title = 'dynamicsyntax';
     innerDocument.head.appendChild(innerStyle);
     const headLines = [];
-    hooks.callAll('aceInitInnerdocbodyHead', {iframeHTML: headLines});
+    hooks.callAll('aceInitInnerdocbodyHead', { iframeHTML: headLines });
     innerDocument.head.appendChild(
-        innerDocument.createRange().createContextualFragment(headLines.join('\n')));
+      innerDocument.createRange().createContextualFragment(headLines.join('\n')));
 
     // <body> tag
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
     innerDocument.body.setAttribute('spellcheck', 'false');
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
-/*
-    debugLog('Ace2Editor.init() waiting for require kernel load');
-    await eventFired(requireKernel, 'load');
-    debugLog('Ace2Editor.init() require kernel loaded');
-    const require = innerWindow.require;
-    require.setRootURI(absUrl('../javascripts/src'));
-    require.setLibraryURI(absUrl('../javascripts/lib'));
-    require.setGlobalKeyPath('require');
-*/
+    /*
+        debugLog('Ace2Editor.init() waiting for require kernel load');
+        await eventFired(requireKernel, 'load');
+        debugLog('Ace2Editor.init() require kernel loaded');
+        const require = innerWindow.require;
+        require.setRootURI(absUrl('../javascripts/src'));
+        require.setLibraryURI(absUrl('../javascripts/lib'));
+        require.setGlobalKeyPath('require');
+    */
     // intentially moved before requiring client_plugins to save a 307
     innerWindow.Ace2Inner = ace2_inner;
     innerWindow.plugins = cl_plugins;


### PR DESCRIPTION
## Summary

Browser extensions like BitWarden inject scripts into iframes, which can cause errors that crash Etherpad's pad initialization. The `eventFired()` function's error handler catches these extension-originated errors and rejects the promise, preventing the pad from loading.

This PR filters out errors originating from browser extension URLs (`chrome-extension://`, `moz-extension://`, `safari-extension://`) so they don't block pad initialization.

Closes #6802

### Changes

- Modified `errorCb` in `eventFired()` to accept the error event parameter
- Added URL pattern check to ignore errors from browser extension sources
- Real Etherpad errors still propagate normally

### Testing

- Tested with BitWarden browser extension installed
- Verified pad loads correctly without spurious error messages
- Verified real errors (e.g. missing resources) still trigger proper error handling

*This is a focused split from #7341 as discussed with maintainers.*
