### PR TITLE
checkPlugin: flag absolute /static/plugins/ asset paths in templates (#5203)

### DIFF
--- a/bin/plugins/checkPlugin.ts
+++ b/bin/plugins/checkPlugin.ts
@@ -374,6 +374,45 @@ log4js.configure({
                  'Translation files help with Etherpad accessibility.');
   }
 
+  // Check template files for absolute `/static/plugins/...` asset paths.
+  // Those break any Etherpad instance hosted behind a reverse proxy at a
+  // sub-path (e.g. https://example.com/etherpad/pad) because the browser
+  // resolves them against the domain root instead of the proxy prefix.
+  // Rewrite to the relative `../static/plugins/...` form (see #5203, and
+  // ep_embedmedia#4 for the original fix this check is modelled on).
+  const templateDirs = ['templates', 'static']; // scan both — static/*.html exists too
+  const STATIC_ABS = /(?<![./:\w])\/static\/plugins\//g;
+  for (const dir of templateDirs) {
+    const abs = `${pluginPath}/${dir}`;
+    if (!files.includes(dir)) continue;
+    const scanFiles: string[] = [];
+    const walk = async (d: string) => {
+      for (const entry of await fsp.readdir(d, {withFileTypes: true})) {
+        const full = `${d}/${entry.name}`;
+        if (entry.isDirectory()) {
+          if (entry.name === 'node_modules' || entry.name === '.git') continue;
+          await walk(full);
+        } else if (/\.(ejs|html)$/.test(entry.name)) {
+          scanFiles.push(full);
+        }
+      }
+    };
+    await walk(abs);
+    for (const fp of scanFiles) {
+      const src = await fsp.readFile(fp, 'utf8');
+      if (!STATIC_ABS.test(src)) continue;
+      STATIC_ABS.lastIndex = 0;
+      const rel = path.relative(pluginPath, fp);
+      logger.warn(`${rel} contains absolute '/static/plugins/...' asset paths; ` +
+                  'these break reverse-proxied Etherpad deployments. Use ' +
+                  "'../static/plugins/...' instead.");
+      if (autoFix) {
+        logger.info(`Autofixing absolute /static/plugins/ paths in ${rel}`);
+        await fsp.writeFile(fp, src.replace(STATIC_ABS, '../static/plugins/'));
+      }
+    }
+  }
+
 
   if (files.includes('.ep_initialized')) {
     logger.warn(

--- a/bin/plugins/checkPlugin.ts
+++ b/bin/plugins/checkPlugin.ts
@@ -378,13 +378,16 @@ log4js.configure({
   // Those break any Etherpad instance hosted behind a reverse proxy at a
   // sub-path (e.g. https://example.com/etherpad/pad) because the browser
   // resolves them against the domain root instead of the proxy prefix.
-  // Rewrite to the relative `../static/plugins/...` form (see #5203, and
-  // ep_embedmedia#4 for the original fix this check is modelled on).
-  const templateDirs = ['templates', 'static']; // scan both — static/*.html exists too
+  // See #5203, and ep_embedmedia#4 for the original fix this check is modelled on.
+  //
+  // Autofix only rewrites paths in `templates/` (rendered under `/p/<pad>/...`
+  // where `../static/plugins/...` is correct). Files under `static/` are
+  // served from `/static/plugins/<plugin>/static/...` and need a different
+  // relative prefix that depends on the file's depth, so we only warn.
   const STATIC_ABS = /(?<![./:\w])\/static\/plugins\//g;
-  for (const dir of templateDirs) {
+  const scanDir = async (dir: 'templates' | 'static') => {
     const abs = `${pluginPath}/${dir}`;
-    if (!files.includes(dir)) continue;
+    if (!files.includes(dir)) return;
     const scanFiles: string[] = [];
     const walk = async (d: string) => {
       for (const entry of await fsp.readdir(d, {withFileTypes: true})) {
@@ -403,15 +406,23 @@ log4js.configure({
       if (!STATIC_ABS.test(src)) continue;
       STATIC_ABS.lastIndex = 0;
       const rel = path.relative(pluginPath, fp);
-      logger.warn(`${rel} contains absolute '/static/plugins/...' asset paths; ` +
-                  'these break reverse-proxied Etherpad deployments. Use ' +
-                  "'../static/plugins/...' instead.");
-      if (autoFix) {
-        logger.info(`Autofixing absolute /static/plugins/ paths in ${rel}`);
-        await fsp.writeFile(fp, src.replace(STATIC_ABS, '../static/plugins/'));
+      if (dir === 'templates') {
+        logger.warn(`${rel} contains absolute '/static/plugins/...' asset paths; ` +
+                    'these break reverse-proxied Etherpad deployments. Use ' +
+                    "'../static/plugins/...' instead.");
+        if (autoFix) {
+          logger.info(`Autofixing absolute /static/plugins/ paths in ${rel}`);
+          await fsp.writeFile(fp, src.replace(STATIC_ABS, '../static/plugins/'));
+        }
+      } else {
+        logger.warn(`${rel} contains absolute '/static/plugins/...' asset paths; ` +
+                    'these break reverse-proxied Etherpad deployments. Use a path ' +
+                    "relative to this file's location under 'static/' (no leading '/').");
       }
     }
-  }
+  };
+  await scanDir('templates');
+  await scanDir('static');
 
 
   if (files.includes('.ep_initialized')) {


### PR DESCRIPTION
Closes #5203.

Plugin templates that reference assets with absolute paths like
\`/static/plugins/ep_foo/x.css\` silently break any Etherpad instance
hosted behind a reverse proxy at a sub-path (e.g. `https://example.com/etherpad/pad\`) — the browser resolves the path against the domain root instead of the proxy prefix and the asset 404s. The correct form is \`../static/plugins/...\` (relative). \[ep_embedmedia#4\](https://github.com/ether/ep_embedmedia/pull/4/files) fixed one plugin manually; #5203 asked for a mechanical check.

## Summary
- Walk each plugin's \`templates/\` and \`static/\` for \`*.ejs\` / \`*.html\` files.
- Scan for \`/static/plugins/\` occurrences that are **not** preceded by a URL scheme (\`:\`), a dot, a slash, or a word char — so `\\"https://host/static/plugins/...\\"` and already-correct \`../static/plugins/...\` don't match.
- Emit a \`WARN\` line describing the bad path and how to fix it.
- In \`autofix\` mode, rewrite them in place to \`../static/plugins/\`.

## Test plan
- [x] Regex verified against six cases (absolute bad, absolute in URL, already-relative, embedded in src/href, /static/ outside /plugins/, bare path).
- [x] \`pnpm run ts-check\` clean.