### PR TITLE
fix(socialMeta): coerced numeric/boolean override silently dropped

### DIFF
--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -166,7 +166,13 @@ export type SettingsType = {
   favicon: string | null,
   publicURL: string | null,
   socialMeta: {
-    description: string | null,
+    // Runtime type is wider than what an operator writes by hand: when
+    // `socialMeta.description` is sourced from an env var (e.g.
+    // `"${SOCIAL_META_DESCRIPTION:null}"` in settings.json.docker), the
+    // settings loader's `coerceValue()` turns numeric-looking strings into
+    // numbers and "true"/"false" into booleans. Downstream code stringifies
+    // before use; the wider type stops callers (and tests) needing casts.
+    description: string | number | boolean | null,
   },
   ttl: {
     AccessToken: number,

--- a/src/node/utils/socialMeta.ts
+++ b/src/node/utils/socialMeta.ts
@@ -161,16 +161,23 @@ export type RenderOpts = {
   padName?: string,
 };
 
-// Operator override wins, but only when it's a non-empty string. An empty
-// string from settings would silently blank out og:description / twitter:
-// description and break previews, so we treat empty/whitespace-only as unset
-// and fall back to the i18n catalog.
+// Operator override wins when set. Settings.ts coerces env-var strings to
+// their typed form (e.g. SOCIAL_META_DESCRIPTION="123" arrives as the number
+// 123 and ="true" as the boolean true), so we accept string | number | boolean
+// and stringify before comparing. Empty / whitespace-only values are treated
+// as unset — an accidental "" in settings would otherwise silently blank out
+// og:description and break previews entirely.
 const resolveDescriptionWithOverride = (
-  override: string | null | undefined,
+  override: unknown,
   locales: {[lang: string]: {[key: string]: string}} | undefined,
   renderLang: string,
 ): string => {
-  if (typeof override === 'string' && override.trim() !== '') return override;
+  if (override !== null && override !== undefined &&
+      (typeof override === 'string' || typeof override === 'number' ||
+       typeof override === 'boolean')) {
+    const s = String(override);
+    if (s.trim() !== '') return s;
+  }
   return resolveDescription(locales, renderLang);
 };
 

--- a/src/node/utils/socialMeta.ts
+++ b/src/node/utils/socialMeta.ts
@@ -102,7 +102,11 @@ type SocialMetaSettings = {
   favicon?: string | null,
   publicURL?: string | null,
   socialMeta?: {
-    description?: string | null,
+    // Wider than the operator-facing type: env-var-driven settings get
+    // pre-coerced by Settings.coerceValue(), so we may receive number/boolean
+    // even though "the value an operator types" is a string. Stringified at
+    // resolve time.
+    description?: string | number | boolean | null,
   },
 };
 
@@ -168,13 +172,11 @@ export type RenderOpts = {
 // as unset — an accidental "" in settings would otherwise silently blank out
 // og:description and break previews entirely.
 const resolveDescriptionWithOverride = (
-  override: unknown,
+  override: string | number | boolean | null | undefined,
   locales: {[lang: string]: {[key: string]: string}} | undefined,
   renderLang: string,
 ): string => {
-  if (override !== null && override !== undefined &&
-      (typeof override === 'string' || typeof override === 'number' ||
-       typeof override === 'boolean')) {
+  if (override !== null && override !== undefined) {
     const s = String(override);
     if (s.trim() !== '') return s;
   }

--- a/src/tests/backend/specs/socialMeta-unit.ts
+++ b/src/tests/backend/specs/socialMeta-unit.ts
@@ -249,6 +249,40 @@ describe(__filename, function () {
       });
       assert.equal(ogTag(html, 'og:description'), 'Catalog');
     });
+
+    it('numeric override is stringified (env-var coercion safety)', function () {
+      // Settings.ts coerceValue() turns numeric-looking env vars into numbers,
+      // so SOCIAL_META_DESCRIPTION="2026" arrives here as the number 2026.
+      // Without this branch the resolver would silently fall back to i18n.
+      const html = renderSocialMeta({
+        req: fakeReq(),
+        // Cast through unknown — the public type is string|null, but at
+        // runtime Settings hands us the coerced value.
+        settings: {
+          title: 'Etherpad', favicon: null,
+          socialMeta: {description: 2026 as unknown as string},
+        },
+        availableLangs: {en: {}}, locales: enLocales,
+        kind: 'pad', padName: 'P',
+      });
+      assert.equal(ogTag(html, 'og:description'), '2026');
+    });
+
+    it('boolean override is stringified (covers "true"/"false" env-var coercion)', function () {
+      // Less likely than the numeric case but possible: setting
+      // SOCIAL_META_DESCRIPTION="true" yields a boolean. Treat it like the
+      // operator wrote that literal string rather than silently dropping it.
+      const html = renderSocialMeta({
+        req: fakeReq(),
+        settings: {
+          title: 'Etherpad', favicon: null,
+          socialMeta: {description: true as unknown as string},
+        },
+        availableLangs: {en: {}}, locales: enLocales,
+        kind: 'pad', padName: 'P',
+      });
+      assert.equal(ogTag(html, 'og:description'), 'true');
+    });
   });
 
   describe('renderSocialMeta — image URL', function () {

--- a/src/tests/backend/specs/socialMeta-unit.ts
+++ b/src/tests/backend/specs/socialMeta-unit.ts
@@ -253,14 +253,12 @@ describe(__filename, function () {
     it('numeric override is stringified (env-var coercion safety)', function () {
       // Settings.ts coerceValue() turns numeric-looking env vars into numbers,
       // so SOCIAL_META_DESCRIPTION="2026" arrives here as the number 2026.
-      // Without this branch the resolver would silently fall back to i18n.
+      // Without stringification the resolver would silently fall back to i18n.
       const html = renderSocialMeta({
         req: fakeReq(),
-        // Cast through unknown — the public type is string|null, but at
-        // runtime Settings hands us the coerced value.
         settings: {
           title: 'Etherpad', favicon: null,
-          socialMeta: {description: 2026 as unknown as string},
+          socialMeta: {description: 2026},
         },
         availableLangs: {en: {}}, locales: enLocales,
         kind: 'pad', padName: 'P',
@@ -276,7 +274,7 @@ describe(__filename, function () {
         req: fakeReq(),
         settings: {
           title: 'Etherpad', favicon: null,
-          socialMeta: {description: true as unknown as string},
+          socialMeta: {description: true},
         },
         availableLangs: {en: {}}, locales: enLocales,
         kind: 'pad', padName: 'P',


### PR DESCRIPTION
## Summary

Action follow-up to Qodo's bug-find on #7691. `Settings.coerceValue()` turns numeric-looking env vars into numbers and `"true"`/`"false"` into booleans, so e.g. `SOCIAL_META_DESCRIPTION=\"2026\"` arrives at the resolver as the number `2026` — and the previous resolver gated on `typeof override === 'string'`, so it silently fell back to the i18n catalog. Operator's docker config would appear broken with no log.

Resolver now accepts `string | number | boolean`, stringifies, and runs the same empty/whitespace-treated-as-unset check as before. `null` / `undefined` / unsupported types still fall through to the i18n catalog.

## Test plan

- [x] 2 new unit specs: numeric override stringified; boolean override stringified
- [x] All 33 socialMeta-unit specs passing
- [x] All 15 socialMeta integration specs passing (no behaviour change for the already-covered string path)
- [ ] Verify in docker: `SOCIAL_META_DESCRIPTION=2026` → og:description renders as `"2026"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)