### PR TITLE
test(playwright): un-skip ep_headings2 spec under WITH_PLUGINS (#7626)

### DIFF
--- a/src/playwright.config.ts
+++ b/src/playwright.config.ts
@@ -20,14 +20,7 @@ const PLUGIN_SPECS = [
 ];
 const FRONTEND_MATCH = [CORE_SPECS, ...PLUGIN_SPECS];
 
-// Vendored plugin specs we can't edit that are flaky under the WITH_PLUGINS
-// firefox run (keystrokes drop when the /ether plugin set is loaded). Skip
-// only when WITH_PLUGINS=1 so the standalone plugin runs still cover them.
-// Tracking issue: #7611. Mirror of the `test.skip(WITH_PLUGINS)` pattern
-// used in our own core specs.
-const FRONTEND_IGNORE = process.env.WITH_PLUGINS === '1' ? [
-  '**/ep_headings2*/static/tests/frontend-new/specs/headings.spec.ts',
-] : [];
+const FRONTEND_IGNORE: string[] = [];
 
 /**
  * See https://playwright.dev/docs/test-configuration.


### PR DESCRIPTION
## Summary
- Drops `'**/ep_headings2*/static/tests/frontend-new/specs/headings.spec.ts'` from `FRONTEND_IGNORE` in `src/playwright.config.ts`. The ignore was added in #7628 while the WITH_PLUGINS keystroke-drop flake (#7611) was still being investigated; #7630 then identified the real root cause (ep_cursortrace's per-keystroke `cursorPosition` socket spam) and removed ep_cursortrace from the WITH_PLUGINS plugin set, plus added `waitForEditorReady()` to `goToNewPad` / `goToPad`.
- With both root causes addressed, this skip is likely stale. The spec's `Option select is changed when heading is changed` test (line 44) already uses `insertText` for second-line typing (ep_headings2@65afe68), so it should clear the same bar that #7630 cleared for `ep_markdown` and `ep_spellcheck` — both of which are now passing on develop CI under Firefox + WITH_PLUGINS.
- Closes #7626 if CI confirms.

## Risk
Lowest possible: one config entry removed, no test or production code touched. If the spec is still flaky under WITH_PLUGINS, CI fails on this PR (firefox + WITH_PLUGINS retries 5×) and we put the ignore back with a narrower comment about what specifically still races. No release artefacts affected.

## Semver
patch — test infrastructure only.

## Test plan
- [ ] `Playwright Firefox with plugins` job passes on this PR
- [ ] `Playwright Chrome with plugins` job passes (sanity check — wasn't ignored there but worth confirming)
- [ ] `ep_headings2 .../headings.spec.ts:44 Option select is changed when heading is changed` line appears in the firefox-with-plugins log as `✓` (not skipped, not failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)