### PR TITLE
Fix Docker production build: use production-only workspace config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,11 @@ ARG ETHERPAD_GITHUB_PLUGINS=
 ENV NODE_ENV=production
 ENV ETHERPAD_PRODUCTION=true
 
+# The full pnpm-workspace.yaml references admin, doc, ui which are not
+# needed at runtime. Overwrite it with a production-only version so
+# pnpm install doesn't warn about missing workspace directories.
+RUN printf 'packages:\n  - src\n  - bin\n' > pnpm-workspace.yaml
+
 COPY --chown=etherpad:etherpad ./src ./src
 COPY --chown=etherpad:etherpad --from=adminbuild /opt/etherpad-lite/src/templates/admin ./src/templates/admin
 COPY --chown=etherpad:etherpad --from=adminbuild /opt/etherpad-lite/src/static/oidc ./src/static/oidc


### PR DESCRIPTION
## Summary

The Docker production build has been failing because `pnpm-workspace.yaml` references `admin`, `doc`, and `ui` packages that aren't copied into the production image. This caused:

- `WARN Installing a dependency from a non-existent directory: /opt/etherpad-lite/admin`
- `WARN Failed to create bin at .../acorn`, `.../vite`
- Container crashes on startup

This was masked before because ueberdb2 was a single bundled file. After ueberdb2 switched to modular builds (separate files per database driver), the incomplete pnpm install caused missing module errors.

## Fix

Overwrite `pnpm-workspace.yaml` in the production Dockerfile stage with a minimal version listing only the packages present in the image (`src` and `bin`).

## Test plan

- [ ] Docker CI should pass — container starts and health check succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)