### PR TITLE
fix: ignore errors from browser extensions in error handler and editor init

### DIFF
--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -50,7 +50,15 @@ const eventFired = async (obj, event, cleanups = [], predicate = () => true) => 
       cleanup();
       resolve();
     };
-    const errorCb = () => {
+    const errorCb = (evt) => {
+      // Ignore error events from browser extension scripts — they are unrelated
+      // to Etherpad and should not block editor initialization.
+      // See https://github.com/ether/etherpad-lite/issues/6802
+      const src = evt?.target?.src || evt?.filename || '';
+      if (/^(moz|chrome|safari)-extension:\/\//.test(src)) {
+        debugLog('Ace2Editor.init() ignoring error from browser extension:', src);
+        return;
+      }
       const err = new Error(`Ace2Editor.init() error event while waiting for ${event} event`);
       debugLog(`${err} on object`, obj);
       cleanup();

--- a/src/static/js/pad_utils.ts
+++ b/src/static/js/pad_utils.ts
@@ -416,6 +416,13 @@ class PadUtils {
         if (err.name != null && msg !== err.name && !msg.startsWith(`${err.name}: `)) {
           msg = `${err.name}: ${msg}`;
         }
+
+        // Ignore errors from browser extensions — they are unrelated to Etherpad
+        // and should not block the pad from loading.
+        // See https://github.com/ether/etherpad-lite/issues/6802
+        const source = url || err.stack || '';
+        if (/^(moz|chrome|safari)-extension:\/\//.test(source)) return;
+
         const errorId = randomString(20);
 
         const errorKey = `${type}:${msg}:${url}:${linenumber}`;


### PR DESCRIPTION
## Summary

Browser extensions (BitWarden, Dashlane, password managers, FIDO2 authenticators) inject scripts into pages that can throw errors. Etherpad's error handling catches these unrelated errors and either shows a scary error popup or blocks the editor from loading entirely.

### Two fixes:

**globalExceptionHandler (pad_utils.ts):** Errors where the source URL matches `moz-extension://`, `chrome-extension://`, or `safari-extension://` are silently ignored instead of showing a gritter error popup.

**Ace2Editor.init (ace.ts):** The `eventFired()` error callback checks if the error event's target `src` is a browser extension URL. If so, it ignores the error instead of rejecting the promise and killing editor initialization.

## Root Cause

Extensions inject `<script>` elements that can trigger `error` events on the iframe during load, and throw JS errors caught by `window.addEventListener('error')`. Neither of these are Etherpad bugs, but the handler treated all errors equally.

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)
- [ ] Manual: install BitWarden + Dashlane extensions, log into BitWarden, load a pad → should load without error popup

Fixes https://github.com/ether/etherpad-lite/issues/6802

🤖 Generated with [Claude Code](https://claude.com/claude-code)