### PR TITLE
fix: use pnpm instead of npm in updatePlugins.sh

### DIFF
--- a/bin/updatePlugins.sh
+++ b/bin/updatePlugins.sh
@@ -2,10 +2,10 @@
 set -e
 mydir=$(cd "${0%/*}" && pwd -P) || exit 1
 cd "${mydir}"/..
-OUTDATED=$(npm outdated --depth=0 | awk '{print $1}' | grep '^ep_') || {
+OUTDATED=$(pnpm outdated --depth=0 | awk '{print $1}' | grep '^ep_') || {
   echo "All plugins are up-to-date"
   exit 0
 }
 set -- ${OUTDATED}
 echo "Updating plugins: $*"
-exec pnpm install "$@"
+exec pnpm update "$@"

--- a/bin/updatePlugins.sh
+++ b/bin/updatePlugins.sh
@@ -2,10 +2,12 @@
 set -e
 mydir=$(cd "${0%/*}" && pwd -P) || exit 1
 cd "${mydir}"/..
-OUTDATED=$(pnpm outdated --depth=0 | awk '{print $1}' | grep '^ep_') || {
+outdated_raw=$(pnpm --filter ep_etherpad-lite outdated --depth=0 2>&1) || true
+OUTDATED=$(printf '%s\n' "$outdated_raw" | awk '{print $1}' | grep '^ep_' | grep -v '^ep_etherpad-lite$') || true
+if [ -z "$OUTDATED" ]; then
   echo "All plugins are up-to-date"
   exit 0
-}
+fi
 set -- ${OUTDATED}
 echo "Updating plugins: $*"
-exec pnpm update "$@"
+exec pnpm --filter ep_etherpad-lite update "$@"


### PR DESCRIPTION
## Summary

- `updatePlugins.sh` used `npm outdated` which doesn't work with pnpm workspaces, so it never detected outdated plugins
- Also used `pnpm install` instead of `pnpm update`, which doesn't update existing packages

## Test plan

- [ ] Install an older version of a plugin, run `bin/updatePlugins.sh`, verify it updates
- [ ] Run with all plugins up-to-date, verify "All plugins are up-to-date" message

Fixes #6670

🤖 Generated with [Claude Code](https://claude.com/claude-code)