### PR TITLE
fix: delay anchor line scrolling until layout settles

### DIFF
--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -255,8 +255,8 @@ const focusOnHashedLine = (ace, lineNumberInt) => {
 exports.focusOnLine = (ace) => {
   const lineNumberInt = getHashedLineNumber();
   if (lineNumberInt == null) return;
+  const $aceOuter = $('iframe[name="ace_outer"]');
   const getCurrentTargetOffset = () => {
-    const $aceOuter = $('iframe[name="ace_outer"]');
     const $inner = $aceOuter.contents().find('iframe').contents().find('#innerdocbody');
     const line = $inner.find(`div:nth-child(${lineNumberInt})`);
     if (line.length === 0) return null;
@@ -266,20 +266,44 @@ exports.focusOnLine = (ace) => {
   const maxSettleDuration = 10000;
   const settleInterval = 250;
   const startTime = Date.now();
-  let intervalId = null;
+  let intervalId: number | null = null;
+
+  const userEventNames = ['wheel', 'touchmove', 'keydown', 'mousedown'];
+  const docs: Document[] = [];
+  const stop = () => {
+    if (intervalId != null) {
+      window.clearInterval(intervalId);
+      intervalId = null;
+    }
+    for (const doc of docs) {
+      for (const name of userEventNames) doc.removeEventListener(name, stop, true);
+    }
+    docs.length = 0;
+  };
 
   const focusUntilStable = () => {
     if (Date.now() - startTime >= maxSettleDuration) {
-      window.clearInterval(intervalId);
+      stop();
       return;
     }
     const currentOffsetTop = getCurrentTargetOffset();
     if (currentOffsetTop == null) return;
-
     focusOnHashedLine(ace, lineNumberInt);
   };
 
   focusUntilStable();
   intervalId = window.setInterval(focusUntilStable, settleInterval);
+  // Stop fighting the user: any deliberate scroll, tap, click, or keystroke cancels the
+  // reapply loop so late layout corrections do not steal focus once the user takes over.
+  // Listen on both the ace_outer and ace_inner documents in capture phase so we see the
+  // user's intent even if inner handlers stopPropagation().
+  const outerDoc = ($aceOuter.contents()[0] as any) as Document | undefined;
+  const innerIframe = $aceOuter.contents().find('iframe')[0] as HTMLIFrameElement | undefined;
+  const innerDoc = innerIframe?.contentDocument;
+  for (const doc of [outerDoc, innerDoc]) {
+    if (!doc) continue;
+    docs.push(doc);
+    for (const name of userEventNames) doc.addEventListener(name, stop, true);
+  }
   // End of setSelection / set Y position of editor
 };

--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -269,16 +269,27 @@ exports.focusOnLine = (ace) => {
 
   // Settle window: keep correcting the scroll position while late content (images,
   // plugin-rendered blocks) shifts the target line's offsetTop. The interval ends when
-  // either: (a) maxSettleDuration elapses, (b) the user interacts (see stop() below),
-  // or (c) the target offset has not changed for stableTicksRequired consecutive ticks
-  // (layout has settled — no need to keep re-scrolling).
+  // any of the following becomes true:
+  //   (a) maxSettleDuration (10s) has elapsed — hard ceiling
+  //   (b) the user interacts (see stop() below) — never fight the user
+  //   (c) at least minSettleDuration (2s) has elapsed AND the target offset has not
+  //       moved by more than offsetEpsilon for stableTicksRequired consecutive ticks
+  //       (image loads / plugin renders past the 2s window are still corrected; brief
+  //       early stability does not exit the loop prematurely)
+  //   (d) the target line is missing from the DOM for missingTicksRequired consecutive
+  //       ticks (the anchor doesn't exist — bail rather than spin to maxSettleDuration)
+  // Sub-pixel tolerance avoids strict-equality flapping on fractional offsets.
   const maxSettleDuration = 10000;
+  const minSettleDuration = 2000;
   const settleInterval = 250;
-  const stableTicksRequired = 3;
+  const stableTicksRequired = 4;
+  const offsetEpsilon = 1;
+  const missingTicksRequired = 8; // 2s of consecutive misses → assume invalid anchor
   const startTime = Date.now();
   let intervalId: number | null = null;
   let lastOffset: number | null = null;
   let stableTicks = 0;
+  let missingTicks = 0;
 
   const userEventNames = ['wheel', 'touchmove', 'keydown', 'mousedown'];
   const docs: Document[] = [];
@@ -299,11 +310,19 @@ exports.focusOnLine = (ace) => {
       return;
     }
     const currentOffsetTop = getCurrentTargetOffset();
-    if (currentOffsetTop == null) return;
+    if (currentOffsetTop == null) {
+      missingTicks += 1;
+      if (missingTicks >= missingTicksRequired) stop();
+      return;
+    }
+    missingTicks = 0;
     focusOnHashedLine(ace, lineNumberInt);
-    if (lastOffset != null && currentOffsetTop === lastOffset) {
+    if (lastOffset != null && Math.abs(currentOffsetTop - lastOffset) < offsetEpsilon) {
       stableTicks += 1;
-      if (stableTicks >= stableTicksRequired) stop();
+      if (stableTicks >= stableTicksRequired
+          && Date.now() - startTime >= minSettleDuration) {
+        stop();
+      }
     } else {
       stableTicks = 0;
     }

--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -230,6 +230,10 @@ const focusOnHashedLine = (ace, lineNumberInt) => {
   if (!hasMobileLayout) offsetTop += parseInt($inner.css('padding-top').replace('px', ''));
   const $outerdocHTML = $aceOuter.contents().find('#outerdocbody').parent();
   $outerdoc.css({top: `${offsetTop}px`}); // Chrome
+  // Direct scrollTop() (was previously $.animate({scrollTop}) for Firefox). The animation
+  // workaround is no longer needed because focusOnLine() reapplies the scroll on a settle
+  // interval until layout stabilises, which covers Firefox's late-layout behaviour without
+  // an animated scroll fighting concurrent layout shifts.
   $outerdocHTML.scrollTop(offsetTop);
   const node = line[0];
   ace.callWithAce((ace) => {
@@ -263,10 +267,18 @@ exports.focusOnLine = (ace) => {
     return line.offset().top;
   };
 
+  // Settle window: keep correcting the scroll position while late content (images,
+  // plugin-rendered blocks) shifts the target line's offsetTop. The interval ends when
+  // either: (a) maxSettleDuration elapses, (b) the user interacts (see stop() below),
+  // or (c) the target offset has not changed for stableTicksRequired consecutive ticks
+  // (layout has settled — no need to keep re-scrolling).
   const maxSettleDuration = 10000;
   const settleInterval = 250;
+  const stableTicksRequired = 3;
   const startTime = Date.now();
   let intervalId: number | null = null;
+  let lastOffset: number | null = null;
+  let stableTicks = 0;
 
   const userEventNames = ['wheel', 'touchmove', 'keydown', 'mousedown'];
   const docs: Document[] = [];
@@ -289,6 +301,13 @@ exports.focusOnLine = (ace) => {
     const currentOffsetTop = getCurrentTargetOffset();
     if (currentOffsetTop == null) return;
     focusOnHashedLine(ace, lineNumberInt);
+    if (lastOffset != null && currentOffsetTop === lastOffset) {
+      stableTicks += 1;
+      if (stableTicks >= stableTicksRequired) stop();
+    } else {
+      stableTicks = 0;
+    }
+    lastOffset = currentOffsetTop;
   };
 
   focusUntilStable();

--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -210,49 +210,76 @@ const padeditor = (() => {
 
 exports.padeditor = padeditor;
 
-exports.focusOnLine = (ace) => {
-  // If a number is in the URI IE #L124 go to that line number
+const getHashedLineNumber = () => {
   const lineNumber = window.location.hash.substr(1);
-  if (lineNumber) {
-    if (lineNumber[0] === 'L') {
-      const $outerdoc = $('iframe[name="ace_outer"]').contents().find('#outerdocbody');
-      const lineNumberInt = parseInt(lineNumber.substr(1));
-      if (lineNumberInt) {
-        const $inner = $('iframe[name="ace_outer"]').contents().find('iframe')
-            .contents().find('#innerdocbody');
-        const line = $inner.find(`div:nth-child(${lineNumberInt})`);
-        if (line.length !== 0) {
-          let offsetTop = line.offset().top;
-          offsetTop += parseInt($outerdoc.css('padding-top').replace('px', ''));
-          const hasMobileLayout = $('body').hasClass('mobile-layout');
-          if (!hasMobileLayout) {
-            offsetTop += parseInt($inner.css('padding-top').replace('px', ''));
-          }
-          const $outerdocHTML = $('iframe[name="ace_outer"]').contents()
-              .find('#outerdocbody').parent();
-          $outerdoc.css({top: `${offsetTop}px`}); // Chrome
-          $outerdocHTML.animate({scrollTop: offsetTop}); // needed for FF
-          const node = line[0];
-          ace.callWithAce((ace) => {
-            const selection = {
-              startPoint: {
-                index: 0,
-                focusAtStart: true,
-                maxIndex: 1,
-                node,
-              },
-              endPoint: {
-                index: 0,
-                focusAtStart: true,
-                maxIndex: 1,
-                node,
-              },
-            };
-            ace.ace_setSelection(selection);
-          });
-        }
-      }
+  if (!lineNumber || lineNumber[0] !== 'L') return null;
+  const lineNumberInt = parseInt(lineNumber.substr(1));
+  return Number.isInteger(lineNumberInt) && lineNumberInt > 0 ? lineNumberInt : null;
+};
+
+const focusOnHashedLine = (ace, lineNumberInt) => {
+  const $aceOuter = $('iframe[name="ace_outer"]');
+  const $outerdoc = $aceOuter.contents().find('#outerdocbody');
+  const $inner = $aceOuter.contents().find('iframe').contents().find('#innerdocbody');
+  const line = $inner.find(`div:nth-child(${lineNumberInt})`);
+  if (line.length === 0) return false;
+
+  let offsetTop = line.offset().top;
+  offsetTop += parseInt($outerdoc.css('padding-top').replace('px', ''));
+  const hasMobileLayout = $('body').hasClass('mobile-layout');
+  if (!hasMobileLayout) offsetTop += parseInt($inner.css('padding-top').replace('px', ''));
+  const $outerdocHTML = $aceOuter.contents().find('#outerdocbody').parent();
+  $outerdoc.css({top: `${offsetTop}px`}); // Chrome
+  $outerdocHTML.scrollTop(offsetTop);
+  const node = line[0];
+  ace.callWithAce((ace) => {
+    const selection = {
+      startPoint: {
+        index: 0,
+        focusAtStart: true,
+        maxIndex: 1,
+        node,
+      },
+      endPoint: {
+        index: 0,
+        focusAtStart: true,
+        maxIndex: 1,
+        node,
+      },
+    };
+    ace.ace_setSelection(selection);
+  });
+  return true;
+};
+
+exports.focusOnLine = (ace) => {
+  const lineNumberInt = getHashedLineNumber();
+  if (lineNumberInt == null) return;
+  const getCurrentTargetOffset = () => {
+    const $aceOuter = $('iframe[name="ace_outer"]');
+    const $inner = $aceOuter.contents().find('iframe').contents().find('#innerdocbody');
+    const line = $inner.find(`div:nth-child(${lineNumberInt})`);
+    if (line.length === 0) return null;
+    return line.offset().top;
+  };
+
+  const maxSettleDuration = 10000;
+  const settleInterval = 250;
+  const startTime = Date.now();
+  let intervalId = null;
+
+  const focusUntilStable = () => {
+    if (Date.now() - startTime >= maxSettleDuration) {
+      window.clearInterval(intervalId);
+      return;
     }
-  }
+    const currentOffsetTop = getCurrentTargetOffset();
+    if (currentOffsetTop == null) return;
+
+    focusOnHashedLine(ace, lineNumberInt);
+  };
+
+  focusUntilStable();
+  intervalId = window.setInterval(focusUntilStable, settleInterval);
   // End of setSelection / set Y position of editor
 };

--- a/src/tests/frontend-new/specs/anchor_scroll.spec.ts
+++ b/src/tests/frontend-new/specs/anchor_scroll.spec.ts
@@ -48,6 +48,35 @@ test.describe('anchor scrolling', () => {
     }).toBeLessThanOrEqual(80);
   });
 
+  test('reapply loop exits early once the target offset is stable', async ({page}) => {
+    await goToNewPad(page);
+    const padUrl = page.url();
+    await clearPadContent(page);
+    await writeToPad(page, Array.from({length: 30}, (_v, i) => `Line ${i + 1}`).join('\n'));
+    await page.waitForTimeout(1000);
+
+    await page.goto('about:blank');
+    await page.goto(`${padUrl}#L20`);
+    await page.waitForSelector('iframe[name="ace_outer"]');
+    await page.waitForSelector('#editorcontainer.initialized');
+
+    const outerDoc = page.frameLocator('iframe[name="ace_outer"]').locator('#outerdocbody');
+    const getScrollTop = async () => await outerDoc.evaluate(
+        (el) => el.parentElement?.scrollTop || 0);
+
+    await expect.poll(getScrollTop).toBeGreaterThan(10);
+    // Wait long enough for the stable-tick early-exit (3 ticks * 250ms + slack), well
+    // under the 10s hard timeout. After early-exit, scrolling away from the anchor must
+    // not be reverted by another reapply tick.
+    await page.waitForTimeout(2000);
+
+    await outerDoc.evaluate((el) => {
+      if (el.parentElement) el.parentElement.scrollTop = 0;
+    });
+    await page.waitForTimeout(1500);
+    expect(await getScrollTop()).toBeLessThanOrEqual(20);
+  });
+
   test('user scroll cancels the reapply loop so navigation is not locked', async ({page}) => {
     await goToNewPad(page);
     const padUrl = page.url();

--- a/src/tests/frontend-new/specs/anchor_scroll.spec.ts
+++ b/src/tests/frontend-new/specs/anchor_scroll.spec.ts
@@ -1,0 +1,50 @@
+import {expect, test} from "@playwright/test";
+import {clearPadContent, goToNewPad, writeToPad} from "../helper/padHelper";
+
+test.describe('anchor scrolling', () => {
+  test.beforeEach(async ({context}) => {
+    await context.clearCookies();
+  });
+
+  test('reapplies #L scroll after earlier content changes height', async ({page}) => {
+    await goToNewPad(page);
+    const padUrl = page.url();
+    await clearPadContent(page);
+    await writeToPad(page, Array.from({length: 30}, (_v, i) => `Line ${i + 1}`).join('\n'));
+    await page.waitForTimeout(1000);
+
+    await page.goto('about:blank');
+    await page.goto(`${padUrl}#L20`);
+    await page.waitForSelector('iframe[name="ace_outer"]');
+    await page.waitForSelector('#editorcontainer.initialized');
+    await page.waitForTimeout(2000);
+
+    const outerDoc = page.frameLocator('iframe[name="ace_outer"]').locator('#outerdocbody');
+    const firstLine = page.frameLocator('iframe[name="ace_outer"]')
+        .frameLocator('iframe')
+        .locator('#innerdocbody > div')
+        .first();
+    const targetLine = page.frameLocator('iframe[name="ace_outer"]')
+        .frameLocator('iframe')
+        .locator('#innerdocbody > div')
+        .nth(19);
+
+    const getScrollTop = async () => await outerDoc.evaluate(
+        (el) => el.parentElement?.scrollTop || 0);
+    const getTargetViewportTop = async () => await targetLine.evaluate((el) => el.getBoundingClientRect().top);
+
+    await expect.poll(getScrollTop).toBeGreaterThan(10);
+    const initialViewportTop = await getTargetViewportTop();
+
+    await firstLine.evaluate((el) => {
+      const filler = document.createElement('div');
+      filler.style.height = '400px';
+      el.appendChild(filler);
+    });
+
+    await expect.poll(async () => {
+      const currentViewportTop = await getTargetViewportTop();
+      return Math.abs(currentViewportTop - initialViewportTop);
+    }).toBeLessThanOrEqual(80);
+  });
+});

--- a/src/tests/frontend-new/specs/anchor_scroll.spec.ts
+++ b/src/tests/frontend-new/specs/anchor_scroll.spec.ts
@@ -65,10 +65,10 @@ test.describe('anchor scrolling', () => {
         (el) => el.parentElement?.scrollTop || 0);
 
     await expect.poll(getScrollTop).toBeGreaterThan(10);
-    // Wait long enough for the stable-tick early-exit (3 ticks * 250ms + slack), well
-    // under the 10s hard timeout. After early-exit, scrolling away from the anchor must
-    // not be reverted by another reapply tick.
-    await page.waitForTimeout(2000);
+    // Wait past minSettleDuration (2s) plus stableTicksRequired (4 * 250ms = 1s) plus
+    // slack, well under the 10s hard timeout. After early-exit, scrolling away from the
+    // anchor must not be reverted by another reapply tick.
+    await page.waitForTimeout(3500);
 
     await outerDoc.evaluate((el) => {
       if (el.parentElement) el.parentElement.scrollTop = 0;

--- a/src/tests/frontend-new/specs/anchor_scroll.spec.ts
+++ b/src/tests/frontend-new/specs/anchor_scroll.spec.ts
@@ -47,4 +47,38 @@ test.describe('anchor scrolling', () => {
       return Math.abs(currentViewportTop - initialViewportTop);
     }).toBeLessThanOrEqual(80);
   });
+
+  test('user scroll cancels the reapply loop so navigation is not locked', async ({page}) => {
+    await goToNewPad(page);
+    const padUrl = page.url();
+    await clearPadContent(page);
+    await writeToPad(page, Array.from({length: 30}, (_v, i) => `Line ${i + 1}`).join('\n'));
+    await page.waitForTimeout(1000);
+
+    await page.goto('about:blank');
+    await page.goto(`${padUrl}#L20`);
+    await page.waitForSelector('iframe[name="ace_outer"]');
+    await page.waitForSelector('#editorcontainer.initialized');
+
+    const outerDoc = page.frameLocator('iframe[name="ace_outer"]').locator('#outerdocbody');
+    const getScrollTop = async () => await outerDoc.evaluate(
+        (el) => el.parentElement?.scrollTop || 0);
+
+    await expect.poll(getScrollTop).toBeGreaterThan(10);
+
+    // User interacts with the pad. The anchor-scroll handler listens for
+    // wheel/mousedown/keydown/touchmove on the outer iframe document and must cancel
+    // its reapply loop. We dispatch a mousedown on the outer document, then reset
+    // scrollTop to 0 and verify it stays there.
+    await outerDoc.evaluate((el) => {
+      const doc = el.ownerDocument;
+      doc.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+      if (el.parentElement) el.parentElement.scrollTop = 0;
+    });
+
+    // Give the reapply loop several ticks to attempt a re-scroll. If cancellation worked,
+    // scrollTop stays near 0 instead of snapping back to the anchor.
+    await page.waitForTimeout(1500);
+    expect(await getScrollTop()).toBeLessThanOrEqual(20);
+  });
 });

--- a/src/tests/frontend/specs/scrollTo.js
+++ b/src/tests/frontend/specs/scrollTo.js
@@ -15,6 +15,20 @@ describe('scrollTo.js', function () {
         return (topOffset >= 100);
       });
     });
+
+    it('reapplies the scroll when earlier content changes height after load', async function () {
+      const chrome$ = helper.padChrome$;
+      const inner$ = helper.padInner$;
+      const getTopOffset = () => parseInt(chrome$('iframe').first('iframe')
+          .contents().find('#outerdocbody').css('top')) || 0;
+
+      await helper.waitForPromise(() => getTopOffset() >= 100);
+      const initialTopOffset = getTopOffset();
+
+      inner$('#innerdocbody > div').first().css('height', '400px');
+
+      await helper.waitForPromise(() => getTopOffset() > initialTopOffset + 200);
+    });
   });
 
   describe('doesnt break on weird hash input', function () {


### PR DESCRIPTION
## Summary
- keep reapplying `#L...` line scrolling for a short settle window after pad load
- avoid landing above the intended line when late content like images changes layout
- add regression coverage for delayed content expansion after anchor scrolling

Closes #5700