### PR TITLE
docs(openapi): document apikey auth in openapi.json

### DIFF
--- a/src/node/handler/RestAPI.ts
+++ b/src/node/handler/RestAPI.ts
@@ -192,6 +192,16 @@ const prepareDefinition = (mapping: Map<string, Record<string, RestAPIMapping>>,
           "in": string
 
         },
+        "apiKeyAlias": {
+          "type": string,
+          "name": string,
+          "in": string
+        },
+        "apiKeyHeader": {
+          "type": string,
+          "name": string,
+          "in": string
+        },
         "sso"?: {
           "type": string,
           "flows": {
@@ -243,6 +253,16 @@ const prepareDefinition = (mapping: Map<string, Record<string, RestAPIMapping>>,
           "in": "query"
 
         },
+        "apiKeyAlias": {
+          "type": "apiKey",
+          "name": "api_key",
+          "in": "query"
+        },
+        "apiKeyHeader": {
+          "type": "apiKey",
+          "name": "apikey",
+          "in": "header"
+        },
       },
     },
     "servers": [
@@ -256,9 +276,9 @@ const prepareDefinition = (mapping: Map<string, Record<string, RestAPIMapping>>,
 
   if (authenticationMethod === "apikey") {
     definitions.security = [
-      {
-        "apiKey": []
-      }
+      {"apiKey": []},
+      {"apiKeyAlias": []},
+      {"apiKeyHeader": []},
     ]
   } else if (authenticationMethod === "sso") {
     definitions.components.securitySchemes.sso = {

--- a/src/node/handler/RestAPI.ts
+++ b/src/node/handler/RestAPI.ts
@@ -192,12 +192,12 @@ const prepareDefinition = (mapping: Map<string, Record<string, RestAPIMapping>>,
           "in": string
 
         },
-        "apiKeyAlias": {
+        "apiKeyAlias"?: {
           "type": string,
           "name": string,
           "in": string
         },
-        "apiKeyHeader": {
+        "apiKeyHeader"?: {
           "type": string,
           "name": string,
           "in": string
@@ -253,16 +253,6 @@ const prepareDefinition = (mapping: Map<string, Record<string, RestAPIMapping>>,
           "in": "query"
 
         },
-        "apiKeyAlias": {
-          "type": "apiKey",
-          "name": "api_key",
-          "in": "query"
-        },
-        "apiKeyHeader": {
-          "type": "apiKey",
-          "name": "apikey",
-          "in": "header"
-        },
       },
     },
     "servers": [
@@ -275,6 +265,16 @@ const prepareDefinition = (mapping: Map<string, Record<string, RestAPIMapping>>,
   }
 
   if (authenticationMethod === "apikey") {
+    definitions.components.securitySchemes.apiKeyAlias = {
+      type: "apiKey",
+      name: "api_key",
+      in: "query",
+    };
+    definitions.components.securitySchemes.apiKeyHeader = {
+      type: "apiKey",
+      name: "apikey",
+      in: "header",
+    };
     definitions.security = [
       {"apiKey": []},
       {"apiKeyAlias": []},

--- a/src/node/hooks/express/openapi.ts
+++ b/src/node/hooks/express/openapi.ts
@@ -482,26 +482,44 @@ const generateDefinitionForVersion = (version:string, style = APIPathStyle.FLAT)
       responses: {
         ...defaultResponses,
       },
-      securitySchemes: {
-        openid: {
-          type: "oauth2",
-          flows: {
-            authorizationCode: {
-              authorizationUrl: settings.sso.issuer+"/oidc/auth",
-              tokenUrl: settings.sso.issuer+"/oidc/token",
-              scopes: {
-                openid: "openid",
-                profile: "profile",
-                email: "email",
-                admin: "admin"
-              }
-            }
+      securitySchemes: {} as Record<string, any>,
+    },
+    security: [] as Array<Record<string, string[]>>,
+  };
+
+  if (settings.authenticationMethod === 'apikey') {
+    definition.components.securitySchemes.apiKey = {
+      type: 'apiKey', name: 'apikey', in: 'query',
+    };
+    definition.components.securitySchemes.apiKeyAlias = {
+      type: 'apiKey', name: 'api_key', in: 'query',
+    };
+    definition.components.securitySchemes.apiKeyHeader = {
+      type: 'apiKey', name: 'apikey', in: 'header',
+    };
+    definition.security = [
+      {apiKey: []},
+      {apiKeyAlias: []},
+      {apiKeyHeader: []},
+    ];
+  } else {
+    definition.components.securitySchemes.openid = {
+      type: 'oauth2',
+      flows: {
+        authorizationCode: {
+          authorizationUrl: settings.sso.issuer + '/oidc/auth',
+          tokenUrl: settings.sso.issuer + '/oidc/token',
+          scopes: {
+            openid: 'openid',
+            profile: 'profile',
+            email: 'email',
+            admin: 'admin',
           },
         },
       },
-    },
-    security: [{openid: []}],
-  };
+    };
+    definition.security = [{openid: []}];
+  }
 
   // build operations
   for (const funcName of Object.keys(apiHandler.version[version])) {
@@ -566,14 +584,16 @@ exports.expressPreSession = async (hookName:string, {app}:any) => {
     for (const style of [APIPathStyle.FLAT, APIPathStyle.REST]) {
       const apiRoot = getApiRootForVersion(version, style);
 
-      // generate openapi definition for this API version
+      // generate openapi definition for this API version (used for openapi-backend routing)
       const definition = generateDefinitionForVersion(version, style);
 
-      // serve version specific openapi definition
+      // serve version specific openapi definition; regenerate per request so runtime
+      // settings (e.g. authenticationMethod) are reflected
       app.get(`${apiRoot}/openapi.json`, (req:any, res:any) => {
         // For openapi definitions, wide CORS is probably fine
         res.header('Access-Control-Allow-Origin', '*');
-        res.json({...definition, servers: [generateServerForApiVersion(apiRoot, req)]});
+        const liveDefinition = generateDefinitionForVersion(version, style);
+        res.json({...liveDefinition, servers: [generateServerForApiVersion(apiRoot, req)]});
       });
 
       // serve latest openapi definition file under /api/openapi.json
@@ -581,7 +601,8 @@ exports.expressPreSession = async (hookName:string, {app}:any) => {
       if (isLatestAPIVersion) {
         app.get(`/${style}/openapi.json`, (req:any, res:any) => {
           res.header('Access-Control-Allow-Origin', '*');
-          res.json({...definition, servers: [generateServerForApiVersion(apiRoot, req)]});
+          const liveDefinition = generateDefinitionForVersion(version, style);
+          res.json({...liveDefinition, servers: [generateServerForApiVersion(apiRoot, req)]});
         });
       }
 

--- a/src/tests/backend/specs/api/api.ts
+++ b/src/tests/backend/specs/api/api.ts
@@ -10,6 +10,7 @@
 
 const common = require('../../common');
 const validateOpenAPI = require('openapi-schema-validation').validate;
+import settings from '../../../../node/utils/Settings';
 
 let agent: any;
 let apiVersion = 1;
@@ -53,5 +54,62 @@ describe(__filename, function () {
                             `validation errors:\n${prettyErrors}`);
           }
         });
+  });
+
+  describe('security schemes with authenticationMethod=apikey', function () {
+    let originalAuthMethod: string;
+
+    before(function () {
+      originalAuthMethod = settings.authenticationMethod;
+      settings.authenticationMethod = 'apikey';
+    });
+
+    after(function () {
+      settings.authenticationMethod = originalAuthMethod;
+    });
+
+    it('/api-docs.json documents apikey query param (primary name)', async function () {
+      const res = await agent.get('/api-docs.json').expect(200);
+      const schemes = res.body.components.securitySchemes;
+      const apiKeyQuery = Object.values(schemes).find(
+          (s: any) => s.type === 'apiKey' && s.in === 'query' && s.name === 'apikey');
+      if (!apiKeyQuery) {
+        throw new Error(`Expected apiKey query param 'apikey' in securitySchemes: ` +
+                        `${JSON.stringify(schemes)}`);
+      }
+    });
+
+    it('/api-docs.json documents api_key query param alias', async function () {
+      const res = await agent.get('/api-docs.json').expect(200);
+      const schemes = res.body.components.securitySchemes;
+      const apiKeyQueryAlias = Object.values(schemes).find(
+          (s: any) => s.type === 'apiKey' && s.in === 'query' && s.name === 'api_key');
+      if (!apiKeyQueryAlias) {
+        throw new Error(`Expected apiKey query param 'api_key' in securitySchemes: ` +
+                        `${JSON.stringify(schemes)}`);
+      }
+    });
+
+    it('/api-docs.json documents apikey header', async function () {
+      const res = await agent.get('/api-docs.json').expect(200);
+      const schemes = res.body.components.securitySchemes;
+      const apiKeyHeader = Object.values(schemes).find(
+          (s: any) => s.type === 'apiKey' && s.in === 'header' && s.name === 'apikey');
+      if (!apiKeyHeader) {
+        throw new Error(`Expected apiKey header 'apikey' in securitySchemes: ` +
+                        `${JSON.stringify(schemes)}`);
+      }
+    });
+
+    it('/api/openapi.json exposes apiKey security in apikey mode', async function () {
+      this.timeout(15000);
+      const res = await agent.get('/api/openapi.json').expect(200);
+      const schemes = res.body.components.securitySchemes;
+      const hasApiKey = Object.values(schemes).some((s: any) => s.type === 'apiKey');
+      if (!hasApiKey) {
+        throw new Error(`Expected at least one apiKey securityScheme in ` +
+                        `/api/openapi.json, got: ${JSON.stringify(schemes)}`);
+      }
+    });
   });
 });


### PR DESCRIPTION
Fixes #7532.

## Summary
- The API accepts the key via `?apikey=`, `?api_key=`, and the `apikey` header, but only `?apikey=` was advertised in `/api-docs.json`.
- `/api/{version}/openapi.json` was worse: it hardcoded an OAuth2 (`openid`) scheme even when Etherpad was started in apikey auth mode, so the doc contradicted how the server actually authenticated.
- Both generators now key `securitySchemes` / `security` off `settings.authenticationMethod`. When it's `apikey`, they publish three schemes: `apikey` in query, `api_key` in query (alias), and `apikey` in header.
- `openapi.ts` regenerates the definition per request so runtime settings are reflected (it used to cache at startup).

The raw `authorization: <key>` header still works in code but is deliberately **not** documented — pinning it in the spec would ossify a quirk.

## Test plan
- [x] New mocha specs in `src/tests/backend/specs/api/api.ts` verify `/api-docs.json` exposes all three schemes and `/api/openapi.json` exposes an `apiKey` scheme when `authenticationMethod === 'apikey'`.
- [x] `pnpm ts-check` clean.
- [x] Existing `api.ts` specs still pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)