### PR TITLE
fix(test): make disables helper's pass 2 fail-fast

### DIFF
--- a/bin/run-frontend-tests-with-disables.sh
+++ b/bin/run-frontend-tests-with-disables.sh
@@ -105,12 +105,25 @@ echo "=== Pass 1: regression — tests NOT tagged with disabled features must pa
 pnpm exec playwright test --grep-invert "($GREP_PATTERN)" "${PLAYWRIGHT_ARGS[@]}"
 
 echo
-echo "=== Pass 2: honesty — tests tagged with $DISABLES must FAIL (feature is disabled) ==="
-# Run with --reporter=list so we get test names but suppress the noisy
-# default reporter output for expected failures. Capture the exit code
-# without `set -e` aborting.
+echo "=== Pass 2: honesty — at least one test tagged with $DISABLES must FAIL (feature is disabled) ==="
+# Pass 2 only needs evidence that the disabled feature is genuinely
+# absent — *one* failing tagged test is sufficient proof. Without
+# --max-failures, every tagged test runs to completion (each failing
+# at the per-test timeout, e.g. 90s) which can take 10+ minutes for
+# a busy tag like @feature:chat. --max-failures=1 stops on the first
+# failure (~30s) and --timeout=30000 caps any single test at 30s, so
+# the worst case stays bounded even if the first tagged test
+# unexpectedly passes and we have to wait for the next one to fail.
+# --retries=0 matters too: default CI retries (up to 5 with
+# WITH_PLUGINS=1) would retry an "expected failure" several times.
 set +e
-pnpm exec playwright test --grep "($GREP_PATTERN)" --reporter=list --retries=0 "${PLAYWRIGHT_ARGS[@]}"
+pnpm exec playwright test \
+  --grep "($GREP_PATTERN)" \
+  --reporter=list \
+  --retries=0 \
+  --max-failures=1 \
+  --timeout=30000 \
+  "${PLAYWRIGHT_ARGS[@]}"
 PASS2_EXIT=$?
 set -e
 


### PR DESCRIPTION
Pass 2 was running every test tagged with a disabled feature to completion. For a busy tag like @feature:chat (12 tests) with the default 90s per-test timeout, that's 10+ minutes of expected failures piling up — ep_disable_chat's first PR #75 ran 14+ min before being cancelled.

Pass 2 only needs *evidence* the feature is gone — one failing tagged test is enough. Add:
  --max-failures=1   stop on the first failure (~30s vs ~10min)
  --timeout=30000    cap any single test at 30s
  --retries=0        already there, but flagged: CI retry default
                     (up to 5 with WITH_PLUGINS=1) would retry an
                     "expected failure" multiple times.

Worst case (first tagged test happens to pass): we wait for the second one to fail, ~60s. Still bounded.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
