### PR TITLE
Pin ep_markdown@10.0.1 in CI workflows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -126,7 +126,7 @@ jobs:
           ep_font_size
           ep_hash_auth
           ep_headings2
-          ep_markdown
+          ep_markdown@10.0.1
           ep_readonly_guest
           ep_set_title_on_pad
           ep_spellcheck
@@ -242,7 +242,7 @@ jobs:
           ep_font_size
           ep_hash_auth
           ep_headings2
-          ep_markdown
+          ep_markdown@10.0.1
           ep_readonly_guest
           ep_set_title_on_pad
           ep_spellcheck

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -100,7 +100,7 @@ jobs:
           ep_font_size
           ep_hash_auth
           ep_headings2
-          ep_markdown
+          ep_markdown@10.0.1
           ep_readonly_guest
           ep_set_title_on_pad
           ep_spellcheck

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -78,7 +78,7 @@ jobs:
           ep_font_size
           ep_hash_auth
           ep_headings2
-          ep_markdown
+          ep_markdown@10.0.1
           ep_readonly_guest
           ep_set_title_on_pad
           ep_spellcheck


### PR DESCRIPTION
## Summary
- Pin `ep_markdown@10.0.1` in all CI workflows that install plugins
- `ep_markdown@1.0.7` was published today (2026-04-01 06:42 UTC) and took over the `latest` npm dist-tag, causing a downgrade from 10.0.1
- This broke all "with plugins" backend tests with 500 Internal Server Errors

Once npm is back up, we should also run `npm dist-tag add ep_markdown@10.0.1 latest` to fix the tag, then remove the pins.

## Test plan
- [ ] Verify "with plugins" backend tests pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)