### PR TITLE
fix(docker): share corepack cache so etherpad user can resolve pnpm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,6 +81,51 @@ jobs:
           (cd src && pnpm run test-container)
           git clean -dxf .
 
+  build-test-local-plugin:
+    # Regression coverage for #7687: the Docker image's
+    # `bin/installLocalPlugins.sh` step runs as the `etherpad` user and
+    # invokes pnpm via the corepack shim. A previous corepack/cache bug
+    # made that path fail when ETHERPAD_LOCAL_PLUGINS was set. This job
+    # builds the development target with a stub local plugin so the
+    # regression cannot silently come back.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      -
+        name: Check out
+        uses: actions/checkout@v6
+        with:
+          path: etherpad
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      -
+        name: Stub a local plugin
+        run: |
+          mkdir -p etherpad/local_plugins/ep_test_corepack
+          cat > etherpad/local_plugins/ep_test_corepack/package.json <<'EOF'
+          {
+            "name": "ep_test_corepack",
+            "version": "0.0.1",
+            "description": "regression-test stub for ether/etherpad#7687",
+            "main": "index.js"
+          }
+          EOF
+          cat > etherpad/local_plugins/ep_test_corepack/index.js <<'EOF'
+          exports.placeholder = true;
+          EOF
+      -
+        name: Build with ETHERPAD_LOCAL_PLUGINS (must succeed)
+        uses: docker/build-push-action@v7
+        with:
+          context: ./etherpad
+          target: development
+          load: false
+          build-args: |
+            ETHERPAD_LOCAL_PLUGINS=ep_test_corepack
+          cache-from: type=gha
+
   build-test-db-drivers:
     # Spinning up MySQL + Postgres + cross-driver smoke is expensive; only
     # run it on pushes to develop (and tagged release pushes), not on every

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,21 @@ RUN groupadd --system ${EP_GID:+--gid "${EP_GID}" --non-unique} etherpad && \
 ARG EP_DIR=/opt/etherpad-lite
 RUN mkdir -p "${EP_DIR}" && chown etherpad:etherpad "${EP_DIR}"
 
+# Share corepack's cache between root (which activates pnpm here) and
+# the `etherpad` user (which invokes pnpm later via the corepack shim).
+# $COREPACK_HOME defaults to ~/.cache/node/corepack and is per-user;
+# without this pin the etherpad user finds an empty cache, re-resolves
+# pnpm, and corepack can fall back to "latest" from the registry. See
+# https://github.com/ether/etherpad/issues/7687.
+ENV COREPACK_HOME=/opt/corepack
+
 # the mkdir is needed for configuration of openjdk-11-jre-headless, see
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN  \
-    mkdir -p /usr/share/man/man1 && \
+    mkdir -p /usr/share/man/man1 /opt/corepack && \
     npm install -g corepack@latest && \
     corepack enable && corepack prepare pnpm@${PnpmVersion} --activate && \
+    chown -R etherpad:etherpad /opt/corepack && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx && \
     apk update && apk upgrade && \
     apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,10 +110,10 @@ ENV COREPACK_HOME=/opt/corepack
 # the mkdir is needed for configuration of openjdk-11-jre-headless, see
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 RUN  \
-    mkdir -p /usr/share/man/man1 /opt/corepack && \
+    mkdir -p /usr/share/man/man1 "${COREPACK_HOME}" && \
     npm install -g corepack@latest && \
     corepack enable && corepack prepare pnpm@${PnpmVersion} --activate && \
-    chown -R etherpad:etherpad /opt/corepack && \
+    chown -R etherpad:etherpad "${COREPACK_HOME}" && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx && \
     apk update && apk upgrade && \
     apk add --no-cache \


### PR DESCRIPTION
## Summary

- Pins `COREPACK_HOME=/opt/corepack` and chowns it to the `etherpad` user, so the corepack `lastKnownGood` activation file written by root is visible after the `USER etherpad` switch.
- Without this, the etherpad user's per-user corepack cache is empty when `bin/installLocalPlugins.sh` invokes `pnpm`; corepack re-resolves and (for builds without a matching `packageManager` pin) falls back to `pnpm@latest` (currently 10.33.4), failing the workspace's `engines.pnpm` check.

## Why

PR #7674 (docker CVE sweep) replaced `npm install -g pnpm` with `corepack prepare pnpm@${PnpmVersion} --activate`. `corepack prepare --activate` writes to `$COREPACK_HOME`, which defaults to `~/.cache/node/corepack` — a **per-user** path. We activate as root, then drop to `etherpad`, whose home dir has no cache. Sharing `$COREPACK_HOME` is the smallest fix.

Reported by @ferrlen in #7687 — they hit:
```
Your pnpm version is incompatible with "/opt/etherpad-lite/src".
Expected version: >=11.0.0
Got: 10.33.4
```

## Test plan

- [x] `docker build --target build .` succeeds.
- [x] `docker run --rm <build> sh -c 'pnpm --version'` as `etherpad` reports the activated pnpm version (11.0.6) instead of falling back to "latest".
- [x] `docker build --target development --build-arg ETHERPAD_LOCAL_PLUGINS=ep_test_corepack .` with a stub local plugin runs `installLocalPlugins.sh` cleanly (`Done in 16.6s using pnpm v11.0.6`) — the original failure scenario.
- [ ] CI image-build job stays green.

## Follow-up (not blocking)

`corepack prepare pnpm@11.0.6 --activate` resolves to the highest matching patch (`11.0.8`) and caches that, while `package.json` pins `packageManager: "pnpm@11.0.6"` exactly. Result: corepack emits a one-time "about to download pnpm-11.0.6.tgz" line at runtime even though the activated version is in the cache. Functional, just inefficient — worth a separate small PR to either drop the `packageManager` exact pin or align with corepack's resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)