### PR TITLE
Fix backend-tests find pattern for versioned plugin paths

### DIFF
--- a/bin/plugins/lib/backend-tests.yml
+++ b/bin/plugins/lib/backend-tests.yml
@@ -62,7 +62,7 @@ jobs:
         name: Run the backend tests
         working-directory: ./etherpad-lite
         run: |
-          res=$(find . -path "./src/plugin_packages/ep_*/static/tests/backend/specs/**" | wc -l)
+          res=$(find . -path "./src/plugin_packages/ep_*@*/static/tests/backend/specs/**" | wc -l)
           if [ $res -eq 0 ]; then
           echo "No backend tests found"
           else


### PR DESCRIPTION
live-plugin-manager installs to src/plugin_packages/ep_name@version/, not src/plugin_packages/ep_name/. Update the glob to match the versioned directory format.

Sorry for the noise, I might end up reverting these commits and squashing but I have to push to develop in order to properly test plugin fixes -_-