### PR TITLE
fix: numbered list wrapped lines now indent correctly

### DIFF
--- a/src/static/css/lists_and_indents.css
+++ b/src/static/css/lists_and_indents.css
@@ -77,22 +77,22 @@ ol > li {
 }
 
 /* Set the indentation */
-ol.list-number1{ text-indent: 0px; }
-ol.list-number2{ text-indent: 10px; }
-ol.list-number3{ text-indent: 20px; }
-ol.list-number4{ text-indent: 30px; }
-ol.list-number5{ text-indent: 40px; }
-ol.list-number6{ text-indent: 50px; }
-ol.list-number7{ text-indent: 60px; }
-ol.list-number8{ text-indent: 70px; }
-ol.list-number9{ text-indent: 80px; }
-ol.list-number10{ text-indent: 90px; }
-ol.list-number11{ text-indent: 100px; }
-ol.list-number12{ text-indent: 110px; }
-ol.list-number13{ text-indent: 120px; }
-ol.list-number14{ text-indent: 130px; }
-ol.list-number15{ text-indent: 140px; }
-ol.list-number16{ text-indent: 150px; }
+ol.list-number1{ padding-left: 0px; }
+ol.list-number2{ padding-left: 10px; }
+ol.list-number3{ padding-left: 20px; }
+ol.list-number4{ padding-left: 30px; }
+ol.list-number5{ padding-left: 40px; }
+ol.list-number6{ padding-left: 50px; }
+ol.list-number7{ padding-left: 60px; }
+ol.list-number8{ padding-left: 70px; }
+ol.list-number9{ padding-left: 80px; }
+ol.list-number10{ padding-left: 90px; }
+ol.list-number11{ padding-left: 100px; }
+ol.list-number12{ padding-left: 110px; }
+ol.list-number13{ padding-left: 120px; }
+ol.list-number14{ padding-left: 130px; }
+ol.list-number15{ padding-left: 140px; }
+ol.list-number16{ padding-left: 150px; }
 
 /* Add styling to the first item in a list */
 

--- a/src/tests/frontend-new/specs/list_wrap_indent.spec.ts
+++ b/src/tests/frontend-new/specs/list_wrap_indent.spec.ts
@@ -1,0 +1,35 @@
+import {expect, test} from "@playwright/test";
+import {clearPadContent, getPadBody, goToNewPad, writeToPad} from "../helper/padHelper";
+
+test.beforeEach(async ({page}) => {
+  await goToNewPad(page);
+});
+
+// Regression test for https://github.com/ether/etherpad-lite/issues/2581
+test.describe('numbered list wrapped line indentation', function () {
+  test('wrapped lines in a numbered list item are indented', async function ({page}) {
+    const padBody = await getPadBody(page);
+    await clearPadContent(page);
+
+    // Type a long line that will wrap
+    const longText = 'This is a very long numbered list item that should wrap to multiple lines ' +
+      'in the editor viewport so we can verify that the wrapped continuation lines are properly ' +
+      'indented to match the first line of the list item instead of snapping back to the left edge.';
+    await writeToPad(page, longText);
+
+    // Make it an ordered list
+    const $insertorderedlistButton = page.locator('.buttonicon-insertorderedlist');
+    await padBody.locator('div').first().selectText();
+    await $insertorderedlistButton.first().click();
+
+    // Verify the list item has padding-left applied (not text-indent)
+    const ol = padBody.locator('ol').first();
+    await expect(ol).toBeVisible();
+    const paddingLeft = await ol.evaluate((el) => window.getComputedStyle(el).paddingLeft);
+    const textIndent = await ol.evaluate((el) => window.getComputedStyle(el).textIndent);
+
+    // padding-left should be used instead of text-indent for proper wrapping
+    // text-indent should be 0px (not used for indentation)
+    expect(textIndent).toBe('0px');
+  });
+});


### PR DESCRIPTION
## Summary

- `text-indent` was used for ordered list indentation, but it only affects the first line of a block
- When list text wraps to the next line, wrapped text snapped back to the left edge
- Changed to `padding-left` which applies to all lines including wrapped ones

## Test plan

- [x] Type check passes
- [ ] Manual: create a numbered list with a very long item that wraps, verify wrapped lines are indented

Fixes #2581

🤖 Generated with [Claude Code](https://claude.com/claude-code)