### PR TITLE
fix: very old .etherpad imports could break import due to lack of aut…

### DIFF
--- a/src/node/db/Pad.ts
+++ b/src/node/db/Pad.ts
@@ -172,7 +172,7 @@ class Pad {
 
   async getRevisionAuthor(revNum: number) {
     // @ts-ignore
-    return await this.db.getSub(`pad:${this.id}:revs:${revNum}`, ['meta', 'author']);
+    return await this.db.getSub(`pad:${this.id}:revs:${revNum}`, ['meta', 'author']) ?? '';
   }
 
   async getRevisionDate(revNum: number) {

--- a/src/tests/backend/specs/ImportEtherpad.ts
+++ b/src/tests/backend/specs/ImportEtherpad.ts
@@ -171,6 +171,49 @@ describe(__filename, function () {
     }
   });
 
+  // Regression test for https://github.com/ether/etherpad-lite/issues/6785
+  describe('old .etherpad imports without author metadata', function () {
+    // Old exports (circa 2014) have revisions where meta.author is missing entirely
+    const makeOldExportNoAuthor = () => ({
+      'pad:testing': {
+        atext: {
+          text: 'foo\n',
+          attribs: '|1+4',
+        },
+        pool: {
+          numToAttrib: {},
+          nextNum: 0,
+        },
+        head: 0,
+        savedRevisions: [],
+      },
+      // Revision 0 has no meta.author — this is how very old etherpads exported
+      'pad:testing:revs:0': {
+        changeset: 'Z:1>3+3$foo',
+        meta: {
+          timestamp: 1273769875976,
+          atext: {
+            text: 'foo\n',
+            attribs: '|1+4',
+          },
+        },
+      },
+    });
+
+    it('imports without error when revision lacks meta.author', async function () {
+      await importEtherpad.setPadRaw(padId, JSON.stringify(makeOldExportNoAuthor()));
+      const pad = await padManager.getPad(padId);
+      assert.equal(pad.text(), 'foo\n');
+      assert.equal(pad.head, 0);
+    });
+
+    it('getRevisionAuthor returns empty string for missing author', async function () {
+      await importEtherpad.setPadRaw(padId, JSON.stringify(makeOldExportNoAuthor()));
+      const pad = await padManager.getPad(padId);
+      assert.equal(await pad.getRevisionAuthor(0), '');
+    });
+  });
+
   describe('exportEtherpadAdditionalContent', function () {
     let hookBackup: Function;
 


### PR DESCRIPTION
We didn't use to export all author metadata in imports, if it was missing import would fail.  Now if we import old data and data is missing we just replace it with a nameless author.

Resolves https://github.com/ether/etherpad-lite/issues/6785