### PR TITLE
chore: show individual test names in CI Playwright output

### DIFF
--- a/src/playwright.config.ts
+++ b/src/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-    reporter: process.env.CI ? 'github' : 'html',
+    reporter: process.env.CI ? [['github'], ['list']] : 'html',
     expect: { timeout: defaultExpectTimeout },
     timeout: defaultTestTimeout,
     retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Summary

One-line config change: adds `list` reporter alongside `github` in CI.

**Before:** Playwright CI output only showed failures (via `github` reporter annotations). Passing tests were invisible.

**After:** Each test is listed with its pass/fail status in the CI log:
```
  ✓  1 [chromium] › specs/bold.spec.ts:10 › bold button › makes text bold on click (1.2s)
  ✓  2 [chromium] › specs/chat.spec.ts:15 › chat › sends a message (2.1s)
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)