### PR TITLE
Add aceRegisterLineAttributes hook for line attribute preservation on Enter

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -2399,8 +2399,32 @@ function Ace2Inner(editorInfo, cssManagers) {
         setLineListType(lineNum + 1, type + level);
       }
     } else {
+      const caretColumn = rep.selStart[1];
       performDocumentReplaceSelection('\n');
       handleReturnIndentation();
+
+      // Preserve line attributes (heading, align, etc.) across line splits.
+      // When Enter is pressed in the middle or end of a line, copy attributes
+      // to the new line (same as list behavior). When Enter is pressed at the
+      // start of a line (column 0), keep attributes on the line with text
+      // (the new line below) and clear the now-empty line above.
+      const lineAttrs = hooks.callAll('aceRegisterLineAttributes');
+      if (lineAttrs.length > 0) {
+        for (const attrName of lineAttrs) {
+          const value = documentAttributeManager.getAttributeOnLine(lineNum, attrName);
+          if (!value) continue;
+
+          if (caretColumn === 0) {
+            // Enter at start of line: attribute moves down with text.
+            // lineNum is now the empty line above, lineNum+1 has the text.
+            documentAttributeManager.removeAttributeOnLine(lineNum, attrName);
+            documentAttributeManager.setAttributeOnLine(lineNum + 1, attrName, value);
+          } else {
+            // Enter in middle or end: new line below inherits the attribute.
+            documentAttributeManager.setAttributeOnLine(lineNum + 1, attrName, value);
+          }
+        }
+      }
     }
   };
   editorInfo.ace_doReturnKey = doReturnKey;


### PR DESCRIPTION
## Summary

When pressing Enter in a line with plugin-provided attributes (like heading or align), the attributes were lost. Lists had special-case code in `doReturnKey()` but all other line attributes were silently dropped.

This adds a new client hook `aceRegisterLineAttributes` that lets plugins declare which attributes should be preserved when a line is split:

- **Enter at middle/end of line**: attribute is copied to the new line below
- **Enter at start of line (col 0)**: attribute moves down with the text, the now-empty line above is cleared

## How plugins use it

In `ep.json`:
```json
"client_hooks": {
  "aceRegisterLineAttributes": "ep_headings2/static/js/index"
}
```

In the plugin JS:
```js
exports.aceRegisterLineAttributes = () => ['heading'];
```

This follows the same pattern as the existing `aceRegisterBlockElements` hook.

## Backwards compatibility

- Plugins that register this hook on older Etherpad versions are unaffected — the hook is simply not called (hooks.callAll returns `[]` for unknown hooks)
- No changes to existing list behavior
- The hook is purely additive

## Fixes

- ether/ep_headings2#7 — "Paragraph style lost when hitting Enter on line start"
- Affects all line attribute plugins: ep_headings2, ep_align, and future ones

## Test plan

- [ ] Type text, apply Heading 1, press Enter at the end — new line should also be Heading 1
- [ ] Type text, apply Heading 1, move caret to start of line, press Enter — empty line above should be Normal, heading line moves down with text
- [ ] Verify list Enter behavior is unchanged
- [ ] Plugin-level tests will be added in ep_headings2

🤖 Generated with [Claude Code](https://claude.com/claude-code)