### PR TITLE
fix: sort language dropdown alphabetically by native name

### DIFF
--- a/src/node/hooks/i18n.ts
+++ b/src/node/hooks/i18n.ts
@@ -106,9 +106,17 @@ const getAllLocales = () => {
 // returns a hash of all available languages availables with nativeName and direction
 // e.g. { es: {nativeName: "español", direction: "ltr"}, ... }
 const getAvailableLangs = (locales:MapArrayType<any>) => {
-  const result:MapArrayType<string> = {};
+  const unsorted:MapArrayType<string> = {};
   for (const langcode of Object.keys(locales)) {
-    result[langcode] = languages.getLanguageInfo(langcode);
+    unsorted[langcode] = languages.getLanguageInfo(langcode);
+  }
+  // Sort by native name so the language dropdown is alphabetical
+  const sorted = Object.entries(unsorted).sort(([, a]: any, [, b]: any) =>
+    (a.nativeName || '').localeCompare(b.nativeName || '', undefined, {sensitivity: 'base'})
+  );
+  const result:MapArrayType<string> = {};
+  for (const [langcode, info] of sorted) {
+    result[langcode] = info;
   }
   return result;
 };

--- a/src/tests/backend/specs/i18n.ts
+++ b/src/tests/backend/specs/i18n.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('assert').strict;
+const common = require('../common');
+const i18n = require('../../../node/hooks/i18n');
+
+describe(__filename, function () {
+  before(async function () {
+    await common.init();
+  });
+
+  it('availableLangs are sorted by nativeName (case-insensitive)', async function () {
+    const langs = i18n.availableLangs;
+    assert(langs != null, 'availableLangs should be populated after server init');
+
+    const nativeNames: string[] = Object.values(langs).map((info: any) => info.nativeName || '');
+    assert(nativeNames.length > 1, 'expected more than one language');
+
+    for (let i = 1; i < nativeNames.length; i++) {
+      const cmp = nativeNames[i - 1].localeCompare(nativeNames[i], undefined, {sensitivity: 'base'});
+      assert(
+        cmp <= 0,
+        `languages not sorted: "${nativeNames[i - 1]}" should come before "${nativeNames[i]}" ` +
+        `(index ${i - 1} vs ${i})`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Language dropdown was ordered by language code (ar, de, en, es...) making it hard to find languages
- Now sorted alphabetically by native display name (العربية, Deutsch, English, Español...)
- Fix is in `getAvailableLangs()` in `i18n.ts`, no template changes needed

## Test plan

- [x] Type check passes
- [ ] Manual: open pad settings, verify language dropdown is alphabetically sorted

Fixes #3263

🤖 Generated with [Claude Code](https://claude.com/claude-code)