### PR TITLE
Add CJS compatibility for Settings and ReadOnlyManager

### DIFF
--- a/src/node/db/ReadOnlyManager.ts
+++ b/src/node/db/ReadOnlyManager.ts
@@ -74,7 +74,7 @@ const getIds = async (id:string) => {
   return {readOnlyPadId, padId, readonly};
 };
 
-export default {
+const readOnlyManager = {
   isReadOnlyId,
   getReadOnlyId,
   getPadId,
@@ -82,4 +82,8 @@ export default {
   // Export for testing purposes
   __getReadOnlyId: getReadOnlyId, // eslint-disable-line no-underscore-dangle
   __getPadId: getPadId, // eslint-disable-line no-underscore-dangle
-}
+};
+export default readOnlyManager;
+// CJS compat for plugins using require('ep_etherpad-lite/node/db/ReadOnlyManager')
+module.exports = readOnlyManager;
+module.exports.default = readOnlyManager;

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -658,6 +658,9 @@ const settings: SettingsType = {
 }
 
 export default settings;
+// CJS compat for plugins using require('ep_etherpad-lite/node/utils/Settings')
+module.exports = settings;
+module.exports.default = settings;
 
 /**
  * This setting is passed with dbType to ueberDB to set up the database


### PR DESCRIPTION
## Summary
- Add `module.exports` shim to Settings.ts and ReadOnlyManager.ts
- Both modules use `export default` which breaks plugins that `require()` them
- Plugins get `{ default: ... }` instead of the module directly
- This affects 28+ plugins that `require('ep_etherpad-lite/node/utils/Settings')`
- And ep_comments_page which requires ReadOnlyManager

## Test plan
- [ ] Verify `require('ep_etherpad-lite/node/utils/Settings')` returns the settings object directly
- [ ] Verify `import settings from 'ep_etherpad-lite/node/utils/Settings'` still works
- [ ] Run etherpad-lite backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)