### PR TITLE
fix: locale issues — custom strings caching, lang race, and window._()

### DIFF
--- a/admin/src/localization/i18n.ts
+++ b/admin/src/localization/i18n.ts
@@ -20,9 +20,7 @@ const LazyImportPlugin: BackendModule = {
       baseURL+=`/${namespace}/${language}.json`
     }
 
-    const localeJSON = await fetch(baseURL, {
-      cache: "force-cache"
-    })
+    const localeJSON = await fetch(baseURL)
     let json;
 
     try {

--- a/src/static/js/pad.ts
+++ b/src/static/js/pad.ts
@@ -150,22 +150,24 @@ const getParameters = [
 ];
 
 const getParams = () => {
-  // Tries server enforced options first..
-  for (const setting of getParameters) {
-    let value = clientVars.padOptions[setting.name];
-    if (value == null) continue;
-    value = value.toString();
-    if (value === setting.checkVal || setting.checkVal == null) {
-      setting.callback(value);
-    }
-  }
-
-  // Then URL applied stuff
   const params = getUrlVars();
+
   for (const setting of getParameters) {
-    const value = params.get(setting.name);
-    if (value && (value === setting.checkVal || setting.checkVal == null)) {
-      setting.callback(value);
+    // URL query params take priority over server-enforced options.
+    // This prevents race conditions where both fire async callbacks
+    // (e.g., lang setting triggers html10n.localize twice).
+    const urlValue = params.get(setting.name);
+    if (urlValue && (urlValue === setting.checkVal || setting.checkVal == null)) {
+      setting.callback(urlValue);
+      continue;
+    }
+
+    // Fall back to server-enforced option
+    let serverValue = clientVars.padOptions[setting.name];
+    if (serverValue == null) continue;
+    serverValue = serverValue.toString();
+    if (serverValue === setting.checkVal || setting.checkVal == null) {
+      setting.callback(serverValue);
     }
   }
 };

--- a/src/static/js/vendors/html10n.ts
+++ b/src/static/js/vendors/html10n.ts
@@ -995,8 +995,7 @@ export default html10n
 // @ts-ignore
 window.html10n = html10n
 
-// gettext-like shortcut
-if (window._ === undefined){
-  // @ts-ignore
-  window._ = html10n.get;
-}
+// gettext-like shortcut — always set this so plugins can use window._() for localization.
+// Internal code uses underscore via require(), not window._, so this is safe.
+// @ts-ignore
+window._ = html10n.get;


### PR DESCRIPTION
## Summary

Three localization fixes:

### #6390 — customLocaleStrings ignored
Removed `cache: "force-cache"` from the admin panel's locale fetch. The browser was aggressively caching locale JSON, so custom strings from `settings.json` never appeared after a server restart. The server already sets appropriate `Cache-Control` headers.

### #5510 — URL lang param doesn't reliably override server default
`getParams()` processed server options and URL params in two separate passes, both calling `html10n.localize()` for the `lang` setting. Since `localize()` is async, the two calls raced and the displayed language was nondeterministic. Now each setting is processed once: URL param wins if present, otherwise falls back to server option.

### #6627 — window._() localization not available for plugins
`html10n.ts` only set `window._` to `html10n.get` if `window._` was undefined, but underscore.js was already setting it via the esbuild bundle. Since internal code uses underscore via `require()` not `window._`, it's safe to always set `window._` to the localization function so plugins can use it in hooks like `documentReady`.

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)

Fixes https://github.com/ether/etherpad-lite/issues/6390
Fixes https://github.com/ether/etherpad-lite/issues/5510
Fixes https://github.com/ether/etherpad-lite/issues/6627

🤖 Generated with [Claude Code](https://claude.com/claude-code)