### PR TITLE
fix: also declare pnpm build-script policy in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,13 @@
   },
   "engineStrict": true,
   "version": "2.6.1",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ],
+    "ignoredBuiltDependencies": [
+      "@scarf/scarf"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
PR #7523 moved the build-script allowlist into \`pnpm-workspace.yaml\`, which is the modern location. But some pnpm versions / setups still read these settings from \`package.json\` only — and plugin CI is hitting that case: \`ERR_PNPM_IGNORED_BUILDS\` is back even though \`pnpm-workspace.yaml\` correctly lists \`esbuild\` under \`onlyBuiltDependencies\` and \`@scarf/scarf\` under \`ignoredBuiltDependencies\`.

Mirror the same configuration into \`package.json\`'s \`\"pnpm\"\` field. Whichever location pnpm reads, it now finds the policy.

Verified locally that a fresh \`pnpm install\` (with store pruned) still:
- runs esbuild's \`postinstall\` (downloads native binary)
- silently skips \`@scarf/scarf\`'s \`postinstall\` (telemetry)
- exits 0 (no \`ERR_PNPM_IGNORED_BUILDS\`)

Generated with [Claude Code](https://claude.com/claude-code)