### PR TITLE
fix(7686): username 'false' / 'malformed color: false' for legacy settings.json

### DIFF
--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -1094,14 +1094,20 @@ export const reloadSettings = () => {
     // applying it, which then propagates as the user's name and color and
     // triggers `malformed color: false` on the server (#7686). Normalize
     // legacy booleans to null at the boundary so downstream code sees the
-    // expected sentinel.
-    for (const key of ['userName', 'userColor'] as const) {
-      if ((settings.padOptions as any)[key] === false) {
-        logger.warn(
-            `padOptions.${key}=false is a legacy default (pre-2021) and is ` +
-            `now treated as null. Update settings.json to use null instead ` +
-            `to silence this warning.`);
-        (settings.padOptions as any)[key] = null;
+    // expected sentinel. Guard against a malformed padOptions (null, array,
+    // primitive) — storeSettings() will overwrite it raw if settings.json
+    // declares it as anything other than a plain object.
+    if (settings.padOptions != null
+        && typeof settings.padOptions === 'object'
+        && !Array.isArray(settings.padOptions)) {
+      for (const key of ['userName', 'userColor'] as const) {
+        if ((settings.padOptions as any)[key] === false) {
+          logger.warn(
+              `padOptions.${key}=false is a legacy default (pre-2021) and is ` +
+              `now treated as null. Update settings.json to use null instead ` +
+              `to silence this warning.`);
+          (settings.padOptions as any)[key] = null;
+        }
       }
     }
 

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -1087,6 +1087,24 @@ export const reloadSettings = () => {
       settings.privacyBanner.dismissal = 'dismissible';
     }
 
+    // Settings.json files generated before December 2021 used `false` as the
+    // default for these string options. The client treats the boolean `false`
+    // as a sentinel meaning "no enforced value", but the dispatch in
+    // pad.ts:getParams() coerces the boolean to the string "false" before
+    // applying it, which then propagates as the user's name and color and
+    // triggers `malformed color: false` on the server (#7686). Normalize
+    // legacy booleans to null at the boundary so downstream code sees the
+    // expected sentinel.
+    for (const key of ['userName', 'userColor'] as const) {
+      if ((settings.padOptions as any)[key] === false) {
+        logger.warn(
+            `padOptions.${key}=false is a legacy default (pre-2021) and is ` +
+            `now treated as null. Update settings.json to use null instead ` +
+            `to silence this warning.`);
+        (settings.padOptions as any)[key] = null;
+      }
+    }
+
     // Init logging config
     settings.logconfig = defaultLogConfig(
       settings.loglevel ? settings.loglevel : defaultLogLevel,

--- a/src/static/js/pad.ts
+++ b/src/static/js/pad.ts
@@ -136,6 +136,14 @@ const getParameters = [
     name: 'userName',
     checkVal: null,
     callback: (val) => {
+      // The default for globalUserName/globalUserColor is the boolean `false`
+      // (sentinel meaning "no enforced value"). Older settings.json files used
+      // boolean `false` for these options too, which getParams() coerces to
+      // the string "false" — that fooled the !== false sentinel checks at
+      // _afterHandshake and shipped the literal string "false" as the user's
+      // name and color (#7686). Reject the sentinel string here so URL
+      // parameters like ?userName=false also no-op.
+      if (!val || val === 'false') return;
       settings.globalUserName = val;
       clientVars.userName = val;
     },
@@ -144,6 +152,7 @@ const getParameters = [
     name: 'userColor',
     checkVal: null,
     callback: (val) => {
+      if (!val || val === 'false') return;
       settings.globalUserColor = val;
       clientVars.userColor = val;
     },

--- a/src/tests/backend/specs/padOptionsLegacyDefaults.ts
+++ b/src/tests/backend/specs/padOptionsLegacyDefaults.ts
@@ -7,9 +7,11 @@ describe(__filename, function () {
   // assert the mapping without rebooting the whole server in this spec.
   // Keep this in lockstep with the production block — if you change the
   // shim there, change it here too.
-  const applyShim = (padOptions: Record<string, any>) => {
-    for (const key of ['userName', 'userColor']) {
-      if (padOptions[key] === false) padOptions[key] = null;
+  const applyShim = (padOptions: any) => {
+    if (padOptions != null && typeof padOptions === 'object' && !Array.isArray(padOptions)) {
+      for (const key of ['userName', 'userColor']) {
+        if (padOptions[key] === false) padOptions[key] = null;
+      }
     }
     return padOptions;
   };
@@ -71,6 +73,26 @@ describe(__filename, function () {
       const out = applyShim({userName: 'false', userColor: 'false'});
       assert.strictEqual(out.userName, 'false');
       assert.strictEqual(out.userColor, 'false');
+    });
+
+    it('skips the shim if padOptions is null', function () {
+      // storeSettings() overwrites settings.padOptions raw if settings.json
+      // declares it as a non-object — the shim must not throw on that.
+      assert.doesNotThrow(() => applyShim(null));
+      assert.strictEqual(applyShim(null), null);
+    });
+
+    it('skips the shim if padOptions is a primitive', function () {
+      assert.doesNotThrow(() => applyShim(false));
+      assert.doesNotThrow(() => applyShim('not an object'));
+      assert.doesNotThrow(() => applyShim(42));
+    });
+
+    it('skips the shim if padOptions is an array', function () {
+      const arr: any = [false, false];
+      assert.doesNotThrow(() => applyShim(arr));
+      // Arrays pass through untouched — index 0/1 (numeric) are not coerced.
+      assert.deepEqual(applyShim(arr), [false, false]);
     });
   });
 });

--- a/src/tests/backend/specs/padOptionsLegacyDefaults.ts
+++ b/src/tests/backend/specs/padOptionsLegacyDefaults.ts
@@ -1,0 +1,76 @@
+'use strict';
+
+import {strict as assert} from 'assert';
+
+describe(__filename, function () {
+  // Replicates the shim block from Settings.ts::reloadSettings so we can
+  // assert the mapping without rebooting the whole server in this spec.
+  // Keep this in lockstep with the production block — if you change the
+  // shim there, change it here too.
+  const applyShim = (padOptions: Record<string, any>) => {
+    for (const key of ['userName', 'userColor']) {
+      if (padOptions[key] === false) padOptions[key] = null;
+    }
+    return padOptions;
+  };
+
+  describe('legacy padOptions.userName/userColor=false → null shim', function () {
+    it('coerces userName=false to null', function () {
+      const out = applyShim({userName: false});
+      assert.strictEqual(out.userName, null);
+    });
+
+    it('coerces userColor=false to null', function () {
+      const out = applyShim({userColor: false});
+      assert.strictEqual(out.userColor, null);
+    });
+
+    it('coerces both legacy defaults in one pass', function () {
+      const out = applyShim({userName: false, userColor: false});
+      assert.strictEqual(out.userName, null);
+      assert.strictEqual(out.userColor, null);
+    });
+
+    it('leaves an explicit string userName intact', function () {
+      const out = applyShim({userName: 'Etherpad User'});
+      assert.strictEqual(out.userName, 'Etherpad User');
+    });
+
+    it('leaves an explicit hex userColor intact', function () {
+      const out = applyShim({userColor: '#ff9900'});
+      assert.strictEqual(out.userColor, '#ff9900');
+    });
+
+    it('leaves null values untouched', function () {
+      const out = applyShim({userName: null, userColor: null});
+      assert.strictEqual(out.userName, null);
+      assert.strictEqual(out.userColor, null);
+    });
+
+    it('does not affect other padOptions keys that legitimately use false', function () {
+      // showChat:false, rtl:false, etc. are real, meaningful values — only
+      // the two string options carry the legacy boolean sentinel.
+      const out = applyShim({
+        userName: false,
+        userColor: false,
+        showChat: false,
+        rtl: false,
+        useMonospaceFont: false,
+      });
+      assert.strictEqual(out.userName, null);
+      assert.strictEqual(out.userColor, null);
+      assert.strictEqual(out.showChat, false);
+      assert.strictEqual(out.rtl, false);
+      assert.strictEqual(out.useMonospaceFont, false);
+    });
+
+    it('does not coerce the string "false" — that is handled in the client guard', function () {
+      // The server-side shim only normalizes the boolean sentinel from
+      // legacy settings.json. URL-supplied or stringified "false" is
+      // rejected by pad.ts::getParameters.userName/userColor callbacks.
+      const out = applyShim({userName: 'false', userColor: 'false'});
+      assert.strictEqual(out.userName, 'false');
+      assert.strictEqual(out.userColor, 'false');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7686.

Settings.json files generated before December 2021 still ship `"userName": false` / `"userColor": false` for `padOptions`. These two options are documented as strings, so the boolean was always meaningless — commit [8c857a85a](https://github.com/ether/etherpad-lite/commit/8c857a85ac9af08ebec1c94031ca7c54bed34c38) switched the template default to `null` and explicitly warned: *"this change has no effect due to a bug in how pad options are processed; that bug will be fixed in a future commit."* The follow-up never landed.

The cascade:

1. `clientVars.padOptions.userName === false` (legacy) reaches `pad.ts:getParams()`.
2. `if (serverValue == null) continue;` — `false != null`, doesn't skip.
3. `serverValue = serverValue.toString();` → `"false"`.
4. `settings.globalUserName = "false"`, `clientVars.userColor = "false"`.
5. `pad.myUserInfo.colorId = clientVars.userColor` → `"false"`.
6. `if (settings.globalUserName !== false)` → `"false" !== false` is `true` → `notifyChangeName("false")` ships USERINFO_UPDATE with `name="false"`, `colorId="false"`.
7. Server's hex regex throws `Error: COLLABROOM: USERINFO_UPDATE: malformed color: false`.

The user sees their name as `false` and a white swatch.

## Fix (defense in depth)

- **Server boundary** — `Settings.ts::reloadSettings()` coerces `padOptions.userName === false` and `padOptions.userColor === false` to `null` and warns once, matching the existing `disableIPlogging` shim pattern.
- **Client guard** — `pad.ts` `userName`/`userColor` callbacks reject empty / literal `"false"` so URL params like `?userName=false` are also a no-op.
- **Regression test** — `tests/backend/specs/padOptionsLegacyDefaults.ts` mirrors the shim and asserts it normalizes the legacy boolean, leaves explicit string/null values intact, doesn't touch `showChat: false`/`rtl: false`/etc., and does not coerce the string `"false"` (that's the client guard's job).

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec mocha tests/backend/specs/padOptionsLegacyDefaults.ts` — 8 passing
- [x] `pnpm exec mocha tests/backend/specs/settings.ts tests/backend/specs/ipLoggingSetting.ts tests/backend/specs/padOptionsLegacyDefaults.ts` — 48 passing
- [ ] CI runs the full backend + Playwright suite
- [ ] Reporter (@tpokorra) confirms the warning appears and the bug is gone after upgrading

🤖 Generated with [Claude Code](https://claude.com/claude-code)