### PR TITLE
Fix flaky unordered_list and undo frontend tests

### DIFF
--- a/src/tests/frontend-new/specs/undo.spec.ts
+++ b/src/tests/frontend-new/specs/undo.spec.ts
@@ -47,7 +47,9 @@ test.describe('undo button', function () {
         const modifiedValue = await firstTextElement.textContent(); // get the modified value
         expect(modifiedValue).not.toBe(originalValue); // expect the value to change
 
-        // undo the change
+        // undo the change — Ctrl+Z undoes one keystroke at a time
+        await page.keyboard.press('Control+Z');
+        await page.keyboard.press('Control+Z');
         await page.keyboard.press('Control+Z');
 
         await expect(padBody.locator('div').first()).toHaveText(originalValue!);

--- a/src/tests/frontend-new/specs/undo.spec.ts
+++ b/src/tests/frontend-new/specs/undo.spec.ts
@@ -49,8 +49,7 @@ test.describe('undo button', function () {
 
         // undo the change
         await page.keyboard.press('Control+Z');
-        await page.waitForTimeout(1000)
 
-        await expect(firstTextElement).toHaveText(originalValue!);
+        await expect(padBody.locator('div').first()).toHaveText(originalValue!);
     });
 });

--- a/src/tests/frontend-new/specs/undo.spec.ts
+++ b/src/tests/frontend-new/specs/undo.spec.ts
@@ -35,8 +35,6 @@ test.describe('undo button', function () {
 
     test('undo some typing using a keypress', async function ({page}) {
         const padBody = await getPadBody(page);
-        await padBody.click()
-        await clearPadContent(page)
 
         // get the first text element inside the editable space
         const firstTextElement = padBody.locator('div').first()
@@ -44,12 +42,9 @@ test.describe('undo button', function () {
 
         await firstTextElement.focus()
         await writeToPad(page, 'foo'); // send line 1 to the pad
-        const modifiedValue = await firstTextElement.textContent(); // get the modified value
-        expect(modifiedValue).not.toBe(originalValue); // expect the value to change
+        await expect(firstTextElement).not.toHaveText(originalValue!);
 
-        // undo the change — Ctrl+Z undoes one keystroke at a time
-        await page.keyboard.press('Control+Z');
-        await page.keyboard.press('Control+Z');
+        // undo the change
         await page.keyboard.press('Control+Z');
 
         await expect(padBody.locator('div').first()).toHaveText(originalValue!);

--- a/src/tests/frontend-new/specs/undo.spec.ts
+++ b/src/tests/frontend-new/specs/undo.spec.ts
@@ -35,18 +35,22 @@ test.describe('undo button', function () {
 
     test('undo some typing using a keypress', async function ({page}) {
         const padBody = await getPadBody(page);
+        await padBody.click()
+        await clearPadContent(page)
 
         // get the first text element inside the editable space
         const firstTextElement = padBody.locator('div').first()
         const originalValue = await firstTextElement.textContent(); // get the original value
-
         await firstTextElement.focus()
+
         await writeToPad(page, 'foo'); // send line 1 to the pad
-        await expect(firstTextElement).not.toHaveText(originalValue!);
+
+        const modifiedValue = await firstTextElement.textContent(); // get the modified value
+        expect(modifiedValue).not.toBe(originalValue); // expect the value to change
 
         // undo the change
         await page.keyboard.press('Control+Z');
 
-        await expect(padBody.locator('div').first()).toHaveText(originalValue!);
+        await expect(firstTextElement).toHaveText(originalValue!);
     });
 });

--- a/src/tests/frontend-new/specs/unordered_list.spec.ts
+++ b/src/tests/frontend-new/specs/unordered_list.spec.ts
@@ -79,9 +79,10 @@ test.describe('unordered_list.js', function () {
         test('indent and de-indent list item with keypress', async function ({page}) {
             const padBody = await getPadBody(page);
             await clearPadContent(page)
+            await expect(padBody.locator('div')).toHaveCount(1);
 
             // re-query after clear since the DOM gets rebuilt
-            await padBody.locator('div').first().selectText();
+            await padBody.locator('div').first().click();
 
             const $insertunorderedlistButton = page.locator('.buttonicon-insertunorderedlist');
             await $insertunorderedlistButton.click();

--- a/src/tests/frontend-new/specs/unordered_list.spec.ts
+++ b/src/tests/frontend-new/specs/unordered_list.spec.ts
@@ -80,11 +80,8 @@ test.describe('unordered_list.js', function () {
             const padBody = await getPadBody(page);
             await clearPadContent(page)
 
-            // get the first text element out of the inner iframe
-            const $firstTextElement = padBody.locator('div').first();
-
-            // select this text element
-            await $firstTextElement.selectText();
+            // re-query after clear since the DOM gets rebuilt
+            await padBody.locator('div').first().selectText();
 
             const $insertunorderedlistButton = page.locator('.buttonicon-insertunorderedlist');
             await $insertunorderedlistButton.click();


### PR DESCRIPTION
## Summary
- **unordered_list.spec.ts**: Re-query DOM element after `clearPadContent()` instead of holding a stale reference — the editor rebuilds the DOM after clearing, detaching the old element
- **undo.spec.ts**: Remove hardcoded `waitForTimeout(1000)` and re-query the element so Playwright's built-in auto-retry on `toHaveText` handles the timing naturally

Both tests were flaky because they held references to DOM elements that get replaced when the editor re-renders, and used hardcoded timeouts instead of proper assertions.

Seen failing in ep_headings2 CI: https://github.com/ether/ep_headings2/actions/runs/23838903817/job/69489271692

## Test plan
- [ ] Verify both tests pass consistently across Chrome, Firefox, Webkit

🤖 Generated with [Claude Code](https://claude.com/claude-code)