### PR TITLE
fix: consecutive numbering fails after indented sub-bullets

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2314,7 +2314,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         listType = /([a-z]+)([0-9]+)/.exec(listType);
         curLevel = Number(listType[2]);
         const curType = listType[1];
-        if (isNaN(curLevel) || listType[0] === 'indent') {
+        if (isNaN(curLevel) || listType[1] === 'indent') {
           return line;
         } else if (curLevel === level) {
           // Reset position when switching between list types at the same level

--- a/src/tests/frontend-new/specs/ordered_list.spec.ts
+++ b/src/tests/frontend-new/specs/ordered_list.spec.ts
@@ -92,6 +92,48 @@ test.describe('ordered_list.js', function () {
     await expect(fifthLine.locator('ol')).toHaveAttribute('start', '3', {timeout: 5000});
   });
 
+  // Regression test for https://github.com/ether/etherpad-lite/issues/5718
+  test('issue #5718 consecutive numbering works after indented sub-bullets', async function ({page}) {
+    const padBody = await getPadBody(page);
+    await clearPadContent(page);
+
+    // Create a bullet point
+    const $insertUnorderedButton = page.locator('.buttonicon-insertunorderedlist');
+    await $insertUnorderedButton.click({force: true});
+    await writeToPad(page, 'Bullet item');
+    await page.keyboard.press('Enter');
+
+    // Indent to create a sub-bullet
+    await page.keyboard.press('Tab');
+    await writeToPad(page, 'Sub-bullet');
+    await page.keyboard.press('Enter');
+
+    // De-indent back to level 1
+    await page.keyboard.press('Shift+Tab');
+
+    // Switch to numbered list
+    const $insertOrderedButton = page.locator('.buttonicon-insertorderedlist');
+    await $insertOrderedButton.click({force: true});
+    await writeToPad(page, 'Number 1');
+    await page.keyboard.press('Enter');
+    await writeToPad(page, 'Number 2');
+    await page.keyboard.press('Enter');
+    await writeToPad(page, 'Number 3');
+
+    // Wait for renumbering
+    await page.waitForTimeout(500);
+
+    // Lines 3, 4, 5 should be numbered 1, 2, 3
+    const line3 = padBody.locator('div').nth(2);
+    await expect(line3.locator('ol')).toHaveAttribute('start', '1', {timeout: 5000});
+
+    const line4 = padBody.locator('div').nth(3);
+    await expect(line4.locator('ol')).toHaveAttribute('start', '2', {timeout: 5000});
+
+    const line5 = padBody.locator('div').nth(4);
+    await expect(line5.locator('ol')).toHaveAttribute('start', '3', {timeout: 5000});
+  });
+
   test.describe('Pressing Tab in an OL increases and decreases indentation', function () {
 
     test('indent and de-indent list item with keypress', async function ({page}) {

--- a/src/tests/frontend-new/specs/ordered_list.spec.ts
+++ b/src/tests/frontend-new/specs/ordered_list.spec.ts
@@ -106,6 +106,11 @@ test.describe('ordered_list.js', function () {
     // Indent to create a sub-bullet
     await page.keyboard.press('Tab');
     await writeToPad(page, 'Sub-bullet');
+
+    // Verify the sub-bullet is actually indented (level 2)
+    const subBulletLine = padBody.locator('div').nth(1);
+    await expect(subBulletLine.locator('.list-bullet2')).toHaveCount(1, {timeout: 5000});
+
     await page.keyboard.press('Enter');
 
     // De-indent back to level 1
@@ -119,9 +124,6 @@ test.describe('ordered_list.js', function () {
     await writeToPad(page, 'Number 2');
     await page.keyboard.press('Enter');
     await writeToPad(page, 'Number 3');
-
-    // Wait for renumbering
-    await page.waitForTimeout(500);
 
     // Lines 3, 4, 5 should be numbered 1, 2, 3
     const line3 = padBody.locator('div').nth(2);


### PR DESCRIPTION
## Summary

One-character fix in `ace2_inner.ts`: `listType[0]` → `listType[1]` in the `applyNumberList()` function inside `renumberList()`.

## Root Cause

After `listType = /([a-z]+)([0-9]+)/.exec(listType)`, the array indices are:
- `listType[0]` = full match (e.g., `"indent1"`) — **never** just `"indent"`
- `listType[1]` = capture group 1 (e.g., `"indent"`, `"number"`, `"bullet"`)
- `listType[2]` = capture group 2 (e.g., `"1"`, `"2"`)

The check `listType[0] === 'indent'` was always false, so indent-type lines were never recognized during renumbering. This broke the numbering sequence when numbered lists followed indented content — all items showed "1" instead of incrementing.

Note: the same function's parent `renumberList()` correctly uses `type[1] === 'indent'` at lines 2290 and 2297 — this was just a typo in the inner `applyNumberList()` helper.

## Test plan

- [x] Backend tests pass (754/754)
- [x] New Playwright test: numbered list after indented sub-bullets shows consecutive numbers (chromium pass)
- [x] All existing ordered_list tests pass on chromium

Fixes https://github.com/ether/etherpad-lite/issues/5718

🤖 Generated with [Claude Code](https://claude.com/claude-code)