### PR TITLE
fix: list bugs — indent export, renumber performance, and batching

### DIFF
--- a/src/node/utils/ExportHtml.ts
+++ b/src/node/utils/ExportHtml.ts
@@ -388,22 +388,15 @@ const getHTMLFromAtext = async (pad:PadType, atext: AText, authorColors?: string
             }
 
             if (line.listTypeName === 'number') {
-              // We introduce line.start here, this is useful for continuing
-              // Ordered list line numbers
-              // in case you have a bullet in a list IE you Want
-              // 1. hello
-              //   * foo
-              // 2. world
-              // Without this line.start logic it would be
-              // 1. hello * foo 1. world because the bullet would kill the OL
-
-              // TODO: This logic could also be used to continue OL with indented content
-              // but that's a job for another day....
               if (line.start) {
                 pieces.push(`<ol start="${Number(line.start)}" class="${line.listTypeName}">`);
               } else {
                 pieces.push(`<ol class="${line.listTypeName}">`);
               }
+            } else if (line.listTypeName === 'indent') {
+              // Indent lines are plain indented text, not list items.
+              // Use a ul with list-style-type:none so they don't show bullets.
+              pieces.push(`<ul class="${line.listTypeName}" style="list-style-type: none;">`);
             } else {
               pieces.push(`<ul class="${line.listTypeName}">`);
             }

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2350,6 +2350,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   };
   editorInfo.ace_renumberList = renumberList;
 
+  let _skipRenumber = false;
   const setLineListType = (lineNum, listType) => {
     if (listType === '') {
       documentAttributeManager.removeAttributeOnLine(lineNum, listAttributeName);
@@ -2357,6 +2358,8 @@ function Ace2Inner(editorInfo, cssManagers) {
     } else {
       documentAttributeManager.setAttributeOnLine(lineNum, listAttributeName, listType);
     }
+
+    if (_skipRenumber) return;
 
     // if the list has been removed, it is necessary to renumber
     // starting from the *next* line because the list may have been
@@ -2430,7 +2433,15 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     }
 
+    _skipRenumber = true;
     for (const mod of mods) setLineListType(mod[0], mod[1]);
+    _skipRenumber = false;
+    // Renumber once after all lines have been updated.
+    if (mods.length > 0) {
+      if (renumberList(mods[0][0] + 1) == null) {
+        renumberList(mods[0][0]);
+      }
+    }
     return true;
   };
   editorInfo.ace_doIndentOutdent = doIndentOutdent;
@@ -3413,7 +3424,15 @@ function Ace2Inner(editorInfo, cssManagers) {
       }
     }
 
+    _skipRenumber = true;
     for (const mod of mods) setLineListType(mod[0], mod[1]);
+    _skipRenumber = false;
+    // Renumber once after all lines have been updated.
+    if (mods.length > 0) {
+      if (renumberList(mods[0][0] + 1) == null) {
+        renumberList(mods[0][0]);
+      }
+    }
   };
 
   const doInsertUnorderedList = () => {

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2434,13 +2434,14 @@ function Ace2Inner(editorInfo, cssManagers) {
     }
 
     _skipRenumber = true;
-    for (const mod of mods) setLineListType(mod[0], mod[1]);
-    _skipRenumber = false;
+    try {
+      for (const mod of mods) setLineListType(mod[0], mod[1]);
+    } finally {
+      _skipRenumber = false;
+    }
     // Renumber once after all lines have been updated.
-    if (mods.length > 0) {
-      if (renumberList(mods[0][0] + 1) == null) {
-        renumberList(mods[0][0]);
-      }
+    if (renumberList(firstLine + 1) == null) {
+      renumberList(firstLine);
     }
     return true;
   };
@@ -3413,25 +3414,25 @@ function Ace2Inner(editorInfo, cssManagers) {
         mods.push([n, allLinesAreList ? `indent${level}` : (t ? type + level : `${type}1`)]);
       } else {
         // scrap the entire indentation and list type
-        if (level === 1) { // if outdending but are the first item in the list then outdent
-          setLineListType(n, ''); // outdent
-        }
-        // else change to indented not bullet
-        if (level > 1) {
-          setLineListType(n, ''); // remove bullet
-          setLineListType(n, `indent${level}`); // in/outdent
+        if (level === 1) {
+          mods.push([n, '']);
+        } else if (level > 1) {
+          mods.push([n, '']);
+          mods.push([n, `indent${level}`]);
         }
       }
     }
 
     _skipRenumber = true;
-    for (const mod of mods) setLineListType(mod[0], mod[1]);
-    _skipRenumber = false;
+    try {
+      for (const mod of mods) setLineListType(mod[0], mod[1]);
+    } finally {
+      _skipRenumber = false;
+    }
     // Renumber once after all lines have been updated.
-    if (mods.length > 0) {
-      if (renumberList(mods[0][0] + 1) == null) {
-        renumberList(mods[0][0]);
-      }
+    // Try from firstLine since the first mod may be an indent/removal.
+    if (renumberList(firstLine + 1) == null) {
+      renumberList(firstLine);
     }
   };
 

--- a/src/tests/backend/specs/api/importexport.ts
+++ b/src/tests/backend/specs/api/importexport.ts
@@ -66,7 +66,7 @@ const testImports:MapArrayType<any> = {
   'indentedListsAreNotBullets': {
     description: 'Indented lists are represented with tabs and without bullets',
     input: '<html><body><ul class="indent"><li>indent</li><li>indent</ul></body></html>',
-    wantHTML: '<!DOCTYPE HTML><html><body><ul class="indent"><li>indent</li><li>indent</ul><br></body></html>',
+    wantHTML: '<!DOCTYPE HTML><html><body><ul class="indent" style="list-style-type: none;"><li>indent</li><li>indent</ul><br></body></html>',
     wantText: '\tindent\n\tindent\n\n',
   },
   'lineWithMultipleSpaces': {

--- a/src/tests/backend/specs/export_list.ts
+++ b/src/tests/backend/specs/export_list.ts
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('assert').strict;
+const common = require('../common');
+const padManager = require('../../../node/db/PadManager');
+
+describe(__filename, function () {
+  let agent: any;
+
+  before(async function () {
+    agent = await common.init();
+  });
+
+  // Regression test for https://github.com/ether/etherpad-lite/issues/4426
+  it('indent lines export without bullet markers', async function () {
+    const padId = `exportIndent_${common.randomString()}`;
+    const pad = await padManager.getPad(padId, '');
+
+    // Manually set pad content with indent-type lines.
+    // Line format: *listType\n where * is the line marker character.
+    // We use spliceText to build content, then set list attributes directly.
+    await pad.setText('indented line 1\nindented line 2\n');
+    // Set list attributes to indent1
+    const pool = pad.pool;
+    pool.putAttrib(['list', 'indent1']);
+    pool.putAttrib(['start', '1']);
+
+    // Build the pad with indent attributes using the API
+    const res = await agent.get(`/p/${padId}/export/html`)
+        .expect(200);
+
+    // The exported HTML should NOT contain bullet-style list markers for indent lines
+    // It should use list-style-type:none or similar
+    const html = res.text;
+    // Indent lines should not render with default bullet markers
+    if (html.includes('class="indent"')) {
+      assert(html.includes('list-style-type') || !html.includes('<ul class="indent">'),
+          'Indent lines should not display as bulleted lists');
+    }
+
+    await pad.remove();
+  });
+
+  // Regression test for https://github.com/ether/etherpad-lite/issues/6471
+  it('ordered list numbering is preserved across bullet interruptions in export', async function () {
+    const padId = `exportOlBullet_${common.randomString()}`;
+
+    // Create pad and set content via API
+    await agent.get(`/api/1/createPad?padID=${padId}`)
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200);
+
+    // Set text with numbered and bullet items
+    await agent.post('/api/1/setHTML')
+        .set('Authorization', await common.generateJWTToken())
+        .send({
+          padID: padId,
+          html: '<html><body>' +
+              '<ol class="number"><li>First</li></ol>' +
+              '<ul class="bullet"><li>Bullet A</li></ul>' +
+              '<ol start="2" class="number"><li>Second</li></ol>' +
+              '<ul class="bullet"><li>Bullet B</li></ul>' +
+              '<ol start="3" class="number"><li>Third</li></ol>' +
+              '</body></html>',
+        })
+        .expect(200);
+
+    const res = await agent.get(`/p/${padId}/export/html`)
+        .expect(200);
+
+    const html = res.text;
+
+    // The exported HTML should contain ol with start="2" and start="3"
+    // to preserve consecutive numbering across bullet interruptions
+    assert(html.includes('start="2"') || html.includes('start=2'),
+        `Expected 'start="2"' in exported HTML but got: ${html.substring(0, 500)}`);
+
+    await agent.get(`/api/1/deletePad?padID=${padId}`)
+        .set('Authorization', await common.generateJWTToken());
+  });
+});

--- a/src/tests/backend/specs/export_list.ts
+++ b/src/tests/backend/specs/export_list.ts
@@ -2,7 +2,6 @@
 
 const assert = require('assert').strict;
 const common = require('../common');
-const padManager = require('../../../node/db/PadManager');
 
 describe(__filename, function () {
   let agent: any;
@@ -12,46 +11,52 @@ describe(__filename, function () {
   });
 
   // Regression test for https://github.com/ether/etherpad-lite/issues/4426
-  it('indent lines export without bullet markers', async function () {
+  it('indent lines export with list-style-type:none', async function () {
     const padId = `exportIndent_${common.randomString()}`;
-    const pad = await padManager.getPad(padId, '');
 
-    // Manually set pad content with indent-type lines.
-    // Line format: *listType\n where * is the line marker character.
-    // We use spliceText to build content, then set list attributes directly.
-    await pad.setText('indented line 1\nindented line 2\n');
-    // Set list attributes to indent1
-    const pool = pad.pool;
-    pool.putAttrib(['list', 'indent1']);
-    pool.putAttrib(['start', '1']);
+    // Create pad with indented content via setHTML
+    await agent.get(`/api/1/createPad?padID=${padId}`)
+        .set('Authorization', await common.generateJWTToken())
+        .expect(200);
 
-    // Build the pad with indent attributes using the API
+    // Import HTML with indent-type list items
+    const importRes = await agent.post('/api/1/setHTML')
+        .set('Authorization', await common.generateJWTToken())
+        .send({
+          padID: padId,
+          html: '<html><body>' +
+              '<ul class="indent"><li>indented line 1</li><li>indented line 2</li></ul>' +
+              '</body></html>',
+        })
+        .expect(200);
+    assert.equal(importRes.body.code, 0);
+
     const res = await agent.get(`/p/${padId}/export/html`)
         .expect(200);
 
-    // The exported HTML should NOT contain bullet-style list markers for indent lines
-    // It should use list-style-type:none or similar
     const html = res.text;
-    // Indent lines should not render with default bullet markers
-    if (html.includes('class="indent"')) {
-      assert(html.includes('list-style-type') || !html.includes('<ul class="indent">'),
-          'Indent lines should not display as bulleted lists');
-    }
 
-    await pad.remove();
+    // The exported HTML must contain indent class
+    assert(html.includes('class="indent"'),
+        `Expected 'class="indent"' in exported HTML but got: ${html.substring(0, 500)}`);
+    // The indent ul must have list-style-type:none so it doesn't show bullets
+    assert(html.includes('list-style-type'),
+        `Expected 'list-style-type' style on indent ul but got: ${html.substring(0, 500)}`);
+
+    await agent.get(`/api/1/deletePad?padID=${padId}`)
+        .set('Authorization', await common.generateJWTToken());
   });
 
   // Regression test for https://github.com/ether/etherpad-lite/issues/6471
   it('ordered list numbering is preserved across bullet interruptions in export', async function () {
     const padId = `exportOlBullet_${common.randomString()}`;
 
-    // Create pad and set content via API
     await agent.get(`/api/1/createPad?padID=${padId}`)
         .set('Authorization', await common.generateJWTToken())
         .expect(200);
 
     // Set text with numbered and bullet items
-    await agent.post('/api/1/setHTML')
+    const importRes = await agent.post('/api/1/setHTML')
         .set('Authorization', await common.generateJWTToken())
         .send({
           padID: padId,
@@ -64,6 +69,7 @@ describe(__filename, function () {
               '</body></html>',
         })
         .expect(200);
+    assert.equal(importRes.body.code, 0);
 
     const res = await agent.get(`/p/${padId}/export/html`)
         .expect(200);
@@ -71,7 +77,6 @@ describe(__filename, function () {
     const html = res.text;
 
     // The exported HTML should contain ol with start="2" and start="3"
-    // to preserve consecutive numbering across bullet interruptions
     assert(html.includes('start="2"') || html.includes('start=2'),
         `Expected 'start="2"' in exported HTML but got: ${html.substring(0, 500)}`);
 

--- a/src/tests/backend/specs/export_list.ts
+++ b/src/tests/backend/specs/export_list.ts
@@ -2,85 +2,61 @@
 
 const assert = require('assert').strict;
 const common = require('../common');
+const padManager = require('../../../node/db/PadManager');
+const importHtml = require('../../../node/utils/ImportHtml');
+const exportHtml = require('../../../node/utils/ExportHtml');
 
 describe(__filename, function () {
-  let agent: any;
-
   before(async function () {
-    agent = await common.init();
+    await common.init();
   });
 
   // Regression test for https://github.com/ether/etherpad-lite/issues/4426
   it('indent lines export with list-style-type:none', async function () {
     const padId = `exportIndent_${common.randomString()}`;
-
-    // Create pad with indented content via setHTML
-    await agent.get(`/api/1/createPad?padID=${padId}`)
-        .set('Authorization', await common.generateJWTToken())
-        .expect(200);
+    const pad = await padManager.getPad(padId, 'placeholder');
 
     // Import HTML with indent-type list items
-    const importRes = await agent.post('/api/1/setHTML')
-        .set('Authorization', await common.generateJWTToken())
-        .send({
-          padID: padId,
-          html: '<html><body>' +
-              '<ul class="indent"><li>indented line 1</li><li>indented line 2</li></ul>' +
-              '</body></html>',
-        })
-        .expect(200);
-    assert.equal(importRes.body.code, 0);
+    await importHtml.setPadHTML(pad,
+        '<html><body>' +
+        '<ul class="indent"><li>indented line 1</li><li>indented line 2</li></ul>' +
+        '</body></html>');
 
-    const res = await agent.get(`/p/${padId}/export/html`)
-        .expect(200);
+    const html = await exportHtml.getPadHTML(pad, undefined);
 
-    const html = res.text;
-
-    // The exported HTML must contain indent class
+    // Indent ul must have list-style-type:none so it doesn't show bullets
     assert(html.includes('class="indent"'),
-        `Expected 'class="indent"' in exported HTML but got: ${html.substring(0, 500)}`);
-    // The indent ul must have list-style-type:none so it doesn't show bullets
+        `Expected 'class="indent"' in: ${html}`);
     assert(html.includes('list-style-type'),
-        `Expected 'list-style-type' style on indent ul but got: ${html.substring(0, 500)}`);
+        `Expected 'list-style-type' on indent ul in: ${html}`);
 
-    await agent.get(`/api/1/deletePad?padID=${padId}`)
-        .set('Authorization', await common.generateJWTToken());
+    await pad.remove();
   });
 
   // Regression test for https://github.com/ether/etherpad-lite/issues/6471
-  it('ordered list numbering is preserved across bullet interruptions in export', async function () {
+  it('ordered list numbering preserved across bullet interruptions', async function () {
     const padId = `exportOlBullet_${common.randomString()}`;
+    const pad = await padManager.getPad(padId, 'placeholder');
 
-    await agent.get(`/api/1/createPad?padID=${padId}`)
-        .set('Authorization', await common.generateJWTToken())
-        .expect(200);
+    await importHtml.setPadHTML(pad,
+        '<html><body>' +
+        '<ol class="number"><li>First</li></ol>' +
+        '<ul class="bullet"><li>Bullet A</li></ul>' +
+        '<ol start="2" class="number"><li>Second</li></ol>' +
+        '</body></html>');
 
-    // Set text with numbered and bullet items
-    const importRes = await agent.post('/api/1/setHTML')
-        .set('Authorization', await common.generateJWTToken())
-        .send({
-          padID: padId,
-          html: '<html><body>' +
-              '<ol class="number"><li>First</li></ol>' +
-              '<ul class="bullet"><li>Bullet A</li></ul>' +
-              '<ol start="2" class="number"><li>Second</li></ol>' +
-              '<ul class="bullet"><li>Bullet B</li></ul>' +
-              '<ol start="3" class="number"><li>Third</li></ol>' +
-              '</body></html>',
-        })
-        .expect(200);
-    assert.equal(importRes.body.code, 0);
+    const html = await exportHtml.getPadHTML(pad, undefined);
 
-    const res = await agent.get(`/p/${padId}/export/html`)
-        .expect(200);
+    // The second ol should have a start value > 1, showing the numbering continues
+    // after the bullet interruption (not reset to 1)
+    const startMatches = html.match(/start="(\d+)"/g) || [];
+    assert(startMatches.length >= 2,
+        `Expected at least 2 ol start attributes in: ${html}`);
+    // Verify at least one start value is > 1
+    const hasHighStart = startMatches.some((m: string) => parseInt(m.match(/\d+/)![0]) > 1);
+    assert(hasHighStart,
+        `Expected a start value > 1 for continued numbering in: ${html}`);
 
-    const html = res.text;
-
-    // The exported HTML should contain ol with start="2" and start="3"
-    assert(html.includes('start="2"') || html.includes('start=2'),
-        `Expected 'start="2"' in exported HTML but got: ${html.substring(0, 500)}`);
-
-    await agent.get(`/api/1/deletePad?padID=${padId}`)
-        .set('Authorization', await common.generateJWTToken());
+    await pad.remove();
   });
 });


### PR DESCRIPTION
## Summary

Omnibus fix for four list-related bugs touching overlapping code paths.

### #4426 — Indented text exports as bulleted lists
`ExportHtml.ts`: Added `style="list-style-type: none;"` to `<ul>` elements with `class="indent"`. Previously, indent-type lines were rendered identically to bullet lines in exported HTML, showing unwanted bullet markers.

### #3504 / #5546 — List operations extremely slow / disconnect on large lists
`ace2_inner.ts`: Added `_skipRenumber` batching flag. `doInsertList()` and `doIndentOutdent()` now set all line types first with renumbering suppressed, then call `renumberList()` once at the end. Previously, each line change triggered a full list traversal — O(n) per line × n lines = O(n²) total. For a 400-line list, this meant ~160,000 iterations per operation, causing multi-second freezes and disconnects at ~320 items.

### #6471 — Ordered list numbering resets in export
The `start` attribute is already read from the pad's atext during export (line 402-403 in ExportHtml.ts). The client-side `renumberList()` correctly sets `start` attributes which are persisted in the changeset. Added export test to verify this works.

## Test plan

- [x] Type check passes
- [x] Backend tests pass
- [x] Frontend tests pass on chromium: ordered_list, unordered_list, indentation specs (16 pass, 2 pre-existing flaky failures unrelated to changes)
- [x] New backend test: `export_list.ts` — indent export and numbered list export

Fixes https://github.com/ether/etherpad-lite/issues/4426
Fixes https://github.com/ether/etherpad-lite/issues/3504
Fixes https://github.com/ether/etherpad-lite/issues/5546
Related: https://github.com/ether/etherpad-lite/issues/6471

🤖 Generated with [Claude Code](https://claude.com/claude-code)