### PR TITLE
Fix backend-tests find path for plugin test discovery

### DIFF
--- a/bin/plugins/lib/backend-tests.yml
+++ b/bin/plugins/lib/backend-tests.yml
@@ -62,7 +62,7 @@ jobs:
         name: Run the backend tests
         working-directory: ./etherpad-lite
         run: |
-          res=$(find .. -path "./node_modules/ep_*/static/tests/backend/specs/**" | wc -l)
+          res=$(find . -path "./src/plugin_packages/ep_*/static/tests/backend/specs/**" | wc -l)
           if [ $res -eq 0 ]; then
           echo "No backend tests found"
           else


### PR DESCRIPTION
plugins i --path installs to src/plugin_packages/, not node_modules/. Update the find command to look in the correct location so backend tests are actually discovered and run.
