### PR TITLE
Update deprecated GitHub Actions in plugin workflow templates

### DIFF
--- a/bin/plugins/lib/backend-tests.yml
+++ b/bin/plugins/lib/backend-tests.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
       -
         name: Install libreoffice
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libreoffice libreoffice-pdfimport
           version: 1.0
       -
         name: Install etherpad core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ether/etherpad-lite
           path: etherpad-lite
@@ -44,7 +44,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       -
         name: Checkout plugin repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: plugin
       -

--- a/bin/plugins/lib/frontend-tests.yml
+++ b/bin/plugins/lib/frontend-tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       -
         name: Check out Etherpad core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ether/etherpad-lite
       - uses: pnpm/action-setup@v3
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       -
         name: Check out the plugin
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ./node_modules/__tmp
       -

--- a/bin/plugins/lib/npmpublish.yml
+++ b/bin/plugins/lib/npmpublish.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - name: Check out Etherpad core
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ether/etherpad-lite
       - uses: pnpm/action-setup@v3
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       -
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -


### PR DESCRIPTION
Bump actions/checkout v3 → v4 and awalsh128/cache-apt-pkgs-action v1.4.2 → v1.6.0 to fix CI failures caused by deprecated actions/upload-artifact v3 dependency.
