### PR TITLE
fix(docs): replace dead privacy.md link with GitHub URL

### DIFF
--- a/doc/privacy.md
+++ b/doc/privacy.md
@@ -56,6 +56,6 @@ See [`cookies.md`](cookies.md) for the full cookie list.
 ## Right to erasure
 
 See
-[`../docs/superpowers/specs/2026-04-18-gdpr-pr1-deletion-controls-design.md`](../docs/superpowers/specs/2026-04-18-gdpr-pr1-deletion-controls-design.md)
+[`docs/superpowers/specs/2026-04-18-gdpr-pr1-deletion-controls-design.md`](https://github.com/ether/etherpad/blob/develop/docs/superpowers/specs/2026-04-18-gdpr-pr1-deletion-controls-design.md)
 for the deletion-token mechanism. Full author erasure is tracked as a
 follow-up in [ether/etherpad#6701](https://github.com/ether/etherpad/issues/6701).


### PR DESCRIPTION
## Summary
- PR #7546 added a relative link in `doc/privacy.md` to `../docs/superpowers/specs/2026-04-18-gdpr-pr1-deletion-controls-design.md`. That spec file lives outside vitepress's `doc/` source root, so VitePress flags it as a dead link and the **Deploy Docs to GitHub Pages** workflow on develop fails:
  > `Found dead link ./../docs/superpowers/specs/2026-04-18-gdpr-pr1-deletion-controls-design in file doc/privacy.md` → `Error: 1 dead link(s) found.`
- Repoint the link at the file on GitHub so the published site resolves it and readers can still find the spec.
- Follows up #7640 (the docs build now reaches the dead-link check thanks to that fix).

## Test plan
- [x] `pnpm run docs:build` succeeds locally (`build complete in 2.29s`)
- [ ] CI: **Deploy Docs to GitHub Pages** turns green on develop after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)