### PR TITLE
fix: wait for server confirmation before navigating after pad delete

### DIFF
--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -235,7 +235,7 @@ const handlePadDelete = async (socket: any, padDeleteMessage: PadDeleteMessage) 
     // Only the one doing the first revision can delete the pad, otherwise people could troll a lot
     const firstContributor = await retrievedPad.getRevisionAuthor(0)
     if (session.author === firstContributor) {
-      retrievedPad.remove()
+      await retrievedPad.remove()
     } else {
 
       type ShoutMessage = {

--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -90,12 +90,26 @@ const padeditor = (() => {
           // Navigating immediately caused a race condition where the browser
           // (especially Firefox) would close the WebSocket before the delete
           // message reached the server. See #7306.
+          let handled = false;
           pad.socket.on('message', (data: any) => {
             if (data && data.disconnect === 'deleted') {
+              handled = true;
               window.location.href = '/';
             }
           });
+          // If the user is not the pad creator, the server sends a shout
+          // message instead of deleting. Listen for it and show the error.
+          pad.socket.on('shout', (data: any) => {
+            handled = true;
+            const msg = data?.data?.payload?.message?.message;
+            if (msg) window.alert(msg);
+          });
           pad.collabClient.sendMessage({type: 'PAD_DELETE', data:{padId: pad.getPadId()}});
+          // Fallback: if the server doesn't respond within 5 seconds
+          // (e.g. socket dropped), navigate away anyway.
+          setTimeout(() => {
+            if (!handled) window.location.href = '/';
+          }, 5000);
         }
       })
 

--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -86,9 +86,16 @@ const padeditor = (() => {
       // delete pad
       $('#delete-pad').on('click', () => {
         if (window.confirm(html10n.get('pad.delete.confirm'))) {
+          // Wait for the server to confirm deletion before navigating away.
+          // Navigating immediately caused a race condition where the browser
+          // (especially Firefox) would close the WebSocket before the delete
+          // message reached the server. See #7306.
+          pad.socket.on('message', (data: any) => {
+            if (data && data.disconnect === 'deleted') {
+              window.location.href = '/';
+            }
+          });
           pad.collabClient.sendMessage({type: 'PAD_DELETE', data:{padId: pad.getPadId()}});
-          // redirect to home page after deletion
-          window.location.href = '/';
         }
       })
 


### PR DESCRIPTION
## Summary

- **Client** (`pad_editor.ts`): The delete pad handler now waits for the server's response before navigating:
  - Listens for `{disconnect: 'deleted'}` on the `message` event — navigates to `/` on success
  - Listens for the `shout` event — shows an alert when a non-creator tries to delete (server sends an error message instead of deleting)
  - 5-second timeout fallback — navigates to `/` if the server doesn't respond (socket dropped, etc.)
- **Server** (`PadMessageHandler.ts`): `await` the `pad.remove()` call so the deletion completes before `kickSessionsFromPad` sends the disconnect response.

## Root Cause

The delete pad click handler called `sendMessage` then immediately set `window.location.href = '/'`. In Firefox (and mobile Chrome), the browser tears down the WebSocket connection during page navigation before the outgoing message is flushed. The message never reaches the server, so the pad is never deleted — but the user sees the home page and thinks it worked.

Additionally, when a non-creator tries to delete, the server sends a `shoutMessage` on the `shout` event (not a disconnect). The old code navigated away before this could be received, so the user never saw the error. Now the client listens for this and displays the message.

## Test plan

- [x] Backend: `messages.ts` tests pass (10/10)
- [x] Backend: pre-existing pad API delete test failures confirmed on develop (not caused by this change)
- [ ] Manual (creator, Firefox): create pad, modify, Delete Pad → should delete and redirect
- [ ] Manual (creator, Chrome): same test → verify no regression
- [ ] Manual (non-creator): open someone else's pad, try Delete Pad → should see error alert, NOT navigate away
- [ ] Manual (timeout): disconnect network after clicking Delete Pad → should redirect after 5s

Fixes https://github.com/ether/etherpad-lite/issues/7306
Fixes https://github.com/ether/etherpad-lite/issues/7311

🤖 Generated with [Claude Code](https://claude.com/claude-code)