### PR TITLE
fix: handle git submodule in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,13 @@ COPY --chown=etherpad:etherpad ./pnpm-workspace.yaml ./package.json ./
 
 
 FROM build AS build_git
-ONBUILD COPY --chown=etherpad:etherpad ./.git/HEA[D] ./.git/HEAD
-ONBUILD COPY --chown=etherpad:etherpad ./.git/ref[s] ./.git/refs
+# When checked out as a git submodule, .git is a file (gitlink) instead of a
+# directory, so .git/HEAD and .git/refs do not exist.  Copy the whole .git
+# entry (the .dockerignore already strips the heavy objects) and normalise it
+# with a shell step so the build succeeds in both cases and across builders
+# (Docker, buildah, podman).  See #6663 and containers/buildah#5742.
+ONBUILD COPY --chown=etherpad:etherpad ./.git ./.git
+ONBUILD RUN if [ -f .git ]; then rm .git; fi
 
 FROM build AS build_copy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 # https://github.com/ether/etherpad-lite
 #
 # Author: muxator
+# Set to "copy" for builds without git metadata (source tarballs, some CI):
+#   docker build --build-arg BUILD_ENV=copy .
 ARG BUILD_ENV=git
 
 ARG PnpmVersion=10.28.2


### PR DESCRIPTION
## Summary

- When etherpad-lite is checked out as a git submodule, `.git` is a file (gitlink) instead of a directory, so `COPY .git/HEAD` fails
- The previous glob trick (`HEA[D]`, `ref[s]`) from #6495 doesn't work with buildah/podman (containers/buildah#5742)
- Replaced with `COPY ./.git ./.git` (`.dockerignore` already filters to just HEAD and refs) followed by a `RUN` step that removes the gitlink file if present

## Test plan

- [ ] `docker build .` works with normal git checkout
- [ ] `docker build .` works when repo is a git submodule
- [ ] `buildah build .` works in both cases
- [ ] Version detection still works in normal checkout (check server header)

Fixes #6663

🤖 Generated with [Claude Code](https://claude.com/claude-code)