### PR TITLE
fix: accessibility — keyboard trap, screen reader support, aria-live

### DIFF
--- a/src/static/css/pad.css
+++ b/src/static/css/pad.css
@@ -13,6 +13,19 @@
 @import url("pad/loadingbox.css");
 @import url("pad/form.css");
 
+/* Screen reader only — visually hidden but announced by assistive technology */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 html {
   font-size: 15px;
   color: #3e3e3e;

--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -284,6 +284,9 @@ const Ace2Editor = function () {
     // <body> tag
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
+    innerDocument.body.setAttribute('role', 'textbox');
+    innerDocument.body.setAttribute('aria-multiline', 'true');
+    innerDocument.body.setAttribute('aria-label', 'Pad content');
     innerDocument.body.setAttribute('spellcheck', 'false');
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
 /*

--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -287,7 +287,14 @@ const Ace2Editor = function () {
     innerDocument.body.setAttribute('role', 'textbox');
     innerDocument.body.setAttribute('aria-multiline', 'true');
     innerDocument.body.setAttribute('aria-label', 'Pad content');
+    innerDocument.body.setAttribute('aria-describedby', 'editor-keyboard-hint');
     innerDocument.body.setAttribute('spellcheck', 'false');
+    // Screen-reader-only keyboard hint inside the iframe so it's announced on focus.
+    const hint = innerDocument.createElement('div');
+    hint.id = 'editor-keyboard-hint';
+    hint.style.cssText = 'position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)';
+    hint.textContent = 'Press Escape to exit the editor. Press Alt+F9 to access the toolbar.';
+    innerDocument.body.appendChild(hint);
     innerDocument.body.appendChild(innerDocument.createTextNode('\u00A0')); // &nbsp;
 /*
     debugLog('Ace2Editor.init() waiting for require kernel load');

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2689,22 +2689,25 @@ function Ace2Inner(editorInfo, cssManagers) {
         if (!specialHandled && isTypeForSpecialKey &&
             keyCode === 27 &&
             padShortcutEnabled.esc) {
-          // Escape key: close gritter notifications and move focus to the toolbar
-          // so keyboard-only users can escape the editor (WCAG 2.1.2).
+          // Escape key: if gritter popups are visible, close them and stay in editor.
+          // Otherwise, move focus to the toolbar (WCAG 2.1.2 keyboard trap escape).
           fastIncorp(4);
           evt.preventDefault();
           specialHandled = true;
 
+          const hasGritters = window.$('.gritter-item').length > 0;
           window.$.gritter.removeAll();
 
-          // Move focus to the first toolbar button so the user can navigate
-          // away from the editor with Tab.
-          try {
-            const toolbar = window.parent.document.querySelector('[role="toolbar"]');
-            const firstButton = toolbar?.querySelector('button');
-            if (firstButton) firstButton.focus();
-          } catch (e) {
-            // Cross-origin frame restrictions — ignore.
+          if (!hasGritters) {
+            // No popups to dismiss — move focus to the toolbar so the user
+            // can navigate away from the editor with Tab.
+            try {
+              const toolbar = window.parent.document.querySelector('[role="toolbar"]');
+              const firstButton = toolbar?.querySelector('button');
+              if (firstButton) firstButton.focus();
+            } catch (e) {
+              // Cross-origin frame restrictions — ignore.
+            }
           }
         }
         if (!specialHandled && isTypeForCmdKey &&

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2689,15 +2689,23 @@ function Ace2Inner(editorInfo, cssManagers) {
         if (!specialHandled && isTypeForSpecialKey &&
             keyCode === 27 &&
             padShortcutEnabled.esc) {
-          // prevent esc key;
-          // in mozilla versions 14-19 avoid reconnecting pad.
-
+          // Escape key: close gritter notifications and move focus to the toolbar
+          // so keyboard-only users can escape the editor (WCAG 2.1.2).
           fastIncorp(4);
           evt.preventDefault();
           specialHandled = true;
 
-          // close all gritters when the user hits escape key
           window.$.gritter.removeAll();
+
+          // Move focus to the first toolbar button so the user can navigate
+          // away from the editor with Tab.
+          try {
+            const toolbar = window.parent.document.querySelector('[role="toolbar"]');
+            const firstButton = toolbar?.querySelector('button');
+            if (firstButton) firstButton.focus();
+          } catch (e) {
+            // Cross-origin frame restrictions — ignore.
+          }
         }
         if (!specialHandled && isTypeForCmdKey &&
             /* Do a saved revision on ctrl S */

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -464,6 +464,7 @@ function Ace2Inner(editorInfo, cssManagers) {
   const setEditable = (newVal) => {
     isEditable = newVal;
     targetBody.contentEditable = isEditable ? 'true' : 'false';
+    targetBody.setAttribute('aria-readonly', isEditable ? 'false' : 'true');
     targetBody.classList.toggle('static', !isEditable);
   };
 

--- a/src/static/js/domline.ts
+++ b/src/static/js/domline.ts
@@ -62,8 +62,6 @@ domline.createDomLine = (nonEmpty, doesWrap, optBrowser, optDocument) => {
 
   if (document) {
     result.node = document.createElement('div');
-    // JAWS and NVDA screen reader compatibility. Only needed if in a real browser.
-    result.node.setAttribute('aria-live', 'assertive');
   } else {
     result.node = {
       innerHTML: '',

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -84,8 +84,7 @@
       <!--- PAD EDITOR (in iframe) -->
       <!----------------------------->
 
-      <div id="editorcontainer" class="editorcontainer" aria-label="Document editor" aria-describedby="editor-keyboard-hint"></div>
-      <div id="editor-keyboard-hint" class="sr-only">Press Escape to exit the editor. Press Alt+F9 to access the toolbar.</div>
+      <div id="editorcontainer" class="editorcontainer" aria-label="Document editor"></div>
 
       <div id="editorloadingbox">
         <% e.begin_block("permissionDenied"); %>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -84,7 +84,8 @@
       <!--- PAD EDITOR (in iframe) -->
       <!----------------------------->
 
-      <div id="editorcontainer" class="editorcontainer"></div>
+      <div id="editorcontainer" class="editorcontainer" aria-label="Document editor" aria-describedby="editor-keyboard-hint"></div>
+      <div id="editor-keyboard-hint" class="sr-only">Press Escape to exit the editor. Press Alt+F9 to access the toolbar.</div>
 
       <div id="editorloadingbox">
         <% e.begin_block("permissionDenied"); %>
@@ -363,7 +364,7 @@
                   <input type="text" id="myusernameedit" disabled="disabled" data-l10n-id="pad.userlist.entername">
                 </div>
             </div>
-            <div id="otherusers" aria-role="document">
+            <div id="otherusers" role="document">
                 <table id="otheruserstable" cellspacing="0" cellpadding="0" border="0">
                     <tr><td></td></tr>
                 </table>


### PR DESCRIPTION
## Summary

Three accessibility fixes addressing WCAG compliance and screen reader support.

### #6581 — Keyboard trap (WCAG 2.1.2)
- **Escape key** now moves focus from the editor to the first toolbar button
- Previously, keyboard-only users were trapped in the editor with no discoverable exit (Alt+F9 existed but was undocumented)
- Added a screen-reader-only hint: "Press Escape to exit the editor. Press Alt+F9 to access the toolbar."
- Added `.sr-only` CSS utility class

### #7255 — Screen reader access
- Added `role="textbox"`, `aria-multiline="true"`, and `aria-label="Pad content"` to the contenteditable `#innerdocbody` element
- Screen readers can now identify the editor as a text input area and interact with its content
- Fixed `aria-role="document"` → `role="document"` in pad.html (non-standard attribute)

### #5695 — aria-live causing character echo
- Removed `aria-live="assertive"` from every line div in `domline.ts`
- This was causing screen readers (NVDA) to announce every character typed, even when keyboard echo was disabled
- The attribute was added in PR #5149 for JAWS but `aria-live` on individual contenteditable lines is a misuse per WCAG guidelines

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)
- [ ] Manual: with NVDA/JAWS, verify typing doesn't repeat characters
- [ ] Manual: press Escape in editor → focus moves to toolbar
- [ ] Manual: screen reader announces "Pad content" when entering the editor

Fixes https://github.com/ether/etherpad-lite/issues/6581
Fixes https://github.com/ether/etherpad-lite/issues/7255
Fixes https://github.com/ether/etherpad-lite/issues/5695

🤖 Generated with [Claude Code](https://claude.com/claude-code)