### PR TITLE
fix: add periodic cleanup of expired/stale sessions from database

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -463,7 +463,13 @@
      * Automatic session refreshes can be disabled (not recommended) by setting
      * this to null.
      */
-    "sessionRefreshInterval": 86400000 // = 1d * 24h/d * 60m/h * 60s/m * 1000ms/s
+    "sessionRefreshInterval": 86400000, // = 1d * 24h/d * 60m/h * 60s/m * 1000ms/s
+
+    /*
+     * Whether to periodically clean up expired and stale sessions from the
+     * database. Set to false to disable. Default: true.
+     */
+    "sessionCleanup": true
   },
 
   /*

--- a/src/node/db/SessionStore.ts
+++ b/src/node/db/SessionStore.ts
@@ -9,9 +9,6 @@ const util = require('util');
 
 const logger = log4js.getLogger('SessionStore');
 
-// Sessions without an expiry date older than this are considered stale and will be cleaned up.
-const STALE_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-
 // How often to run the cleanup of expired/stale sessions.
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
@@ -36,33 +33,47 @@ class SessionStore extends expressSession.Store {
     //     equal to `db`.
     //   - `timeout`: Timeout ID for a timeout that will clean up the database record.
     this._expirations = new Map();
-    this._cleanupInterval = null;
+    this._cleanupTimer = null;
+    this._cleanupRunning = false;
   }
 
   /**
    * Start periodic cleanup of expired/stale sessions from the database.
+   * Uses chained setTimeout (not setInterval) to prevent overlapping runs.
    */
   startCleanup() {
-    // Run once on startup (deferred to avoid blocking), then periodically.
-    setTimeout(() => this._cleanup().catch((err) => logger.error('Session cleanup error:', err)), 5000);
-    this._cleanupInterval = setInterval(
-        () => this._cleanup().catch((err) => logger.error('Session cleanup error:', err)),
-        CLEANUP_INTERVAL_MS);
+    this._scheduleCleanup(5000); // First run 5s after startup.
+  }
+
+  _scheduleCleanup(delay: number) {
+    this._cleanupTimer = setTimeout(async () => {
+      try {
+        await this._cleanup();
+      } catch (err) {
+        logger.error('Session cleanup error:', err);
+      }
+      // Schedule the next run only after this one completes.
+      this._scheduleCleanup(CLEANUP_INTERVAL_MS);
+    }, delay);
     // Don't prevent Node.js from exiting.
-    if (this._cleanupInterval.unref) this._cleanupInterval.unref();
+    if (this._cleanupTimer.unref) this._cleanupTimer.unref();
   }
 
   shutdown() {
     for (const {timeout} of this._expirations.values()) clearTimeout(timeout);
-    if (this._cleanupInterval) {
-      clearInterval(this._cleanupInterval);
-      this._cleanupInterval = null;
+    if (this._cleanupTimer) {
+      clearTimeout(this._cleanupTimer);
+      this._cleanupTimer = null;
     }
   }
 
   /**
-   * Remove expired and stale sessions from the database. Expired sessions have a cookie.expires
-   * date in the past. Stale sessions have no expiry and haven't been touched in STALE_SESSION_MAX_AGE_MS.
+   * Remove expired and empty sessions from the database.
+   *
+   * - Sessions with an `expires` date in the past are removed (expired).
+   * - Sessions with no expiry that contain no data beyond the default cookie are removed.
+   *   These are the empty sessions that accumulate indefinitely (bug #5010) — they have
+   *   `{cookie: {path: "/", _expires: null, ...}}` and nothing else.
    */
   async _cleanup() {
     const keys = await DB.findKeys('sessionstorage:*', null);
@@ -84,11 +95,7 @@ class SessionStore extends expressSession.Store {
           removed++;
         }
       } else {
-        // Session has no expiry — remove if it has no meaningful data beyond the default cookie.
-        // These are the sessions that accumulate indefinitely (bug #5010).
-        // We can't know when they were created, so we check if they have any data beyond the
-        // cookie itself. If they only contain the cookie (no user session data), they're safe
-        // to remove as stale.
+        // Session has no expiry and no user data beyond the cookie — remove as empty/stale.
         const hasData = Object.keys(sess).some((k) => k !== 'cookie');
         if (!hasData) {
           await DB.remove(key);

--- a/src/node/db/SessionStore.ts
+++ b/src/node/db/SessionStore.ts
@@ -9,6 +9,12 @@ const util = require('util');
 
 const logger = log4js.getLogger('SessionStore');
 
+// Sessions without an expiry date older than this are considered stale and will be cleaned up.
+const STALE_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// How often to run the cleanup of expired/stale sessions.
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
 class SessionStore extends expressSession.Store {
   /**
    * @param {?number} [refresh] - How often (in milliseconds) `touch()` will update a session's
@@ -30,10 +36,69 @@ class SessionStore extends expressSession.Store {
     //     equal to `db`.
     //   - `timeout`: Timeout ID for a timeout that will clean up the database record.
     this._expirations = new Map();
+    this._cleanupInterval = null;
+  }
+
+  /**
+   * Start periodic cleanup of expired/stale sessions from the database.
+   */
+  startCleanup() {
+    // Run once on startup (deferred to avoid blocking), then periodically.
+    setTimeout(() => this._cleanup().catch((err) => logger.error('Session cleanup error:', err)), 5000);
+    this._cleanupInterval = setInterval(
+        () => this._cleanup().catch((err) => logger.error('Session cleanup error:', err)),
+        CLEANUP_INTERVAL_MS);
+    // Don't prevent Node.js from exiting.
+    if (this._cleanupInterval.unref) this._cleanupInterval.unref();
   }
 
   shutdown() {
     for (const {timeout} of this._expirations.values()) clearTimeout(timeout);
+    if (this._cleanupInterval) {
+      clearInterval(this._cleanupInterval);
+      this._cleanupInterval = null;
+    }
+  }
+
+  /**
+   * Remove expired and stale sessions from the database. Expired sessions have a cookie.expires
+   * date in the past. Stale sessions have no expiry and haven't been touched in STALE_SESSION_MAX_AGE_MS.
+   */
+  async _cleanup() {
+    const keys = await DB.findKeys('sessionstorage:*', null);
+    if (!keys || keys.length === 0) return;
+    const now = Date.now();
+    let removed = 0;
+    for (const key of keys) {
+      const sess = await DB.get(key);
+      if (!sess) {
+        await DB.remove(key);
+        removed++;
+        continue;
+      }
+      const expires = sess.cookie?.expires;
+      if (expires) {
+        // Session has an expiry — remove if expired.
+        if (new Date(expires).getTime() <= now) {
+          await DB.remove(key);
+          removed++;
+        }
+      } else {
+        // Session has no expiry — remove if it has no meaningful data beyond the default cookie.
+        // These are the sessions that accumulate indefinitely (bug #5010).
+        // We can't know when they were created, so we check if they have any data beyond the
+        // cookie itself. If they only contain the cookie (no user session data), they're safe
+        // to remove as stale.
+        const hasData = Object.keys(sess).some((k) => k !== 'cookie');
+        if (!hasData) {
+          await DB.remove(key);
+          removed++;
+        }
+      }
+    }
+    if (removed > 0) {
+      logger.info(`Session cleanup: removed ${removed} expired/stale sessions out of ${keys.length}`);
+    }
   }
 
   async _updateExpirations(sid: string, sess: any, updateDbExp = true) {

--- a/src/node/hooks/express.ts
+++ b/src/node/hooks/express.ts
@@ -201,6 +201,7 @@ exports.restartServer = async () => {
   app.use(cookieParser(secret, {}));
 
   sessionStore = new SessionStore(settings.cookie.sessionRefreshInterval);
+  sessionStore.startCleanup();
   exports.sessionMiddleware = expressSession({
     rolling: true,
     secret,

--- a/src/node/hooks/express.ts
+++ b/src/node/hooks/express.ts
@@ -201,7 +201,9 @@ exports.restartServer = async () => {
   app.use(cookieParser(secret, {}));
 
   const store = new SessionStore(settings.cookie.sessionRefreshInterval);
-  store.startCleanup();
+  if (settings.cookie.sessionCleanup !== false) {
+    store.startCleanup();
+  }
   sessionStore = store;
   exports.sessionMiddleware = expressSession({
     rolling: true,

--- a/src/node/hooks/express.ts
+++ b/src/node/hooks/express.ts
@@ -200,8 +200,9 @@ exports.restartServer = async () => {
 
   app.use(cookieParser(secret, {}));
 
-  sessionStore = new SessionStore(settings.cookie.sessionRefreshInterval);
-  sessionStore.startCleanup();
+  const store = new SessionStore(settings.cookie.sessionRefreshInterval);
+  store.startCleanup();
+  sessionStore = store;
   exports.sessionMiddleware = expressSession({
     rolling: true,
     secret,

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -255,6 +255,7 @@ export type SettingsType = {
     prefix: string,
     sameSite: boolean | "lax" | "strict" | "none" | undefined,
     sessionLifetime: number,
+    sessionCleanup: boolean,
     sessionRefreshInterval: number,
   },
   requireAuthentication: boolean,
@@ -534,6 +535,7 @@ const settings: SettingsType = {
     prefix: '',
     sameSite: 'lax',
     sessionLifetime: 10 * 24 * 60 * 60 * 1000,
+    sessionCleanup: true,
     sessionRefreshInterval: 1 * 24 * 60 * 60 * 1000,
   },
   /*

--- a/src/tests/backend/specs/SessionStore.ts
+++ b/src/tests/backend/specs/SessionStore.ts
@@ -12,6 +12,9 @@ type Session = {
   destroy: (sid:string|null) => void;
   touch: (sid:string|null, sess:any, sess2:any) => void;
   shutdown: () => void;
+  startCleanup: () => void;
+  _cleanup: () => Promise<void>;
+  _cleanupTimer: any;
 }
 
 describe(__filename, function () {
@@ -241,6 +244,57 @@ describe(__filename, function () {
       await db.remove(`sessionstorage:${sid}`);
       await touch(sess); // No change in expiration time.
       assert.equal(JSON.stringify(await db.get(`sessionstorage:${sid}`)), JSON.stringify(sess));
+    });
+  });
+
+  // Regression tests for https://github.com/ether/etherpad-lite/issues/5010
+  describe('cleanup', function () {
+    it('removes expired sessions', async function () {
+      const expiredSid = `cleanup_expired_${common.randomString()}`;
+      await db.set(`sessionstorage:${expiredSid}`, {
+        cookie: {path: '/', expires: new Date(1).toJSON(), httpOnly: true},
+      });
+      await ss!._cleanup();
+      assert(await db.get(`sessionstorage:${expiredSid}`) == null);
+    });
+
+    it('removes empty sessions with no expiry', async function () {
+      const emptySid = `cleanup_empty_${common.randomString()}`;
+      await db.set(`sessionstorage:${emptySid}`, {
+        cookie: {path: '/', _expires: null, originalMaxAge: null, httpOnly: true},
+      });
+      await ss!._cleanup();
+      assert(await db.get(`sessionstorage:${emptySid}`) == null);
+    });
+
+    it('preserves sessions with user data and no expiry', async function () {
+      const dataSid = `cleanup_data_${common.randomString()}`;
+      const sess = {
+        cookie: {path: '/', _expires: null, httpOnly: true},
+        user: {name: 'test'},
+      };
+      await db.set(`sessionstorage:${dataSid}`, sess);
+      await ss!._cleanup();
+      assert.equal(JSON.stringify(await db.get(`sessionstorage:${dataSid}`)), JSON.stringify(sess));
+      await db.remove(`sessionstorage:${dataSid}`);
+    });
+
+    it('preserves non-expired sessions', async function () {
+      const validSid = `cleanup_valid_${common.randomString()}`;
+      const sess = {
+        cookie: {path: '/', expires: new Date(Date.now() + 60000).toJSON(), httpOnly: true},
+      };
+      await db.set(`sessionstorage:${validSid}`, sess);
+      await ss!._cleanup();
+      assert.equal(JSON.stringify(await db.get(`sessionstorage:${validSid}`)), JSON.stringify(sess));
+      await db.remove(`sessionstorage:${validSid}`);
+    });
+
+    it('shutdown cancels pending cleanup timer', async function () {
+      ss!.startCleanup();
+      ss!.shutdown();
+      // After shutdown, the timer should be cleared.
+      assert(ss!._cleanupTimer == null);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds periodic session cleanup to `SessionStore` that removes expired and stale sessions from the database, preventing unbounded growth.

## Root Cause

Session storage grew indefinitely (16M+ records reported) because:
1. Sessions with no expiry (`_expires: null`) accumulated forever with no cleanup
2. In-memory expiration timeouts were lost on server restart
3. No DB-level cleanup mechanism existed

## Fix

`SessionStore._cleanup()` runs periodically (chained `setTimeout`, not `setInterval`, to prevent overlapping runs) which:
- Removes sessions with expired cookies
- Removes sessions with no expiry that contain no data beyond the default cookie (the empty sessions from #5010)
- Preserves sessions with user data or valid expiry dates

All timers use `.unref()` and are properly cancelled in `shutdown()`.

## Test plan

- [x] Backend tests pass (759/759)
- [x] Type check passes
- [x] 5 new tests in `SessionStore.ts`: expired removed, empty removed, data preserved, valid preserved, shutdown cancels timer

Fixes https://github.com/ether/etherpad-lite/issues/5010

🤖 Generated with [Claude Code](https://claude.com/claude-code)