### PR TITLE
test(playwright): use insertText so Firefox stops dropping keystrokes

### DIFF
--- a/src/tests/frontend-new/helper/padHelper.ts
+++ b/src/tests/frontend-new/helper/padHelper.ts
@@ -142,7 +142,18 @@ export const clearPadContent = async (page: Page) => {
 export const writeToPad = async (page: Page, text: string) => {
   const body = await getPadBody(page);
   await body.click();
-  await page.keyboard.type(text);
+  // Use insertText (single input event) instead of keyboard.type
+  // (one keydown/keyup per char). Firefox under WITH_PLUGINS load
+  // racily drops characters from per-key events; insertText delivers
+  // each chunk in one event, which Etherpad's incorporateUserChanges
+  // pipeline handles atomically. insertText does not translate \n
+  // into a real Enter keystroke, so split on newlines and press
+  // Enter between segments to preserve multi-line input.
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]) await page.keyboard.insertText(lines[i]);
+    if (i < lines.length - 1) await page.keyboard.press('Enter');
+  }
 }
 
 export const clearAuthorship = async (page: Page) => {


### PR DESCRIPTION
## Summary

`writeToPad` has been calling `page.keyboard.type`, which dispatches one keydown/keyup per character against the inner `#innerdocbody` contenteditable. Under WITH_PLUGINS load Firefox's input pipeline can't keep up while plugin hooks are still warming, and randomly swallows characters from the tail of the string — the pad ends up with e.g. \`aligned tex\` instead of \`aligned text\`. The dropped character is irrecoverable: there's no event for the helper to retry against.

Switch to `page.keyboard.insertText`, which dispatches a **single** input event per call. Etherpad's `incorporateUserChanges` loop reads the resulting DOM atomically, so the visible result is identical to typing — minus the per-key race.

`insertText` does not translate `\n` into a real Enter keystroke (it concatenates `"One\nTwo"` into `"OneTwo"`), so split on newlines and press Enter between segments to preserve multi-line input. This matches what the existing callers (`timeslider_line_numbers`, `page_up_down`, etc.) rely on.

**Change type:** patch (test infrastructure only; no production behaviour change).

## Why this matters

After #7622 began discovering plugin Playwright specs in CI, the Firefox-with-plugins job started failing on every run. The most visible casualty was `ep_align`'s `Alignment of Text` suite (all 4 cases × 5 retries = 20 failures per run). Tracing it down showed the `<center>` wrapper element never appeared because the click into the toolbar was never preceded by the text actually being typed — `keyboard.type` had silently dropped the trailing char(s), leaving `selectAllText` selecting nothing and the alignment click no-op.

The same root cause was producing intermittent failures across other plugin specs that exercise typing.

## Test plan

- [x] `Playwright Chrome with plugins` ep_align Alignment: 4/4 pass locally (was 4/4 before; no regression)
- [x] `Playwright Firefox with plugins` ep_align Alignment: 4/4 pass locally (was 0/4 with retries previously)
- [x] `Playwright Firefox` core italic.spec: 2/2 pass
- [x] `tests/frontend-new/specs/timeslider_line_numbers.spec.ts` (which writes \`One\nTwo\nThree\` and asserts three lines): passes — confirms the newline-splitting branch
- [ ] CI to verify across the full suite

## What this PR does **not** address

There are still independent failures in the Firefox-with-plugins suite that have **different** root causes (plugin spec asserts that don't match runtime DOM, missing/wrong selectors, etc.):

- \`ep_headings2\` "Option select is changed when heading is changed"
- \`ep_markdown\` "Bold section renders the markdown class on body when 'Show Markdown' is enabled"
- \`ep_spellcheck\` "Spellcheck is on by default when not disabled"
- core \`tests/frontend-new/specs/timeslider_identity_changeset.spec.ts\` "timeslider playback advances..."

Those need per-spec fixes — out of scope here. Filing a tracking issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)