### PR TITLE
fix: correct numConnectedUsers count for joining user

### DIFF
--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -1030,7 +1030,7 @@ const handleClientReady = async (socket:any, message: ClientReadyMessage) => {
       // tell the client the number of the latest chat-message, which will be
       // used to request the latest 100 chat-messages later (GET_CHAT_MESSAGES)
       chatHead: pad.chatHead,
-      numConnectedUsers: roomSockets.length,
+      numConnectedUsers: roomSockets.length + 1, // +1 for this user (not yet in room)
       readOnlyId: sessionInfo.readOnlyPadId,
       readonly: sessionInfo.readonly,
       serverTimestamp: Date.now(),


### PR DESCRIPTION
## Summary

One-line fix: `roomSockets.length` → `roomSockets.length + 1` when computing `numConnectedUsers` in CLIENT_VARS.

## Root Cause

`numConnectedUsers` is computed at line 1033 from `roomSockets`, which is captured at line 897 — before the new socket joins the room at line 1078. So the joining user always receives a count that's one less than the actual number of connected users.

This means when user B joins a pad where user A is already connected, user B sees "1 user online" instead of "2 users online".

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)

Fixes https://github.com/ether/etherpad-lite/issues/6145

🤖 Generated with [Claude Code](https://claude.com/claude-code)