### PR TITLE
fix: use atomic git push in plugin npmpublish workflow

### DIFF
--- a/bin/plugins/lib/npmpublish.yml
+++ b/bin/plugins/lib/npmpublish.yml
@@ -15,7 +15,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # for `git push --follow-tags` of the version bump
+      contents: write   # for the atomic version-bump push (branch + tag)
       id-token: write   # for npm OIDC trusted publishing
     steps:
       - uses: actions/setup-node@v6
@@ -60,8 +60,22 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           pnpm i
+          # `pnpm version patch` bumps package.json, makes a commit, and creates
+          # a `v<new-version>` tag. Capture the new tag name from package.json
+          # rather than parsing pnpm's output, which has historically varied.
           pnpm version patch
-          git push --follow-tags
+          NEW_TAG="v$(node -p "require('./package.json').version")"
+          # CRITICAL: use --atomic so the branch update and the tag update
+          # succeed (or fail) as a single transaction on the server. The old
+          # `git push --follow-tags` was non-atomic per ref: if a concurrent
+          # publish run won the race, the branch fast-forward would be rejected
+          # but the tag push would still land — leaving a dangling tag with no
+          # matching commit on the branch. Subsequent runs would then forever
+          # try to bump to the same already-existing tag and fail with
+          # `tag 'vN+1' already exists`. With --atomic, a rejected branch push
+          # rejects the tag push too, and the next workflow tick can retry
+          # cleanly against the up-to-date refs.
+          git push --atomic origin "${GITHUB_REF_NAME}" "${NEW_TAG}"
       # This is required if the package has a prepare script that uses something
       # in dependencies or devDependencies.
       -

--- a/src/tests/backend/specs/npmpublish-workflow.ts
+++ b/src/tests/backend/specs/npmpublish-workflow.ts
@@ -1,0 +1,81 @@
+'use strict';
+
+// Regression test for bin/plugins/lib/npmpublish.yml.
+//
+// This file is the source-of-truth template that `bin/plugins/checkPlugin.ts`
+// propagates into every `ether/ep_*` plugin's `.github/workflows/`. The
+// version-bump step in it MUST use `git push --atomic` rather than the older
+// `git push --follow-tags`, otherwise concurrent publish runs can leave
+// dangling `vN+1` tags on plugin repos with no matching version-bump commit —
+// at which point every subsequent push fails forever with
+// `npm error fatal: tag 'vN+1' already exists` until someone reconciles the
+// repo by hand.
+//
+// On 2026-04-08 a single churn day produced ~46 broken plugins this way; the
+// recovery was painful enough to be worth a regression test.
+
+import {strict as assert} from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const NPMPUBLISH_YML = path.join(REPO_ROOT, 'bin', 'plugins', 'lib', 'npmpublish.yml');
+
+describe(__filename, function () {
+  let yml: string;
+
+  before(function () {
+    yml = fs.readFileSync(NPMPUBLISH_YML, 'utf8');
+  });
+
+  it('uses git push --atomic for the version bump', function () {
+    assert.match(
+      yml, /git push --atomic\b/,
+      'npmpublish.yml must use `git push --atomic` so the branch update and ' +
+      'the tag push happen as a single transaction. Without --atomic, a ' +
+      'rejected branch fast-forward (e.g. lost race against a concurrent ' +
+      'publish run) can still leave the tag pushed, producing a dangling ' +
+      'vN+1 tag and breaking every future publish on the plugin.',
+    );
+  });
+
+  it('does not regress to `git push --follow-tags`', function () {
+    // Strip YAML comments before checking — the historical bug is described
+    // in a comment block above the new code, and that's an intentional
+    // forensic note, not a regression. We only care if the actual command
+    // line uses --follow-tags.
+    const commandLines = yml
+      .split('\n')
+      .filter((l) => !/^\s*#/.test(l))
+      .join('\n');
+    assert.doesNotMatch(
+      commandLines, /git push --follow-tags\b/,
+      '`git push --follow-tags` is non-atomic per ref and is the exact ' +
+      'failure mode this workflow used to have. Use `git push --atomic ' +
+      'origin <branch> <tag>` instead.',
+    );
+  });
+
+  it('pushes both the branch ref and the version tag in the atomic command', function () {
+    // Find the atomic push line and assert it carries at least two refspecs
+    // (the branch + the tag). We don't pin the exact variable names — just
+    // require that the line names something tag-shaped and something
+    // branch-shaped — but we DO require the new tag to be derived from the
+    // freshly-bumped package.json so it can't drift from what `pnpm version
+    // patch` actually wrote.
+    const lines = yml.split('\n');
+    const pushLine = lines.find((l) => /git push --atomic\b/.test(l));
+    assert.ok(pushLine, 'expected to find a `git push --atomic` line');
+    // Branch ref — workflow_call inherits the caller's ref via GITHUB_REF_NAME.
+    assert.match(
+      pushLine!, /\$\{?GITHUB_REF_NAME\}?/,
+      'atomic push must include the branch ref via $GITHUB_REF_NAME so it ' +
+      'works for both `main`- and `master`-default plugins',
+    );
+    // Tag ref — must reference the variable holding the just-bumped tag.
+    assert.match(
+      pushLine!, /\$\{?NEW_TAG\}?|\$\{?TAG\}?/,
+      'atomic push must include the version tag (NEW_TAG / TAG) it just created',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `git push --follow-tags` with `git push --atomic origin <branch> <tag>` in `bin/plugins/lib/npmpublish.yml`, the source-of-truth template that `checkPlugin.ts` propagates into every `ether/ep_*` plugin's `.github/workflows/`.
- Derives the new tag name explicitly from `package.json` after `pnpm version patch`, instead of relying on parsing pnpm's stdout.
- Adds `src/tests/backend/specs/npmpublish-workflow.ts` — a regression test that asserts the workflow uses `--atomic`, has no literal `git push --follow-tags` command (ignoring forensic comments), and includes both the branch ref and the freshly-bumped tag in the atomic push.

## Why

`git push --follow-tags` updates the branch and tag refs in two separate server-side transactions. If a concurrent publish run wins the race, the branch fast-forward gets rejected — but the tag push still lands. That leaves a dangling `vN+1` tag with no matching version-bump commit on the branch, and `package.json` still at version `N`.

Every subsequent push then runs `pnpm version patch`, derives the same `vN+1` tag name from the unchanged `package.json`, and dies with `npm error fatal: tag 'vN+1' already exists`. The plugin can never publish again until someone hand-reconciles the repo.

On 2026-04-08, a single churn day (mass badge fixes + Dependabot auto-merge from #7493 firing back-to-back across ~80 plugins) put **~46 plugins** into this state at once. The recovery required hand-bumping `package.json` past the dangling tag on every affected repo, twice — a second wave appeared after the first sweep finished, racing the next wave of publish runs that the sweep itself had triggered.

`git push --atomic` makes branch + tag a single server-side transaction. A rejected branch fast-forward also rejects the tag push, the run aborts cleanly, and the next workflow tick retries against up-to-date refs with no orphans left behind.

## Propagation

This file is the canonical template; the daily `update-plugins.yml` cron in this repo runs `checkPlugin.ts` against every plugin, which copies this file into each plugin's `.github/workflows/npmpublish.yml`. So one commit here heals every plugin on the next cron tick (or `workflow_dispatch`).

## Test plan

- [x] `pnpm run ts-check` — clean
- [x] New regression test runs green: `npx mocha --import=tsx tests/backend/specs/npmpublish-workflow.ts` (3 passing)
- [ ] After merge, trigger `update-plugins.yml` manually and confirm the new file is propagated to plugin repos
- [ ] On the next plugin Dependabot churn, confirm no new tag-drift incidents appear

## Notes

The end-to-end behaviour of `git push --atomic` against the actual Git server isn't unit-testable (atomicity is a server feature, not local). The regression test is a static-analysis check that the workflow keeps using `--atomic`, which catches the most likely regression: someone reverting the change in a refactor without realizing why it matters. The forensic comment in the workflow file explains the historical bug for anyone reading the diff later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)