### PR TITLE
test: tag wcag_author_color describe with @feature:authorship-bg-color

### DIFF
--- a/src/tests/frontend-new/specs/wcag_author_color.spec.ts
+++ b/src/tests/frontend-new/specs/wcag_author_color.spec.ts
@@ -50,7 +50,17 @@ const renderedAuthorContrast = async (page: Page) => {
   return result;
 };
 
-test.describe('WCAG author colour (issue #7377)', () => {
+// `@feature:authorship-bg-color` because every assertion here measures the
+// author span's `background-color` against its computed text colour. Plugins
+// that disable the author *background* colouring entirely — e.g.
+// ep_author_neat2, which switches to coloured underlines — can't satisfy the
+// WCAG bg/text contrast invariant (there's no background to measure). Those
+// plugins declare `disables: ["@feature:authorship-bg-color"]` and the
+// disables contract excludes this describe block from their pass-1 regression
+// run.
+test.describe('WCAG author colour (issue #7377)', {
+  tag: '@feature:authorship-bg-color',
+}, () => {
   test('issue scenario: #9AB3FA renders >= AA against the author text', async ({page}) => {
     await setUserColor(page, '#9AB3FA');
     const r = await renderedAuthorContrast(page);


### PR DESCRIPTION
## Summary

Tag the `WCAG author colour (issue #7377)` describe block in `wcag_author_color.spec.ts` with `@feature:authorship-bg-color`.

Every assertion in that block reads the author span's `background-color` and computes WCAG contrast against the text colour. Plugins that disable author *background* colouring entirely — e.g. `ep_author_neat2`, which renders authorship as coloured underlines — can't satisfy that invariant (there's no background to measure, transparent-vs-transparent yields no ratio). They already declare `disables: ["@feature:authorship-bg-color"]` and `change_user_color.spec.ts` is already tagged with the same feature; this PR just fills in the gap that `wcag_author_color.spec.ts` was missed when the contract was rolled out.

Unblocks `ep_author_neat2` CI (its latest main run fails on the three wcag tests).

## Test plan

- [ ] `pnpm exec playwright test --grep '@feature:authorship-bg-color'` matches both `change_user_color` and `wcag_author_color` describe blocks.
- [ ] `pnpm exec playwright test --grep-invert '@feature:authorship-bg-color'` excludes both.