### PR TITLE
feat(pad): add theme-color meta to match toolbar on mobile (#7606)

### DIFF
--- a/src/node/utils/SkinColors.ts
+++ b/src/node/utils/SkinColors.ts
@@ -1,0 +1,30 @@
+'use strict';
+
+// Toolbar background colors that the colibris skin variants resolve to.
+// Mirrors --bg-color in src/static/skins/colibris/src/pad-variants.css so
+// that <meta name="theme-color"> can match the toolbar on first paint
+// (before client-side JS runs).
+const TOOLBAR_COLORS: {[variant: string]: string} = {
+  'super-light-toolbar': '#ffffff',
+  'light-toolbar': '#f2f3f4',
+  'dark-toolbar': '#576273',
+  'super-dark-toolbar': '#485365',
+};
+
+const DEFAULT_LIGHT = '#ffffff';
+const DEFAULT_DARK = '#485365';
+
+export const toolbarThemeColors = (skinVariants: string | undefined | null) => {
+  const tokens = (skinVariants || '').split(/\s+/).filter(Boolean);
+  let light = DEFAULT_LIGHT;
+  let dark = DEFAULT_DARK;
+  for (const token of tokens) {
+    const color = TOOLBAR_COLORS[token];
+    if (!color) continue;
+    if (token.includes('dark')) dark = color;
+    else light = color;
+  }
+  return {light, dark};
+};
+
+module.exports = {toolbarThemeColors};

--- a/src/node/utils/SkinColors.ts
+++ b/src/node/utils/SkinColors.ts
@@ -1,34 +1,34 @@
 'use strict';
 
 // Toolbar background colors that the colibris skin variants resolve to.
-// Mirrors --bg-color in src/static/skins/colibris/src/pad-variants.css so
-// that <meta name="theme-color"> can match the toolbar on first paint
-// (before client-side JS runs).
-const TOOLBAR_COLORS: {[variant: string]: string} = {
-  'super-light-toolbar': '#ffffff',
-  'light-toolbar': '#f2f3f4',
-  'dark-toolbar': '#576273',
-  'super-dark-toolbar': '#485365',
-};
+// Mirrors --bg-color in src/static/skins/colibris/src/pad-variants.css. Only
+// the colibris skin has a known mapping; for any other skin we cannot derive
+// the toolbar color server-side and emit no theme-color meta.
+//
+// Order matters: when skinVariants contains multiple *-toolbar tokens the
+// CSS cascade picks the rule defined last in pad-variants.css, so iterate in
+// source order and let the last matching token win.
+const TOOLBAR_COLORS_IN_CSS_ORDER: Array<[string, string]> = [
+  ['super-light-toolbar', '#ffffff'],
+  ['light-toolbar', '#f2f3f4'],
+  ['super-dark-toolbar', '#485365'],
+  ['dark-toolbar', '#576273'],
+];
 
-const DEFAULT_TOOLBAR_COLOR = '#ffffff';
+const COLIBRIS_DEFAULT_TOOLBAR_COLOR = '#ffffff';
 
-// The colibris dark-mode auto-switch in pad.ts forces the toolbar variant to
-// 'super-dark-toolbar' regardless of what skinVariants was configured with, so
-// the prefers-color-scheme: dark theme-color meta must always resolve to that
-// color rather than to whatever dark variant the operator picked.
-export const DARK_MODE_TOOLBAR_COLOR = TOOLBAR_COLORS['super-dark-toolbar'];
-
-// The toolbar color that the configured skinVariants resolves to (the color
-// the user sees before any client-side dark-mode override). Returns the first
-// recognized *-toolbar token; falls back to the default light color.
-export const configuredToolbarColor = (skinVariants: string | undefined | null) => {
-  const tokens = (skinVariants || '').split(/\s+/).filter(Boolean);
-  for (const token of tokens) {
-    const color = TOOLBAR_COLORS[token];
-    if (color) return color;
+// The toolbar color the user actually sees on first paint, derived from the
+// configured skin and skinVariants. Returns null when the skin is unknown so
+// callers can omit the meta rather than emit a misleading value.
+export const configuredToolbarColor = (
+  skinName: string | undefined | null,
+  skinVariants: string | undefined | null,
+): string | null => {
+  if (skinName !== 'colibris') return null;
+  const tokens = new Set((skinVariants || '').split(/\s+/).filter(Boolean));
+  let color: string | null = null;
+  for (const [variant, c] of TOOLBAR_COLORS_IN_CSS_ORDER) {
+    if (tokens.has(variant)) color = c;
   }
-  return DEFAULT_TOOLBAR_COLOR;
+  return color || COLIBRIS_DEFAULT_TOOLBAR_COLOR;
 };
-
-module.exports = {DARK_MODE_TOOLBAR_COLOR, configuredToolbarColor};

--- a/src/node/utils/SkinColors.ts
+++ b/src/node/utils/SkinColors.ts
@@ -11,33 +11,24 @@ const TOOLBAR_COLORS: {[variant: string]: string} = {
   'super-dark-toolbar': '#485365',
 };
 
-const DEFAULT_LIGHT = '#ffffff';
-const DEFAULT_DARK = '#485365';
+const DEFAULT_TOOLBAR_COLOR = '#ffffff';
 
-export const toolbarThemeColors = (skinVariants: string | undefined | null) => {
-  const tokens = (skinVariants || '').split(/\s+/).filter(Boolean);
-  let light = DEFAULT_LIGHT;
-  let dark = DEFAULT_DARK;
-  for (const token of tokens) {
-    const color = TOOLBAR_COLORS[token];
-    if (!color) continue;
-    if (token.includes('dark')) dark = color;
-    else light = color;
-  }
-  return {light, dark};
-};
+// The colibris dark-mode auto-switch in pad.ts forces the toolbar variant to
+// 'super-dark-toolbar' regardless of what skinVariants was configured with, so
+// the prefers-color-scheme: dark theme-color meta must always resolve to that
+// color rather than to whatever dark variant the operator picked.
+export const DARK_MODE_TOOLBAR_COLOR = TOOLBAR_COLORS['super-dark-toolbar'];
 
-// The toolbar color that the configured skinVariants resolves to with no
-// client-side dark-mode toggling. Used by pages (e.g. timeslider) that do not
-// switch skin variants based on prefers-color-scheme, so that theme-color
-// always matches what the user actually sees.
+// The toolbar color that the configured skinVariants resolves to (the color
+// the user sees before any client-side dark-mode override). Returns the first
+// recognized *-toolbar token; falls back to the default light color.
 export const configuredToolbarColor = (skinVariants: string | undefined | null) => {
   const tokens = (skinVariants || '').split(/\s+/).filter(Boolean);
   for (const token of tokens) {
     const color = TOOLBAR_COLORS[token];
     if (color) return color;
   }
-  return DEFAULT_LIGHT;
+  return DEFAULT_TOOLBAR_COLOR;
 };
 
-module.exports = {toolbarThemeColors, configuredToolbarColor};
+module.exports = {DARK_MODE_TOOLBAR_COLOR, configuredToolbarColor};

--- a/src/node/utils/SkinColors.ts
+++ b/src/node/utils/SkinColors.ts
@@ -27,4 +27,17 @@ export const toolbarThemeColors = (skinVariants: string | undefined | null) => {
   return {light, dark};
 };
 
-module.exports = {toolbarThemeColors};
+// The toolbar color that the configured skinVariants resolves to with no
+// client-side dark-mode toggling. Used by pages (e.g. timeslider) that do not
+// switch skin variants based on prefers-color-scheme, so that theme-color
+// always matches what the user actually sees.
+export const configuredToolbarColor = (skinVariants: string | undefined | null) => {
+  const tokens = (skinVariants || '').split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    const color = TOOLBAR_COLORS[token];
+    if (color) return color;
+  }
+  return DEFAULT_LIGHT;
+};
+
+module.exports = {toolbarThemeColors, configuredToolbarColor};

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -6,12 +6,12 @@
   var renderLang = (req && typeof req.acceptsLanguages === 'function'
     && req.acceptsLanguages(Object.keys(langs))) || 'en';
   var renderDir = (langs[renderLang] && langs[renderLang].direction === 'rtl') ? 'rtl' : 'ltr';
-  // The baseline theme-color matches the configured toolbar (whatever skinVariants
-  // resolved to). When dark mode is enabled, the client-side override forces the
-  // toolbar to super-dark-toolbar on dark-OS clients, so the dark media-query
-  // meta uses that fixed color rather than anything derived from skinVariants.
-  var configuredColor = skinColors.configuredToolbarColor(settings.skinVariants);
-  var darkModeColor = skinColors.DARK_MODE_TOOLBAR_COLOR;
+  // theme-color matches the configured toolbar so mobile address bars don't
+  // paint a mismatched system color above the toolbar on first paint. We do
+  // not emit a prefers-color-scheme: dark variant: the client-side dark-mode
+  // auto-switch is gated on enableDarkMode, matchMedia, and a localStorage
+  // white-mode override, none of which a media query can express.
+  var configuredColor = skinColors.configuredToolbarColor(settings.skinName, settings.skinVariants);
 %>
 <!doctype html>
 <html lang="<%=renderLang%>" dir="<%=renderDir%>" translate="no" class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
@@ -48,8 +48,7 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-  <meta name="theme-color" content="<%=configuredColor%>">
-  <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=darkModeColor%>" media="(prefers-color-scheme: dark)"><% } %>
+  <% if (configuredColor) { %><meta name="theme-color" content="<%=configuredColor%>"><% } %>
   <link rel="shortcut icon" href="../favicon.ico">
 
   <% e.begin_block("styles"); %>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -43,7 +43,7 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-  <meta name="theme-color" content="<%=themeColors.light%>" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="<%=themeColors.light%>">
   <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=themeColors.dark%>" media="(prefers-color-scheme: dark)"><% } %>
   <link rel="shortcut icon" href="../favicon.ico">
 

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -6,7 +6,12 @@
   var renderLang = (req && typeof req.acceptsLanguages === 'function'
     && req.acceptsLanguages(Object.keys(langs))) || 'en';
   var renderDir = (langs[renderLang] && langs[renderLang].direction === 'rtl') ? 'rtl' : 'ltr';
-  var themeColors = skinColors.toolbarThemeColors(settings.skinVariants);
+  // The baseline theme-color matches the configured toolbar (whatever skinVariants
+  // resolved to). When dark mode is enabled, the client-side override forces the
+  // toolbar to super-dark-toolbar on dark-OS clients, so the dark media-query
+  // meta uses that fixed color rather than anything derived from skinVariants.
+  var configuredColor = skinColors.configuredToolbarColor(settings.skinVariants);
+  var darkModeColor = skinColors.DARK_MODE_TOOLBAR_COLOR;
 %>
 <!doctype html>
 <html lang="<%=renderLang%>" dir="<%=renderDir%>" translate="no" class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
@@ -43,8 +48,8 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-  <meta name="theme-color" content="<%=themeColors.light%>">
-  <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=themeColors.dark%>" media="(prefers-color-scheme: dark)"><% } %>
+  <meta name="theme-color" content="<%=configuredColor%>">
+  <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=darkModeColor%>" media="(prefers-color-scheme: dark)"><% } %>
   <link rel="shortcut icon" href="../favicon.ico">
 
   <% e.begin_block("styles"); %>

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -1,10 +1,12 @@
 <%
   var langs = require("ep_etherpad-lite/node/hooks/i18n").availableLangs
     , pluginUtils = require('ep_etherpad-lite/static/js/pluginfw/shared')
+    , skinColors = require('ep_etherpad-lite/node/utils/SkinColors')
     ;
   var renderLang = (req && typeof req.acceptsLanguages === 'function'
     && req.acceptsLanguages(Object.keys(langs))) || 'en';
   var renderDir = (langs[renderLang] && langs[renderLang].direction === 'rtl') ? 'rtl' : 'ltr';
+  var themeColors = skinColors.toolbarThemeColors(settings.skinVariants);
 %>
 <!doctype html>
 <html lang="<%=renderLang%>" dir="<%=renderDir%>" translate="no" class="pad <%=pluginUtils.clientPluginNames().join(' '); %> <%=settings.skinVariants%>">
@@ -41,6 +43,8 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+  <meta name="theme-color" content="<%=themeColors.light%>" media="(prefers-color-scheme: light)">
+  <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=themeColors.dark%>" media="(prefers-color-scheme: dark)"><% } %>
   <link rel="shortcut icon" href="../favicon.ico">
 
   <% e.begin_block("styles"); %>

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -4,10 +4,7 @@
   var renderLang = (req && typeof req.acceptsLanguages === 'function'
     && req.acceptsLanguages(Object.keys(langs))) || 'en';
   var renderDir = (langs[renderLang] && langs[renderLang].direction === 'rtl') ? 'rtl' : 'ltr';
-  // Timeslider does not switch skin variants based on prefers-color-scheme, so
-  // emit a single theme-color matching the configured toolbar to avoid a
-  // dark address-bar over a light toolbar mismatch.
-  var themeColor = skinColors.configuredToolbarColor(settings.skinVariants);
+  var themeColor = skinColors.configuredToolbarColor(settings.skinName, settings.skinVariants);
 %>
 <!doctype html>
 <html lang="<%=renderLang%>" dir="<%=renderDir%>" translate="no" class="pad <%=settings.skinVariants%>">
@@ -41,7 +38,7 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-  <meta name="theme-color" content="<%=themeColor%>">
+  <% if (themeColor) { %><meta name="theme-color" content="<%=themeColor%>"><% } %>
   <link rel="shortcut icon" href="../../favicon.ico">
   <% e.begin_block("timesliderStyles"); %>
   <link rel="stylesheet" href="../../static/css/pad.css?v=<%=settings.randomVersionString%>">

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -4,7 +4,10 @@
   var renderLang = (req && typeof req.acceptsLanguages === 'function'
     && req.acceptsLanguages(Object.keys(langs))) || 'en';
   var renderDir = (langs[renderLang] && langs[renderLang].direction === 'rtl') ? 'rtl' : 'ltr';
-  var themeColors = skinColors.toolbarThemeColors(settings.skinVariants);
+  // Timeslider does not switch skin variants based on prefers-color-scheme, so
+  // emit a single theme-color matching the configured toolbar to avoid a
+  // dark address-bar over a light toolbar mismatch.
+  var themeColor = skinColors.configuredToolbarColor(settings.skinVariants);
 %>
 <!doctype html>
 <html lang="<%=renderLang%>" dir="<%=renderDir%>" translate="no" class="pad <%=settings.skinVariants%>">
@@ -38,8 +41,7 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
-  <meta name="theme-color" content="<%=themeColors.light%>" media="(prefers-color-scheme: light)">
-  <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=themeColors.dark%>" media="(prefers-color-scheme: dark)"><% } %>
+  <meta name="theme-color" content="<%=themeColor%>">
   <link rel="shortcut icon" href="../../favicon.ico">
   <% e.begin_block("timesliderStyles"); %>
   <link rel="stylesheet" href="../../static/css/pad.css?v=<%=settings.randomVersionString%>">

--- a/src/templates/timeslider.html
+++ b/src/templates/timeslider.html
@@ -1,8 +1,10 @@
 <%
   var langs = require("ep_etherpad-lite/node/hooks/i18n").availableLangs
+  var skinColors = require('ep_etherpad-lite/node/utils/SkinColors');
   var renderLang = (req && typeof req.acceptsLanguages === 'function'
     && req.acceptsLanguages(Object.keys(langs))) || 'en';
   var renderDir = (langs[renderLang] && langs[renderLang].direction === 'rtl') ? 'rtl' : 'ltr';
+  var themeColors = skinColors.toolbarThemeColors(settings.skinVariants);
 %>
 <!doctype html>
 <html lang="<%=renderLang%>" dir="<%=renderDir%>" translate="no" class="pad <%=settings.skinVariants%>">
@@ -36,6 +38,8 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="referrer" content="no-referrer">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+  <meta name="theme-color" content="<%=themeColors.light%>" media="(prefers-color-scheme: light)">
+  <% if (settings.enableDarkMode) { %><meta name="theme-color" content="<%=themeColors.dark%>" media="(prefers-color-scheme: dark)"><% } %>
   <link rel="shortcut icon" href="../../favicon.ico">
   <% e.begin_block("timesliderStyles"); %>
   <link rel="stylesheet" href="../../static/css/pad.css?v=<%=settings.randomVersionString%>">

--- a/src/tests/backend-new/specs/SkinColors.ts
+++ b/src/tests/backend-new/specs/SkinColors.ts
@@ -1,43 +1,11 @@
-import {toolbarThemeColors, configuredToolbarColor} from "../../../node/utils/SkinColors";
+import {DARK_MODE_TOOLBAR_COLOR, configuredToolbarColor} from "../../../node/utils/SkinColors";
 import {expect, describe, it} from "vitest";
 
-describe('SkinColors.toolbarThemeColors', function () {
-  it('returns defaults for an empty skinVariants string', function () {
-    expect(toolbarThemeColors('')).toEqual({light: '#ffffff', dark: '#485365'});
-  });
-
-  it('returns defaults for null/undefined', function () {
-    expect(toolbarThemeColors(null)).toEqual({light: '#ffffff', dark: '#485365'});
-    expect(toolbarThemeColors(undefined)).toEqual({light: '#ffffff', dark: '#485365'});
-  });
-
-  it('maps super-light-toolbar to white', function () {
-    expect(toolbarThemeColors('super-light-toolbar super-light-editor light-background').light)
-        .toBe('#ffffff');
-  });
-
-  it('maps light-toolbar to its --light-color value', function () {
-    expect(toolbarThemeColors('light-toolbar').light).toBe('#f2f3f4');
-  });
-
-  it('maps dark-toolbar to its --dark-color value', function () {
-    expect(toolbarThemeColors('dark-toolbar').dark).toBe('#576273');
-  });
-
-  it('maps super-dark-toolbar to its --super-dark-color value', function () {
-    expect(toolbarThemeColors('super-dark-toolbar').dark).toBe('#485365');
-  });
-
-  it('ignores unrelated tokens', function () {
-    const colors = toolbarThemeColors('super-light-toolbar full-width-editor light-background');
-    expect(colors.light).toBe('#ffffff');
-    expect(colors.dark).toBe('#485365');
-  });
-
-  it('handles a mix of light and dark toolbar tokens', function () {
-    const colors = toolbarThemeColors('light-toolbar dark-toolbar');
-    expect(colors.light).toBe('#f2f3f4');
-    expect(colors.dark).toBe('#576273');
+describe('SkinColors.DARK_MODE_TOOLBAR_COLOR', function () {
+  it('matches the super-dark-toolbar color forced by client-side dark mode', function () {
+    // pad.ts swaps to super-dark-toolbar on dark OS, so the dark theme-color
+    // must match that fixed value, not whatever was configured in skinVariants.
+    expect(DARK_MODE_TOOLBAR_COLOR).toBe('#485365');
   });
 });
 

--- a/src/tests/backend-new/specs/SkinColors.ts
+++ b/src/tests/backend-new/specs/SkinColors.ts
@@ -1,0 +1,42 @@
+import {toolbarThemeColors} from "../../../node/utils/SkinColors";
+import {expect, describe, it} from "vitest";
+
+describe('SkinColors.toolbarThemeColors', function () {
+  it('returns defaults for an empty skinVariants string', function () {
+    expect(toolbarThemeColors('')).toEqual({light: '#ffffff', dark: '#485365'});
+  });
+
+  it('returns defaults for null/undefined', function () {
+    expect(toolbarThemeColors(null)).toEqual({light: '#ffffff', dark: '#485365'});
+    expect(toolbarThemeColors(undefined)).toEqual({light: '#ffffff', dark: '#485365'});
+  });
+
+  it('maps super-light-toolbar to white', function () {
+    expect(toolbarThemeColors('super-light-toolbar super-light-editor light-background').light)
+        .toBe('#ffffff');
+  });
+
+  it('maps light-toolbar to its --light-color value', function () {
+    expect(toolbarThemeColors('light-toolbar').light).toBe('#f2f3f4');
+  });
+
+  it('maps dark-toolbar to its --dark-color value', function () {
+    expect(toolbarThemeColors('dark-toolbar').dark).toBe('#576273');
+  });
+
+  it('maps super-dark-toolbar to its --super-dark-color value', function () {
+    expect(toolbarThemeColors('super-dark-toolbar').dark).toBe('#485365');
+  });
+
+  it('ignores unrelated tokens', function () {
+    const colors = toolbarThemeColors('super-light-toolbar full-width-editor light-background');
+    expect(colors.light).toBe('#ffffff');
+    expect(colors.dark).toBe('#485365');
+  });
+
+  it('handles a mix of light and dark toolbar tokens', function () {
+    const colors = toolbarThemeColors('light-toolbar dark-toolbar');
+    expect(colors.light).toBe('#f2f3f4');
+    expect(colors.dark).toBe('#576273');
+  });
+});

--- a/src/tests/backend-new/specs/SkinColors.ts
+++ b/src/tests/backend-new/specs/SkinColors.ts
@@ -1,28 +1,38 @@
-import {DARK_MODE_TOOLBAR_COLOR, configuredToolbarColor} from "../../../node/utils/SkinColors";
+import {configuredToolbarColor} from "../../../node/utils/SkinColors";
 import {expect, describe, it} from "vitest";
 
-describe('SkinColors.DARK_MODE_TOOLBAR_COLOR', function () {
-  it('matches the super-dark-toolbar color forced by client-side dark mode', function () {
-    // pad.ts swaps to super-dark-toolbar on dark OS, so the dark theme-color
-    // must match that fixed value, not whatever was configured in skinVariants.
-    expect(DARK_MODE_TOOLBAR_COLOR).toBe('#485365');
-  });
-});
-
 describe('SkinColors.configuredToolbarColor', function () {
-  it('returns the default light color when no toolbar token is set', function () {
-    expect(configuredToolbarColor('')).toBe('#ffffff');
-    expect(configuredToolbarColor(null)).toBe('#ffffff');
-    expect(configuredToolbarColor('full-width-editor')).toBe('#ffffff');
+  it('returns null for non-colibris skins so the meta is omitted', function () {
+    expect(configuredToolbarColor('no-skin', 'super-light-toolbar')).toBeNull();
+    expect(configuredToolbarColor(null, 'super-light-toolbar')).toBeNull();
+    expect(configuredToolbarColor('custom-skin', 'dark-toolbar')).toBeNull();
   });
 
-  it('returns the configured light toolbar color', function () {
-    expect(configuredToolbarColor('super-light-toolbar super-light-editor')).toBe('#ffffff');
-    expect(configuredToolbarColor('light-toolbar')).toBe('#f2f3f4');
+  it('returns the colibris default when no toolbar token is set', function () {
+    expect(configuredToolbarColor('colibris', '')).toBe('#ffffff');
+    expect(configuredToolbarColor('colibris', null)).toBe('#ffffff');
+    expect(configuredToolbarColor('colibris', 'full-width-editor')).toBe('#ffffff');
   });
 
-  it('returns the configured dark toolbar color', function () {
-    expect(configuredToolbarColor('dark-toolbar dark-editor')).toBe('#576273');
-    expect(configuredToolbarColor('super-dark-toolbar')).toBe('#485365');
+  it('maps each *-toolbar token to its colibris --bg-color', function () {
+    expect(configuredToolbarColor('colibris', 'super-light-toolbar')).toBe('#ffffff');
+    expect(configuredToolbarColor('colibris', 'light-toolbar')).toBe('#f2f3f4');
+    expect(configuredToolbarColor('colibris', 'super-dark-toolbar')).toBe('#485365');
+    expect(configuredToolbarColor('colibris', 'dark-toolbar')).toBe('#576273');
+  });
+
+  it('respects CSS source order when multiple toolbar tokens are present', function () {
+    // pad-variants.css declares dark-toolbar last, so it wins on tie regardless of token order.
+    expect(configuredToolbarColor('colibris', 'super-light-toolbar dark-toolbar')).toBe('#576273');
+    expect(configuredToolbarColor('colibris', 'dark-toolbar super-light-toolbar')).toBe('#576273');
+    // super-dark-toolbar precedes dark-toolbar in CSS, so dark wins when both are present.
+    expect(configuredToolbarColor('colibris', 'super-dark-toolbar dark-toolbar')).toBe('#576273');
+    // super-dark-toolbar wins over light-toolbar.
+    expect(configuredToolbarColor('colibris', 'light-toolbar super-dark-toolbar')).toBe('#485365');
+  });
+
+  it('ignores unrelated tokens', function () {
+    expect(configuredToolbarColor('colibris', 'super-light-toolbar full-width-editor light-background'))
+        .toBe('#ffffff');
   });
 });

--- a/src/tests/backend-new/specs/SkinColors.ts
+++ b/src/tests/backend-new/specs/SkinColors.ts
@@ -1,4 +1,4 @@
-import {toolbarThemeColors} from "../../../node/utils/SkinColors";
+import {toolbarThemeColors, configuredToolbarColor} from "../../../node/utils/SkinColors";
 import {expect, describe, it} from "vitest";
 
 describe('SkinColors.toolbarThemeColors', function () {
@@ -38,5 +38,23 @@ describe('SkinColors.toolbarThemeColors', function () {
     const colors = toolbarThemeColors('light-toolbar dark-toolbar');
     expect(colors.light).toBe('#f2f3f4');
     expect(colors.dark).toBe('#576273');
+  });
+});
+
+describe('SkinColors.configuredToolbarColor', function () {
+  it('returns the default light color when no toolbar token is set', function () {
+    expect(configuredToolbarColor('')).toBe('#ffffff');
+    expect(configuredToolbarColor(null)).toBe('#ffffff');
+    expect(configuredToolbarColor('full-width-editor')).toBe('#ffffff');
+  });
+
+  it('returns the configured light toolbar color', function () {
+    expect(configuredToolbarColor('super-light-toolbar super-light-editor')).toBe('#ffffff');
+    expect(configuredToolbarColor('light-toolbar')).toBe('#f2f3f4');
+  });
+
+  it('returns the configured dark toolbar color', function () {
+    expect(configuredToolbarColor('dark-toolbar dark-editor')).toBe('#576273');
+    expect(configuredToolbarColor('super-dark-toolbar')).toBe('#485365');
   });
 });

--- a/src/tests/backend/specs/specialpages.ts
+++ b/src/tests/backend/specs/specialpages.ts
@@ -54,4 +54,59 @@ describe(__filename, function () {
         .expect(200);
     });
   });
+
+  describe('theme-color meta', function () {
+    const backupVariants:MapArrayType<any> = {};
+    beforeEach(function () {
+      backupVariants.skinVariants = settings.skinVariants;
+      backupVariants.enableDarkMode = settings.enableDarkMode;
+    });
+    afterEach(function () {
+      settings.skinVariants = backupVariants.skinVariants;
+      settings.enableDarkMode = backupVariants.enableDarkMode;
+    });
+
+    it('pad page emits theme-color matching the configured toolbar', async function () {
+      settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
+      settings.enableDarkMode = true;
+      const res = await agent.get('/p/testpad').expect(200);
+      assert.match(
+          res.text,
+          /<meta name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)">/);
+      assert.match(
+          res.text,
+          /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
+    });
+
+    it('pad page omits dark theme-color when dark mode is disabled', async function () {
+      settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
+      settings.enableDarkMode = false;
+      const res = await agent.get('/p/testpad').expect(200);
+      assert.match(
+          res.text,
+          /<meta name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)">/);
+      assert.doesNotMatch(res.text, /prefers-color-scheme: dark/);
+    });
+
+    it('pad page picks up an explicit dark toolbar variant', async function () {
+      settings.skinVariants = 'dark-toolbar dark-editor dark-background';
+      settings.enableDarkMode = true;
+      const res = await agent.get('/p/testpad').expect(200);
+      assert.match(
+          res.text,
+          /<meta name="theme-color" content="#576273" media="\(prefers-color-scheme: dark\)">/);
+    });
+
+    it('timeslider page emits theme-color', async function () {
+      settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
+      settings.enableDarkMode = true;
+      const res = await agent.get('/p/testpad/timeslider').expect(200);
+      assert.match(
+          res.text,
+          /<meta name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)">/);
+      assert.match(
+          res.text,
+          /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
+    });
+  });
 });

--- a/src/tests/backend/specs/specialpages.ts
+++ b/src/tests/backend/specs/specialpages.ts
@@ -86,13 +86,18 @@ describe(__filename, function () {
       assert.doesNotMatch(res.text, /prefers-color-scheme/);
     });
 
-    it('pad page picks up an explicit dark toolbar variant', async function () {
+    it('pad page baseline theme-color tracks an explicit dark toolbar variant', async function () {
       settings.skinVariants = 'dark-toolbar dark-editor dark-background';
       settings.enableDarkMode = true;
       const res = await agent.get('/p/testpad').expect(200);
+      // Baseline meta matches the configured toolbar (#576273 = dark-toolbar) so
+      // light-OS users see the right color.
+      assert.match(res.text, /<meta name="theme-color" content="#576273">/);
+      // The dark media-query meta is hardcoded to super-dark because pad.ts
+      // forces super-dark-toolbar on dark-OS clients regardless of skinVariants.
       assert.match(
           res.text,
-          /<meta name="theme-color" content="#576273" media="\(prefers-color-scheme: dark\)">/);
+          /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
     });
 
     it('timeslider page emits a single theme-color matching the configured toolbar', async function () {

--- a/src/tests/backend/specs/specialpages.ts
+++ b/src/tests/backend/specs/specialpages.ts
@@ -97,16 +97,21 @@ describe(__filename, function () {
           /<meta name="theme-color" content="#576273" media="\(prefers-color-scheme: dark\)">/);
     });
 
-    it('timeslider page emits theme-color', async function () {
+    it('timeslider page emits a single theme-color matching the configured toolbar', async function () {
       settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
       settings.enableDarkMode = true;
       const res = await agent.get('/p/testpad/timeslider').expect(200);
-      assert.match(
-          res.text,
-          /<meta name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)">/);
-      assert.match(
-          res.text,
-          /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
+      assert.match(res.text, /<meta name="theme-color" content="#ffffff">/);
+      // No prefers-color-scheme variants — timeslider does not switch skin variants on OS theme.
+      assert.doesNotMatch(res.text, /prefers-color-scheme/);
+    });
+
+    it('timeslider page picks up an explicitly dark configured toolbar', async function () {
+      settings.skinVariants = 'super-dark-toolbar super-dark-editor dark-background';
+      settings.enableDarkMode = true;
+      const res = await agent.get('/p/testpad/timeslider').expect(200);
+      assert.match(res.text, /<meta name="theme-color" content="#485365">/);
+      assert.doesNotMatch(res.text, /prefers-color-scheme/);
     });
   });
 });

--- a/src/tests/backend/specs/specialpages.ts
+++ b/src/tests/backend/specs/specialpages.ts
@@ -70,9 +70,9 @@ describe(__filename, function () {
       settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
       settings.enableDarkMode = true;
       const res = await agent.get('/p/testpad').expect(200);
-      assert.match(
-          res.text,
-          /<meta name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)">/);
+      // Unconditional light theme-color so dark-OS users with dark mode disabled
+      // still match the (light) toolbar.
+      assert.match(res.text, /<meta name="theme-color" content="#ffffff">/);
       assert.match(
           res.text,
           /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
@@ -82,10 +82,8 @@ describe(__filename, function () {
       settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
       settings.enableDarkMode = false;
       const res = await agent.get('/p/testpad').expect(200);
-      assert.match(
-          res.text,
-          /<meta name="theme-color" content="#ffffff" media="\(prefers-color-scheme: light\)">/);
-      assert.doesNotMatch(res.text, /prefers-color-scheme: dark/);
+      assert.match(res.text, /<meta name="theme-color" content="#ffffff">/);
+      assert.doesNotMatch(res.text, /prefers-color-scheme/);
     });
 
     it('pad page picks up an explicit dark toolbar variant', async function () {

--- a/src/tests/backend/specs/specialpages.ts
+++ b/src/tests/backend/specs/specialpages.ts
@@ -56,65 +56,53 @@ describe(__filename, function () {
   });
 
   describe('theme-color meta', function () {
-    const backupVariants:MapArrayType<any> = {};
+    const backups:MapArrayType<any> = {};
     beforeEach(function () {
-      backupVariants.skinVariants = settings.skinVariants;
-      backupVariants.enableDarkMode = settings.enableDarkMode;
+      backups.skinName = settings.skinName;
+      backups.skinVariants = settings.skinVariants;
     });
     afterEach(function () {
-      settings.skinVariants = backupVariants.skinVariants;
-      settings.enableDarkMode = backupVariants.enableDarkMode;
+      settings.skinName = backups.skinName;
+      settings.skinVariants = backups.skinVariants;
     });
 
-    it('pad page emits theme-color matching the configured toolbar', async function () {
+    it('pad page emits theme-color matching the configured colibris toolbar', async function () {
+      settings.skinName = 'colibris';
       settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
-      settings.enableDarkMode = true;
-      const res = await agent.get('/p/testpad').expect(200);
-      // Unconditional light theme-color so dark-OS users with dark mode disabled
-      // still match the (light) toolbar.
-      assert.match(res.text, /<meta name="theme-color" content="#ffffff">/);
-      assert.match(
-          res.text,
-          /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
-    });
-
-    it('pad page omits dark theme-color when dark mode is disabled', async function () {
-      settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
-      settings.enableDarkMode = false;
       const res = await agent.get('/p/testpad').expect(200);
       assert.match(res.text, /<meta name="theme-color" content="#ffffff">/);
+      // No media-query variants — runtime dark-mode also depends on localStorage,
+      // which a server-rendered media query cannot account for.
       assert.doesNotMatch(res.text, /prefers-color-scheme/);
     });
 
-    it('pad page baseline theme-color tracks an explicit dark toolbar variant', async function () {
+    it('pad page tracks an explicit dark toolbar variant', async function () {
+      settings.skinName = 'colibris';
       settings.skinVariants = 'dark-toolbar dark-editor dark-background';
-      settings.enableDarkMode = true;
       const res = await agent.get('/p/testpad').expect(200);
-      // Baseline meta matches the configured toolbar (#576273 = dark-toolbar) so
-      // light-OS users see the right color.
       assert.match(res.text, /<meta name="theme-color" content="#576273">/);
-      // The dark media-query meta is hardcoded to super-dark because pad.ts
-      // forces super-dark-toolbar on dark-OS clients regardless of skinVariants.
-      assert.match(
-          res.text,
-          /<meta name="theme-color" content="#485365" media="\(prefers-color-scheme: dark\)">/);
     });
 
-    it('timeslider page emits a single theme-color matching the configured toolbar', async function () {
-      settings.skinVariants = 'super-light-toolbar super-light-editor light-background';
-      settings.enableDarkMode = true;
-      const res = await agent.get('/p/testpad/timeslider').expect(200);
-      assert.match(res.text, /<meta name="theme-color" content="#ffffff">/);
-      // No prefers-color-scheme variants — timeslider does not switch skin variants on OS theme.
-      assert.doesNotMatch(res.text, /prefers-color-scheme/);
+    it('pad page omits theme-color for non-colibris skins', async function () {
+      settings.skinName = 'no-skin';
+      settings.skinVariants = 'super-light-toolbar';
+      const res = await agent.get('/p/testpad').expect(200);
+      assert.doesNotMatch(res.text, /theme-color/);
     });
 
-    it('timeslider page picks up an explicitly dark configured toolbar', async function () {
+    it('timeslider page emits theme-color matching the configured toolbar', async function () {
+      settings.skinName = 'colibris';
       settings.skinVariants = 'super-dark-toolbar super-dark-editor dark-background';
-      settings.enableDarkMode = true;
       const res = await agent.get('/p/testpad/timeslider').expect(200);
       assert.match(res.text, /<meta name="theme-color" content="#485365">/);
       assert.doesNotMatch(res.text, /prefers-color-scheme/);
+    });
+
+    it('timeslider page omits theme-color for non-colibris skins', async function () {
+      settings.skinName = 'no-skin';
+      settings.skinVariants = 'super-light-toolbar';
+      const res = await agent.get('/p/testpad/timeslider').expect(200);
+      assert.doesNotMatch(res.text, /theme-color/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #7606.

Mobile browsers paint the address-bar / status-bar strip above the viewport using a system color when `<meta name="theme-color">` is absent, leaving a visible gap above the Etherpad toolbar. This PR renders `theme-color` server-side so the bar blends into the configured toolbar from the first paint.

- New `src/node/utils/SkinColors.ts` resolves the colibris `*-toolbar` skin variants to the `--bg-color` values declared in `colibris/src/pad-variants.css`. Iteration order matches the CSS source so the last applicable token wins, mirroring the cascade.
- The helper returns `null` for non-colibris skins (`no-skin`, third-party skins) since their toolbar colors aren't known server-side; the templates then omit the meta rather than emit a misleading value.
- `pad.html` and `timeslider.html` emit a single unconditional `<meta name="theme-color">` when the helper returns a color. No `prefers-color-scheme` media-query variants — the runtime dark-mode auto-switch in `pad.ts` is also gated on a localStorage white-mode override that a media query cannot express, so any media-query variant would risk painting a dark address bar over a still-light toolbar.
- Backend tests in `specialpages.ts` cover the rendered metas and the non-colibris skip path; vitest unit tests cover the helper.

## Semver

`patch` — additive HTML metadata, no behavior change for existing clients.

## Test plan

- [ ] Open a pad on a mobile device / Chromium devtools mobile emulator and confirm the address bar matches the toolbar.
- [ ] Configure `skinVariants` with `dark-toolbar`; confirm the address bar matches the dark toolbar.
- [ ] Configure `skinName: "no-skin"`; confirm the page renders with no `theme-color` meta.
- [ ] cd src && pnpm test -- tests/backend/specs/specialpages.ts
- [ ] cd src && pnpm test:vitest tests/backend-new/specs/SkinColors.ts

Generated with Claude Code