### PR TITLE
Bump ueberdb2 to ^5.0.41 and update lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,8 +277,8 @@ importers:
         specifier: 4.21.0
         version: 4.21.0
       ueberdb2:
-        specifier: ^5.0.40
-        version: 5.0.40
+        specifier: ^5.0.41
+        version: 5.0.41
       underscore:
         specifier: 1.13.8
         version: 1.13.8
@@ -5002,8 +5002,8 @@ packages:
     resolution: {integrity: sha512-5lwD62pD97OcxUnGpHustvB7SmbJkL/991YoBGfh8VgLFAUNINnDBoXgxIdak3wJGBBfNLCHEPv18uXXKCjczQ==}
     engines: {node: '>=16.20.1'}
 
-  ueberdb2@5.0.40:
-    resolution: {integrity: sha512-v6J2BMvNG4bOjWYW4mbkePlOcJ2YLa9y4qWILZGlviKOLExHSBGKkFdw+0aML7ndBriFjpVsUt+ONVlC3Sgcpw==}
+  ueberdb2@5.0.41:
+    resolution: {integrity: sha512-4zdlLhOls1PcDcO3sQE3q/B2olxwgPYckNr138NYDlNqMeYvyaadb+adqeKLdCpFVC3X/bX11KMiMqZyPX8jJQ==}
     engines: {node: '>=22.22.0'}
 
   uid-safe@2.1.5:
@@ -7786,10 +7786,10 @@ snapshots:
       '@rushstack/eslint-patch': 1.11.0
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(typescript@6.0.2)
       '@typescript-eslint/parser': 7.18.0(eslint@10.2.0)(typescript@6.0.2)
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@10.2.0)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0)
       eslint-plugin-cypress: 2.15.2(eslint@10.2.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@10.2.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
       eslint-plugin-mocha: 10.5.0(eslint@10.2.0)
       eslint-plugin-n: 16.6.2(eslint@10.2.0)
       eslint-plugin-prefer-arrow: 1.2.3(eslint@10.2.0)
@@ -7810,7 +7810,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@10.2.0):
+  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -7821,18 +7821,18 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.3.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@10.2.0)(typescript@6.0.2)
       eslint: 10.2.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@10.2.0)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7854,7 +7854,7 @@ snapshots:
       eslint: 10.2.0
       ignore: 5.3.2
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7865,7 +7865,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.2.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -10095,7 +10095,7 @@ snapshots:
 
   ueberdb2@5.0.34: {}
 
-  ueberdb2@5.0.40: {}
+  ueberdb2@5.0.41: {}
 
   uid-safe@2.1.5:
     dependencies:

--- a/src/package.json
+++ b/src/package.json
@@ -73,7 +73,7 @@
     "swagger-ui-express": "^5.0.1",
     "tinycon": "0.6.8",
     "tsx": "4.21.0",
-    "ueberdb2": "^5.0.40",
+    "ueberdb2": "^5.0.41",
     "underscore": "1.13.8",
     "unorm": "1.6.0",
     "wtfnode": "^0.10.1"


### PR DESCRIPTION
The previous bump (#7511) updated package.json but the lockfile still pinned 5.0.40 which was missing the rolldown runtime file. This updates both package.json and pnpm-lock.yaml to resolve 5.0.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)