### PR TITLE
fix: add setters to CJS compatibility layer in Settings

### DIFF
--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -670,6 +670,7 @@ if (typeof module !== 'undefined' && module.exports) {
     if (!(key in currentExports)) {
       Object.defineProperty(currentExports, key, {
         get: () => (settings as any)[key],
+        set: (v: any) => { (settings as any)[key] = v; },
         enumerable: true,
         configurable: true,
       });


### PR DESCRIPTION
## Summary
- The CJS compatibility block added in fd97532 only defined getters on `module.exports`, making settings read-only for CJS consumers.
- Plugins like ep_webrtc need to mutate settings in tests (e.g. `settings.requireAuthentication = false`), which throws `TypeError: Cannot set property which has only a getter`.
- Add `set` to the property descriptors so CJS consumers can both read and write settings.

## Test plan
- [ ] Core backend tests still pass
- [ ] ep_webrtc CI passes after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)