### PR TITLE
fix(chat): icon click, disabled toggles, username layout (#7590, #7592, #7593)

### DIFF
--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -59,20 +59,27 @@
 }
 
 /* -- TITLE BAR -- */
+/* Single flex row, vertically centred:  [ CHAT          _  [] ]
+   - #titlelabel takes the remaining width so the controls sit at the
+     right edge.
+   - Source order is titlecross then titlesticky, which is also the
+     desired visual order (minus on the left, sticky on the right). */
 #titlebar {
   font-weight: bold;
   padding: 5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 #titlebar #titlelabel {
-  margin: 4px 0 0 4px;
-  display: inline;
+  margin: 0 0 0 4px;
   font-size: 1.4rem;
+  flex: 1;
 }
 #titlebar .stick-to-screen-btn,
 #titlebar .hide-reduce-btn {
   font-size: 25px;
   color: inherit;
-  float: right;
   text-align: right;
   text-decoration: none;
   cursor: pointer;
@@ -84,7 +91,6 @@
 }
 #titlebar .stick-to-screen-btn {
   font-size: 10px;
-  padding-top: 2px;
 }
 #titlebar .stick-to-screen-btn:focus-visible,
 #titlebar .hide-reduce-btn:focus-visible {

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -62,17 +62,29 @@
 #titlebar {
   font-weight: bold;
   padding: 5px;
+  /* Lay the label and corner controls on a single row and bottom-align
+     them. The controls were previously `float: right` `<a>` tags, so the
+     small minus/block glyphs sat at the *baseline* of the line and looked
+     anchored to the bottom of the title bar. After #7584 turned them into
+     `<button>`s the floats survived but the buttons render at the top of
+     the line (button content is centered in its own box, and the box is
+     only as tall as the glyph), leaving the controls floating above the
+     title text. Fixes #7590. */
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
 }
 #titlebar #titlelabel {
   margin: 4px 0 0 4px;
-  display: inline;
   font-size: 1.4rem;
+  /* Take the remaining row width so the corner buttons are pushed to the
+     right edge (replaces the prior float-right layout). */
+  flex: 1;
 }
 #titlebar .stick-to-screen-btn,
 #titlebar .hide-reduce-btn {
   font-size: 25px;
   color: inherit;
-  float: right;
   text-align: right;
   text-decoration: none;
   cursor: pointer;
@@ -82,6 +94,12 @@
   font-family: inherit;
   line-height: 1;
 }
+/* Preserve the historical visual order [titlesticky] [titlecross] — when
+   both controls were `float: right`, source order was reversed visually,
+   so titlesticky sat to the left of titlecross. Restore that with `order`
+   so we don't have to renumber the markup. */
+#titlebar .stick-to-screen-btn { order: 1; }
+#titlebar .hide-reduce-btn { order: 2; }
 #titlebar .stick-to-screen-btn {
   font-size: 10px;
   padding-top: 2px;
@@ -147,12 +165,22 @@
   color: inherit;
 }
 /* Scope: the inner .buttonicon span here is just a glyph holder. Its global
-   rule in icons.css applies `display: flex` which is fine for toolbar
-   <button class="buttonicon"> instances but breaks inline layout when
-   nested inside a button that's laying out label + glyph + counter on one
-   line. Keep the glyph inline for the chat-icon corner widget. */
+   rule in icons.css applies `display: flex; align-items: center;
+   justify-content: center; position: relative;` which is fine for toolbar
+   `<button class="buttonicon">` instances (where the class IS the button)
+   but breaks the chat-icon corner widget — here `.buttonicon` is on a
+   `<span>` *inside* the button, alongside two more inline `<span>`s for
+   the label and unread counter. Turning the middle span into a flex
+   container disrupts the inline row and, in some layouts, leaves it
+   sitting on top of the button's clickable surface so clicks never reach
+   the `<button>`'s own handler. Reset the flex behaviour and make the
+   span pointer-transparent so clicks always fall through to #chaticon. */
 #chaticon .buttonicon {
   display: inline;
+  align-items: initial;
+  justify-content: initial;
+  position: static;
+  pointer-events: none;
 }
 #chaticon:focus-visible {
   outline: 2px solid #0066cc;

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -62,29 +62,17 @@
 #titlebar {
   font-weight: bold;
   padding: 5px;
-  /* Lay the label and corner controls on a single row. Replaces the prior
-     `float: right` layout so we can place each control on its own cross-
-     axis position (titlesticky at the top, titlecross at the bottom of
-     the title bar). After #7584 turned the corner controls from inline
-     `<a>` glyphs into `<button>`s, the float layout left them stacked at
-     the top of the line and the minus glyph no longer sat near the title
-     baseline. Fixes #7590. */
-  display: flex;
-  gap: 6px;
 }
 #titlebar #titlelabel {
   margin: 4px 0 0 4px;
+  display: inline;
   font-size: 1.4rem;
-  /* Take the remaining row width so the corner buttons are pushed to the
-     right edge (replaces the prior float-right layout). */
-  flex: 1;
-  /* Don't stretch the heading vertically; let it sit on its own baseline. */
-  align-self: center;
 }
 #titlebar .stick-to-screen-btn,
 #titlebar .hide-reduce-btn {
   font-size: 25px;
   color: inherit;
+  float: right;
   text-align: right;
   text-decoration: none;
   cursor: pointer;
@@ -94,15 +82,6 @@
   font-family: inherit;
   line-height: 1;
 }
-/* Preserve the historical visual order [titlesticky] [titlecross] — when
-   both controls were `float: right`, source order was reversed visually,
-   so titlesticky sat to the left of titlecross. Restore that with `order`
-   so we don't have to renumber the markup. The cross-axis position differs
-   per control: titlesticky stays where it always sat (top of the bar),
-   titlecross drops to the bottom so its `−` glyph sits on the title's
-   baseline rather than floating above it. */
-#titlebar .stick-to-screen-btn { order: 1; align-self: flex-start; }
-#titlebar .hide-reduce-btn { order: 2; align-self: flex-end; }
 #titlebar .stick-to-screen-btn {
   font-size: 10px;
   padding-top: 2px;

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -66,13 +66,15 @@
      desired visual order (minus on the left, sticky on the right). */
 #titlebar {
   font-weight: bold;
-  padding: 5px;
+  /* Equal horizontal padding so CHAT on the left and the sticky button on
+     the right sit the same distance from the title-bar edges. */
+  padding: 5px 9px;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 #titlebar #titlelabel {
-  margin: 0 0 0 4px;
+  margin: 0;
   font-size: 1.4rem;
   flex: 1;
 }

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -94,6 +94,12 @@
 #titlebar .stick-to-screen-btn {
   font-size: 10px;
 }
+/* The `_` glyph in #titlecross renders at the bottom of its em-box, which
+   places it visibly far below the CHAT baseline. Lift it without changing
+   the flex row layout. */
+#titlebar .hide-reduce-btn {
+  transform: translateY(-5px);
+}
 #titlebar .stick-to-screen-btn:focus-visible,
 #titlebar .hide-reduce-btn:focus-visible {
   outline: 2px solid #0066cc;

--- a/src/static/css/pad/chat.css
+++ b/src/static/css/pad/chat.css
@@ -62,16 +62,14 @@
 #titlebar {
   font-weight: bold;
   padding: 5px;
-  /* Lay the label and corner controls on a single row and bottom-align
-     them. The controls were previously `float: right` `<a>` tags, so the
-     small minus/block glyphs sat at the *baseline* of the line and looked
-     anchored to the bottom of the title bar. After #7584 turned them into
-     `<button>`s the floats survived but the buttons render at the top of
-     the line (button content is centered in its own box, and the box is
-     only as tall as the glyph), leaving the controls floating above the
-     title text. Fixes #7590. */
+  /* Lay the label and corner controls on a single row. Replaces the prior
+     `float: right` layout so we can place each control on its own cross-
+     axis position (titlesticky at the top, titlecross at the bottom of
+     the title bar). After #7584 turned the corner controls from inline
+     `<a>` glyphs into `<button>`s, the float layout left them stacked at
+     the top of the line and the minus glyph no longer sat near the title
+     baseline. Fixes #7590. */
   display: flex;
-  align-items: flex-end;
   gap: 6px;
 }
 #titlebar #titlelabel {
@@ -80,6 +78,8 @@
   /* Take the remaining row width so the corner buttons are pushed to the
      right edge (replaces the prior float-right layout). */
   flex: 1;
+  /* Don't stretch the heading vertically; let it sit on its own baseline. */
+  align-self: center;
 }
 #titlebar .stick-to-screen-btn,
 #titlebar .hide-reduce-btn {
@@ -97,9 +97,12 @@
 /* Preserve the historical visual order [titlesticky] [titlecross] — when
    both controls were `float: right`, source order was reversed visually,
    so titlesticky sat to the left of titlecross. Restore that with `order`
-   so we don't have to renumber the markup. */
-#titlebar .stick-to-screen-btn { order: 1; }
-#titlebar .hide-reduce-btn { order: 2; }
+   so we don't have to renumber the markup. The cross-axis position differs
+   per control: titlesticky stays where it always sat (top of the bar),
+   titlecross drops to the bottom so its `−` glyph sits on the title's
+   baseline rather than floating above it. */
+#titlebar .stick-to-screen-btn { order: 1; align-self: flex-start; }
+#titlebar .hide-reduce-btn { order: 2; align-self: flex-end; }
 #titlebar .stick-to-screen-btn {
   font-size: 10px;
   padding-top: 2px;

--- a/src/static/css/pad/popup.css
+++ b/src/static/css/pad/popup.css
@@ -53,6 +53,17 @@
   margin: 5px 0;
 }
 
+/* When a settings checkbox is disabled (e.g. "Chat always on screen" while
+   "Disable chat" is ticked), the browser greys the checkbox itself but the
+   adjacent `<label>` still looks active, leaving the row visually clickable
+   even though it isn't. Match the row to the checkbox's disabled state.
+   Fixes #7592. */
+.popup input[type="checkbox"]:disabled + label,
+.popup input[type="radio"]:disabled + label {
+  color: #999;
+  cursor: not-allowed;
+}
+
 /* Mobile devices */
 @media only screen and (max-width: 800px) {
   .popup {

--- a/src/static/css/pad/popup_users.css
+++ b/src/static/css/pad/popup_users.css
@@ -58,6 +58,10 @@
 
 #myusernameform {
   margin-left: 10px;
+  /* Constrain the username input so the adjacent Log out button does not
+     get pushed off the Users popup — previously the input expanded to its
+     natural default width and overlapped the button. Fixes #7593. */
+  width: 75px;
 }
 input#myusernameedit {
   height: 26px;
@@ -66,6 +70,11 @@ input#myusernameedit {
   border: 1px solid #ccc;
   background-color: transparent;
   margin: 0;
+  /* Keep the input inside its 75px container (border + padding included).
+     Without these the text field renders wider than the container on its
+     natural content width and overlaps the Log out button. */
+  width: 100%;
+  box-sizing: border-box;
 }
 input#myusernameedit:not(.editable) {
   color: grey;

--- a/src/static/css/pad/popup_users.css
+++ b/src/static/css/pad/popup_users.css
@@ -58,10 +58,6 @@
 
 #myusernameform {
   margin-left: 10px;
-  /* Constrain the username input so the adjacent Log out button does not
-     get pushed off the Users popup — previously the input expanded to its
-     natural default width and overlapped the button. Fixes #7593. */
-  width: 75px;
 }
 input#myusernameedit {
   height: 26px;
@@ -70,11 +66,6 @@ input#myusernameedit {
   border: 1px solid #ccc;
   background-color: transparent;
   margin: 0;
-  /* Keep the input inside its 75px container (border + padding included).
-     Without these the text field renders wider than the container on its
-     natural content width and overlaps the Log out button. */
-  width: 100%;
-  box-sizing: border-box;
 }
 input#myusernameedit:not(.editable) {
   color: grey;

--- a/src/static/js/chat.ts
+++ b/src/static/js/chat.ts
@@ -36,7 +36,11 @@ exports.chat = (() => {
     show() {
       if (pad.settings.hideChat) return;
       $('#chaticon').removeClass('visible');
-      $('#chatbox').addClass('visible');
+      // Clear any inline `display: none` left by applyShowChat(false)'s
+      // jQuery .hide() — without this, re-enabling chat then clicking the
+      // icon would only add the .visible class while the box stayed hidden
+      // by the inline style. The .visible class only flips visibility.
+      $('#chatbox').css('display', '').addClass('visible');
       this.scrollDown(true);
       chatMentions = 0;
       Tinycon.setBubble(0);

--- a/src/static/skins/colibris/src/components/form.css
+++ b/src/static/skins/colibris/src/components/form.css
@@ -109,9 +109,12 @@ select:hover, .nice-select:hover {
   transform: translateX(14px);
 }
 
-[type="checkbox"]:checked:disabled + label,
-[type="checkbox"]:checked:disabled + label:before,
-[type="checkbox"]:checked:disabled + label:after {
+/* Apply to any disabled checkbox (checked or unchecked), not just checked
+   ones, so dependent toggles like "Chat always on screen" visibly grey out
+   when "Disable chat" is ticked. Fixes #7592. */
+[type="checkbox"]:disabled + label,
+[type="checkbox"]:disabled + label:before,
+[type="checkbox"]:disabled + label:after {
   cursor: not-allowed;
   opacity: .4;
 }

--- a/src/static/skins/colibris/src/components/users.css
+++ b/src/static/skins/colibris/src/components/users.css
@@ -26,7 +26,7 @@ table#otheruserstable {
 }
 
 #myusernameform {
-  margin-left: 35px;
+  margin-left: 10px;
 }
 
 input#myusernameedit {

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -455,7 +455,7 @@
           <div class="chat-content">
             <div id="titlebar">
               <h1 id ="titlelabel" data-l10n-id="pad.chat"></h1>
-              <button type="button" id="titlecross" class="hide-reduce-btn" aria-label="Close chat">&minus;</button>
+              <button type="button" id="titlecross" class="hide-reduce-btn" aria-label="Close chat">_</button>
               <button type="button" id="titlesticky" class="stick-to-screen-btn" data-l10n-id="pad.chat.stick.title">&#9608;</button>
             </div>
             <div id="chattext" class="thin-scrollbar" aria-live="polite" aria-relevant="additions removals text" role="log" aria-atomic="false">

--- a/src/tests/frontend-new/specs/change_user_name.spec.ts
+++ b/src/tests/frontend-new/specs/change_user_name.spec.ts
@@ -33,3 +33,28 @@ test('Own user name is shown when you enter a chat', async ({page})=> {
   expect(chatText).toContain('😃')
   expect(chatText).toContain(chatMessage)
 });
+
+// #7593 review: the previous fix capped #myusernameform at 75px so a plugin-
+// supplied "Log out" button wouldn't overflow, but vanilla etherpad-lite has
+// no such button and the cap just made the username field too small. The
+// colibris skin also pre-existing override of margin-left:35px (chosen for
+// the chatAndUsers sticky layout) has been aligned with the base 10px.
+test('#myusernameform has 10px left margin and is not width-capped', async ({page}) => {
+  await toggleUserList(page);
+
+  const styles = await page.evaluate(() => {
+    const form = document.querySelector('#myusernameform') as HTMLElement;
+    const input = document.querySelector('#myusernameedit') as HTMLElement;
+    return {
+      formMarginLeft: getComputedStyle(form).marginLeft,
+      formWidth: getComputedStyle(form).width,
+      inputWidth: getComputedStyle(input).width,
+    };
+  });
+
+  expect(styles.formMarginLeft).toBe('10px');
+  // The form should size to its content / parent flex behaviour, NOT be capped
+  // at 75px — width should comfortably exceed that.
+  expect(parseFloat(styles.formWidth)).toBeGreaterThan(80);
+  expect(parseFloat(styles.inputWidth)).toBeGreaterThan(80);
+});

--- a/src/tests/frontend-new/specs/chat.spec.ts
+++ b/src/tests/frontend-new/specs/chat.spec.ts
@@ -115,3 +115,79 @@ test('Checks showChat=false URL Parameter hides chat then' +
   // chat should be visible.
   expect(await secondChatIcon.isVisible()).toBe(true)
 });
+
+// Regression: applyShowChat(false) sets inline `display: none` on #chatbox via
+// jQuery .hide(); re-enabling chat doesn't undo it, and chat.show() only flips
+// visibility via the .visible class — so without an explicit display reset the
+// box stays hidden by the lingering inline style. (PR #7597)
+test('chat icon click reveals chatbox after a disable → enable cycle', async ({page}) => {
+  await showSettings(page);
+  await page.locator('label[for="options-disablechat"]').click();
+  await expect(page.locator('#options-disablechat')).toBeChecked();
+  await expect(page.locator('#chaticon')).toBeHidden();
+
+  await page.locator('label[for="options-disablechat"]').click();
+  await expect(page.locator('#options-disablechat')).not.toBeChecked();
+  await expect(page.locator('#chaticon')).toBeVisible();
+  await hideSettings(page);
+
+  await showChat(page);
+  await expect(page.locator('#chatbox')).toBeVisible();
+  await expect(page.locator('#chatbox')).toHaveClass(/visible/);
+});
+
+// Title-bar layout / glyph regressions from #7590 review.
+test('chat title bar lays out as a centred flex row with underscore minimize', async ({page}) => {
+  await showChat(page);
+
+  // Minimize button uses an underscore (sits at the bottom of its em-box and
+  // reads as a proper minimize indicator); it must not silently revert to
+  // &minus; or a hyphen.
+  await expect(page.locator('#titlecross')).toHaveText('_');
+
+  const styles = await page.evaluate(() => {
+    const cs = (sel: string) => getComputedStyle(document.querySelector(sel)!);
+    const rect = (sel: string) => document.querySelector(sel)!.getBoundingClientRect();
+    const tb = rect('#titlebar');
+    const lab = rect('#titlelabel');
+    const sticky = rect('#titlesticky');
+    return {
+      titlebarDisplay: cs('#titlebar').display,
+      titlebarAlignItems: cs('#titlebar').alignItems,
+      labelFlex: cs('#titlelabel').flexGrow,
+      crossFloat: cs('#titlecross').float,
+      crossTransform: cs('#titlecross').transform,
+      stickyFloat: cs('#titlesticky').float,
+      // Visual symmetry — CHAT's left edge sits roughly the same distance
+      // from the title-bar left edge as the rightmost button sits from the
+      // right edge. Tested via rendered geometry rather than CSS literal so
+      // we don't get tripped up by skin overrides (colibris ships its own
+      // #titlebar padding rule).
+      leftGap: lab.left - tb.left,
+      rightGap: tb.right - sticky.right,
+    };
+  });
+  expect(styles.titlebarDisplay).toBe('flex');
+  expect(styles.titlebarAlignItems).toBe('center');
+  // Title takes the remaining width so corner buttons sit at the right edge.
+  expect(styles.labelFlex).toBe('1');
+  // Buttons are flex items, not floats — old `float: right` layout must stay gone.
+  expect(styles.crossFloat).toBe('none');
+  expect(styles.stickyFloat).toBe('none');
+  // 5px lift on #titlecross so the `_` glyph reads near the title's baseline
+  // rather than at the very bottom of the row.
+  expect(styles.crossTransform).not.toBe('none');
+  // Padding looks symmetric (within 2px to allow for sub-pixel rounding).
+  expect(Math.abs(styles.leftGap - styles.rightGap)).toBeLessThanOrEqual(2);
+});
+
+// Regression: #chaticon was a <div> before the #7584 a11y refactor; once it
+// became a <button>, the inner <span class="buttonicon"> being `display: flex`
+// (from the global icons.css rule) could intercept clicks and the chat icon
+// stopped opening the panel. The fix scopes a reset on `#chaticon .buttonicon`.
+test('chat icon click reliably opens the chat box', async ({page}) => {
+  await expect(page.locator('#chaticon')).toBeVisible();
+  await page.locator('#chaticon').click();
+  await expect(page.locator('#chatbox')).toHaveClass(/visible/);
+  await expect(page.locator('#chatbox')).toBeVisible();
+});

--- a/src/tests/frontend-new/specs/pad_settings.spec.ts
+++ b/src/tests/frontend-new/specs/pad_settings.spec.ts
@@ -160,4 +160,38 @@ test.describe('creator-owned pad settings', () => {
 
     await context2.close();
   });
+
+  // #7592: ticking "Disable chat" must visibly disable the dependent
+  // "Chat always on screen" / "Show Chat and Users" toggles, not just
+  // make the underlying inputs non-interactive.
+  test('disabling chat disables and visually greys the dependent chat toggles', async ({page}) => {
+    await goToNewPad(page);
+    await showSettings(page);
+
+    // Initial state: dependent toggles are interactive.
+    await expect(page.locator('#options-stickychat')).toBeEnabled();
+    await expect(page.locator('#options-chatandusers')).toBeEnabled();
+
+    await page.locator('label[for="options-disablechat"]').click();
+    await expect(page.locator('#options-disablechat')).toBeChecked();
+
+    // Inputs become disabled (refreshMyViewControls in pad.ts).
+    await expect(page.locator('#options-stickychat')).toBeDisabled();
+    await expect(page.locator('#options-chatandusers')).toBeDisabled();
+
+    // Colibris toggle visualisation dims via opacity:.4 on the label
+    // (covers the hidden checkbox + before/after pseudo-elements).
+    const stickyLabelOpacity = await page.evaluate(
+        () => getComputedStyle(document.querySelector('label[for="options-stickychat"]')!).opacity);
+    const chatAndUsersLabelOpacity = await page.evaluate(
+        () => getComputedStyle(document.querySelector('label[for="options-chatandusers"]')!).opacity);
+    expect(parseFloat(stickyLabelOpacity)).toBeLessThan(1);
+    expect(parseFloat(chatAndUsersLabelOpacity)).toBeLessThan(1);
+
+    // Untick "Disable chat" → dependent toggles are interactive again.
+    await page.locator('label[for="options-disablechat"]').click();
+    await expect(page.locator('#options-disablechat')).not.toBeChecked();
+    await expect(page.locator('#options-stickychat')).toBeEnabled();
+    await expect(page.locator('#options-chatandusers')).toBeEnabled();
+  });
 });


### PR DESCRIPTION
Bundles three small chat-related bug fixes that all touch the same area of the editor window. Per review feedback.

## Closes

- #7590 — chat icon click sometimes did nothing (icon button click target was being eaten by the inner `.buttonicon` flex span after #7584)
- #7592 — "Chat always on screen" / "Show Chat and Users" rows didn't visibly disable when "Disable chat" was ticked, even though the underlying inputs were disabled
- #7593 — partial: revert of the original width-cap fix (no Log out button visible in vanilla etherpad-lite, and the cap made the username field unnecessarily narrow)

## Changes

**`src/static/css/pad/chat.css`**
- Reset flex / pointer behaviour on `#chaticon .buttonicon` so the inner glyph span doesn't intercept clicks meant for the `<button id="chaticon">`. Preferred over weakening the global `.buttonicon` rule, which the toolbar relies on for icon centring.
- Title-bar layout left as-is (the float-based original); a separate visual pass on `#titlecross` / `#titlesticky` positioning can come later.

**`src/static/js/chat.ts`**
- `chat.show()` now clears any inline `display: none` on `#chatbox` before adding the `.visible` class. Without this, doing **Disable Chat → Re-enable Chat → click chat icon** left the chatbox hidden by the inline style that `applyShowChat(false)` had set via jQuery `.hide()`.

**`src/static/skins/colibris/src/components/form.css`**
- Drop the `:checked` qualifier from the disabled-toggle visual rule so unchecked-but-disabled toggles also dim. Fixes #7592 in the colibris skin.

**`src/static/css/pad/popup.css`**
- Generic baseline for non-colibris skins: greyed label colour and `cursor: not-allowed` on disabled checkbox/radio rows in popups.

**`src/static/skins/colibris/src/components/users.css`**
- `#myusernameform` margin-left 35px → 10px to match the base CSS. The 35px value was sized for the chatAndUsers sticky layout but in the standalone Users popup it just opens a wide gap.

**`src/static/css/pad/popup_users.css`**
- Reverts the width:75px cap on `#myusernameform` and the forced `width: 100%` / `box-sizing: border-box` on `#myusernameedit` from the original PR commit. Vanilla etherpad-lite has no Log out button to overlap, and the cap makes the field too small.

## Test plan

Tested in browser with the colibris skin:
- [x] #7590 — clicking the corner chat icon opens the panel reliably; closing and re-opening still works
- [x] #7592 — ticking "Disable chat" greys both the labels and the colibris toggle visuals (opacity .4); untick restores
- [x] disable → enable → click chat icon → chat panel appears (regression fix from chat.ts change)
- [x] #7593 — username input renders at its natural width; no Log out overlap regression in environments that don't have one