### PR TITLE
fix: add padId to padUpdate/padCreate hook context

### DIFF
--- a/src/node/db/Pad.ts
+++ b/src/node/db/Pad.ts
@@ -125,6 +125,7 @@ class Pad {
       authorId && authorManager.addPad(authorId, this.id),
       hooks.aCallAll(hook, {
         pad: this,
+        padId: this.id,
         authorId,
         get author() {
           pad_utils.warnDeprecated(`${hook} hook author context is deprecated; use authorId instead`);


### PR DESCRIPTION
## Summary

One-line fix: adds `padId: this.id` to the `padUpdate` and `padCreate` hook context object.

## Root Cause

The `pad` object's `toJSON()` intentionally strips the `id` property (line 151 in Pad.ts) because it's redundant with the database key (`pad:{id}`). This meant that when plugins serialized the hook context (e.g., logging), the pad ID was missing.

While `context.pad.id` works on the live object, adding `padId` as a top-level property is clearer and survives serialization.

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)

Fixes https://github.com/ether/etherpad-lite/issues/5814

🤖 Generated with [Claude Code](https://claude.com/claude-code)