### PR TITLE
test(ci): log unhandledRejection in backend test bootstrap to debug ~22% silent CI flake

### DIFF
--- a/src/tests/backend/common.ts
+++ b/src/tests/backend/common.ts
@@ -30,7 +30,27 @@ const logLevel = logger.level;
 
 // Mocha doesn't monitor unhandled Promise rejections, so convert them to uncaught exceptions.
 // https://github.com/mochajs/mocha/issues/2640
-process.on('unhandledRejection', (reason: string) => { throw reason; });
+//
+// Log via process.stderr.write before throwing: when the rethrown rejection
+// kills mocha between specs, the runner exits with code 1 and no summary.
+// Without this, the rejection reason is lost (worst on Windows runners,
+// where stderr is not always flushed before abrupt exit) and CI shows a
+// silent ELIFECYCLE with no clue what rejected.
+process.on('unhandledRejection', (reason: any) => {
+  process.stderr.write(`[backend tests] unhandledRejection: ${
+    reason && reason.stack ? reason.stack : String(reason)}\n`);
+  throw reason;
+});
+
+// Surface uncaught exceptions for the same reason. Node's default behavior
+// (exit non-zero) is preserved by the explicit process.exit below — without
+// the handler, Node would write to stderr and exit; with the handler we have
+// to do it ourselves.
+process.on('uncaughtException', (err: any) => {
+  process.stderr.write(`[backend tests] uncaughtException: ${
+    err && err.stack ? err.stack : String(err)}\n`);
+  process.exit(1);
+});
 
 before(async function () {
   this.timeout(60000);


### PR DESCRIPTION
## Summary

Backend tests on `develop` fail silently ~22% of the time (13 of the last 60 runs). Mocha exits with code 1 mid-suite, producing no test-failure marker, no error, and no Mocha summary. Different exit points each run, mostly on Windows runners but occasionally Linux too.

Root cause discovery is blocked by `src/tests/backend/common.ts:33`, which rethrows unhandled Promise rejections as uncaught exceptions but **never logs the reason first**:

```ts
process.on('unhandledRejection', (reason: string) => { throw reason; });
```

When the rethrow fires between specs (e.g. a delayed DirtyDB write rejecting after a test completed), mocha exits with code 1 and the original rejection is lost — especially on Windows, where stderr is not always flushed before abrupt exit. CI logs end with `ELIFECYCLE  Test failed` and a clean ✔ from the previous test, with no clue what rejected.

## What this PR does

Pure diagnostic patch — no behavior change on success:

- `unhandledRejection` handler now writes the reason (or stack) to stderr before rethrowing.
- Adds a matching `uncaughtException` handler so non-Promise crashes also leave a trace.

The next CI failure will surface what is actually rejecting (DirtyDB write? plugin lifecycle? socket cleanup?), at which point we can fix the real cause.

## Why this isn't using the test logger

The 'test' logger goes through log4js, which uses console layouts on top of process.stdout/stderr — same flushing problem. `process.stderr.write` is the most deterministic synchronous-ish path, and matters specifically on Windows.

## Test plan
- [x] `pnpm exec tsc --noEmit` — type-checks cleanly (no new errors in `src/tree)
- [x] `pnpm exec mocha --import=tsx tests/backend/specs/anonymizeIp.ts` — 15/15 passing locally
- [ ] After merge: wait for the next Backend tests CI failure and inspect the surfaced rejection reason; open follow-up PR to fix the real culprit

🤖 Generated with [Claude Code](https://claude.com/claude-code)