### PR TITLE
ci(security): restrict GITHUB_TOKEN permissions in update-plugins workflow

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 6 * * *'  # Daily at 06:00 UTC
   workflow_dispatch:  # Allow manual trigger
 
+# The cross-repo work (cloning ether/ep_* repos, pushing updates, merging
+# Dependabot PRs) is authenticated via secrets.PLUGINS_PAT. The default
+# GITHUB_TOKEN only needs read access to this repo for actions/checkout.
+permissions:
+  contents: read
+
 jobs:
   update-plugins:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Addresses CodeQL code-scanning alert [#115](https://github.com/ether/etherpad/security/code-scanning/115) — *"Workflow does not contain permissions"*.

`update-plugins.yml` was the only workflow without an explicit `permissions:` block; all the others already scope the default `GITHUB_TOKEN` down. The cross-repo work (cloning `ether/ep_*` repos, pushing updates, merging Dependabot PRs) is authenticated via `secrets.PLUGINS_PAT`, so the default `GITHUB_TOKEN` only needs `contents: read` for `actions/checkout`.

## Test plan
- [x] Lint diff is 6 added lines of YAML; no other files change
- [ ] Next scheduled run still succeeds (`actions/checkout`, `pnpm install`, and the PAT-authenticated git/gh calls all work under `contents: read`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)