### PR TITLE
fix: downgrade ERR_PNPM_IGNORED_BUILDS to a warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-dep-builds=false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,7 @@ onlyBuiltDependencies:
 # encountered as transitive deps (e.g. scarf pulled in via swagger-ui-dist).
 ignoredBuiltDependencies:
   - '@scarf/scarf'
+# Belt-and-suspenders: even if a fresh transitive dep slips through with a
+# postinstall script, downgrade to a warning so CI doesn't break for
+# downstream plugin repos that pull etherpad-lite as their core install.
+strictDepBuilds: false


### PR DESCRIPTION
## Summary
Plugin CI is still failing on \`ERR_PNPM_IGNORED_BUILDS\` even with the build-script allowlist declared in both \`pnpm-workspace.yaml\` (#7523) and \`package.json\` (#7525) — every downstream plugin repo's backend tests now fail when running \`bin/installDeps.sh\` against \`develop\`.

The root cause: pnpm's \`strict-dep-builds\` defaults to \`true\` in 10.x, so any transitive dep with an unrecognized postinstall fails the install. That makes any new transitive landing in \`pnpm-lock.yaml\` a footgun for every plugin repo's CI.

## Fix
Set the strict-mode setting to \`false\` in two places:
- \`pnpm-workspace.yaml\` → \`strictDepBuilds: false\` (the modern location)
- \`.npmrc\` → \`strict-dep-builds=false\` (the universally-supported location, in case some pnpm version doesn't read the workspace setting)

Unknown postinstalls now emit a warning instead of failing. The existing \`onlyBuiltDependencies\` (esbuild) and \`ignoredBuiltDependencies\` (@scarf/scarf) lists still control what actually runs.

Verified locally that a fresh \`pnpm install\` (with store pruned) still:
- runs esbuild's \`postinstall\`
- silently skips \`@scarf/scarf\`'s \`postinstall\`
- exits 0

Generated with [Claude Code](https://claude.com/claude-code)