### PR TITLE
i18n + a11y for admin disables warning

### DIFF
--- a/admin/src/pages/HomePage.tsx
+++ b/admin/src/pages/HomePage.tsx
@@ -234,7 +234,8 @@ export const HomePage = () => {
                               {plugin.disables && plugin.disables.length > 0 && (
                                 <div
                                   className="plugin-disables"
-                                  title="This plugin intentionally removes the listed Etherpad features."
+                                  role="alert"
+                                  title={t('admin_plugins.disables.warning_title')}
                                   style={{
                                     marginTop: '0.25rem',
                                     padding: '0.2rem 0.5rem',
@@ -246,7 +247,7 @@ export const HomePage = () => {
                                     display: 'inline-block',
                                   }}
                                 >
-                                  <strong>Disables: </strong>
+                                  <strong><Trans i18nKey="admin_plugins.disables.label"/></strong>{' '}
                                   {plugin.disables
                                       .map((tag) => tag.replace(/^@feature:/, ''))
                                       .join(', ')}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,6 +7,8 @@
   "admin_plugins.available_install.value": "Install",
   "admin_plugins.available_search.placeholder": "Search for plugins to install",
   "admin_plugins.description": "Description",
+  "admin_plugins.disables.label": "Disables:",
+  "admin_plugins.disables.warning_title": "This plugin intentionally removes the listed Etherpad features.",
   "admin_plugins.installed": "Installed plugins",
   "admin_plugins.installed_fetching": "Fetching installed plugins…",
   "admin_plugins.installed_nothing": "You haven't installed any plugins yet.",


### PR DESCRIPTION
Follow-up to #7649 (already merged). The user's review on that PR asked for i18n on the new "Disables: …" warning in the admin plugin browser, but the request landed after the squash-merge had already gone through, so the i18n commit was orphaned on the deleted branch.

This PR ports it onto develop unchanged:

- `admin/src/pages/HomePage.tsx` — replace hardcoded English label and `title=` attribute with `<Trans i18nKey="admin_plugins.disables.label"/>` and `t('admin_plugins.disables.warning_title')`. Add `role="alert"` so screen readers announce the warning rather than treating it as visual noise.
- `src/locales/en.json` — add the two new keys (other locales pick up via the usual translation flow).

Behaviour is unchanged for English readers; localised builds now actually localise instead of leaking the literal "Disables:" string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)