### PR TITLE
Add scheduled workflow to update all plugins daily

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -1,0 +1,63 @@
+name: Update Plugins
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  update-plugins:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out etherpad-lite
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        name: Install pnpm
+        with:
+          version: 10
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install bin dependencies
+        working-directory: ./bin
+        run: pnpm install
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Clone and update all plugins
+        env:
+          GH_TOKEN: ${{ secrets.PLUGINS_PAT }}
+        run: |
+          # Configure git to use the PAT for all ether/ repos
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/ether/".insteadOf "https://github.com/ether/"
+
+          cd ..
+          # List all ep_* repos from ether org
+          plugins=$(gh repo list ether --limit 200 --json name --jq '.[] | select(.name | startswith("ep_")) | .name')
+
+          for plugin in $plugins; do
+            echo "============================================================"
+            echo "Processing $plugin"
+            echo "============================================================"
+
+            # Clone if not present
+            if [ ! -d "$plugin" ]; then
+              git clone "https://github.com/ether/${plugin}.git" "$plugin" || { echo "SKIP: clone failed"; continue; }
+            fi
+
+            # Pull latest
+            (cd "$plugin" && git pull --ff-only) || { echo "SKIP: pull failed"; continue; }
+
+            # Run checkPlugin with autopush
+            cd etherpad-lite/bin
+            pnpm run checkPlugin "$plugin" autopush 2>&1 | tail -20 || echo "WARN: checkPlugin failed for $plugin"
+            cd ../..
+          done


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs daily at 06:00 UTC
- Clones all `ether/ep_*` repos and runs `checkPlugin autopush` on each
- Updates workflows, dependencies (including `pnpm update`), linting, and version bumps
- Can also be triggered manually via workflow_dispatch

## Setup required
Create a `PLUGINS_PAT` org secret at https://github.com/organizations/ether/settings/secrets/actions with a Personal Access Token that has push access to all `ether/ep_*` repos (needs `repo` scope or fine-grained with contents write access to the ether org).

## Test plan
- [ ] Create PLUGINS_PAT secret
- [ ] Trigger workflow manually to verify it works
- [ ] Verify plugins get updated commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)