### PR TITLE
Bump ueberdb2 to ^5.0.42 — production dependencies for db drivers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,8 +277,8 @@ importers:
         specifier: 4.21.0
         version: 4.21.0
       ueberdb2:
-        specifier: ^5.0.42
-        version: 5.0.42
+        specifier: ^5.0.43
+        version: 5.0.43
       underscore:
         specifier: 1.13.8
         version: 1.13.8
@@ -5035,9 +5035,9 @@ packages:
     resolution: {integrity: sha512-5lwD62pD97OcxUnGpHustvB7SmbJkL/991YoBGfh8VgLFAUNINnDBoXgxIdak3wJGBBfNLCHEPv18uXXKCjczQ==}
     engines: {node: '>=16.20.1'}
 
-  ueberdb2@5.0.42:
-    resolution: {integrity: sha512-dIVJr8j61pmxEbXpOwnWQ0ssZV/TG8AfCFTxtlj/B1deNG/WcRr8QxyTpVfu4L+eUohY7V9ILwF+40jo/de7Ag==}
-    engines: {node: '>=22.22.0'}
+  ueberdb2@5.0.43:
+    resolution: {integrity: sha512-rMJKW9Nft0V4O3a1QVqOEiKwVqJWpU0KZOvesQ6nrHk2IgPipDu7FiuV4KcbYzlEdc01b1VthJAqQ2xyao+JzQ==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       '@elastic/elasticsearch': ^9.3.4
       cassandra-driver: ^4.8.0
@@ -5046,7 +5046,7 @@ packages:
       mysql2: ^3.22.0
       nano: ^11.0.5
       pg: ^8.20.0
-      redis: ^5.11.0
+      redis: ^5.12.1
       rethinkdb: ^2.4.2
       surrealdb: ^2.0.3
     peerDependenciesMeta:
@@ -10202,7 +10202,7 @@ snapshots:
 
   ueberdb2@5.0.34: {}
 
-  ueberdb2@5.0.42:
+  ueberdb2@5.0.43:
     dependencies:
       async: 3.2.6
       dirty-ts: 1.1.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,8 +277,8 @@ importers:
         specifier: 4.21.0
         version: 4.21.0
       ueberdb2:
-        specifier: ^5.0.41
-        version: 5.0.41
+        specifier: ^5.0.42
+        version: 5.0.42
       underscore:
         specifier: 1.13.8
         version: 1.13.8
@@ -417,6 +417,14 @@ importers:
         version: rolldown-vite@7.2.10(@types/node@25.6.0)(tsx@4.21.0)
 
 packages:
+
+  2@1.0.2:
+    resolution: {integrity: sha512-G0Eca6Fz2qJKvjM9/niouz5kWTZy7pm+LRAMXir5v+DOt4bMszVlfIYKy2T+TPKnGxpp236pzK7/chNuToWlnQ==}
+    engines: {node: '>=7.0.0'}
+
+  3@2.1.0:
+    resolution: {integrity: sha512-rEoeK/qBZCLzqt9a3Q3Dnb5TUyXnZlxVaWr9ZXBV65Ppzcz59dx3Ik5YUxtni+36CtZgJdhQaYkLgHBdqjxjoA==}
+    engines: {node: '>=7.0.0'}
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
@@ -1195,6 +1203,12 @@ packages:
     peerDependencies:
       koa: ^2.0.0 || ^3.0.0
 
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1745,6 +1759,12 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -2594,6 +2614,9 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
 
+  chunk-array@1.0.2:
+    resolution: {integrity: sha512-NdHMmQ59t0VOwG+md2fYfLbmeaN1ZeX+4rEKgOj2vqgJsuXyTvSgYLZ9jEU8xwmB4nm6DeuuAkU/Y67LpGlvHQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2821,6 +2844,10 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dirty-ts@1.1.8:
+    resolution: {integrity: sha512-RvnzXCdg5GuAvUgAUa5b5O74fXd11JJxZD5OoBXOQrkjuQwDV6LBJYdtX9hjxBA7Q9y9gcp4mZnDWVVpCzftvQ==}
+    engines: {node: '>=12.13.0'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -2858,6 +2885,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  enforce-range@1.0.0:
+    resolution: {integrity: sha512-iOYthPljA5P/S823In8avtTbeUl8/uTP1+pqy08ryb8jeMO2enuIO/f72QFFqT4GTNiOe0yWPIzXB9nR3u6O5A==}
 
   engine.io-client@6.6.4:
     resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
@@ -4722,6 +4752,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
   sinon@21.1.2:
     resolution: {integrity: sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==}
 
@@ -5002,9 +5035,41 @@ packages:
     resolution: {integrity: sha512-5lwD62pD97OcxUnGpHustvB7SmbJkL/991YoBGfh8VgLFAUNINnDBoXgxIdak3wJGBBfNLCHEPv18uXXKCjczQ==}
     engines: {node: '>=16.20.1'}
 
-  ueberdb2@5.0.41:
-    resolution: {integrity: sha512-4zdlLhOls1PcDcO3sQE3q/B2olxwgPYckNr138NYDlNqMeYvyaadb+adqeKLdCpFVC3X/bX11KMiMqZyPX8jJQ==}
+  ueberdb2@5.0.42:
+    resolution: {integrity: sha512-dIVJr8j61pmxEbXpOwnWQ0ssZV/TG8AfCFTxtlj/B1deNG/WcRr8QxyTpVfu4L+eUohY7V9ILwF+40jo/de7Ag==}
     engines: {node: '>=22.22.0'}
+    peerDependencies:
+      '@elastic/elasticsearch': ^9.3.4
+      cassandra-driver: ^4.8.0
+      mongodb: ^7.1.1
+      mssql: ^12.2.1
+      mysql2: ^3.22.0
+      nano: ^11.0.5
+      pg: ^8.20.0
+      redis: ^5.11.0
+      rethinkdb: ^2.4.2
+      surrealdb: ^2.0.3
+    peerDependenciesMeta:
+      '@elastic/elasticsearch':
+        optional: true
+      cassandra-driver:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      nano:
+        optional: true
+      pg:
+        optional: true
+      redis:
+        optional: true
+      rethinkdb:
+        optional: true
+      surrealdb:
+        optional: true
 
   uid-safe@2.1.5:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
@@ -5389,6 +5454,14 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  2@1.0.2: {}
+
+  3@2.1.0:
+    dependencies:
+      '2': 1.0.2
+      chunk-array: 1.0.2
+      enforce-range: 1.0.0
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
     dependencies:
@@ -6000,6 +6073,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
@@ -6424,6 +6505,12 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@sinonjs/commons@3.0.1':
     dependencies:
@@ -7343,6 +7430,8 @@ snapshots:
 
   chownr@2.0.0: {}
 
+  chunk-array@1.0.2: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -7528,6 +7617,10 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dirty-ts@1.1.8:
+    dependencies:
+      '3': 2.1.0
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -7557,6 +7650,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  enforce-range@1.0.0:
+    dependencies:
+      '2': 1.0.2
 
   engine.io-client@6.6.4:
     dependencies:
@@ -7786,10 +7883,10 @@ snapshots:
       '@rushstack/eslint-patch': 1.11.0
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(typescript@6.0.2)
       '@typescript-eslint/parser': 7.18.0(eslint@10.2.0)(typescript@6.0.2)
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@10.2.0)
       eslint-plugin-cypress: 2.15.2(eslint@10.2.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@10.2.0)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0)
       eslint-plugin-mocha: 10.5.0(eslint@10.2.0)
       eslint-plugin-n: 16.6.2(eslint@10.2.0)
       eslint-plugin-prefer-arrow: 1.2.3(eslint@10.2.0)
@@ -7810,7 +7907,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0):
+  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@10.2.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -7821,18 +7918,18 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.3.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@10.2.0)(typescript@6.0.2)
       eslint: 10.2.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@10.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7854,7 +7951,7 @@ snapshots:
       eslint: 10.2.0
       ignore: 5.3.2
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7865,7 +7962,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.2.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0))(eslint@10.2.0))(eslint@10.2.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@10.2.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@10.2.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9768,6 +9865,16 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   sinon@21.1.2:
     dependencies:
       '@sinonjs/commons': 3.0.1
@@ -10095,7 +10202,14 @@ snapshots:
 
   ueberdb2@5.0.34: {}
 
-  ueberdb2@5.0.41: {}
+  ueberdb2@5.0.42:
+    dependencies:
+      async: 3.2.6
+      dirty-ts: 1.1.8
+      rusty-store-kv: 1.3.1
+      simple-git: 3.36.0
+    transitivePeerDependencies:
+      - supports-color
 
   uid-safe@2.1.5:
     dependencies:

--- a/src/package.json
+++ b/src/package.json
@@ -73,7 +73,7 @@
     "swagger-ui-express": "^5.0.1",
     "tinycon": "0.6.8",
     "tsx": "4.21.0",
-    "ueberdb2": "^5.0.41",
+    "ueberdb2": "^5.0.42",
     "underscore": "1.13.8",
     "unorm": "1.6.0",
     "wtfnode": "^0.10.1"

--- a/src/package.json
+++ b/src/package.json
@@ -73,7 +73,7 @@
     "swagger-ui-express": "^5.0.1",
     "tinycon": "0.6.8",
     "tsx": "4.21.0",
-    "ueberdb2": "^5.0.42",
+    "ueberdb2": "^5.0.43",
     "underscore": "1.13.8",
     "unorm": "1.6.0",
     "wtfnode": "^0.10.1"


### PR DESCRIPTION
## Summary

ueberdb2 5.0.42 (ether/ueberDB#926) moves core database drivers to production dependencies:
- `dirty-ts` and `rusty-store-kv` are now installed in production
- Optional drivers (cassandra, mongodb, etc.) are optional peerDependencies

This fixes `Cannot find module 'dirty-ts'` on Windows CI and Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)