### PR TITLE
test: use selectAllText in timeslider_identity_changeset spec

### DIFF
--- a/src/tests/frontend-new/specs/timeslider_identity_changeset.spec.ts
+++ b/src/tests/frontend-new/specs/timeslider_identity_changeset.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from "@playwright/test";
-import {goToNewPad, getPadBody, clearPadContent, writeToPad} from "../helper/padHelper";
+import {goToNewPad, getPadBody, clearPadContent, selectAllText, writeToPad}
+  from "../helper/padHelper";
 
 /**
  * Regression test for https://github.com/ether/etherpad-lite/issues/5214
@@ -25,10 +26,12 @@ test.describe('Timeslider with identity changesets (bug #5214)', function () {
     await writeToPad(page, 'First revision text');
     await page.waitForTimeout(500);
 
-    // Select all and delete (creates a "delete everything" revision)
-    await page.keyboard.down('Control');
-    await page.keyboard.press('A');
-    await page.keyboard.up('Control');
+    // Select all and delete (creates a "delete everything" revision).
+    // Use selectAllText helper instead of raw keyboard chord: under
+    // Firefox + WITH_PLUGINS the keyboard.down/press/up('Control')
+    // sequence races with the focus delegation into the inner ace
+    // iframe and can drop either the Control or the A keystroke.
+    await selectAllText(page);
     await page.keyboard.press('Backspace');
     await page.waitForTimeout(500);
 


### PR DESCRIPTION
## Summary

- Resolves the Firefox failure on `timeslider playback advances through all revisions including identity changesets` tracked in #7626.
- Replaces the raw `keyboard.down/press/up('Control')` + `keyboard.press('A')` chord with `selectAllText(page)`. Under Firefox + WITH_PLUGINS the chord races with focus delegation into the inner ace iframe and drops either the Control or the A keystroke; the subsequent Backspace then deletes a single character, the "delete everything" revision the test relies on never gets created, and the test sits idle until the 90s timeout.

## Semver

patch — test-only change, no public-API impact.

## Test plan

- [ ] `pnpm test-ui --project=firefox` from `src/` with `WITH_PLUGINS=1`.
- [ ] Spot-check chromium remains green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)