### PR TITLE
test: tag two chat-toggle pad_settings specs with @feature:chat

### DIFF
--- a/src/tests/frontend-new/specs/pad_settings.spec.ts
+++ b/src/tests/frontend-new/specs/pad_settings.spec.ts
@@ -143,7 +143,9 @@ test.describe('creator-owned pad settings', () => {
         await expect(page.locator('#options-colorscheck')).not.toBeChecked();
       });
 
-  test('disabling chat suppresses chat gritter notifications', async ({page, browser}) => {
+  test('disabling chat suppresses chat gritter notifications', {
+    tag: '@feature:chat',
+  }, async ({page, browser}) => {
     const padId = await goToNewPad(page);
     const context2 = await browser.newContext();
     const page2 = await context2.newPage();
@@ -164,7 +166,9 @@ test.describe('creator-owned pad settings', () => {
   // #7592: ticking "Disable chat" must visibly disable the dependent
   // "Chat always on screen" / "Show Chat and Users" toggles, not just
   // make the underlying inputs non-interactive.
-  test('disabling chat disables and visually greys the dependent chat toggles', async ({page}) => {
+  test('disabling chat disables and visually greys the dependent chat toggles', {
+    tag: '@feature:chat',
+  }, async ({page}) => {
     await goToNewPad(page);
     await showSettings(page);
 


### PR DESCRIPTION
Surfaced by ep_disable_chat#75 (the disables contract PoC). Pass 1 of the disables-aware runner failed on:

- `pad_settings.spec.ts:146 — disabling chat suppresses chat gritter notifications`
- `pad_settings.spec.ts:167 — disabling chat disables and visually greys the dependent chat toggles`

Both click `label[for="options-disablechat"]` — the "Disable chat" toggle that ep_disable_chat removes from the UI by design. Tagging them with `@feature:chat` lets them be excluded from pass 1 (regression — they SHOULDN'T run when chat is removed) and counted in pass 2 (honesty — they should fail).

Without these tags, ep_disable_chat (and any future chat-removing plugin) cannot ship green CI even with a correct `disables` declaration. Pure follow-up to the upstream tagging in #7648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)