### PR TITLE
fix: prevent crash when pasting bare <li> without parent list element

### DIFF
--- a/src/static/js/contentcollector.ts
+++ b/src/static/js/contentcollector.ts
@@ -504,9 +504,14 @@ const makeContentCollector = (collectStyles, abrowser, apool, className2Author) 
             // See https://github.com/ether/etherpad-lite/issues/2412 for reasoning
             if (!abrowser.chrome) oldListTypeOrNull = (_enterList(state, undefined) || 'none');
           } else if (tname === 'li') {
+            // If the <li> has no parent <ul>/<ol> (e.g., pasted bare HTML), default to bullet list.
+            // See https://github.com/ether/etherpad-lite/issues/6665
+            if (!state.lineAttributes.list) {
+              oldListTypeOrNull = (_enterList(state, 'bullet1') || 'none');
+            }
             state.lineAttributes.start = state.start || 0;
             _recalcAttribString(state);
-            if (state.lineAttributes.list.indexOf('number') !== -1) {
+            if (state.lineAttributes.list && state.lineAttributes.list.indexOf('number') !== -1) {
               /*
                Nested OLs are not --> <ol><li>1</li><ol>nested</ol></ol>
                They are           --> <ol><li>1</li><li><ol><li>nested</li></ol></li></ol>

--- a/src/tests/backend/specs/contentcollector.ts
+++ b/src/tests/backend/specs/contentcollector.ts
@@ -332,6 +332,33 @@ pre
     wantAlines: ['+f*1+2+2'],
     wantText: ['Need more space s !'],
   },
+  {
+    description: 'Bare <li> without parent <ul>/<ol> should not crash (bug #6665)',
+    html: '<html><body><li>this should not crash</li></body></html>',
+    wantAlines: [
+      '*0*2*6+1+l',
+    ],
+    wantText: ['*this should not crash'],
+  },
+  {
+    description: 'Multiple bare <li> elements without parent list',
+    html: '<html><body><li>first</li><li>second</li></body></html>',
+    wantAlines: [
+      '*0*2*6+1+5',
+      '*0*2*6+1+6',
+    ],
+    wantText: ['*first', '*second'],
+  },
+  {
+    description: 'Mixed bare <li> and normal content',
+    html: '<html><body><p>before</p><li>bare item</li><p>after</p></body></html>',
+    wantAlines: [
+      '+6',
+      '*0*2*6+1+9',
+      '+5',
+    ],
+    wantText: ['before', '*bare item', 'after'],
+  },
 ];
 
 describe(__filename, function () {


### PR DESCRIPTION
## Summary

- **Fix** (`contentcollector.ts`): When a bare `<li>` element (no parent `<ul>`/`<ol>`) is encountered during content collection, default it to `bullet1` list type instead of crashing. The list state is properly cleaned up via `oldListTypeOrNull` so subsequent non-list elements aren't affected.
- **Guard** added on `state.lineAttributes.list.indexOf()` call to prevent the TypeError even if the list attribute is somehow undefined.
- **Tests**: 3 new backend contentcollector tests covering bare `<li>`, multiple bare `<li>` elements, and mixed bare `<li>` with normal content.

## Root Cause

`contentcollector.ts:509` calls `state.lineAttributes.list.indexOf('number')` when processing an `<li>` element. This assumes `state.lineAttributes.list` was set by a parent `<ul>`/`<ol>` via `_enterList()`. When pasting HTML with bare `<li>` elements (common when copying from ChatGPT or malformed HTML), no parent list element exists, so `.list` is `undefined` and `.indexOf()` throws:

- **Firefox:** `TypeError: b.lineAttributes.list is undefined`
- **Chrome:** `Cannot read properties of undefined (reading 'indexOf')`

## Test plan

- [x] Backend: `contentcollector.ts` — 108 tests passing (3 new, 105 existing), 0 failing
- [x] Backend: full suite — 744 passing, 0 failing
- [ ] Manual: Copy `<li>this should not crash</li>` as HTML to clipboard and paste into a pad

Fixes https://github.com/ether/etherpad-lite/issues/6665

🤖 Generated with [Claude Code](https://claude.com/claude-code)