### PR TITLE
Move load test to daily schedule

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,9 +1,9 @@
 name: "Loadtest"
 
 on:
-  push:
-    paths-ignore:
-      - "doc/**"
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 08:00 UTC
+  workflow_dispatch:  # Allow manual trigger
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Move load test from running on every push to a daily schedule (08:00 UTC)
- Add workflow_dispatch for manual triggers
- Load tests are slow and don't need to gate every push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)