### PR TITLE
test: add @feature:authorship-bg-color tag for plugins that re-render authorship

### DIFF
--- a/src/tests/frontend-new/specs/change_user_color.spec.ts
+++ b/src/tests/frontend-new/specs/change_user_color.spec.ts
@@ -57,7 +57,13 @@ test.describe('change user color', function () {
     });
 
   test('Own user color is shown when you enter a chat', {
-    tag: '@feature:chat',
+    // Asserts the user's colour appears as the chat <p> background. Plugins
+    // that re-render authorship as something other than a background (e.g.
+    // ep_author_neat2 swaps the colour-block for an underline) legitimately
+    // make this assertion stop holding, so they declare
+    // `@feature:authorship-bg-color` in their ep.json `disables` list and
+    // the test is excluded from their pass-1 regression run.
+    tag: ['@feature:chat', '@feature:authorship-bg-color'],
   }, async function ({page}) {
 
     const colorOption = page.locator('#options-colorscheck');


### PR DESCRIPTION
Follow-up to #7648 / #7655 — extends the disables contract to cover plugins that swap Etherpad's coloured-background authorship indicator for something else (`ep_author_neat2` uses underlines).

## Why

`change_user_color.spec.ts:59` hard-asserts:

```ts
const color = await chatP.evaluate((el) =>
  window.getComputedStyle(el).getPropertyValue('background-color'));
expect(color).toBe(testColorRGB);
```

That assertion is correct for stock Etherpad but legitimately false under any plugin that swaps the colour-block rendering (per ep_author_neat2's README: *"uses colored underlines instead of colored backgrounds to indicate authorship"*). Without a tag, those plugins can't pass the disables-aware test runner.

## Change

Adds a second tag alongside the existing `@feature:chat`:

```ts
tag: ['@feature:chat', '@feature:authorship-bg-color'],
```

ep_author_neat2 will declare `"disables": ["@feature:authorship-bg-color"]` in its ep.json. ep_disable_chat continues to exclude it via the existing `@feature:chat` tag (multi-tag tests are excluded if **any** of their tags match `--grep-invert`).

Verified locally: `playwright test --list --grep '@feature:authorship-bg-color'` returns exactly the one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)