### PR TITLE
fix(clientVars): stop mutating the shared plugin registry during sanitization

### DIFF
--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -109,6 +109,34 @@ function getActivePadCountFromSessionInfos() {
 }
 exports.getActivePadCountFromSessionInfos = getActivePadCountFromSessionInfos;
 
+/**
+ * Build a sanitized copy of the plugins registry suitable for sending to the
+ * client as part of clientVars. The shape is preserved but each plugin's
+ * `package` field is reduced to `{name, version}` so internal paths (realPath,
+ * path, location) are not leaked to the browser.
+ *
+ * CRITICAL: this function MUST NOT mutate the shared server-side registry.
+ * Other components — notably `src/node/utils/Minify.ts` — read
+ * `plugins.plugins[x].package.realPath` on every static asset request to
+ * resolve `/static/plugins/ep_<name>/...` URLs to disk. Mutating the shared object
+ * in place would clobber `realPath` and cause every such request to 500 with
+ * `ERR_INVALID_ARG_TYPE: The "path" argument must be of type string`.
+ */
+const sanitizePluginsForWire = (
+  pluginsRegistry: MapArrayType<any>,
+): MapArrayType<any> => {
+  const out: MapArrayType<any> = {};
+  for (const [name, plugin] of Object.entries(pluginsRegistry)) {
+    const p: any = plugin.package;
+    out[name] = {
+      ...plugin,
+      package: {name: p.name, version: p.version},
+    };
+  }
+  return out;
+};
+exports.sanitizePluginsForWire = sanitizePluginsForWire;
+
 stats.gauge('totalUsers', () => getTotalActiveUsers());
 stats.gauge('activePads', () => {
   return getActivePadCountFromSessionInfos();
@@ -1068,11 +1096,7 @@ const handleClientReady = async (socket:any, message: ClientReadyMessage) => {
       throw new Error('corrupt pad');
     }
 
-    let pluginsSanitized: any = plugins.plugins
-    Object.keys(plugins.plugins).forEach(function(element) {
-      const p: any = plugins.plugins[element].package
-      pluginsSanitized[element].package = {name: p.name, version: p.version};
-    });
+    const pluginsSanitized = sanitizePluginsForWire(plugins.plugins);
     // Warning: never ever send sessionInfo.padId to the client. If the client is read only you
     // would open a security hole 1 swedish mile wide...
     const canEditPadSettings = settings.enablePadWideSettings &&

--- a/src/tests/backend/specs/sanitizePluginsForWire.ts
+++ b/src/tests/backend/specs/sanitizePluginsForWire.ts
@@ -1,0 +1,65 @@
+'use strict';
+
+import {strict as assert} from 'assert';
+const {sanitizePluginsForWire} = require('../../../node/handler/PadMessageHandler');
+
+describe(__filename, function () {
+  const makeRegistry = () => ({
+    ep_example: {
+      parts: [{name: 'ep_example', plugin: 'ep_example'}],
+      package: {
+        name: 'ep_example',
+        version: '1.2.3',
+        realPath: '/real/path/to/ep_example',
+        path: '/node_modules/ep_example',
+        location: '/real/path/to/ep_example',
+      },
+    },
+    ep_other: {
+      parts: [{name: 'ep_other', plugin: 'ep_other'}],
+      package: {
+        name: 'ep_other',
+        version: '0.1.0',
+        realPath: '/real/path/to/ep_other',
+        path: '/node_modules/ep_other',
+        location: '/real/path/to/ep_other',
+      },
+    },
+  });
+
+  it('returns a sanitized registry with only name and version in package', function () {
+    const registry = makeRegistry();
+    const sanitized = sanitizePluginsForWire(registry);
+    assert.deepEqual(Object.keys(sanitized).sort(), ['ep_example', 'ep_other']);
+    assert.deepEqual(sanitized.ep_example.package, {name: 'ep_example', version: '1.2.3'});
+    assert.deepEqual(sanitized.ep_other.package, {name: 'ep_other', version: '0.1.0'});
+  });
+
+  it('does not mutate the input registry (issue: realPath clobbered on pad join)', function () {
+    const registry = makeRegistry();
+    sanitizePluginsForWire(registry);
+    // The original objects MUST still carry realPath and the other internal
+    // path fields — Minify.ts relies on them for every /static/plugins/...
+    // asset request. Before the fix, the sanitization mutated these in place
+    // and caused every such request to 500 after the first pad connection.
+    assert.equal(registry.ep_example.package.realPath, '/real/path/to/ep_example');
+    assert.equal(registry.ep_example.package.path, '/node_modules/ep_example');
+    assert.equal(registry.ep_other.package.realPath, '/real/path/to/ep_other');
+    assert.equal(registry.ep_other.package.path, '/node_modules/ep_other');
+  });
+
+  it('repeated calls remain non-destructive', function () {
+    const registry = makeRegistry();
+    for (let i = 0; i < 5; i++) sanitizePluginsForWire(registry);
+    assert.equal(registry.ep_example.package.realPath, '/real/path/to/ep_example');
+    assert.equal(registry.ep_other.package.realPath, '/real/path/to/ep_other');
+  });
+
+  it('returned copy and input are independent (mutation of result does not affect input)', function () {
+    const registry = makeRegistry();
+    const sanitized = sanitizePluginsForWire(registry);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (sanitized.ep_example as any).package.name = 'tampered';
+    assert.equal(registry.ep_example.package.name, 'ep_example');
+  });
+});


### PR DESCRIPTION
## Summary

`PadMessageHandler` was building the `pluginsSanitized` payload for `clientVars` by aliasing `plugins.plugins` and mutating each entry's `package` field in place:

```js
let pluginsSanitized: any = plugins.plugins;       // alias, not a copy
Object.keys(plugins.plugins).forEach(function(element) {
  const p: any = plugins.plugins[element].package;
  pluginsSanitized[element].package = {name: p.name, version: p.version};
});
```

Because `pluginsSanitized` was a reference to `plugins.plugins`, the assignment clobbered the shared server-side plugin registry. After the first pad connection every plugin's `package` object held only `{name, version}` — the `realPath`, `path`, and `location` fields were gone.

## Impact

`Minify.ts` resolves `/static/plugins/ep_*/...` URLs via `plugin.package.realPath`. Once the field disappeared, every subsequent static asset request for a bundled plugin responded with HTTP 500:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.join (node:path:1354:7)
    at _minify (src/node/utils/Minify.ts:181:23)
```

Observable symptoms:
- Chromium: plugin CSS/JS 500s on first asset request after any pad join. For example `/static/plugins/ep_font_size/static/css/size.css` returns 500. Plugins partially or completely fail to render.
- Firefox: swallows the console/network errors quietly but the plugin assets are still broken.
- Server log: a cascade of the same `ERR_INVALID_ARG_TYPE` stack every time a static asset request hits a bundled plugin.

## Fix

Extract sanitization into a pure helper `sanitizePluginsForWire` that returns a fresh object graph and never touches the input. Replaces the aliasing + mutation pattern with a spread-based copy.

## Tests

New backend spec `sanitizePluginsForWire.ts` covering:
- Sanitized output contains only `{name, version}` in `package`.
- Input registry's `realPath`, `path`, `location` survive the call (regression of this bug).
- Repeated invocations remain non-destructive.
- Mutations to the returned copy don't leak back to the input.

## Test plan

- [x] New spec passes (4/4).
- [x] Full backend suite passes (799 total, +4 from this PR).
- [x] `tsc --noEmit` clean in our code.
- [x] Manual verification with dev server: `/static/plugins/ep_font_size/static/css/size.css` returns 200 both before and after pad connections. Before the fix, the same request 500'd after the first pad visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)