### PR TITLE
feat: add accessibility ARIA attributes in Ace2Editor.init()

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -261,7 +261,9 @@
     "rtl":              false,
     "alwaysShowChat":   false,
     "chatAndUsers":     false,
-    "lang":             null
+    "lang":             null,
+    /* whether to enable ARIA accessibility attributes or not */
+    "accessibilityAttributes": true
   },
 
   /*

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -32,7 +32,6 @@
   "admin_settings.current_restart.value": "Restart Etherpad",
   "admin_settings.current_save.value": "Save Settings",
   "admin_settings.page-title": "Settings - Etherpad",
-
   "index.newPad": "New Pad",
   "index.settings": "Settings",
   "index.transferSessionTitle": "Transfer session",
@@ -55,8 +54,6 @@
   "index.placeholderPadEnter": "Please enter a pad name...",
   "index.createAndShareDocuments": "Create and share documents in real time",
   "index.createAndShareDocumentsDescription": "Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that runs in your browser.",
-
-
   "pad.toolbar.bold.title": "Bold (Ctrl+B)",
   "pad.toolbar.italic.title": "Italic (Ctrl+I)",
   "pad.toolbar.underline.title": "Underline (Ctrl+U)",
@@ -75,14 +72,11 @@
   "pad.toolbar.embed.title": "Share and Embed this pad",
   "pad.toolbar.home.title": "Back to home",
   "pad.toolbar.showusers.title": "Show the users on this pad",
-
   "pad.colorpicker.save": "Save",
   "pad.colorpicker.cancel": "Cancel",
-
   "pad.loading": "Loading...",
   "pad.noCookie": "Cookie could not be found. Please allow cookies in your browser!  Your session and settings will not be saved between visits.  This may be due to Etherpad being included in an iFrame in some Browsers.  Please ensure Etherpad is on the same subdomain/domain as the parent iFrame",
   "pad.permissionDenied": "You do not have permission to access this pad",
-
   "pad.settings.padSettings": "Pad Settings",
   "pad.settings.myView": "My View",
   "pad.settings.stickychat": "Chat always on screen",
@@ -97,7 +91,6 @@
   "pad.delete.confirm": "Do you really want to delete this pad?",
   "pad.settings.about": "About",
   "pad.settings.poweredBy": "Powered by",
-
   "pad.importExport.import_export": "Import/Export",
   "pad.importExport.import": "Upload any text file or document",
   "pad.importExport.importSuccessful": "Successful!",
@@ -109,59 +102,47 @@
   "pad.importExport.exportpdf": "PDF",
   "pad.importExport.exportopen": "ODF (Open Document Format)",
   "pad.importExport.abiword.innerHTML": "You only can import from plain text or HTML formats. For more advanced import features please <a href=\"https://github.com/ether/etherpad-lite/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-AbiWord\">install AbiWord or LibreOffice</a>.",
-
   "pad.modals.connected": "Connected.",
   "pad.modals.reconnecting": "Reconnecting to your pad…",
   "pad.modals.forcereconnect": "Force reconnect",
   "pad.modals.reconnecttimer": "Trying to reconnect in",
   "pad.modals.cancel": "Cancel",
-
   "pad.modals.userdup": "Opened in another window",
   "pad.modals.userdup.explanation": "This pad seems to be opened in more than one browser window on this computer.",
   "pad.modals.userdup.advice": "Reconnect to use this window instead.",
-
   "pad.modals.unauth": "Not authorized",
   "pad.modals.unauth.explanation": "Your permissions have changed while viewing this page. Try to reconnect.",
-
   "pad.modals.looping.explanation": "There are communication problems with the synchronization server.",
   "pad.modals.looping.cause": "Perhaps you connected through an incompatible firewall or proxy.",
-
   "pad.modals.initsocketfail": "Server is unreachable.",
   "pad.modals.initsocketfail.explanation": "Couldn't connect to the synchronization server.",
   "pad.modals.initsocketfail.cause": "This is probably due to a problem with your browser or your internet connection.",
-
   "pad.modals.slowcommit.explanation": "The server is not responding.",
   "pad.modals.slowcommit.cause": "This could be due to problems with network connectivity.",
-
   "pad.modals.badChangeset.explanation": "An edit you have made was classified illegal by the synchronization server.",
   "pad.modals.badChangeset.cause": "This could be due to a wrong server configuration or some other unexpected behavior. Please contact the service administrator, if you feel this is an error. Try to reconnect in order to continue editing.",
-
   "pad.modals.corruptPad.explanation": "The pad you are trying to access is corrupt.",
   "pad.modals.corruptPad.cause": "This may be due to a wrong server configuration or some other unexpected behavior. Please contact the service administrator.",
-
   "pad.modals.deleted": "Deleted.",
   "pad.modals.deleted.explanation": "This pad has been removed.",
-
   "pad.modals.rateLimited": "Rate Limited.",
   "pad.modals.rateLimited.explanation": "You sent too many messages to this pad so it disconnected you.",
-
   "pad.modals.rejected.explanation": "The server rejected a message that was sent by your browser.",
   "pad.modals.rejected.cause": "The server may have been updated while you were viewing the pad, or maybe there is a bug in Etherpad. Try reloading the page.",
-
   "pad.modals.disconnected": "You have been disconnected.",
   "pad.modals.disconnected.explanation": "The connection to the server was lost",
   "pad.modals.disconnected.cause": "The server may be unavailable. Please notify the service administrator if this continues to happen.",
-
   "pad.share": "Share this pad",
   "pad.share.readonly": "Read only",
   "pad.share.link": "Link",
   "pad.share.emebdcode": "Embed URL",
+  "pad.aria.editor": "Etherpad editor",
+  "pad.aria.pad_content": "Pad content",
   "pad.chat": "Chat",
   "pad.chat.title": "Open the chat for this pad.",
   "pad.chat.loadmessages": "Load more messages",
   "pad.chat.stick.title": "Stick chat to screen",
   "pad.chat.writeMessage.placeholder": "Write your message here",
-
   "timeslider.followContents": "Follow pad content updates",
   "timeslider.pageTitle": "{{appTitle}} Timeslider",
   "timeslider.toolbar.returnbutton": "Return to pad",
@@ -171,11 +152,9 @@
   "timeslider.exportCurrent": "Export current version as:",
   "timeslider.version": "Version {{version}}",
   "timeslider.saved": "Saved {{month}} {{day}}, {{year}}",
-
   "timeslider.playPause": "Playback / Pause Pad Contents",
-  "timeslider.backRevision":"Go back a revision in this Pad",
-  "timeslider.forwardRevision":"Go forward a revision in this Pad",
-
+  "timeslider.backRevision": "Go back a revision in this Pad",
+  "timeslider.forwardRevision": "Go forward a revision in this Pad",
   "timeslider.dateformat": "{{month}}/{{day}}/{{year}} {{hours}}:{{minutes}}:{{seconds}}",
   "timeslider.month.january": "January",
   "timeslider.month.february": "February",
@@ -189,14 +168,12 @@
   "timeslider.month.october": "October",
   "timeslider.month.november": "November",
   "timeslider.month.december": "December",
-
   "timeslider.unnamedauthors": "{{num}} unnamed {[plural(num) one: author, other: authors ]}",
   "pad.savedrevs.marked": "This revision is now marked as a saved revision",
   "pad.savedrevs.timeslider": "You can see saved revisions by visiting the timeslider",
   "pad.userlist.entername": "Enter your name",
   "pad.userlist.unnamed": "unnamed",
   "pad.editbar.clearcolors": "Clear authorship colors on entire document? This cannot be undone",
-
   "pad.impexp.importbutton": "Import Now",
   "pad.impexp.importing": "Importing...",
   "pad.impexp.confirmimport": "Importing a file will overwrite the current text of the pad. Are you sure you want to proceed?",

--- a/src/locales/qqq.json
+++ b/src/locales/qqq.json
@@ -87,6 +87,8 @@
 	"pad.share.readonly": "Used as checkbox label",
 	"pad.share.link": "Used as label for a field providing URL of the pad.\n{{Identical|Link}}",
 	"pad.share.emebdcode": "Label for a field providing code that allows you to embed the pad into your website.",
+	"pad.aria.editor": "ARIA label for the outer iframe that contains the editor.",
+	"pad.aria.pad_content": "ARIA label for the inner iframe and the content body of the pad.",
 	"pad.chat": "Used as button text and as title of Chat window.\n{{Identical|Chat}}",
 	"pad.chat.title": "Used as tooltip for the Chat button",
 	"pad.chat.loadmessages": "chat messages",

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -27,50 +27,50 @@
  * limitations under the License.
  */
 
-import {MapArrayType} from "../types/MapType";
-import {SettingsNode} from "./SettingsTree";
+import { MapArrayType } from "../types/MapType";
+import { SettingsNode } from "./SettingsTree";
 
 import * as absolutePaths from './AbsolutePaths';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {argv} from './Cli'
+import { argv } from './Cli'
 import jsonminify from 'jsonminify';
 import log4js from 'log4js';
 import randomString from './randomstring';
 const suppressDisableMsg = ' -- To suppress these warning messages change ' +
-    'suppressErrorsInPadText to true in your settings.json\n';
+  'suppressErrorsInPadText to true in your settings.json\n';
 import _ from 'underscore';
 
 const logger = log4js.getLogger('settings');
 
 // Exported values that settings.json and credentials.json cannot override.
 const nonSettings = [
-    'credentialsFilename',
-    'settingsFilename',
+  'credentialsFilename',
+  'settingsFilename',
 ];
 
 // This is a function to make it easy to create a new instance. It is important to not reuse a
 // config object after passing it to log4js.configure() because that method mutates the object. :(
 const defaultLogConfig = (level: string, layoutType: string) => ({
-    appenders: {console: {type: 'console', layout: {type: layoutType}}},
-    categories: {
-        default: {appenders: ['console'], level},
-    }
+  appenders: { console: { type: 'console', layout: { type: layoutType } } },
+  categories: {
+    default: { appenders: ['console'], level },
+  }
 });
 const defaultLogLevel = 'INFO';
 const defaultLogLayoutType = 'colored';
 
 const initLogging = (config: any) => {
-    // log4js.configure() modifies settings.logconfig so check for equality first.
-    log4js.configure(config);
-    log4js.getLogger('console');
+  // log4js.configure() modifies settings.logconfig so check for equality first.
+  log4js.configure(config);
+  log4js.getLogger('console');
 
-    // Overwrites for console output methods
-    console.debug = logger.debug.bind(logger);
-    console.log = logger.info.bind(logger);
-    console.warn = logger.warn.bind(logger);
-    console.error = logger.error.bind(logger);
+  // Overwrites for console output methods
+  console.debug = logger.debug.bind(logger);
+  console.log = logger.info.bind(logger);
+  console.warn = logger.warn.bind(logger);
+  console.error = logger.error.bind(logger);
 };
 
 // Initialize logging as early as possible with reasonable defaults. Logging will be re-initialized
@@ -177,12 +177,12 @@ export type SettingsType = {
   ip: string,
   port: number | string,
   suppressErrorsInPadText: boolean,
-  ssl: false |  {
+  ssl: false | {
     key: string,
     cert: string,
     ca: string | null,
   },
-  socketTransportProtocols:  any[],
+  socketTransportProtocols: any[],
   socketIo: {
     maxHttpBufferSize: number,
   },
@@ -202,6 +202,7 @@ export type SettingsType = {
     alwaysShowChat: boolean,
     chatAndUsers: boolean,
     lang: string | null,
+    accessibilityAttributes: boolean,
   },
   enableMetrics: boolean,
   padShortcutEnabled: {
@@ -261,7 +262,7 @@ export type SettingsType = {
   users: Record<string, any>,
   sso: {
     issuer: string,
-    clients?: {client_id: string}[]
+    clients?: { client_id: string }[]
   },
   showSettingsInAdminPage: boolean,
   cleanup: {
@@ -292,7 +293,7 @@ export type SettingsType = {
   lowerCasePadIds: boolean,
   randomVersionString: string,
   gitVersion: string
-  getPublicSettings: () => Pick<SettingsType, "title" | "skinVariants"|"randomVersionString"|"skinName"|"toolbar"| "exposeVersion"| "gitVersion">,
+  getPublicSettings: () => Pick<SettingsType, "title" | "skinVariants" | "randomVersionString" | "skinName" | "toolbar" | "exposeVersion" | "gitVersion">,
 }
 
 const settings: SettingsType = {
@@ -406,6 +407,7 @@ const settings: SettingsType = {
     alwaysShowChat: false,
     chatAndUsers: false,
     lang: null,
+    accessibilityAttributes: true,
   },
   /**
    * Wether to enable the /stats endpoint. The functionality in the admin menu is untouched for this.
@@ -662,38 +664,38 @@ export default settings;
 /**
  * This setting is passed with dbType to ueberDB to set up the database
  */
-settings.dbSettings =  {filename: path.join(settings.root, 'var/rusty.db')};
+settings.dbSettings = { filename: path.join(settings.root, 'var/rusty.db') };
 // END OF SETTINGS
 
 // checks if abiword is avaiable
 export const abiwordAvailable = () => {
-    if (settings.abiword != null) {
-        return os.type().indexOf('Windows') !== -1 ? 'withoutPDF' : 'yes';
-    } else {
-        return 'no';
-    }
+  if (settings.abiword != null) {
+    return os.type().indexOf('Windows') !== -1 ? 'withoutPDF' : 'yes';
+  } else {
+    return 'no';
+  }
 };
 
 export const sofficeAvailable = () => {
-    if (settings.soffice != null) {
-        return os.type().indexOf('Windows') !== -1 ? 'withoutPDF' : 'yes';
-    } else {
-        return 'no';
-    }
+  if (settings.soffice != null) {
+    return os.type().indexOf('Windows') !== -1 ? 'withoutPDF' : 'yes';
+  } else {
+    return 'no';
+  }
 };
 
 export const exportAvailable = () => {
-    const abiword = abiwordAvailable();
-    const soffice = sofficeAvailable();
+  const abiword = abiwordAvailable();
+  const soffice = sofficeAvailable();
 
-    if (abiword === 'no' && soffice === 'no') {
-        return 'no';
-    } else if ((abiword === 'withoutPDF' && soffice === 'no') ||
-        (abiword === 'no' && soffice === 'withoutPDF')) {
-        return 'withoutPDF';
-    } else {
-        return 'yes';
-    }
+  if (abiword === 'no' && soffice === 'no') {
+    return 'no';
+  } else if ((abiword === 'withoutPDF' && soffice === 'no') ||
+    (abiword === 'no' && soffice === 'withoutPDF')) {
+    return 'withoutPDF';
+  } else {
+    return 'yes';
+  }
 };
 
 
@@ -710,33 +712,33 @@ export const getEpVersion = () => require('../../package.json').version;
  * both "settings.json" and "credentials.json".
  */
 const storeSettings = (settingsObj: any) => {
-    for (const i of Object.keys(settingsObj || {})) {
-        if (nonSettings.includes(i)) {
-            logger.warn(`Ignoring setting: '${i}'`);
-            continue;
-        }
-
-        // test if the setting starts with a lowercase character
-        if (i.charAt(0).search('[a-z]') !== 0) {
-            logger.warn(`Settings should start with a lowercase character: '${i}'`);
-        }
-
-        // we know this setting, so we overwrite it
-        // or it's a settings hash, specific to a plugin
-        // @ts-ignore
-      if (settings[i] !== undefined || i.indexOf('ep_') === 0) {
-            if (_.isObject(settingsObj[i]) && !Array.isArray(settingsObj[i])) {
-              // @ts-ignore
-              settings[i] = _.defaults(settingsObj[i], settings[i]);
-            } else {
-              // @ts-ignore
-              settings[i] = settingsObj[i];
-            }
-        } else {
-            // this setting is unknown, output a warning and throw it away
-            logger.warn(`Unknown Setting: '${i}'. This setting doesn't exist or it was removed`);
-        }
+  for (const i of Object.keys(settingsObj || {})) {
+    if (nonSettings.includes(i)) {
+      logger.warn(`Ignoring setting: '${i}'`);
+      continue;
     }
+
+    // test if the setting starts with a lowercase character
+    if (i.charAt(0).search('[a-z]') !== 0) {
+      logger.warn(`Settings should start with a lowercase character: '${i}'`);
+    }
+
+    // we know this setting, so we overwrite it
+    // or it's a settings hash, specific to a plugin
+    // @ts-ignore
+    if (settings[i] !== undefined || i.indexOf('ep_') === 0) {
+      if (_.isObject(settingsObj[i]) && !Array.isArray(settingsObj[i])) {
+        // @ts-ignore
+        settings[i] = _.defaults(settingsObj[i], settings[i]);
+      } else {
+        // @ts-ignore
+        settings[i] = settingsObj[i];
+      }
+    } else {
+      // this setting is unknown, output a warning and throw it away
+      logger.warn(`Unknown Setting: '${i}'. This setting doesn't exist or it was removed`);
+    }
+  }
 };
 
 /*
@@ -752,28 +754,28 @@ const storeSettings = (settingsObj: any) => {
  * in the literal string "null", instead.
  */
 const coerceValue = (stringValue: string) => {
-    // cooked from https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
-    // @ts-ignore
-    const isNumeric = !isNaN(stringValue) && !isNaN(parseFloat(stringValue) && isFinite(stringValue));
+  // cooked from https://stackoverflow.com/questions/175739/built-in-way-in-javascript-to-check-if-a-string-is-a-valid-number
+  // @ts-ignore
+  const isNumeric = !isNaN(stringValue) && !isNaN(parseFloat(stringValue) && isFinite(stringValue));
 
-    if (isNumeric) {
-        // detected numeric string. Coerce to a number
+  if (isNumeric) {
+    // detected numeric string. Coerce to a number
 
-        return +stringValue;
-    }
+    return +stringValue;
+  }
 
-    switch (stringValue) {
-        case 'true':
-            return true;
-        case 'false':
-            return false;
-        case 'undefined':
-            return undefined;
-        case 'null':
-            return null;
-        default:
-            return stringValue;
-    }
+  switch (stringValue) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    case 'undefined':
+      return undefined;
+    case 'null':
+      return null;
+    default:
+      return stringValue;
+  }
 };
 
 /**
@@ -813,282 +815,282 @@ const coerceValue = (stringValue: string) => {
  * see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter
  */
 const lookupEnvironmentVariables = (obj: MapArrayType<any>) => {
-    const replaceEnvs = (obj: MapArrayType<any>) => {
-        for (let [key, value] of Object.entries(obj)) {
-            /*
-            * the first invocation of replacer() is with an empty key. Just go on, or
-            * we would zap the entire object.
-            */
-            if (key === '') {
-                obj[key] = value;
-                continue
-            }
+  const replaceEnvs = (obj: MapArrayType<any>) => {
+    for (let [key, value] of Object.entries(obj)) {
+      /*
+      * the first invocation of replacer() is with an empty key. Just go on, or
+      * we would zap the entire object.
+      */
+      if (key === '') {
+        obj[key] = value;
+        continue
+      }
 
-            /*
-             * If we received from the configuration file a number, a boolean or
-             * something that is not a string, we can be sure that it was a literal
-             * value. No need to perform any variable substitution.
-             *
-             * The environment variable expansion syntax "${ENV_VAR}" is just a string
-             * of specific form, after all.
-             */
+      /*
+       * If we received from the configuration file a number, a boolean or
+       * something that is not a string, we can be sure that it was a literal
+       * value. No need to perform any variable substitution.
+       *
+       * The environment variable expansion syntax "${ENV_VAR}" is just a string
+       * of specific form, after all.
+       */
 
-            if(key === 'undefined' || value === undefined) {
-                delete obj[key]
-                continue
-            }
+      if (key === 'undefined' || value === undefined) {
+        delete obj[key]
+        continue
+      }
 
-            if ((typeof value !== 'string' && typeof value !== 'object') || value === null) {
-                obj[key] = value;
-                continue
-            }
+      if ((typeof value !== 'string' && typeof value !== 'object') || value === null) {
+        obj[key] = value;
+        continue
+      }
 
-            if (typeof obj[key] === "object") {
-                replaceEnvs(obj[key]);
-                continue
-            }
+      if (typeof obj[key] === "object") {
+        replaceEnvs(obj[key]);
+        continue
+      }
 
 
-            /*
-             * Let's check if the string value looks like a variable expansion (e.g.:
-             * "${ENV_VAR}" or "${ENV_VAR:default_value}")
-             */
-            // MUXATOR 2019-03-21: we could use named capture groups here once we migrate to nodejs v10
-            const match = value.match(/^\$\{([^:]*)(:((.|\n)*))?\}$/);
+      /*
+       * Let's check if the string value looks like a variable expansion (e.g.:
+       * "${ENV_VAR}" or "${ENV_VAR:default_value}")
+       */
+      // MUXATOR 2019-03-21: we could use named capture groups here once we migrate to nodejs v10
+      const match = value.match(/^\$\{([^:]*)(:((.|\n)*))?\}$/);
 
-            if (match == null) {
-                // no match: use the value literally, without any substitution
-                obj[key] = value;
-                continue
-            }
+      if (match == null) {
+        // no match: use the value literally, without any substitution
+        obj[key] = value;
+        continue
+      }
 
-            /*
-             * We found the name of an environment variable. Let's read its actual value
-             * and its default value, if given
-             */
-            const envVarName = match[1];
-            const envVarValue = process.env[envVarName];
-            const defaultValue = match[3];
+      /*
+       * We found the name of an environment variable. Let's read its actual value
+       * and its default value, if given
+       */
+      const envVarName = match[1];
+      const envVarValue = process.env[envVarName];
+      const defaultValue = match[3];
 
-            if ((envVarValue === undefined) && (defaultValue === undefined)) {
-                logger.warn(`Environment variable "${envVarName}" does not contain any value for ` +
-                    `configuration key "${key}", and no default was given. Using null. ` +
-                    'THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF ETHERPAD; you should ' +
-                    'explicitly use "null" as the default if you want to continue to use null.');
+      if ((envVarValue === undefined) && (defaultValue === undefined)) {
+        logger.warn(`Environment variable "${envVarName}" does not contain any value for ` +
+          `configuration key "${key}", and no default was given. Using null. ` +
+          'THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF ETHERPAD; you should ' +
+          'explicitly use "null" as the default if you want to continue to use null.');
 
-                /*
-                 * We have to return null, because if we just returned undefined, the
-                 * configuration item "key" would be stripped from the returned object.
-                 */
-                obj[key] = null;
-                continue
-            }
+        /*
+         * We have to return null, because if we just returned undefined, the
+         * configuration item "key" would be stripped from the returned object.
+         */
+        obj[key] = null;
+        continue
+      }
 
-            if ((envVarValue === undefined) && (defaultValue !== undefined)) {
-                logger.debug(`Environment variable "${envVarName}" not found for ` +
-                    `configuration key "${key}". Falling back to default value.`);
+      if ((envVarValue === undefined) && (defaultValue !== undefined)) {
+        logger.debug(`Environment variable "${envVarName}" not found for ` +
+          `configuration key "${key}". Falling back to default value.`);
 
-                obj[key] = coerceValue(defaultValue);
-                continue
-            }
+        obj[key] = coerceValue(defaultValue);
+        continue
+      }
 
-            // envVarName contained some value.
+      // envVarName contained some value.
 
-            /*
-             * For numeric and boolean strings let's convert it to proper types before
-             * returning it, in order to maintain backward compatibility.
-             */
-            logger.debug(
-                `Configuration key "${key}" will be read from environment variable "${envVarName}"`);
+      /*
+       * For numeric and boolean strings let's convert it to proper types before
+       * returning it, in order to maintain backward compatibility.
+       */
+      logger.debug(
+        `Configuration key "${key}" will be read from environment variable "${envVarName}"`);
 
-            obj[key] = coerceValue(envVarValue!);
-        }
-        return obj
+      obj[key] = coerceValue(envVarValue!);
     }
+    return obj
+  }
 
-    replaceEnvs(obj);
+  replaceEnvs(obj);
 
-    // Add plugin ENV variables
+  // Add plugin ENV variables
 
-    /**
-     * If the key contains a double underscore, it's a plugin variable
-     * E.g.
-     */
-    let treeEntries = new Map<string, string | undefined>
-    const root = new SettingsNode("EP")
+  /**
+   * If the key contains a double underscore, it's a plugin variable
+   * E.g.
+   */
+  let treeEntries = new Map<string, string | undefined>
+  const root = new SettingsNode("EP")
 
-    for (let [env, envVal] of Object.entries(process.env)) {
-        if (!env.startsWith("EP")) continue
-        treeEntries.set(env, envVal)
-    }
-    treeEntries.forEach((value, key) => {
-        let pathToKey = key.split("__")
-        let currentNode = root
-        let depth = 0
-        depth++
-        currentNode.addChild(pathToKey, value!)
-    })
+  for (let [env, envVal] of Object.entries(process.env)) {
+    if (!env.startsWith("EP")) continue
+    treeEntries.set(env, envVal)
+  }
+  treeEntries.forEach((value, key) => {
+    let pathToKey = key.split("__")
+    let currentNode = root
+    let depth = 0
+    depth++
+    currentNode.addChild(pathToKey, value!)
+  })
 
-    //console.log(root.collectFromLeafsUpwards())
-    const rooting = root.collectFromLeafsUpwards()
-    obj = Object.assign(obj, rooting)
-    return obj;
+  //console.log(root.collectFromLeafsUpwards())
+  const rooting = root.collectFromLeafsUpwards()
+  obj = Object.assign(obj, rooting)
+  return obj;
 };
 
 
 
 export const reloadSettings = () => {
-    const settingsParsed = parseSettings(settings?.settingsFilename, true);
-    const credentials = parseSettings(settings.credentialsFilename, false);
-    storeSettings(settingsParsed);
-    storeSettings(credentials);
+  const settingsParsed = parseSettings(settings?.settingsFilename, true);
+  const credentials = parseSettings(settings.credentialsFilename, false);
+  storeSettings(settingsParsed);
+  storeSettings(credentials);
 
-    // Init logging config
-    settings.logconfig = defaultLogConfig(
-      settings.loglevel ? settings.loglevel : defaultLogLevel,
-      settings.logLayoutType ? settings.logLayoutType : defaultLogLayoutType
-    );
-    logger.warn("loglevel: " + settings.loglevel);
-    logger.warn("logLayoutType: " + settings.logLayoutType);
-    initLogging(settings.logconfig);
+  // Init logging config
+  settings.logconfig = defaultLogConfig(
+    settings.loglevel ? settings.loglevel : defaultLogLevel,
+    settings.logLayoutType ? settings.logLayoutType : defaultLogLayoutType
+  );
+  logger.warn("loglevel: " + settings.loglevel);
+  logger.warn("logLayoutType: " + settings.logLayoutType);
+  initLogging(settings.logconfig);
 
-    if (!settings.skinName) {
-        logger.warn('No "skinName" parameter found. Please check out settings.json.template and ' +
-            'update your settings.json. Falling back to the default "colibris".');
+  if (!settings.skinName) {
+    logger.warn('No "skinName" parameter found. Please check out settings.json.template and ' +
+      'update your settings.json. Falling back to the default "colibris".');
+    settings.skinName = 'colibris';
+  }
+
+  if (!settings.socketTransportProtocols.includes("websocket") || !settings.socketTransportProtocols.includes("polling")) {
+    logger.warn("Invalid socketTransportProtocols setting. Please check out settings.json.template and update your settings.json. Falling back to the default ['websocket', 'polling'].");
+    settings.socketTransportProtocols = ['websocket', 'polling'];
+  }
+
+  // checks if skinName has an acceptable value, otherwise falls back to "colibris"
+  if (settings.skinName) {
+    const skinBasePath = path.join(settings.root, 'src', 'static', 'skins');
+    const countPieces = settings.skinName.split(path.sep).length;
+
+    if (countPieces !== 1) {
+      logger.error(`skinName must be the name of a directory under "${skinBasePath}". This is ` +
+        `not valid: "${settings.skinName}". Falling back to the default "colibris".`);
+
       settings.skinName = 'colibris';
     }
 
-    if (!settings.socketTransportProtocols.includes("websocket") || !settings.socketTransportProtocols.includes("polling")) {
-        logger.warn("Invalid socketTransportProtocols setting. Please check out settings.json.template and update your settings.json. Falling back to the default ['websocket', 'polling'].");
-      settings.socketTransportProtocols = ['websocket', 'polling'];
+    // informative variable, just for the log messages
+    let skinPath = path.join(skinBasePath, settings.skinName);
+
+    // what if someone sets skinName == ".." or "."? We catch him!
+    if (!absolutePaths.isSubdir(skinBasePath, skinPath)) {
+      logger.error(`Skin path ${skinPath} must be a subdirectory of ${skinBasePath}. ` +
+        'Falling back to the default "colibris".');
+
+      settings.skinName = 'colibris';
+      skinPath = path.join(skinBasePath, settings.skinName);
     }
 
-    // checks if skinName has an acceptable value, otherwise falls back to "colibris"
-    if (settings.skinName) {
-        const skinBasePath = path.join(settings.root, 'src', 'static', 'skins');
-        const countPieces = settings.skinName.split(path.sep).length;
-
-        if (countPieces !== 1) {
-            logger.error(`skinName must be the name of a directory under "${skinBasePath}". This is ` +
-                `not valid: "${settings.skinName}". Falling back to the default "colibris".`);
-
-          settings.skinName = 'colibris';
-        }
-
-        // informative variable, just for the log messages
-        let skinPath = path.join(skinBasePath, settings.skinName);
-
-        // what if someone sets skinName == ".." or "."? We catch him!
-        if (!absolutePaths.isSubdir(skinBasePath, skinPath)) {
-            logger.error(`Skin path ${skinPath} must be a subdirectory of ${skinBasePath}. ` +
-                'Falling back to the default "colibris".');
-
-          settings.skinName = 'colibris';
-            skinPath = path.join(skinBasePath, settings.skinName);
-        }
-
-        if (!fs.existsSync(skinPath)) {
-            logger.error(`Skin path ${skinPath} does not exist. Falling back to the default "colibris".`);
-          settings.skinName = 'colibris';
-            skinPath = path.join(skinBasePath, settings.skinName);
-        }
-
-        logger.info(`Using skin "${settings.skinName}" in dir: ${skinPath}`);
+    if (!fs.existsSync(skinPath)) {
+      logger.error(`Skin path ${skinPath} does not exist. Falling back to the default "colibris".`);
+      settings.skinName = 'colibris';
+      skinPath = path.join(skinBasePath, settings.skinName);
     }
 
-    if (settings.abiword) {
-        // Check abiword actually exists
-      fs.exists(settings.abiword, (exists: boolean) => {
-        if (!exists) {
-          const abiwordError = 'Abiword does not exist at this path, check your settings file.';
-          if (!settings.suppressErrorsInPadText) {
-            settings.defaultPadText += `\nError: ${abiwordError}${suppressDisableMsg}`;
-          }
-          logger.error(`${abiwordError} File location: ${settings.abiword}`);
-          settings.abiword = null;
-        }
-      });
-    }
+    logger.info(`Using skin "${settings.skinName}" in dir: ${skinPath}`);
+  }
 
-    if (settings.soffice) {
-        fs.exists(settings.soffice, (exists: boolean) => {
-            if (!exists) {
-                const sofficeError =
-                    'soffice (libreoffice) does not exist at this path, check your settings file.';
-
-                if (!settings.suppressErrorsInPadText) {
-                  settings.defaultPadText += `\nError: ${sofficeError}${suppressDisableMsg}`;
-                }
-                logger.error(`${sofficeError} File location: ${settings.soffice}`);
-              settings.soffice = null;
-            }
-        });
-    }
-
-    const sessionkeyFilename = absolutePaths.makeAbsolute(argv.sessionkey || './SESSIONKEY.txt');
-    if (!settings.sessionKey) {
-        try {
-          settings.sessionKey = fs.readFileSync(sessionkeyFilename, 'utf8');
-            logger.info(`Session key loaded from: ${sessionkeyFilename}`);
-        } catch (err) { /* ignored */
-        }
-        const keyRotationEnabled = settings.cookie.keyRotationInterval && settings.cookie.sessionLifetime;
-        if (!settings.sessionKey && !keyRotationEnabled) {
-            logger.info(
-                `Session key file "${sessionkeyFilename}" not found. Creating with random contents.`);
-          settings.sessionKey = randomString(32);
-            fs.writeFileSync(sessionkeyFilename, settings.sessionKey, 'utf8');
-        }
-    } else {
-        logger.warn('Declaring the sessionKey in the settings.json is deprecated. ' +
-            'This value is auto-generated now. Please remove the setting from the file. -- ' +
-            'If you are seeing this error after restarting using the Admin User ' +
-            'Interface then you can ignore this message.');
-    }
-    if (settings.sessionKey) {
-        logger.warn(`The sessionKey setting and ${sessionkeyFilename} file are deprecated; ` +
-            'use automatic key rotation instead (see the cookie.keyRotationInterval setting).');
-    }
-
-    if (settings.dbType === 'dirty') {
-        const dirtyWarning = 'DirtyDB is used. This is not recommended for production.';
+  if (settings.abiword) {
+    // Check abiword actually exists
+    fs.exists(settings.abiword, (exists: boolean) => {
+      if (!exists) {
+        const abiwordError = 'Abiword does not exist at this path, check your settings file.';
         if (!settings.suppressErrorsInPadText) {
-          settings.defaultPadText += `\nWarning: ${dirtyWarning}${suppressDisableMsg}`;
+          settings.defaultPadText += `\nError: ${abiwordError}${suppressDisableMsg}`;
         }
+        logger.error(`${abiwordError} File location: ${settings.abiword}`);
+        settings.abiword = null;
+      }
+    });
+  }
 
-      settings.dbSettings.filename = absolutePaths.makeAbsolute(settings.dbSettings.filename);
-        logger.warn(`${dirtyWarning} File location: ${settings.dbSettings.filename}`);
+  if (settings.soffice) {
+    fs.exists(settings.soffice, (exists: boolean) => {
+      if (!exists) {
+        const sofficeError =
+          'soffice (libreoffice) does not exist at this path, check your settings file.';
+
+        if (!settings.suppressErrorsInPadText) {
+          settings.defaultPadText += `\nError: ${sofficeError}${suppressDisableMsg}`;
+        }
+        logger.error(`${sofficeError} File location: ${settings.soffice}`);
+        settings.soffice = null;
+      }
+    });
+  }
+
+  const sessionkeyFilename = absolutePaths.makeAbsolute(argv.sessionkey || './SESSIONKEY.txt');
+  if (!settings.sessionKey) {
+    try {
+      settings.sessionKey = fs.readFileSync(sessionkeyFilename, 'utf8');
+      logger.info(`Session key loaded from: ${sessionkeyFilename}`);
+    } catch (err) { /* ignored */
+    }
+    const keyRotationEnabled = settings.cookie.keyRotationInterval && settings.cookie.sessionLifetime;
+    if (!settings.sessionKey && !keyRotationEnabled) {
+      logger.info(
+        `Session key file "${sessionkeyFilename}" not found. Creating with random contents.`);
+      settings.sessionKey = randomString(32);
+      fs.writeFileSync(sessionkeyFilename, settings.sessionKey, 'utf8');
+    }
+  } else {
+    logger.warn('Declaring the sessionKey in the settings.json is deprecated. ' +
+      'This value is auto-generated now. Please remove the setting from the file. -- ' +
+      'If you are seeing this error after restarting using the Admin User ' +
+      'Interface then you can ignore this message.');
+  }
+  if (settings.sessionKey) {
+    logger.warn(`The sessionKey setting and ${sessionkeyFilename} file are deprecated; ` +
+      'use automatic key rotation instead (see the cookie.keyRotationInterval setting).');
+  }
+
+  if (settings.dbType === 'dirty') {
+    const dirtyWarning = 'DirtyDB is used. This is not recommended for production.';
+    if (!settings.suppressErrorsInPadText) {
+      settings.defaultPadText += `\nWarning: ${dirtyWarning}${suppressDisableMsg}`;
     }
 
-    if (settings.dbType === 'rustydb' || settings.dbType === "sqlite") {
-      settings.dbSettings.filename = absolutePaths.makeAbsolute(settings.dbSettings.filename);
-      logger.warn(`File location: ${settings.dbSettings.filename}`);
-    }
+    settings.dbSettings.filename = absolutePaths.makeAbsolute(settings.dbSettings.filename);
+    logger.warn(`${dirtyWarning} File location: ${settings.dbSettings.filename}`);
+  }
+
+  if (settings.dbType === 'rustydb' || settings.dbType === "sqlite") {
+    settings.dbSettings.filename = absolutePaths.makeAbsolute(settings.dbSettings.filename);
+    logger.warn(`File location: ${settings.dbSettings.filename}`);
+  }
 
 
-    if (settings.ip === '') {
-        // using Unix socket for connectivity
-        logger.warn('The settings file contains an empty string ("") for the "ip" parameter. The ' +
-            '"port" parameter will be interpreted as the path to a Unix socket to bind at.');
-    }
+  if (settings.ip === '') {
+    // using Unix socket for connectivity
+    logger.warn('The settings file contains an empty string ("") for the "ip" parameter. The ' +
+      '"port" parameter will be interpreted as the path to a Unix socket to bind at.');
+  }
 
-    /*
-     * At each start, Etherpad generates a random string and appends it as query
-     * parameter to the URLs of the static assets, in order to force their reload.
-     * Subsequent requests will be cached, as long as the server is not reloaded.
-     *
-     * For the rationale behind this choice, see
-     * https://github.com/ether/etherpad-lite/pull/3958
-     *
-     * ACHTUNG: this may prevent caching HTTP proxies to work
-     * TODO: remove the "?v=randomstring" parameter, and replace with hashed filenames instead
-     */
-    settings.randomVersionString = randomString(4);
-    logger.info(`Random string used for versioning assets: ${settings.randomVersionString}`);
+  /*
+   * At each start, Etherpad generates a random string and appends it as query
+   * parameter to the URLs of the static assets, in order to force their reload.
+   * Subsequent requests will be cached, as long as the server is not reloaded.
+   *
+   * For the rationale behind this choice, see
+   * https://github.com/ether/etherpad-lite/pull/3958
+   *
+   * ACHTUNG: this may prevent caching HTTP proxies to work
+   * TODO: remove the "?v=randomstring" parameter, and replace with hashed filenames instead
+   */
+  settings.randomVersionString = randomString(4);
+  logger.info(`Random string used for versioning assets: ${settings.randomVersionString}`);
 };
 
 export const exportedForTestingOnly = {
-    parseSettings,
+  parseSettings,
 };
 
 // initially load settings

--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -32,6 +32,7 @@ const ace2_inner = require('ep_etherpad-lite/static/js/ace2_inner')
 const debugLog = (...args) => { };
 const cl_plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins')
 const rJQuery = require('ep_etherpad-lite/static/js/rjquery')
+const html10n = require('ep_etherpad-lite/static/js/vendors/html10n');
 // The inner and outer iframe's locations are about:blank, so relative URLs are relative to that.
 // Firefox and Chrome seem to do what the developer intends if given a relative URL, but Safari
 // errors out unless given an absolute URL for a JavaScript-created element.
@@ -186,8 +187,10 @@ const Ace2Editor = function () {
     outerFrame.name = 'ace_outer';
     outerFrame.frameBorder = 0; // for IE
     outerFrame.title = 'Ether';
-    outerFrame.setAttribute('role', 'application');
-    outerFrame.setAttribute('aria-label', 'Etherpad editor');
+    if (clientVars.padOptions.accessibilityAttributes) {
+      outerFrame.setAttribute('role', 'application');
+      outerFrame.setAttribute('aria-label', html10n.get('pad.aria.editor'));
+    }
     // Some browsers do strange things unless the iframe has a src or srcdoc property:
     //   - Firefox replaces the frame's contentWindow.document object with a different object after
     //     the frame is created. This can be worked around by waiting for the window's load event
@@ -240,8 +243,10 @@ const Ace2Editor = function () {
     const innerFrame = outerDocument.createElement('iframe');
     innerFrame.name = 'ace_inner';
     innerFrame.title = 'pad';
-    innerFrame.setAttribute('role', 'document');
-    innerFrame.setAttribute('aria-label', 'Pad content');
+    if (clientVars.padOptions.accessibilityAttributes) {
+      innerFrame.setAttribute('role', 'document');
+      innerFrame.setAttribute('aria-label', html10n.get('pad.aria.pad_content'));
+    }
     innerFrame.scrolling = 'no';
     innerFrame.frameBorder = 0;
     innerFrame.allowTransparency = true; // for IE
@@ -290,9 +295,11 @@ const Ace2Editor = function () {
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
     innerDocument.body.setAttribute('spellcheck', 'false');
-    innerDocument.body.setAttribute('role', 'textbox');
-    innerDocument.body.setAttribute('aria-multiline', 'true');
-    innerDocument.body.setAttribute('aria-label', 'Pad content');
+    if (clientVars.padOptions.accessibilityAttributes) {
+      innerDocument.body.setAttribute('role', 'textbox');
+      innerDocument.body.setAttribute('aria-multiline', 'true');
+      innerDocument.body.setAttribute('aria-label', html10n.get('pad.aria.pad_content'));
+    }
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
     /*
         debugLog('Ace2Editor.init() waiting for require kernel load');

--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -29,7 +29,7 @@ const hooks = require('./pluginfw/hooks');
 const makeCSSManager = require('./cssmanager').makeCSSManager;
 const pluginUtils = require('./pluginfw/shared');
 const ace2_inner = require('ep_etherpad-lite/static/js/ace2_inner')
-const debugLog = (...args) => {};
+const debugLog = (...args) => { };
 const cl_plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins')
 const rJQuery = require('ep_etherpad-lite/static/js/rjquery')
 // The inner and outer iframe's locations are about:blank, so relative URLs are relative to that.
@@ -57,7 +57,7 @@ const eventFired = async (obj, event, cleanups = [], predicate = () => true) => 
       reject(err);
     };
     cleanup = () => {
-      cleanup = () => {};
+      cleanup = () => { };
       obj.removeEventListener(event, successCb);
       obj.removeEventListener('error', errorCb);
     };
@@ -89,7 +89,7 @@ const frameReady = async (frame) => {
 };
 
 const Ace2Editor = function () {
-  let info = {editor: this};
+  let info = { editor: this };
   let loaded = false;
 
   let actionsPendingInit = [];
@@ -139,7 +139,7 @@ const Ace2Editor = function () {
   this.exportText = () => loaded ? info.ace_exportText() : '(awaiting init)\n';
 
   this.getInInternationalComposition =
-      () => loaded ? info.ace_getInInternationalComposition() : null;
+    () => loaded ? info.ace_getInInternationalComposition() : null;
 
   // prepareUserChangeset:
   // Returns null if no new changes or ACE not ready.  Otherwise, bundles up all user changes
@@ -175,8 +175,8 @@ const Ace2Editor = function () {
       `../static/css/iframe_editor.css?v=${clientVars.randomVersionString}`,
       `../static/css/pad.css?v=${clientVars.randomVersionString}`,
       ...hooks.callAll('aceEditorCSS').map(
-          // Allow urls to external CSS - http(s):// and //some/path.css
-          (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
+        // Allow urls to external CSS - http(s):// and //some/path.css
+        (p) => /\/\//.test(p) ? p : `../static/plugins/${p}`),
       `../static/skins/${clientVars.skinName}/pad.css?v=${clientVars.randomVersionString}`,
     ];
 
@@ -186,6 +186,8 @@ const Ace2Editor = function () {
     outerFrame.name = 'ace_outer';
     outerFrame.frameBorder = 0; // for IE
     outerFrame.title = 'Ether';
+    outerFrame.setAttribute('role', 'application');
+    outerFrame.setAttribute('aria-label', 'Etherpad editor');
     // Some browsers do strange things unless the iframe has a src or srcdoc property:
     //   - Firefox replaces the frame's contentWindow.document object with a different object after
     //     the frame is created. This can be worked around by waiting for the window's load event
@@ -224,6 +226,7 @@ const Ace2Editor = function () {
     const sideDiv = outerDocument.createElement('div');
     sideDiv.id = 'sidediv';
     sideDiv.classList.add('sidediv');
+    sideDiv.setAttribute('aria-hidden', 'true');
     outerDocument.body.appendChild(sideDiv);
     const sideDivInner = outerDocument.createElement('div');
     sideDivInner.id = 'sidedivinner';
@@ -237,6 +240,8 @@ const Ace2Editor = function () {
     const innerFrame = outerDocument.createElement('iframe');
     innerFrame.name = 'ace_inner';
     innerFrame.title = 'pad';
+    innerFrame.setAttribute('role', 'document');
+    innerFrame.setAttribute('aria-label', 'Pad content');
     innerFrame.scrolling = 'no';
     innerFrame.frameBorder = 0;
     innerFrame.allowTransparency = true; // for IE
@@ -262,7 +267,7 @@ const Ace2Editor = function () {
     //const requireKernel = innerDocument.createElement('script');
     //requireKernel.type = 'text/javascript';
     //requireKernel.src =
-     //   absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
+    //   absUrl(`../static/js/require-kernel.js?v=${clientVars.randomVersionString}`);
     //innerDocument.head.appendChild(requireKernel);
     // Pre-fetch modules to improve load performance.
     /*for (const module of ['ace2_inner', 'ace2_common']) {
@@ -277,24 +282,27 @@ const Ace2Editor = function () {
     innerStyle.title = 'dynamicsyntax';
     innerDocument.head.appendChild(innerStyle);
     const headLines = [];
-    hooks.callAll('aceInitInnerdocbodyHead', {iframeHTML: headLines});
+    hooks.callAll('aceInitInnerdocbodyHead', { iframeHTML: headLines });
     innerDocument.head.appendChild(
-        innerDocument.createRange().createContextualFragment(headLines.join('\n')));
+      innerDocument.createRange().createContextualFragment(headLines.join('\n')));
 
     // <body> tag
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
     innerDocument.body.setAttribute('spellcheck', 'false');
+    innerDocument.body.setAttribute('role', 'textbox');
+    innerDocument.body.setAttribute('aria-multiline', 'true');
+    innerDocument.body.setAttribute('aria-label', 'Pad content');
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
-/*
-    debugLog('Ace2Editor.init() waiting for require kernel load');
-    await eventFired(requireKernel, 'load');
-    debugLog('Ace2Editor.init() require kernel loaded');
-    const require = innerWindow.require;
-    require.setRootURI(absUrl('../javascripts/src'));
-    require.setLibraryURI(absUrl('../javascripts/lib'));
-    require.setGlobalKeyPath('require');
-*/
+    /*
+        debugLog('Ace2Editor.init() waiting for require kernel load');
+        await eventFired(requireKernel, 'load');
+        debugLog('Ace2Editor.init() require kernel loaded');
+        const require = innerWindow.require;
+        require.setRootURI(absUrl('../javascripts/src'));
+        require.setLibraryURI(absUrl('../javascripts/lib'));
+        require.setGlobalKeyPath('require');
+    */
     // intentially moved before requiring client_plugins to save a 307
     innerWindow.Ace2Inner = ace2_inner;
     innerWindow.plugins = cl_plugins;

--- a/src/tests/frontend-new/specs/accessibility.spec.ts
+++ b/src/tests/frontend-new/specs/accessibility.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Accessibility ARIA attributes', () => {
+    test.beforeEach(async ({ page }) => {
+        // Navigate to a new pad
+        await page.goto('http://localhost:9001/p/accessibility-test');
+        // Wait for the pad to load
+        await expect(page.locator('#editorcontainer')).toHaveClass(/initialized/);
+    });
+
+    test('should have ARIA attributes on frames and body by default', async ({ page }) => {
+        // Outer iframe
+        const outerFrameElement = page.locator('iframe[name="ace_outer"]');
+        await expect(outerFrameElement).toHaveAttribute('role', 'application');
+        await expect(outerFrameElement).toHaveAttribute('aria-label', 'Etherpad editor');
+
+        // Inner iframe (inside outer iframe)
+        const outerFrame = page.frameLocator('iframe[name="ace_outer"]');
+        const innerFrameElement = outerFrame.locator('iframe[name="ace_inner"]');
+        await expect(innerFrameElement).toHaveAttribute('role', 'document');
+        await expect(innerFrameElement).toHaveAttribute('aria-label', 'Pad content');
+
+        // Inner doc body (inside inner iframe)
+        const innerFrame = outerFrame.frameLocator('iframe[name="ace_inner"]');
+        const innerBody = innerFrame.locator('body#innerdocbody');
+        await expect(innerBody).toHaveAttribute('role', 'textbox');
+        await expect(innerBody).toHaveAttribute('aria-multiline', 'true');
+        await expect(innerBody).toHaveAttribute('aria-label', 'Pad content');
+    });
+});

--- a/src/tests/frontend/specs/accessibility.js
+++ b/src/tests/frontend/specs/accessibility.js
@@ -1,0 +1,29 @@
+'use strict';
+
+describe('Accessibility ARIA attributes', function () {
+    before(async function () {
+        await helper.aNewPad();
+    });
+
+    it('checks if ARIA attributes are present when enabled (default)', async function () {
+        const chrome$ = helper.padChrome$;
+        const outer$ = helper.padOuter$;
+        const inner$ = helper.padInner$;
+
+        // Outer frame
+        const outerFrame = chrome$('iframe[name="ace_outer"]');
+        expect(outerFrame.attr('role')).to.be('application');
+        expect(outerFrame.attr('aria-label')).to.be('Etherpad editor');
+
+        // Inner frame
+        const innerFrame = outer$('iframe[name="ace_inner"]');
+        expect(innerFrame.attr('role')).to.be('document');
+        expect(innerFrame.attr('aria-label')).to.be('Pad content');
+
+        // Inner doc body
+        const innerBody = inner$('body#innerdocbody');
+        expect(innerBody.attr('role')).to.be('textbox');
+        expect(innerBody.attr('aria-multiline')).to.be('true');
+        expect(innerBody.attr('aria-label')).to.be('Pad content');
+    });
+});


### PR DESCRIPTION
## Summary

Screen readers currently struggle with Etherpad because the editor iframes and content areas lack proper ARIA attributes. Users relying on assistive technology can only cycle through line numbers with no way to read or interact with the actual pad content.

This PR adds appropriate ARIA roles and labels to improve screenreader navigation.

Closes #7255

### Changes

- Added `role="application"` and `aria-label="Etherpad editor"` to the outer iframe
- Added `aria-hidden="true"` to `#sidediv` (line numbers) to hide from screenreaders
- Added `role="document"` and `aria-label="Pad content"` to the inner iframe
- Added `role="textbox"`, `aria-multiline="true"`, and `aria-label="Pad content"` to `#innerdocbody`

### Testing

- Inspected DOM elements in Chrome DevTools to verify ARIA attributes are present
- Verified screenreader navigation announces editor content correctly
- Verified line numbers are correctly hidden from assistive technology

*This is a focused split from #7341 as discussed with maintainers.*
