### PR TITLE
fix: filter already-deleted sessions when deleting a group

### DIFF
--- a/src/node/db/GroupManager.ts
+++ b/src/node/db/GroupManager.ts
@@ -59,8 +59,10 @@ exports.deleteGroup = async (groupID: string): Promise<void> => {
 
   // Delete associated sessions in parallel. This should be done before deleting the group2sessions
   // record because deleting a session updates the group2sessions record.
+  // Filter out already-deleted sessions: deleteSession sets the value to null/undefined via setSub,
+  // but the key remains in the object. See https://github.com/ether/etherpad-lite/issues/5798
   const {sessionIDs = {}} = await db.get(`group2sessions:${groupID}`) || {};
-  await Promise.all(Object.keys(sessionIDs).map(async (sessionId) => {
+  await Promise.all(Object.keys(sessionIDs).filter((id) => sessionIDs[id]).map(async (sessionId) => {
     await sessionManager.deleteSession(sessionId);
   }));
 

--- a/src/tests/backend/specs/api/sessionsAndGroups.ts
+++ b/src/tests/backend/specs/api/sessionsAndGroups.ts
@@ -421,6 +421,54 @@ describe(__filename, function () {
           });
     });
   });
+  // Regression test for https://github.com/ether/etherpad-lite/issues/5798
+  describe('API: deleteGroup after deleteSession (bug #5798)', function () {
+    let testGroupID: string;
+    let testAuthorID: string;
+    let testSessionID: string;
+
+    it('creates group, author, and session', async function () {
+      let res = await preparedAgent.get(endPoint('createGroup'))
+          .set("Authorization", await generateJWTToken())
+          .expect(200);
+      assert.equal(res.body.code, 0);
+      testGroupID = res.body.data.groupID;
+
+      res = await preparedAgent.get(`${endPoint('createAuthor')}?name=testuser`)
+          .set("Authorization", await generateJWTToken())
+          .expect(200);
+      assert.equal(res.body.code, 0);
+      testAuthorID = res.body.data.authorID;
+
+      res = await preparedAgent.get(
+          `${endPoint('createSession')}?authorID=${testAuthorID}&groupID=${testGroupID}` +
+          '&validUntil=999999999999')
+          .set("Authorization", await generateJWTToken())
+          .expect(200);
+      assert.equal(res.body.code, 0);
+      testSessionID = res.body.data.sessionID;
+    });
+
+    it('deleteSession succeeds', async function () {
+      await preparedAgent.get(`${endPoint('deleteSession')}?sessionID=${testSessionID}`)
+          .set("Authorization", await generateJWTToken())
+          .expect(200)
+          .expect((res: any) => {
+            assert.equal(res.body.code, 0);
+          });
+    });
+
+    it('deleteGroup succeeds after session was already deleted', async function () {
+      // This used to fail with "sessionID does not exist" because deleteSession
+      // left a null entry in group2sessions that deleteGroup tried to re-delete.
+      await preparedAgent.get(`${endPoint('deleteGroup')}?groupID=${testGroupID}`)
+          .set("Authorization", await generateJWTToken())
+          .expect(200)
+          .expect((res: any) => {
+            assert.equal(res.body.code, 0);
+          });
+    });
+  });
 });
 
 function makeid() {


### PR DESCRIPTION
## Summary

One-line fix in `GroupManager.ts`: filter out null/falsy entries from `sessionIDs` before iterating in `deleteGroup`.

## Root Cause

`deleteSession` uses `db.setSub(group2sessions:..., ['sessionIDs', sessionID], undefined)` to remove a session reference. While the comment says `undefined` deletes the property (JSON.stringify ignores it), the key can persist as `null` in the object depending on the DB backend.

When `deleteGroup` later calls `Object.keys(sessionIDs).map(id => deleteSession(id))`, it tries to delete sessions that were already deleted, throwing `"sessionID does not exist"`.

## Test plan

- [x] Backend: regression test added to `sessionsAndGroups.ts` — creates group+author+session, deletes session, then deletes group (3/3 passing)
- [x] Backend: `messages.ts` tests pass (10/10)
- [ ] Manual: create group, create author, create session, delete session, delete group → should succeed without error

Fixes https://github.com/ether/etherpad-lite/issues/5798

🤖 Generated with [Claude Code](https://claude.com/claude-code)