### PR TITLE
test: add @feature:line-numbers tag for plugins that hide line numbers

### DIFF
--- a/src/tests/frontend-new/specs/pad_settings.spec.ts
+++ b/src/tests/frontend-new/specs/pad_settings.spec.ts
@@ -28,7 +28,9 @@ test.describe('creator-owned pad settings', () => {
     await context2.close();
   });
 
-  test('pad settings act as defaults until enforcement is enabled', async ({page, browser}) => {
+  test('pad settings act as defaults until enforcement is enabled', {
+    tag: '@feature:line-numbers',
+  }, async ({page, browser}) => {
     const padId = await goToNewPad(page);
 
     const context2 = await browser.newContext();
@@ -122,7 +124,9 @@ test.describe('creator-owned pad settings', () => {
         await context2.close();
       });
 
-  test('uses My View defaults for newly created pads without changing an existing pad default',
+  test('uses My View defaults for newly created pads without changing an existing pad default', {
+    tag: '@feature:line-numbers',
+  },
       async ({page}) => {
         await goToNewPad(page);
         const creatorOuter = page.frameLocator('iframe[name="ace_outer"]').locator('#outerdocbody');


### PR DESCRIPTION
Surfaced by [ep_hide_line_numbers](https://github.com/ether/ep_hide_line_numbers)' red main on the disables-aware test runner.

Two pad_settings specs use `expect(...).not.toHaveClass(/line-numbers-hidden/)` to verify the line-number gutter is visible by default before settings flip it on. Plugins that hide line numbers (ep_hide_line_numbers calls `pad.changeViewOption('showLineNumbers', false)` in postAceInit) keep that class on the body for the entire pad lifetime, so those negative assertions can never hold.

## Change

Adds `@feature:line-numbers` tag to:
- `pad_settings.spec.ts:31` — *pad settings act as defaults until enforcement is enabled*
- `pad_settings.spec.ts:125` — *uses My View defaults for newly created pads without changing an existing pad default*

ep_hide_line_numbers will declare `"disables": ["@feature:line-numbers"]` in ep.json so these are excluded from pass-1 regression and counted in pass-2 honesty.

Note: ep_hide_line_numbers also fails on `rtl_url_param.spec.ts:11/16` for an apparently unrelated reason (the RTL checkbox stays unchecked when both `?rtl=true` and the plugin's `changeViewOption` are in flight). That's a real plugin/core interaction bug, not a feature exclusion — handled separately.

Companion to existing tags (`@feature:chat`, `@feature:username`, `@feature:clear-authorship`, `@feature:error-gritter`, `@feature:authorship-bg-color`). See [`doc/PLUGIN_FEATURE_DISABLES.md`](https://github.com/ether/etherpad-lite/blob/develop/doc/PLUGIN_FEATURE_DISABLES.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)