### PR TITLE
checkPlugin: update all plugin dependencies during autofix

### DIFF
--- a/bin/plugins/checkPlugin.ts
+++ b/bin/plugins/checkPlugin.ts
@@ -403,6 +403,12 @@ log4js.configure({
     logger.warn('Test files not found, please create tests.  https://github.com/ether/etherpad-lite/wiki/Creating-a-plugin#writing-and-running-front-end-tests-for-your-plugin');
   }
 
+  // Update all dependencies to their latest compatible versions.
+  if (autoFix) {
+    logger.info('Updating dependencies...');
+    execSync('pnpm update', {cwd: `${pluginPath}/`, stdio: 'inherit'});
+  }
+
   // Install dependencies so we can run ESLint. This should also create or update package-lock.json
   // if autoFix is enabled.
   const npmInstall = `pnpm install`;


### PR DESCRIPTION
## Summary
- Add `pnpm update` step to checkPlugin.ts when running in autofix mode
- Bumps all dependencies (not just devDependencies) to latest compatible versions
- Reduces dependabot PR noise across plugin repos
- Runs before `pnpm install` and linting

## Test plan
- [ ] Run `pnpm run checkPlugin ep_some_plugin autofix` and verify dependencies are updated
- [ ] Verify lockfile is regenerated with updated versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)