### PR TITLE
ci(docs): build on PRs and pin Node 22 (Qodo follow-up to #7640)

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -1,42 +1,38 @@
-# Workflow for deploying static content to GitHub Pages
+# Workflow for building and deploying the VitePress site to GitHub Pages.
+# Build runs on every push to develop and on every PR that touches docs (so
+# a build regression is caught at review time instead of breaking develop
+# after merge — see #7640). Deploy runs only on push: the github-pages
+# environment has protection rules that reject PR refs, and a PR build
+# never produced an artifact to deploy anyway.
 name: Deploy Docs to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["develop"]
     paths:
-      - doc/** # Only run workflow when changes are made to the doc directory
+      - doc/**
       - .github/workflows/build-and-deploy-docs.yml
-  # Build (but do not deploy) on PRs that touch docs or this workflow, so that
-  # a docs-build regression is caught at PR review time instead of breaking
-  # develop after merge — see #7640.
   pull_request:
     paths:
       - doc/**
       - .github/workflows/build-and-deploy-docs.yml
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
   packages: read
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do NOT cancel in-progress runs — production
+# deployments are allowed to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -84,9 +80,20 @@ jobs:
         if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v5
         with:
-          # Upload entire repository
           path: './doc/.vitepress/dist'
+
+  # Deploy to GitHub Pages on push to develop only. Kept as a separate job
+  # because the github-pages environment's protection rules reject any
+  # non-develop ref (including PR merge refs), which used to fail the entire
+  # workflow at job-creation time before any build step could run.
+  deploy:
+    needs: build
+    if: github.event_name == 'push'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -7,6 +7,14 @@ on:
     branches: ["develop"]
     paths:
       - doc/** # Only run workflow when changes are made to the doc directory
+      - .github/workflows/build-and-deploy-docs.yml
+  # Build (but do not deploy) on PRs that touch docs or this workflow, so that
+  # a docs-build regression is caught at PR review time instead of breaking
+  # develop after merge — see #7640.
+  pull_request:
+    paths:
+      - doc/**
+      - .github/workflows/build-and-deploy-docs.yml
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -52,7 +60,17 @@ jobs:
         with:
           version: 10.33.2
           run_install: false
+      # Pin Node so the build does not silently fall back to whatever the
+      # runner image ships with. oxc-minify (a vitepress peer when
+      # rolldown-vite is in use) requires Node ^20.19.0 || >=22.12.0; the
+      # repo declares engines.node >=22.12.0 to match.
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
       - name: Setup Pages
+        if: github.event_name == 'push'
         uses: actions/configure-pages@v6
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -60,12 +78,15 @@ jobs:
         working-directory: doc
         run: pnpm run docs:build
         env:
+          GITHUB_PAGES: ${{ github.event_name == 'push' && 'true' || '' }}
           COMMIT_REF: ${{ github.sha }}
       - name: Upload artifact
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
           path: './doc/.vitepress/dist'
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking changes
 
-- **Minimum required Node.js version is now 22.** Node.js 20 is reaching end-of-life (see https://nodejs.org/en/about/previous-releases). The CI matrix now targets Node 22, 24, and 25. Upgrading should be straightforward — install a current Node.js release before updating Etherpad.
+- **Minimum required Node.js version is now 22.12.** Node.js 20 is reaching end-of-life (see https://nodejs.org/en/about/previous-releases) and the docs build's `oxc-minify` peer requires `^20.19.0 || >=22.12.0`. The CI matrix now targets Node 22, 24, and 25. Upgrading should be straightforward — install a current Node.js release before updating Etherpad.
 
 ### Notable enhancements
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ volumes:
 
 ### Requirements
 
-[Node.js](https://nodejs.org/) >= 22.
+[Node.js](https://nodejs.org/) >= 22.12.
 
 ### Windows, macOS, Linux
 

--- a/doc/npm-trusted-publishing.md
+++ b/doc/npm-trusted-publishing.md
@@ -85,9 +85,10 @@ If a package previously had an `NPM_TOKEN` secret in CI:
 
 ## Requirements
 
-- **Node.js**: >= 22 on the runner. npm 11 requires `>=22.9.0`, which
-  `setup-node@v6 with version: 22` satisfies (resolves to the latest 22.x).
-  The project's `engines.node` requires `>=22.0.0`.
+- **Node.js**: >= 22.12 on the runner. npm 11 requires `>=22.9.0` and
+  `oxc-minify` (a vitepress peer for the docs build) requires `>=22.12.0`,
+  both of which `setup-node@v6 with version: 22` satisfies (resolves to the
+  latest 22.x). The project's `engines.node` requires `>=22.12.0`.
 - **npm CLI**: >= 11.5.1. The publish workflow runs `npm install -g npm@latest`
   before publishing so the bundled npm version doesn't matter.
 - **Runner**: must be a GitHub-hosted (cloud) runner. Self-hosted runners are

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ui": "link:ui"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Follow-up to #7640 addressing the two Qodo comments on that PR (which is already merged, hence a separate PR rather than a fix-up).

**1. Docs build did not run on PRs.** The Deploy Docs to GitHub Pages workflow only triggered on push to `develop`, so any PR that broke `pnpm run docs:build` was not caught until after merge — exactly how the dead-link regression from #7546 escaped review and forced #7641 as a follow-up. This PR adds a `pull_request` trigger with the same path filters; deploy/upload steps are gated on `if: github.event_name == 'push'` so PRs build-only and never touch GitHub Pages. The workflow file is also added to the path filter so changes to it are exercised on PR.

**2. Node engine inconsistency.** `oxc-minify@0.128.0` (added in #7640 because rolldown-vite requires it) needs Node `^20.19.0 || >=22.12.0`. The repo declared `engines.node: >=22.0.0` with `engineStrict: true`, and the docs workflow did not pin Node — so a runner image (or local dev) on Node 22.0–22.11 would have hit `engineStrict` and refused to install. This PR:
- pins Node 22 in the docs workflow with `actions/setup-node@v6` (matching the rest of CI)
- bumps `engines.node` to `>=22.12.0` so the engineStrict gate matches the actual minimum

## Test plan
- [ ] CI: this PR's own `Deploy Docs to GitHub Pages` run executes the build via the new `pull_request` trigger and stops short of the deploy/upload steps
- [ ] CI: `Backend tests` / `Frontend tests` continue to pass with the pinned Node and bumped engine
- [ ] After merge: the next push to develop still deploys to Pages (the deploy/upload guards only skip on `pull_request`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)