### PR TITLE
Fix plugin frontend-tests template: use dev mode not prod

### DIFF
--- a/bin/plugins/lib/frontend-tests.yml
+++ b/bin/plugins/lib/frontend-tests.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run the frontend tests
         shell: bash
         run: |
-          pnpm run prod &
+          pnpm run dev &
           connected=false
           can_connect() {
           curl -sSfo /dev/null http://localhost:9001/ || return 1


### PR DESCRIPTION
## Summary
- Change `pnpm run prod` to `pnpm run dev` in frontend-tests.yml template
- Prod mode enables rate limiting which causes plugin frontend tests to fail silently (tests fail but step exits 0 because the server is backgrounded)

## Test plan
- [x] Verified on ep_headings2 — prod mode caused silent test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)