### PR TITLE
feat(settings): enable Pad-wide Settings by default; fix misleading modal title

### DIFF
--- a/settings.json.docker
+++ b/settings.json.docker
@@ -247,9 +247,12 @@
 
   /**
   * Enable creator-owned Pad-wide Settings and new-pad default seeding from My View.
-  * Disabled by default to preserve the legacy single-settings behavior.
+  * The pad creator (revision-0 author) gets the "Pad-wide Settings" section,
+  * which lets them set defaults and optionally enforce them for other users.
+  * Other users see only "User Settings" (their own view options).
+  * Set to false to revert to the legacy single-settings behavior.
   **/
-  "enablePadWideSettings": "${ENABLE_PAD_WIDE_SETTINGS:false}",
+  "enablePadWideSettings": "${ENABLE_PAD_WIDE_SETTINGS:true}",
 
   /*
    * Optional privacy banner. See settings.json.template for full field docs.

--- a/settings.json.template
+++ b/settings.json.template
@@ -733,9 +733,12 @@
 
     /**
     * Enable creator-owned Pad-wide Settings and new-pad default seeding from My View.
-    * Disabled by default to preserve the legacy single-settings behavior.
+    * The pad creator (revision-0 author) gets the "Pad-wide Settings" section,
+    * which lets them set defaults and optionally enforce them for other users.
+    * Other users see only "User Settings" (their own view options).
+    * Set to false to revert to the legacy single-settings behavior.
     **/
-    "enablePadWideSettings": "${ENABLE_PAD_WIDE_SETTINGS:false}",
+    "enablePadWideSettings": "${ENABLE_PAD_WIDE_SETTINGS:true}",
 
   /*
    * Optional privacy banner shown once the pad loads. Disabled by default.

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -369,7 +369,7 @@ const settings: SettingsType = {
   },
   updateServer: "https://static.etherpad.org",
   enableDarkMode: true,
-  enablePadWideSettings: false,
+  enablePadWideSettings: true,
   allowPadDeletionByAllUsers: false,
   privacyBanner: {
     enabled: false,

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -127,11 +127,7 @@
       <!------------------------------------------------------------->
 
       <div id="settings" class="popup" role="dialog" aria-modal="true" aria-labelledby="settings-title"><div class="popup-content">
-          <% if (settings.enablePadWideSettings) { %>
           <h1 id="settings-title" data-l10n-id="pad.settings.title">Settings</h1>
-          <% } else { %>
-          <h1 id="settings-title" data-l10n-id="pad.settings.padSettings">Pad Settings</h1>
-          <% } %>
           <div class="settings-sections">
             <div id="user-settings-section" class="settings-section">
             <% e.begin_block("mySettings"); %>

--- a/src/tests/backend/specs/settingsModalHeading.ts
+++ b/src/tests/backend/specs/settingsModalHeading.ts
@@ -1,0 +1,45 @@
+'use strict';
+
+import {MapArrayType} from '../../../node/types/MapType';
+import settings from '../../../node/utils/Settings';
+
+const assert = require('assert').strict;
+const common = require('../common');
+
+// Regression coverage for the settings modal title. With
+// `enablePadWideSettings: false` the template used to render
+// `data-l10n-id="pad.settings.padSettings"` ("Pad-wide Settings") for every
+// user, even though no pad-wide controls were rendered in that mode. The fix
+// removes the conditional and always uses `pad.settings.title` ("Settings").
+describe(__filename, function () {
+  this.timeout(30000);
+  let agent: any;
+  const backup: MapArrayType<any> = {};
+
+  before(async function () { agent = await common.init(); });
+
+  beforeEach(async function () {
+    backup.enablePadWideSettings = settings.enablePadWideSettings;
+  });
+
+  afterEach(async function () {
+    settings.enablePadWideSettings = backup.enablePadWideSettings;
+  });
+
+  const titleH1 = (html: string): string | null => {
+    const m = html.match(/<h1\s+id="settings-title"[^>]*data-l10n-id="([^"]+)"/);
+    return m ? m[1] : null;
+  };
+
+  it('uses pad.settings.title with the feature enabled', async function () {
+    settings.enablePadWideSettings = true;
+    const res = await agent.get('/p/headingTest').expect(200);
+    assert.equal(titleH1(res.text), 'pad.settings.title');
+  });
+
+  it('uses pad.settings.title with the feature disabled (no misleading "Pad-wide" label)', async function () {
+    settings.enablePadWideSettings = false;
+    const res = await agent.get('/p/headingTest').expect(200);
+    assert.equal(titleH1(res.text), 'pad.settings.title');
+  });
+});

--- a/src/tests/backend/specs/socketio.ts
+++ b/src/tests/backend/specs/socketio.ts
@@ -34,7 +34,7 @@ describe(__filename, function () {
       plugins.hooks[hookName] = [];
     }
     backups.settings = {};
-    for (const setting of ['editOnly', 'requireAuthentication', 'requireAuthorization', 'users']) {
+    for (const setting of ['editOnly', 'requireAuthentication', 'requireAuthorization', 'users', 'enablePadWideSettings']) {
       // @ts-ignore
       backups.settings[setting] = settings[setting];
     }
@@ -429,6 +429,66 @@ describe(__filename, function () {
       socketA = null;
       await new Promise((r) => setTimeout(r, 300));
       assert.deepEqual(leaves, [cvA.data.userId]);
+    });
+  });
+
+  describe('Pad-wide settings creator gate', function () {
+    let socketA: any;
+    let socketB: any;
+
+    const removeIfExists = async (padId: string) => {
+      if (await padManager.doesPadExist(padId)) {
+        const p = await padManager.getPad(padId);
+        await p.remove();
+      }
+    };
+
+    beforeEach(async function () {
+      // @ts-ignore - test toggles a public setting
+      settings.enablePadWideSettings = true;
+      await removeIfExists('foo');
+    });
+
+    afterEach(async function () {
+      for (const s of [socketA, socketB]) if (s) s.close();
+      socketA = null;
+      socketB = null;
+      socket = null;
+      await removeIfExists('foo');
+    });
+
+    it('different browsers (separate cookie jars): only the creator gets canEditPadSettings', async function () {
+      const supertest = require('supertest');
+      const browserA = supertest(common.baseUrl);
+      const browserB = supertest(common.baseUrl);
+
+      const resA = await browserA.get('/p/foo').expect(200);
+      socketA = await common.connect(resA);
+      const cvA = await common.handshake(socketA, 'foo');
+      assert.equal(cvA.data.canEditPadSettings, true,
+          'first joiner (creator) should see Pad-wide Settings');
+
+      const resB = await browserB.get('/p/foo').expect(200);
+      socketB = await common.connect(resB);
+      const cvB = await common.handshake(socketB, 'foo');
+      assert.equal(cvB.data.canEditPadSettings, false,
+          'non-creator joiner must NOT see Pad-wide Settings');
+    });
+
+    it('same browser two tabs (shared cookie jar): BOTH get canEditPadSettings=true', async function () {
+      // Reusing the same response (and its set-cookie header) for both
+      // connects is the backend equivalent of two browser tabs sharing the
+      // same HttpOnly token cookie — same authorID, same creator.
+      const res = await agent.get('/p/foo').expect(200);
+
+      socketA = await common.connect(res);
+      const cvA = await common.handshake(socketA, 'foo');
+      assert.equal(cvA.data.canEditPadSettings, true);
+
+      socketB = await common.connect(res);
+      const cvB = await common.handshake(socketB, 'foo');
+      assert.equal(cvB.data.canEditPadSettings, true,
+          'same author across tabs is one identity, both are the creator');
     });
   });
 


### PR DESCRIPTION
## Summary
- Flip the default of `enablePadWideSettings` from `false` to `true` in `src/node/utils/Settings.ts` and both shipped settings files (`settings.json.template`, `settings.json.docker`). The creator-owned pad-wide settings feature (#7545) is now on out of the box.
- Drop the conditional `<h1>` in `src/templates/pad.html` and always use `pad.settings.title` ("Settings"). With the feature off, the H1 was rendering `pad.settings.padSettings` ("Pad-wide Settings") for everyone — a label that lied about a section that wasn't rendered.
- Adds backend regression coverage in `src/tests/backend/specs/socketio.ts` for the creator gate (different cookie jars vs. shared cookie jar / same authorID).

## Why this is a behavior change worth taking
- Reproducing on a default install: open `/p/foo` in two different browsers. Both see the modal heading **"Pad-wide Settings"**, even though there are no pad-wide controls in the body. That looked like a creator-gate regression but turned out to be the H1 copy bug above.
- The intended design of #7545 is: the original creator (`isPadCreator` = `authorId === pad.getRevisionAuthor(0)`) gets a "Pad-wide Settings" section to set defaults / optionally enforce them, while everyone else sees only "User Settings" (their personal view). That's the better default UX, and is what most operators will expect on a fresh install.
- The flag is preserved — operators who want the legacy single-section modal can set `enablePadWideSettings: false`. The settings comments are expanded to describe what the toggle now does.

## Server-side gate is unchanged
`canEditPadSettings` is still computed by:
```ts
const canEditPadSettings = settings.enablePadWideSettings &&
    !sessionInfo.readonly && await isPadCreator(pad, sessionInfo.author);
```
Non-creator clients still receive `canEditPadSettings: false`, and `pad_editor.ts:235` still gates the unhide on it. Flipping the default does not widen who can edit pad-wide settings.

## Test plan
- [x] `tests/backend/specs/socketio.ts` — new `Pad-wide settings creator gate` describe block:
  - Different browsers / cookie jars → only the first joiner is the creator (`canEditPadSettings: true`); the second is not (`false`).
  - Same browser two tabs / shared cookie → BOTH connections are the same authorID, both correctly land on the creator path.
- [x] Full backend specs (952 pass; the 6 favicon/robots failures are pre-existing on develop, unrelated)
- [ ] Manual on a default install: open `/p/foo` from two different browsers — only the first sees "Pad-wide Settings"; the second sees only "User Settings".
- [ ] Manual with `enablePadWideSettings: false` — modal H1 reads "Settings", body still has the legacy "My View" section.

## Reviewer notes
This is a default flip (not a code-path change), so existing operators who rely on the legacy single-modal layout need to set `enablePadWideSettings: false` after upgrade. Worth highlighting in release notes.