### PR TITLE
fix: bold text retains formatting after copy-paste

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -3236,6 +3236,45 @@ function Ace2Inner(editorInfo, cssManagers) {
         documentAttributeManager,
         e,
       });
+
+      // Extract HTML from clipboard before the browser normalizes it.
+      // Browser contentEditable normalization strips inline formatting (bold, italic, etc.)
+      // from pasted Etherpad content because it flattens nested ace-line divs.
+      // See https://github.com/ether/etherpad-lite/issues/5037
+      const clipboardData = e.originalEvent?.clipboardData || (window as any).clipboardData;
+      const pastedHtml = clipboardData?.getData('text/html');
+      if (pastedHtml) {
+        // Parse the pasted HTML in a detached document to extract content
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(pastedHtml, 'text/html');
+        const hasFormatting = doc.querySelector('b, strong, i, em, u, s, del, ins');
+        if (hasFormatting) {
+          e.preventDefault();
+          // Insert the parsed HTML into the editor so the content collector can
+          // properly extract formatting from intact tags.
+          const sel = targetDoc.getSelection();
+          if (sel && sel.rangeCount > 0) {
+            const range = sel.getRangeAt(0);
+            range.deleteContents();
+            // Create a temporary container with the parsed body content
+            const frag = targetDoc.createDocumentFragment();
+            for (const child of Array.from(doc.body.childNodes)) {
+              frag.appendChild(targetDoc.importNode(child, true));
+            }
+            range.insertNode(frag);
+            // Move cursor to end of inserted content
+            range.collapse(false);
+            sel.removeAllRanges();
+            sel.addRange(range);
+          }
+          // Trigger incorporation of the inserted content
+          scheduler.setTimeout(() => {
+            inCallStackIfNecessary('paste', () => {
+              incorporateUserChanges();
+            });
+          }, 0);
+        }
+      }
     });
 
     // We reference document here, this is because if we don't this will expose a bug

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -3250,8 +3250,24 @@ function Ace2Inner(editorInfo, cssManagers) {
         const hasFormatting = doc.querySelector('b, strong, i, em, u, s, del, ins');
         if (hasFormatting) {
           e.preventDefault();
-          // Insert the parsed HTML into the editor so the content collector can
-          // properly extract formatting from intact tags.
+
+          // Sanitize: remove dangerous elements and event handler attributes
+          // to prevent XSS via clipboard content.
+          for (const el of doc.body.querySelectorAll(
+              'script, style, iframe, object, embed, form, link, meta')) {
+            el.remove();
+          }
+          for (const el of doc.body.querySelectorAll('*')) {
+            for (const attr of Array.from(el.attributes)) {
+              if (attr.name.startsWith('on') ||
+                  (attr.name === 'href' && /^\s*javascript:/i.test(attr.value))) {
+                el.removeAttribute(attr.name);
+              }
+            }
+          }
+
+          // Insert the sanitized HTML into the editor so the content collector
+          // can properly extract formatting from intact tags.
           const sel = targetDoc.getSelection();
           if (sel && sel.rangeCount > 0) {
             const range = sel.getRangeAt(0);

--- a/src/tests/frontend-new/specs/bold_paste.spec.ts
+++ b/src/tests/frontend-new/specs/bold_paste.spec.ts
@@ -1,0 +1,57 @@
+import {expect, test} from "@playwright/test";
+import {clearPadContent, getPadBody, goToNewPad, selectAllText, writeToPad} from "../helper/padHelper";
+
+test.beforeEach(async ({page}) => {
+  await goToNewPad(page);
+});
+
+// Regression test for https://github.com/ether/etherpad-lite/issues/5037
+test('bold text retains formatting after copy-paste', async ({page}) => {
+  const padBody = await getPadBody(page);
+  await clearPadContent(page);
+
+  // Type text and bold it
+  await writeToPad(page, 'bold text');
+  await selectAllText(page);
+  await page.keyboard.down('Control');
+  await page.keyboard.press('b');
+  await page.keyboard.up('Control');
+  await page.keyboard.press('End');
+
+  // Verify bold applied
+  await expect(padBody.locator('b').first()).toHaveText('bold text', {timeout: 5000});
+
+  // Add separator line
+  await page.keyboard.press('Enter');
+  await writeToPad(page, 'normal');
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(500);
+
+  // Select the bold text on line 1
+  const innerFrame = page.frame('ace_inner')!;
+  await innerFrame.locator('#innerdocbody div').first().click({clickCount: 3});
+  await page.waitForTimeout(200);
+
+  // Copy
+  await page.keyboard.down('Control');
+  await page.keyboard.press('c');
+  await page.keyboard.up('Control');
+  await page.waitForTimeout(200);
+
+  // Move to end of doc
+  await page.keyboard.down('Control');
+  await page.keyboard.press('End');
+  await page.keyboard.up('Control');
+
+  // Paste
+  await page.keyboard.down('Control');
+  await page.keyboard.press('v');
+  await page.keyboard.up('Control');
+
+  // Wait for paste + incorporation
+  await page.waitForTimeout(2000);
+
+  // Should have at least 2 bold elements (original + pasted)
+  const boldCount = await padBody.locator('b').count();
+  expect(boldCount).toBeGreaterThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary

When pasting bold, italic, underline, or strikethrough text within Etherpad, the formatting was lost. The pasted text appeared as plain text.

## Root Cause

The browser's contentEditable engine normalizes pasted DOM before Etherpad's content collector runs. When Etherpad content is copied, the clipboard HTML contains `<div class="ace-line"><span class="author-a-... b"><b>bold text</b></span></div>`. When pasted, this creates nested `ace-line` divs. The browser then flattens these nested divs, stripping the `<b>` tags in the process. By the time `incorporateUserChanges` calls the content collector, the formatting is gone.

## Fix

The paste handler now:
1. Reads `text/html` from the clipboard data
2. Checks if it contains formatting tags (`<b>`, `<strong>`, `<i>`, `<em>`, `<u>`, `<s>`, `<del>`, `<ins>`)
3. If formatting is present: prevents default browser paste, parses the HTML in a detached `DOMParser` document, and inserts the nodes directly into the editor
4. Triggers `incorporateUserChanges` to process the inserted content

This preserves the formatting tags intact for the content collector to extract.

## Test plan

- [x] Type check passes
- [x] Backend tests pass (744/744)
- [x] New Playwright test: bold text copy-paste retains `<b>` tags (chromium pass)

Fixes https://github.com/ether/etherpad-lite/issues/5037

🤖 Generated with [Claude Code](https://claude.com/claude-code)