### PR TITLE
fix: use correct path for connection diagnostics POST

### DIFF
--- a/src/static/js/pad.ts
+++ b/src/static/js/pad.ts
@@ -742,7 +742,7 @@ const pad = {
   },
   asyncSendDiagnosticInfo: () => {
     const currentUrl = window.location.href;
-    fetch('../ep/pad/connection-diagnostic-info', {
+    fetch(`${exports.baseURL}ep/pad/connection-diagnostic-info`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/tests/backend/specs/apicalls.ts
+++ b/src/tests/backend/specs/apicalls.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+
+describe(__filename, function () {
+  this.timeout(30000);
+  let agent: any;
+  before(async function () { agent = await common.init(); });
+
+  describe('/ep/pad/connection-diagnostic-info', function () {
+    it('POST with valid diagnosticInfo returns 200', async function () {
+      await agent.post('/ep/pad/connection-diagnostic-info')
+        .send({diagnosticInfo: {disconnectedMessage: 'socket.io timeout'}})
+        .expect(200);
+    });
+
+    it('POST without diagnosticInfo returns 400', async function () {
+      await agent.post('/ep/pad/connection-diagnostic-info')
+        .send({})
+        .expect(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The diagnostics POST used relative path `../ep/pad/connection-diagnostic-info` which resolved incorrectly in subdirectory setups
- Now uses `exports.baseURL + 'ep/pad/connection-diagnostic-info'`, matching the pattern used by socket.io connection

## Test plan

- [x] Type check passes
- [ ] Manual: verify diagnostics work in subdirectory reverse proxy setup

Fixes #4191

🤖 Generated with [Claude Code](https://claude.com/claude-code)