### PR TITLE
test: also tag userlist_click_to_chat describe with @feature:username

### DIFF
--- a/src/tests/frontend-new/specs/userlist_click_to_chat.spec.ts
+++ b/src/tests/frontend-new/specs/userlist_click_to_chat.spec.ts
@@ -23,7 +23,13 @@ const setSecondUserName = async (page2: any, name: string) => {
   await page2.keyboard.press('Enter');
 };
 
-test.describe('userlist click → chat prefill', {tag: '@feature:chat'}, () => {
+// `@feature:username` because the entire flow depends on each user
+// having a settable, displayable username — clicking a userlist row
+// reads the user's display name, prefills `@<name>` in the chat
+// input, etc. Plugins that disable username changes (e.g.
+// ep_disable_change_author_name) genuinely break this and should
+// opt out via the disables contract.
+test.describe('userlist click → chat prefill', {tag: ['@feature:chat', '@feature:username']}, () => {
   test('clicking another user opens chat and prefills @<name>',
       async ({browser}) => {
         const padId = await goToNewPad(await browser.newPage());


### PR DESCRIPTION
## Summary

Every test in `userlist_click_to_chat.spec.ts`'s describe block depends on each user having a settable, displayable username — clicking a userlist row reads the user's display name, prefills `@<name>` in the chat input, etc.

`ep_disable_change_author_name` disables exactly that machinery and its CI fails the three userlist tests in pass-1 of the disables contract — see https://github.com/ether/ep_disable_change_author_name/pull/86 for the failure log.

Add `@feature:username` so plugins declaring `disables: ["@feature:username"]` opt out via the contract. Same pattern as `change_user_name.spec.ts` and the other username-dependent specs that were already tagged.

## Test plan

- [ ] `pnpm exec playwright test --grep '@feature:username'` matches this describe + the existing `change_user_name.spec.ts`
- [ ] `pnpm exec playwright test --grep-invert '@feature:username'` excludes both