### PR TITLE
Disable Playwright test retries to surface real failures

### DIFF
--- a/src/playwright.config.ts
+++ b/src/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     reporter: process.env.CI ? 'github' : 'html',
     expect: { timeout: defaultExpectTimeout },
     timeout: defaultTestTimeout,
-    retries: 2,
+    retries: 0,
     workers: 5,
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {


### PR DESCRIPTION
## Summary
- Set Playwright `retries` from 2 to 0
- With retries: 2, tests could fail twice and still pass on the third attempt, marking them as "flaky" which counts as passing
- This hides real bugs like the sticky chat checkbox issue in `chat.spec.ts`

## Test plan
- [ ] Merge and observe which tests actually fail consistently — those are the real bugs to fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)