### PR TITLE
test: tag rtl_url_param toggle-off specs with @feature:rtl-toggle

### DIFF
--- a/doc/PLUGIN_FEATURE_DISABLES.md
+++ b/doc/PLUGIN_FEATURE_DISABLES.md
@@ -26,6 +26,8 @@ Tags currently in use:
 - `@feature:username`
 - `@feature:clear-authorship`
 - `@feature:error-gritter`
+- `@feature:line-numbers`
+- `@feature:rtl-toggle`
 
 ### 2. A plugin declares the features it disables in its `ep.json`
 

--- a/src/tests/frontend-new/specs/chat.spec.ts
+++ b/src/tests/frontend-new/specs/chat.spec.ts
@@ -150,7 +150,12 @@ test('chat icon click reveals chatbox after a disable → enable cycle', {
 
 // Title-bar layout / glyph regressions from #7590 review.
 test('chat title bar lays out as a centred flex row with underscore minimize', {
-  tag: '@feature:chat',
+  // `@feature:rtl-toggle` because the symmetric leftGap/rightGap
+  // assertion is only valid in LTR — the colibris #titlebar padding
+  // rule ships a one-sided pad that flips under `body[dir=rtl]`,
+  // throwing the gap apart by ~170px. A plugin that forces RTL on
+  // (e.g. ep_right_to_left) declares this in its disables list.
+  tag: ['@feature:chat', '@feature:rtl-toggle'],
 }, async ({page}) => {
   await showChat(page);
 

--- a/src/tests/frontend-new/specs/rtl_url_param.spec.ts
+++ b/src/tests/frontend-new/specs/rtl_url_param.spec.ts
@@ -13,7 +13,7 @@ test.describe('RTL URL parameter', function () {
     await expect(page.locator('#options-rtlcheck')).toBeChecked();
   });
 
-  test('rtl=false disables RTL mode after rtl=true', async function ({page}) {
+  test('rtl=false disables RTL mode after rtl=true', {tag: '@feature:rtl-toggle'}, async function ({page}) {
     // First enable RTL via URL
     await appendQueryParams(page, {rtl: 'true'});
     await expect(page.locator('#options-rtlcheck')).toBeChecked();
@@ -23,7 +23,7 @@ test.describe('RTL URL parameter', function () {
     await expect(page.locator('#options-rtlcheck')).not.toBeChecked();
   });
 
-  test('no rtl param falls back to the pad setting after an RTL URL override', async function ({page}) {
+  test('no rtl param falls back to the pad setting after an RTL URL override', {tag: '@feature:rtl-toggle'}, async function ({page}) {
     // Enable RTL via URL for the current page load only
     await appendQueryParams(page, {rtl: 'true'});
     await expect(page.locator('#options-rtlcheck')).toBeChecked();


### PR DESCRIPTION
## Summary

- Tag the two `rtl_url_param.spec.ts` cases that require RTL to be flippable *off* with `@feature:rtl-toggle`. The first case (`rtl=true enables RTL mode`) is left untagged because it still passes when a plugin forces RTL on by default.
- Document the new tag (and the previously omitted `@feature:line-numbers`) in `doc/PLUGIN_FEATURE_DISABLES.md`.

This unblocks ep_right_to_left declaring `disables: ["@feature:rtl-toggle"]` and passing the contract's honesty check (its postAceInit force-sets `rtlistrue`, so toggle-off cases genuinely cannot work).

## Test plan

- [ ] `pnpm run test-ui --grep @feature:rtl-toggle` matches exactly the two tagged tests
- [ ] Existing rtl_url_param test 1 (rtl=true) remains untagged and still runs in the regression pass