### PR TITLE
feat(admin): surface ep.json disables in /admin plugin browser

### DIFF
--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -229,7 +229,30 @@ export const HomePage = () => {
               filteredInstallablePlugins.map((plugin) => {
                         return <tr key={plugin.name}>
                             <td><a rel="noopener noreferrer" href={`https://npmjs.com/${plugin.name}`} target="_blank">{plugin.name}</a></td>
-                            <td>{plugin.description}</td>
+                            <td>
+                              {plugin.description}
+                              {plugin.disables && plugin.disables.length > 0 && (
+                                <div
+                                  className="plugin-disables"
+                                  title="This plugin intentionally removes the listed Etherpad features."
+                                  style={{
+                                    marginTop: '0.25rem',
+                                    padding: '0.2rem 0.5rem',
+                                    borderRadius: '4px',
+                                    fontSize: '0.85em',
+                                    background: 'rgba(180, 83, 9, 0.15)',
+                                    border: '1px solid rgba(180, 83, 9, 0.4)',
+                                    color: '#92400e',
+                                    display: 'inline-block',
+                                  }}
+                                >
+                                  <strong>Disables: </strong>
+                                  {plugin.disables
+                                      .map((tag) => tag.replace(/^@feature:/, ''))
+                                      .join(', ')}
+                                </div>
+                              )}
+                            </td>
                             <td>{plugin.version}</td>
                             <td>{plugin.time}</td>
                             <td>

--- a/admin/src/pages/Plugin.ts
+++ b/admin/src/pages/Plugin.ts
@@ -4,6 +4,12 @@ export type PluginDef = {
   version: string,
   time: string,
   official: boolean,
+  /**
+   * `@feature:*` Playwright tags for core specs the plugin intentionally
+   * disables. See doc/PLUGIN_FEATURE_DISABLES.md. May be undefined for
+   * plugins without a disables list, which is the common case.
+   */
+  disables?: string[],
 }
 
 

--- a/src/node/types/PackageInfo.ts
+++ b/src/node/types/PackageInfo.ts
@@ -10,7 +10,15 @@ export type PackageInfo =  {
   },
   homepage: string,
   repository: string,
-  path: string
+  path: string,
+  /**
+   * `@feature:*` Playwright tags for core specs the plugin intentionally
+   * disables. Sourced from the plugin's ep.json `disables` array; see
+   * doc/PLUGIN_FEATURE_DISABLES.md for the contract. Populated by the
+   * plugin-registry build pipeline; absent for plugins that don't
+   * declare a disables list.
+   */
+  disables?: string[]
 }
 
 


### PR DESCRIPTION
## Why

Companion to [ether/ether.github.com#395](https://github.com/ether/ether.github.com/pull/395) (already merged) — the etherpad.org/plugins listing surfaces a plugin's declared `disables` so users see what they're losing before installing. The `/admin` plugin browser inside Etherpad itself still shows nothing, so an operator clicking Install can't see the warning.

This PR closes that gap.

## Changes

- **`src/node/types/PackageInfo.ts`** — optional `disables?: string[]` on the registry payload type.
- **`admin/src/pages/Plugin.ts`** — same field on the admin-side `PluginDef`.
- **`admin/src/pages/HomePage.tsx`** — render an amber callout under the plugin description when `disables` is present and non-empty:

  > Disables: chat

  Plugins without the field render unchanged.

## Safe to ship now

The data flow into `plugins.json` (the registry endpoint the admin UI queries via `getAvailablePlugins`) is owned by an external build pipeline. Until that pipeline starts sourcing `disables` from each plugin's `ep.json`, the new callout no-ops everywhere. As `disables` starts populating, the callout lights up automatically — same as on etherpad.org/plugins.

## Test plan
- [x] `tsc --noEmit` clean (admin + core).
- [x] Visual sanity-check the amber callout against a synthetic payload locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)