### PR TITLE
ci: test ep_font_color and ep_hash_auth in with-plugins matrix

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -126,7 +126,9 @@ jobs:
           ep_align
           ep_author_hover
           ep_cursortrace
+          ep_font_color
           ep_font_size
+          ep_hash_auth
           ep_headings2
           ep_markdown
           ep_readonly_guest
@@ -238,7 +240,9 @@ jobs:
           ep_align
           ep_author_hover
           ep_cursortrace
+          ep_font_color
           ep_font_size
+          ep_hash_auth
           ep_headings2
           ep_markdown
           ep_readonly_guest

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -217,7 +217,9 @@ jobs:
           pnpm add -w
           ep_align
           ep_author_hover
+          ep_font_color
           ep_font_size
+          ep_hash_auth
           ep_headings2
           ep_markdown
           ep_readonly_guest
@@ -305,7 +307,9 @@ jobs:
           pnpm add -w
           ep_align
           ep_author_hover
+          ep_font_color
           ep_font_size
+          ep_hash_auth
           ep_headings2
           ep_markdown
           ep_readonly_guest

--- a/src/tests/frontend-new/specs/change_user_color.spec.ts
+++ b/src/tests/frontend-new/specs/change_user_color.spec.ts
@@ -84,6 +84,11 @@ test.describe('change user color', function () {
 
 
     await $colorPickerSave.click();
+    // Close the users popup so it stops intercepting pointer events on #chaticon.
+    // Without this, in the with-plugins matrix the popup overlaps the chat icon
+    // and showChat() retries clicks until it times out.
+    await $userButton.click();
+    await expect(page.locator('#users')).not.toHaveClass(/popup-show/);
     // click on the chat button to make chat visible
     await showChat(page)
     await sendChatMessage(page, 'O hi');


### PR DESCRIPTION
## Summary
- Adds `ep_font_color` (#12 by npm last-30d downloads, ~16.3k) and `ep_hash_auth` (#14, ~10.5k) to all four plugin install lists: `withpluginsLinux` / `withpluginsWindows` in backend-tests, and both Playwright with-plugins jobs in frontend-tests.
- These were the only top-15 plugins not already covered. Existing coverage already includes #1–#11; this closes the remaining gaps that don't require special test setup. (`ep_webrtc`, #13, is being stabilized separately and is intentionally excluded for now.)
- Also fixes a pre-existing flake in `change_user_color.spec.ts` ("Own user color is shown when you enter a chat") that surfaced under the broader plugin matrix: the test left the `#users` popup open, which overlapped `#chaticon` and made `showChat()` retry-click for the full 90s × 5 retries until the suite timed out. Now the popup is explicitly toggled closed before opening chat (matching the close pattern used in `a11y_dialogs.spec.ts`).

## Why these two
- `ep_font_color` exercises `aceEditorCSS` / `aceAttribsToClasses` — same plugin family as the already-tested `ep_font_size`, `ep_align`.
- `ep_hash_auth` exercises `authenticate` / `handleMessage`, which no other plugin in the matrix touches. Its `authenticate` hook is a no-op unless a `Basic` header is sent **and** `settings.users[user].hash` exists, so it falls through cleanly under the default test settings — no test config changes needed.

## Semver
patch — CI-only change, no runtime/user-facing impact.

## Test plan
- [ ] `withpluginsLinux` (Node 22/24/25) green
- [ ] `withpluginsWindows` (Node 22/24/25) green
- [ ] Playwright Chrome with plugins green
- [ ] Playwright Firefox with plugins green

🤖 Generated with [Claude Code](https://claude.com/claude-code)