### PR TITLE
🩹 — Avoid duplicate key "types" in tsconfig

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -3,7 +3,6 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
     "moduleDetection": "force",
     "lib": ["ES2023", "DOM"],
-    "types": ["node", "jquery"],
     /* Language and Environment */
     "target": "es6",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     /* Modules */


### PR DESCRIPTION
<!--

1. If you haven't already, please read https://github.com/ether/etherpad/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->

The key `types` is present two times in `src/tsconfig.json`, issuing warnings in log:
```
[2026-04-27T12:32:09.976] [INFO] Minify - Compress CSS file skins/colibris/index.css.
▲ [WARNING] Duplicate key "types" in object literal [duplicate-object-key]
    tsconfig.json:18:4:
      18 │     "types": ["node", "jquery", "mocha"]
         ╵     ~~~~~~~
  The original key "types" is here:
    tsconfig.json:6:4:
      6 │     "types": ["node", "jquery"],
        ╵     ~~~~~~~
```

This PR remove the first `types`, which contains only two values.