### PR TITLE
chore: reduce CI matrix for PRs to prevent runner exhaustion

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -27,7 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [">=20.0.0 <21.0.0", ">=22.0.0 <23.0.0", ">=24.0.0 <25.0.0"]
+        # PRs: test on latest Node only. Push to develop: full matrix.
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[">=24.0.0 <25.0.0"]') || fromJSON('[">=20.0.0 <21.0.0", ">=22.0.0 <23.0.0", ">=24.0.0 <25.0.0"]') }}
     steps:
       -
         name: Checkout repository
@@ -83,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [">=20.0.0 <21.0.0", ">=22.0.0 <23.0.0", ">=24.0.0 <25.0.0"]
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[">=24.0.0 <25.0.0"]') || fromJSON('[">=20.0.0 <21.0.0", ">=22.0.0 <23.0.0", ">=24.0.0 <25.0.0"]') }}
     steps:
       -
         name: Checkout repository
@@ -138,14 +139,12 @@ jobs:
         working-directory: src
         run: gnpm run test:vitest   --runtimeVersion="${{ matrix.node }}"
 
+  # Windows tests only run on push to develop/master, not on PRs
   withoutpluginsWindows:
     env:
       PNPM_HOME: ~\\.pnpm-store
-    # run on pushes to any branch
-    # run on PRs from external forks
     if: |
-      (github.event_name != 'pull_request')
-      || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
+      github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -193,11 +192,8 @@ jobs:
   withpluginsWindows:
     env:
       PNPM_HOME: ~\\.pnpm-store
-    # run on pushes to any branch
-    # run on PRs from external forks
     if: |
-      (github.event_name != 'pull_request')
-      || (github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id)
+      github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        # PRs: single Node version. Push: full matrix.
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[24]') || fromJSON('[20, 22, 24]') }}
 
     steps:
       -
@@ -77,7 +78,7 @@ jobs:
       - name: Run the frontend admin tests
         shell: bash
         run: |
-          gnpm run prod --runtimeVersion="${{ matrix.node }}" &
+          gnpm run prod --runtimeVersion="${{ matrix.node }}" > /tmp/etherpad-server.log 2>&1 &
           connected=false
           can_connect() {
           curl -sSfo /dev/null http://localhost:9001/ || return 1
@@ -90,6 +91,13 @@ jobs:
           done
           cd src
           gnpm run test-admin --runtimeVersion="${{ matrix.node }}"
+      - name: Upload server log on failure
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: server-log-admin-${{ matrix.node }}
+          path: /tmp/etherpad-server.log
+          retention-days: 7
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run the frontend tests
         shell: bash
         run: |
-          gnpm run prod  &
+          gnpm run prod > /tmp/etherpad-server.log 2>&1 &
           connected=false
           can_connect() {
           curl -sSfo /dev/null http://localhost:9001/ || return 1
@@ -61,6 +61,13 @@ jobs:
           cd src
           gnpm exec playwright install chromium  --with-deps
           gnpm run test-ui --project=chromium
+      - name: Upload server log on failure
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: server-log-chrome
+          path: /tmp/etherpad-server.log
+          retention-days: 7
       - uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -99,7 +106,7 @@ jobs:
       - name: Run the frontend tests
         shell: bash
         run: |
-          gnpm run prod &
+          gnpm run prod > /tmp/etherpad-server.log 2>&1 &
           connected=false
           can_connect() {
           curl -sSfo /dev/null http://localhost:9001/ || return 1
@@ -113,6 +120,13 @@ jobs:
           cd src
           gnpm exec playwright install firefox  --with-deps
           gnpm run test-ui --project=firefox
+      - name: Upload server log on failure
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: server-log-firefox
+          path: /tmp/etherpad-server.log
+          retention-days: 7
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -27,7 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        # PRs: single Node version. Push: full matrix.
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[24]') || fromJSON('[20, 22, 24]') }}
     steps:
       -
         name: Check out latest release
@@ -52,12 +53,6 @@ jobs:
         with:
           version: 0.0.12
       - name: Install libreoffice
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: libreoffice libreoffice-pdfimport
-          version: 1.0
-      -
-        name: Install libreoffice
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
           packages: libreoffice libreoffice-pdfimport


### PR DESCRIPTION
## Summary

Two CI improvements:

### 1. Reduce PR matrix to prevent runner exhaustion
PRs now run a minimal test matrix; full matrix runs on push to develop.

| Workflow | Before (per commit) | PR | Push to develop |
|----------|--------------------|----|-----------------|
| Backend tests | 12 (4 configs × 3 nodes) | **2** (Linux only, Node 24) | 12 (unchanged) |
| Upgrade from latest | 3 (3 nodes) | **1** (Node 24) | 3 (unchanged) |
| Frontend admin | 3 (3 nodes) | **1** (Node 24) | 3 (unchanged) |
| Frontend tests | 2 | 2 (unchanged) | 2 (unchanged) |
| Others | ~5 | ~5 (unchanged) | ~5 (unchanged) |
| **Total** | **~25** | **~10** | **~25** |

### 2. Clean up Playwright CI output
Redirect Etherpad server stdout/stderr to `/tmp/etherpad-server.log` during frontend tests so Playwright's test list output isn't interleaved with server log noise (ENTER, LEAVE, INFO, etc.). Server logs are uploaded as artifacts on failure for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)