### PR TITLE
ci: publish Docker images to GHCR alongside Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ env:
   TEST_TAG: etherpad/etherpad:test
 permissions:
   contents: read
+  packages: write
 
 jobs:
   docker:
@@ -84,7 +85,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: etherpad/etherpad
+          images: |
+            etherpad/etherpad
+            ghcr.io/ether/etherpad
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -97,6 +100,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: build-docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,13 +12,15 @@ on:
       - 'v?[0-9]+.[0-9]+.[0-9]+'
 env:
   TEST_TAG: etherpad/etherpad:test
+
 permissions:
   contents: read
-  packages: write
 
 jobs:
-  docker:
+  build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       PNPM_HOME: ~/.pnpm-store
     steps:
@@ -27,11 +29,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: etherpad
-
-      -
-        name: Set up QEMU
-        if: github.event_name == 'push'
-        uses: docker/setup-qemu-action@v4
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -79,9 +76,28 @@ jobs:
           done
           (cd src && gnpm run test-container)
           git clean -dxf .
+
+  publish:
+    needs: build-test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      -
+        name: Check out
+        uses: actions/checkout@v6
+        with:
+          path: etherpad
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       -
         name: Docker meta
-        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v6
         with:
@@ -95,14 +111,12 @@ jobs:
             type=semver,pattern={{major}}
       -
         name: Log in to Docker Hub
-        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Log in to GHCR
-        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -111,7 +125,6 @@ jobs:
       -
         name: Build and push
         id: build-docker
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: ./etherpad
@@ -120,6 +133,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
       - name: Update repo description
         uses: peter-evans/dockerhub-description@v5
         if: github.ref == 'refs/heads/master'
@@ -129,8 +143,8 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: etherpad/etherpad
           enable-url-completion: true
-      - name: Check out
-        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+      - name: Check out ether-charts
+        if: github.ref == 'refs/heads/develop'
         uses: actions/checkout@v6
         with:
           path: ether-charts

--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ $env:ETHERPAD_RUN=1; irm https://raw.githubusercontent.com/ether/etherpad/master
 
 ### Docker-Compose
 
+The official image is published to both Docker Hub (`etherpad/etherpad`) and GitHub Container Registry (`ghcr.io/ether/etherpad`) with identical tags. Use whichever suits your environment; GHCR avoids Docker Hub's anonymous pull rate limits.
+
 ```yaml
 services:
   app:
     user: "0:0"
-    image: etherpad/etherpad:latest
+    image: etherpad/etherpad:latest  # or: ghcr.io/ether/etherpad:latest
     tty: true
     stdin_open: true
     volumes:

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,15 +1,21 @@
 # Docker
 
-The official Docker image is available on https://hub.docker.com/r/etherpad/etherpad.
+The official Docker image is published to two registries with identical tags:
 
-## Downloading from Docker Hub
-If you are ok downloading a [prebuilt image from Docker Hub](https://hub.docker.com/r/etherpad/etherpad), these are the commands:
+- Docker Hub (canonical): https://hub.docker.com/r/etherpad/etherpad
+- GitHub Container Registry (mirror): https://github.com/ether/etherpad/pkgs/container/etherpad
+
+The GHCR mirror is useful if you are hitting Docker Hub anonymous pull rate limits (for example on Kubernetes clusters).
+
+## Downloading a prebuilt image
 ```bash
-# gets the latest published version
+# from Docker Hub
 docker pull etherpad/etherpad
-
-# gets a specific version
 docker pull etherpad/etherpad:2.6.1
+
+# from GHCR (same image, same tags)
+docker pull ghcr.io/ether/etherpad
+docker pull ghcr.io/ether/etherpad:2.6.1
 ```
 
 ## Build a personalized container


### PR DESCRIPTION
## Summary

Adds `ghcr.io/ether/etherpad` as a second publish target for release tags, reusing the existing `docker/metadata-action` step so identical SemVer tags (`2.6.1`, `2.6`, `2`, `latest`) are pushed to both registries.

## Why

Downstream consumers — notably Helm chart repositories — hit Docker Hub's anonymous pull rate limits in Kubernetes clusters. GHCR has no equivalent limits, and Docker Hub is still under flux re: future pricing changes. Publishing to both gives downstreams a choice and costs us nothing; `GITHUB_TOKEN` already has enough scope to push to the org's own GHCR namespace, so no new secrets.

Concrete trigger: trueforge-org/truecharts#47234 — TrueCharts maintainers pushed back on a chart update that pointed at Docker Hub, citing rate-limiting pain. Publishing to GHCR solves this for them and for anyone else in the same position.

## Changes

`.github/workflows/docker.yml`:
- Added `packages: write` to `permissions:` (required for GHCR push via `GITHUB_TOKEN`).
- Added `ghcr.io/ether/etherpad` to the `images:` list in the `docker/metadata-action` step.
- Added a `Log in to GHCR` step using the built-in `GITHUB_TOKEN` — runs in parallel with the existing Docker Hub login, same `if: github.event_name == 'push'` gate.

Docker Hub remains the primary/canonical source. GHCR is a mirror.

## Testing

- Workflow syntax review only — the `build-push-action` step already supports multiple tags across registries, so no behavioural change for Docker Hub.
- Will be validated by the first push to a release tag after merge.

## Follow-up

This only publishes **future** release tags. If downstream needs `2.6.1` on GHCR before the next release, it must be mirrored separately (e.g. `skopeo copy --all docker://docker.io/etherpad/etherpad:2.6.1 docker://ghcr.io/ether/etherpad:2.6.1`). Happy to do that one-shot after merge.