### PR TITLE
fix(pad): restore Accept-Language auto-detect on pad UI (#7586)

### DIFF
--- a/src/node/db/Pad.ts
+++ b/src/node/db/Pad.ts
@@ -39,7 +39,7 @@ type PadSettings = {
   showChat: boolean;
   alwaysShowChat: boolean;
   chatAndUsers: boolean;
-  lang: string;
+  lang: string | null;
   view: PadViewSettings;
 };
 
@@ -91,7 +91,11 @@ class Pad {
         !!rawPadSettings.showChat,
       alwaysShowChat: !!rawPadSettings.alwaysShowChat,
       chatAndUsers: !!rawPadSettings.chatAndUsers,
-      lang: typeof rawPadSettings.lang === 'string' ? rawPadSettings.lang : 'en',
+      // Default to null (not 'en') so the client's l10n auto-detect chain
+      // (cookie -> navigator.language -> 'en' fallback) runs. Hardcoding 'en'
+      // forces English on every pad regardless of the browser's Accept-Language
+      // and broke #7586 (German system saw English pad UI in v2.7.0).
+      lang: typeof rawPadSettings.lang === 'string' ? rawPadSettings.lang : null,
       view: {
         showAuthorColors: rawView.showAuthorColors == null ? true : !!rawView.showAuthorColors,
         showLineNumbers: rawView.showLineNumbers == null ?

--- a/src/tests/backend/specs/Pad.ts
+++ b/src/tests/backend/specs/Pad.ts
@@ -159,4 +159,23 @@ describe(__filename, function () {
       assert.equal(pad!.text(), `${want}\n`);
     });
   });
+
+  describe('normalizePadSettings lang (issue #7586)', function () {
+    it('defaults lang to null when not provided, so client auto-detects locale', function () {
+      const ps = Pad.Pad.normalizePadSettings({});
+      assert.equal(ps.lang, null);
+    });
+
+    it('preserves an explicit string lang (creator override)', function () {
+      const ps = Pad.Pad.normalizePadSettings({lang: 'de'});
+      assert.equal(ps.lang, 'de');
+    });
+
+    it('drops non-string lang values to null rather than coercing to "en"', function () {
+      for (const bogus of [42, true, {}, [], null, undefined]) {
+        const ps = Pad.Pad.normalizePadSettings({lang: bogus});
+        assert.equal(ps.lang, null, `bogus input ${JSON.stringify(bogus)}`);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #7586. In v2.7.0 the pad UI stopped honouring the browser's Accept-Language / locale, always rendering English regardless of system language. The index page and the timeslider were unaffected; only the pad route regressed.

## Root cause

The regression was introduced by #7545 ("Add creator-owned pad settings defaults"), which added this line to `Pad.normalizePadSettings()`:

```ts
lang: typeof rawPadSettings.lang === 'string' ? rawPadSettings.lang : 'en',
```

That default propagates into `clientVars.padOptions.lang`. On the client, `getParams()` in `src/static/js/pad.ts` reads `padOptions.lang` and fires the per-setting callback, which is `html10n.localize([val, 'en'])`. So every pad forced English at load time, defeating the existing auto-detect chain in `src/static/js/l10n.ts`:

```ts
html10n.localize([regexpLang, navigator.language, 'en']);
```

## Fix

Default `lang` to `null` instead of `'en'`. The client-side flow already handles null correctly — `getParams()` at `pad.ts:172` short-circuits with `if (serverValue == null) continue;`, so the forced-localize callback simply doesn't fire, and `l10n.ts`'s browser-language chain takes over. The pad-settings dropdown consumer at `pad.ts:489` already uses `padOptions.lang || 'en'` so it renders `'en'` visually when no override is set, matching prior behaviour.

`PadSettings.lang` is widened from `string` to `string | null` to match.

Creator override (explicit `rawPadSettings.lang = 'de'`) continues to work — that's still a string, so it's preserved verbatim.

## Tests

Added three backend regression tests under `normalizePadSettings lang` in `tests/backend/specs/Pad.ts`:

- defaults to `null` when `lang` is absent (so client auto-detects)
- preserves an explicit string `lang` (creator override still works)
- drops non-string `lang` values to `null` rather than coercing to `'en'`

## Test plan

- [x] `mocha tests/backend/specs/Pad.ts` — 23 passing
- [x] Full backend suite — 802 passing, 0 failing (+3 from this PR)
- [x] `tsc --noEmit` clean in our code
- [x] Manual: Firefox with German locale → fresh pad renders in German. Index and timeslider unchanged. `?lang=de` URL param and `language` cookie continue to override browser detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)