### PR TITLE
ci: auto-merge clean Dependabot PRs on plugin repos in update-plugins cron

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -77,3 +77,34 @@ jobs:
           echo "Succeeded:$(echo $succeeded | wc -w) -$succeeded"
           echo "Failed:$(echo $failed | wc -w) -$failed"
           echo "Skipped:$(echo $skipped | wc -w) -$skipped"
+
+      - name: Merge clean Dependabot PRs on plugin repos
+        env:
+          GH_TOKEN: ${{ secrets.PLUGINS_PAT }}
+        run: |
+          # For every ep_* repo under ether, merge any Dependabot PR whose
+          # mergeStateStatus is CLEAN (no conflicts, branch up to date, all
+          # required checks green). Anything else is left alone for a human.
+          plugins=$(gh repo list ether --limit 200 --json name --jq '.[] | select(.name | startswith("ep_")) | .name')
+
+          merged=""
+          for plugin in $plugins; do
+            repo="ether/${plugin}"
+            prs=$(gh pr list --repo "$repo" \
+              --author "app/dependabot" \
+              --state open \
+              --json number,mergeStateStatus,title \
+              --jq '.[] | select(.mergeStateStatus=="CLEAN") | .number') || continue
+
+            for pr in $prs; do
+              echo "Merging ${repo}#${pr}"
+              if gh pr merge --repo "$repo" --squash --delete-branch "$pr"; then
+                merged="$merged ${repo}#${pr}"
+              else
+                echo "WARN: failed to merge ${repo}#${pr}"
+              fi
+            done
+          done
+
+          echo ""
+          echo "Merged Dependabot PRs:$merged"


### PR DESCRIPTION
## Summary

- Adds a final step to `.github/workflows/update-plugins.yml` that walks every `ether/ep_*` repo and squash-merges any open Dependabot PR whose `mergeStateStatus` is `CLEAN` (no conflicts, branch up to date, all required checks green).
- Anything else (`DIRTY`, `BLOCKED`, `BEHIND`, `UNSTABLE`, …) is left alone for a human to look at.
- No semver gating: a major bump is allowed to merge if the plugin's own CI is green. If a major breaks the API, plugin CI should fail and `mergeStateStatus` won't be `CLEAN` — that's the gate.

## Why

The daily `update-plugins` cron already pushes boilerplate updates (workflows, `dependabot.yml`, etc.) into every plugin repo via `checkPlugin`, which causes Dependabot to open PRs against each plugin. But none of the plugin repos have auto-merge configured at the repo level, so those PRs sit green forever — see e.g. ether/ep_loading_message#77, which has been `MERGEABLE` + `CLEAN` since it was opened.

This step closes the loop centrally from etherpad-lite, instead of needing to enable auto-merge + add per-repo workflows in 100+ plugin repos.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` once merged and verify the new step runs without error against the live plugin set.
- [ ] Confirm that at least one known-clean Dependabot PR (e.g. ether/ep_loading_message#77) is squash-merged on the first run.
- [ ] Confirm that PRs with failing checks / conflicts are skipped, not merged.

## Notes

- Uses the existing `PLUGINS_PAT` secret. The PAT already has `contents: write` (the cron pushes commits to plugin repos), and needs `pull_requests: write` for `gh pr merge` to succeed. If the first run shows `WARN: failed to merge ...` lines, that's the scope to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)