### PR TITLE
Enable nice-select on Safari/WebKit

### DIFF
--- a/src/static/js/pad_editbar.ts
+++ b/src/static/js/pad_editbar.ts
@@ -23,7 +23,6 @@
  * limitations under the License.
  */
 
-const browser = require('./vendors/browser');
 const hooks = require('./pluginfw/hooks');
 import padutils from "./pad_utils";
 const padeditor = require('./pad_editor').padeditor;
@@ -158,15 +157,7 @@ exports.padeditbar = new class {
       ace: padeditor.ace,
     });
 
-    /*
-     * On safari, the dropdown in the toolbar gets hidden because of toolbar
-     * overflow:hidden property. This is a bug from Safari: any children with
-     * position:fixed (like the dropdown) should be displayed no matter
-     * overflow:hidden on parent
-     */
-    if (!browser.safari) {
-      $('select').niceSelect();
-    }
+    $('select').niceSelect();
 
     // When editor is scrolled, we add a class to style the editbar differently
     $('iframe[name="ace_outer"]').contents().on('scroll', (ev) => {


### PR DESCRIPTION
## Summary
- Remove the 2020 workaround that disabled nice-select on Safari due to a `position:fixed` + `overflow:hidden` rendering bug
- This bug has been fixed in modern WebKit — the workaround is no longer needed
- With nice-select disabled, Safari/WebKit got native `<select>` elements while the tests expected `.nice-select` custom dropdowns, causing all font_type and language tests to fail on webkit

## Test plan
- [ ] Verify webkit frontend tests (font_type, language) now pass
- [ ] Verify chrome and firefox tests remain unaffected
- [ ] Manually verify nice-select dropdowns work in Safari

Fixes #7405

🤖 Generated with [Claude Code](https://claude.com/claude-code)