### PR TITLE
fix: popup notification fits small screens

### DIFF
--- a/src/static/css/pad/popup.css
+++ b/src/static/css/pad/popup.css
@@ -28,8 +28,8 @@
   border: 1px solid #ccc;
   box-shadow: 0 2px 4px #ddd;
   background: #f7f7f7;
-  min-width: 300px;
-  max-width: 600px;
+  min-width: min(300px, 90vw);
+  max-width: min(600px, 95vw);
 }
 .popup input[type=text] {
   width: 100%;


### PR DESCRIPTION
## Summary

CSS fix: `.popup-content` had `min-width: 300px` which overflowed on screens narrower than 300px, making the close button inaccessible on some smartphones.

Changed to `min(300px, 90vw)` and `max-width: min(600px, 95vw)` so the popup respects the viewport width.

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)
- [ ] Manual: resize browser to < 300px width, verify popup fits and close button is accessible

Fixes https://github.com/ether/etherpad-lite/issues/7246

🤖 Generated with [Claude Code](https://claude.com/claude-code)