### PR TITLE
fix: dead key / compose key no longer eats preceding space

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2902,7 +2902,14 @@ function Ace2Inner(editorInfo, cssManagers) {
       const isSafariHalfCharacter =
           (browser.safari && evt.altKey && keyCode === 229);
 
-      if (thisKeyDoesntTriggerNormalize || isFirefoxHalfCharacter || isSafariHalfCharacter) {
+      // keyCode 229 indicates an IME/composition event (dead keys, compose key, etc.).
+      // On Firefox Linux, the keydown for a dead key fires before compositionstart,
+      // so inInternationalComposition may not be set yet.
+      // See https://github.com/ether/etherpad-lite/issues/5623
+      const isCompositionKeyCode = (keyCode === 229);
+
+      if (thisKeyDoesntTriggerNormalize || isFirefoxHalfCharacter ||
+          isSafariHalfCharacter || isCompositionKeyCode) {
         idleWorkTimer.atLeast(3000); // give user time to type
         // if this is a keydown, e.g., the keyup shouldn't trigger a normalize
         thisKeyDoesntTriggerNormalize = true;


### PR DESCRIPTION
## Summary

When typing accented characters with a dead key or compose key on Firefox Linux (e.g., `é` via compose+e+', or Greek accented letters like `ά`), the space before the character was deleted, producing `eé` instead of `e é`.

## Root Cause

On Firefox Linux, the `keydown` event for a dead key fires **before** `compositionstart`. The dead key sends `keyCode === 229` (the standard IME composition code). Since `inInternationalComposition` wasn't set yet, `observeChangesAroundSelection()` ran prematurely and marked the line as dirty with a pre-composition DOM snapshot. When the composition completed and `incorporateUserChanges` ran, the dirty range calculation was off, causing the preceding space to be dropped.

## Fix

Treat `keyCode === 229` the same as the existing `isFirefoxHalfCharacter` and `isSafariHalfCharacter` checks: defer the idle timer and suppress normalization until the composition completes. This bridges the gap between the dead key's `keydown` and the subsequent `compositionstart`.

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)
- [ ] Manual (Linux Firefox): type `e`, space, then compose `é` → should produce `e é` not `eé`
- [ ] Manual (Linux Firefox): type Greek `άλλο ένα` → space should be preserved

Fixes https://github.com/ether/etherpad-lite/issues/5623

🤖 Generated with [Claude Code](https://claude.com/claude-code)