### PR TITLE
fix(test): disables helper auto-detect must follow symlinks

### DIFF
--- a/bin/run-frontend-tests-with-disables.sh
+++ b/bin/run-frontend-tests-with-disables.sh
@@ -71,12 +71,22 @@ elif [[ -n "$EP_JSON" ]]; then
   DISABLES="$(read_disables_from_json "$EP_JSON")"
 else
   # Auto-detect from plugin_packages/. Skip if 0 or >1 disabling plugins.
+  #
+  # Live-plugin-manager installs plugins under plugin_packages/.versions/
+  # and exposes them as symlinks at plugin_packages/ep_<name>. find(1)
+  # doesn't follow symlinks by default, so iterate via shell glob and
+  # `-f $dir/ep.json` (which DOES resolve symlinks) instead.
   declare -a CANDIDATES=()
   if [[ -d plugin_packages ]]; then
-    while IFS= read -r f; do
+    shopt -s nullglob
+    for dir in plugin_packages/ep_*; do
+      [[ -L "$dir" || -d "$dir" ]] || continue
+      f="$dir/ep.json"
+      [[ -f "$f" ]] || continue
       d="$(read_disables_from_json "$f")"
       [[ -n "$d" ]] && CANDIDATES+=("$d")
-    done < <(find plugin_packages -maxdepth 3 -name ep.json -not -path '*/.versions/*' 2>/dev/null)
+    done
+    shopt -u nullglob
   fi
   if [[ ${#CANDIDATES[@]} -eq 1 ]]; then
     DISABLES="${CANDIDATES[0]}"


### PR DESCRIPTION
Sequel to #7651 (max-failures fix) and the third reason ep_disable_chat#75 was timing out.

**Symptom:** PR opened with \`disables: [\"@feature:chat\"]\` declared in \`ep.json\`, but the helper announced \"No 'disables' declared — running standard test suite\" and exec'd a plain \`playwright test\`, so chat-tagged specs ran anyway, failed at their per-test timeout, and the run timed out at ~14 min.

**Root cause:** the auto-detect used \`find -maxdepth 3 plugin_packages/ -name ep.json -not -path '*/.versions/*'\`. Live-plugin-manager installs plugins under \`plugin_packages/.versions/<name>@<ver>/\` and exposes them as symlinks at \`plugin_packages/ep_<name>\`. \`find(1)\` doesn't follow symlinks by default, so:
- the real \`.versions/<name>@.../ep.json\` was excluded by \`-not -path\`,
- and the symlink at \`plugin_packages/ep_<name>\` was visited but \`find\` didn't recurse into it because it's a symlink, not a directory.

→ 0 candidates → DISABLES empty → helper falls through to standard test mode.

**Fix:** switch to a shell glob with \`[[ -f \$dir/ep.json ]]\` membership checks (which DO resolve symlinks). Verified against a synthetic plugin_packages install: the helper now prints \"Plugin disables: @feature:chat\" before pass 1.

Once this lands, ep_disable_chat#75 retriggers should actually skip chat-tagged tests in pass 1 and pass 2 should fail-fast on the first one. Total runtime ~5 min instead of ~15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)