### PR TITLE
fix: use hardlink package-import-method so Docker build works on ZFS (#7342)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,7 @@
 strict-dep-builds=false
+# Use hardlinks when populating node_modules instead of clone/copyfile.
+# pnpm's default "auto" mode ends up using copy_file_range which fails on
+# ZFS (https://github.com/pnpm/pnpm/issues/7024) and breaks `docker
+# compose build` on hosts with a ZFS root (#7342). Hardlinks are fast,
+# save disk, and work on every filesystem Etherpad supports.
+package-import-method=hardlink


### PR DESCRIPTION
Fixes #7342. pnpm's default `package-import-method=auto` ends up using `copyfile` + `copy_file_range`, which fails on ZFS with `EAGAIN: resource temporarily unavailable` (upstream https://github.com/pnpm/pnpm/issues/7024). `docker compose build` therefore aborts inside `RUN pnpm install` on any host with a ZFS root. Force `package-import-method=hardlink` in the project-level `.npmrc` so every pnpm invocation — Dockerfile, `bin/installDeps.sh`, `bin/installLocalPlugins.sh`, `bin/updatePlugins.sh` — picks it up automatically instead of requiring per-command flags. Hardlinks are fast, save disk, and work on every filesystem Etherpad supports.