### PR TITLE
fix: createDiffHTML API fails with "Not a changeset: undefined"

### DIFF
--- a/src/node/utils/padDiff.ts
+++ b/src/node/utils/padDiff.ts
@@ -20,7 +20,6 @@ class PadDiff {
     private readonly _toRev: string;
     private _html: any;
     public _authors: any[];
-    private self: PadDiff | undefined
   constructor(pad: PadType, fromRev:string, toRev:string) {
     // check parameters
     if (!pad || !pad.id || !pad.atext || !pad.pool) {
@@ -121,12 +120,10 @@ class PadDiff {
     return {changesets, authors};
   }
   _addAuthors(authors: PadAuthor[]){
-      this.self = this;
-
     // add to array if not in the array
     authors.forEach((author) => {
-      if (this.self!._authors.indexOf(author) === -1) {
-        this.self!._authors.push(author);
+      if (this._authors.indexOf(author) === -1) {
+        this._authors.push(author);
       }
     });
   }
@@ -209,7 +206,7 @@ class PadDiff {
       await this.getHtml();
     }
 
-    return this.self!._authors;
+    return this._authors;
   }
 
   _extendChangesetWithAuthor(changeset: any, author: any, apool: any){
@@ -457,13 +454,6 @@ class PadDiff {
 
 }
 
-
-// this method is 80% like Changeset.inverse. I just changed so instead of reverting,
-// it adds deletions and attribute changes to the atext.
-// @ts-ignore
-PadDiff.prototype._createDeletionChangeset = function (cs, startAText, apool) {
-
-};
 
 // export the constructor
 module.exports = PadDiff;

--- a/src/tests/backend/specs/api/createDiffHTML.ts
+++ b/src/tests/backend/specs/api/createDiffHTML.ts
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert = require('assert').strict;
+const common = require('../../common');
+
+let agent: any;
+let apiVersion = 1;
+const testPadId = `createDiffHTML_${Date.now()}`;
+
+const endPoint = (point: string) => `/api/${apiVersion}/${point}`;
+
+describe(__filename, function () {
+  before(async function () {
+    agent = await common.init();
+    const res = await agent.get('/api/')
+        .expect(200)
+        .expect('Content-Type', /json/);
+    apiVersion = res.body.currentVersion;
+    assert(apiVersion);
+
+    // Create pad with multiple revisions for diff testing
+    await agent.get(`${endPoint('createPad')}?padID=${testPadId}`)
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200);
+
+    await agent.post(endPoint('setText'))
+        .set('Authorization', await common.generateJWTToken())
+        .send({padID: testPadId, text: 'first revision'})
+        .expect(200);
+
+    await agent.post(endPoint('setText'))
+        .set('Authorization', await common.generateJWTToken())
+        .send({padID: testPadId, text: 'second revision'})
+        .expect(200);
+  });
+
+  it('createDiffHTML between two different revisions', async function () {
+    const res = await agent.get(
+        `${endPoint('createDiffHTML')}?padID=${testPadId}&startRev=1&endRev=2`)
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200)
+        .expect('Content-Type', /json/);
+    assert.equal(res.body.code, 0);
+    assert(res.body.data.html);
+    assert(Array.isArray(res.body.data.authors));
+  });
+
+  it('createDiffHTML with same startRev and endRev', async function () {
+    const res = await agent.get(
+        `${endPoint('createDiffHTML')}?padID=${testPadId}&startRev=1&endRev=1`)
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200)
+        .expect('Content-Type', /json/);
+    assert.equal(res.body.code, 0);
+    assert(res.body.data.html);
+  });
+
+  it('createDiffHTML from rev 0 to latest', async function () {
+    const res = await agent.get(
+        `${endPoint('createDiffHTML')}?padID=${testPadId}&startRev=0&endRev=2`)
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200)
+        .expect('Content-Type', /json/);
+    assert.equal(res.body.code, 0);
+    assert(res.body.data.html);
+  });
+
+  after(async function () {
+    await agent.get(`${endPoint('deletePad')}?padID=${testPadId}`)
+        .set('Authorization', await common.generateJWTToken());
+  });
+});

--- a/src/tests/backend/specs/api/createDiffHTML.ts
+++ b/src/tests/backend/specs/api/createDiffHTML.ts
@@ -5,7 +5,16 @@ const common = require('../../common');
 
 let agent: any;
 let apiVersion = 1;
-const testPadId = `createDiffHTML_${Date.now()}`;
+const testPadId = `createDiffHTML_${makeid()}`;
+
+function makeid() {
+  let text = '';
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 10; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+}
 
 const endPoint = (point: string) => `/api/${apiVersion}/${point}`;
 
@@ -67,6 +76,7 @@ describe(__filename, function () {
 
   after(async function () {
     await agent.get(`${endPoint('deletePad')}?padID=${testPadId}`)
-        .set('Authorization', await common.generateJWTToken());
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200);
   });
 });


### PR DESCRIPTION
## Summary

- **Empty prototype override**: `PadDiff.prototype._createDeletionChangeset` was being overwritten with an empty function at the bottom of `padDiff.ts`, replacing the real class method (lines 242-456) with a no-op that returned `undefined`. Removed the dead override.
- **Crash on same-rev diff**: When `startRev === endRev`, `_addAuthors()` was never called, leaving `this.self` as `undefined`. Accessing `this.self!._authors` then threw `Cannot read properties of undefined`. Replaced all `this.self!._authors` references with direct `this._authors` access and removed the unnecessary `self` property.

## Root Cause

The empty prototype override was likely a leftover from a code migration (CJS → class syntax). The comment above it ("this method is 80% like Changeset.inverse") described what the real implementation does, but the override body was empty — silently breaking the API.

## Test plan

- [x] Backend tests pass (754/754)
- [x] New test: `createDiffHTML.ts` — tests diff between revisions, same-rev diff, and rev 0 to latest

Fixes https://github.com/ether/etherpad-lite/issues/6847

🤖 Generated with [Claude Code](https://claude.com/claude-code)