### PR TITLE
docs(7538): soffice is now optional for docx/pdf

### DIFF
--- a/doc/docker.adoc
+++ b/doc/docker.adoc
@@ -62,16 +62,17 @@ The variable value has to be a space separated, double quoted list of plugin nam
 
 Some plugins will need personalized settings. Just refer to the previous section, and include them in your custom `settings.json.docker`.
 
-==== Rebuilding including export functionality for DOC/DOCX/PDF/ODT
+==== Office-format import/export
 
-If you want to be able to export your pads to DOC/DOCX/PDF/ODT files, you can
-install Libreoffice via setting the `INSTALL_SOFFICE` build variable to any
-value.
+DOCX export, PDF export, and DOCX import work out of the box — Etherpad
+ships pure-JS in-process converters and needs no extra dependencies for
+those three formats.
 
-Also, you will need to configure the path to the libreoffice executable
-via setting the `soffice` property in `<BASEDIR>/settings.json.docker` to
-`/usr/bin/soffice` or via setting the environment variable  `SOFFICE` to
-`/usr/bin/soffice`.
+DOC/ODT/RTF export and PDF import still require LibreOffice. To enable
+them, install LibreOffice via the `INSTALL_SOFFICE` build variable (any
+value), and either set the `soffice` property in
+`<BASEDIR>/settings.json.docker` to `/usr/bin/soffice` or set the
+`SOFFICE` environment variable to `/usr/bin/soffice`.
 
 ==== Examples
 
@@ -452,7 +453,7 @@ For the editor container, you can also make it full width by adding `full-width-
 | `21600` (6 hours)
 
 | `SOFFICE`
-| Absolute path to the soffice (LibreOffice) executable. Needed for advanced import/export of pads (docx, pdf, odt). Setting it to null disables LibreOffice and will only allow plain text and HTML import/exports.
+| Absolute path to the soffice (LibreOffice) executable. When configured, all advanced import/export formats use it (docx, pdf, odt, doc, rtf). Setting it to null falls back to in-process pure-JS converters: docx and pdf export, plus docx import, still work; odt/doc/rtf and pdf import remain unavailable.
 | `null`
 
 | `ALLOW_UNKNOWN_FILE_ENDS`

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -35,16 +35,17 @@ The variable value has to be a space separated, double quoted list of plugin nam
 
 Some plugins will need personalized settings. Just refer to the previous section, and include them in your custom `settings.json.docker`.
 
-### Rebuilding including export functionality for DOC/DOCX/PDF/ODT
+### Office-format import/export
 
-If you want to be able to export your pads to DOC/DOCX/PDF/ODT files, you can
-install Libreoffice via setting the `INSTALL_SOFFICE` build variable to any
-value.
+DOCX export, PDF export, and DOCX import work out of the box — Etherpad
+ships pure-JS in-process converters and needs no extra dependencies for
+those three formats.
 
-Also, you will need to configure the path to the libreoffice executable
-via setting the `soffice` property in `<BASEDIR>/settings.json.docker` to
-`/usr/bin/soffice` or via setting the environment variable  `SOFFICE` to
-`/usr/bin/soffice`.
+DOC/ODT/RTF export and PDF import still require LibreOffice. To enable
+them, install LibreOffice via the `INSTALL_SOFFICE` build variable (any
+value), and either set the `soffice` property in
+`<BASEDIR>/settings.json.docker` to `/usr/bin/soffice` or set the
+`SOFFICE` environment variable to `/usr/bin/soffice`.
 
 ### Examples
 

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -424,18 +424,21 @@
   "maxAge": "${MAX_AGE:21600}", // 60 * 60 * 6 = 6 hours
 
   /*
-   * This is the absolute path to the soffice executable.
+   * Absolute path to the soffice (LibreOffice) executable.
    *
-   * LibreOffice is used for advanced import/export of pads (docx, pdf, odt).
-   * Setting it to null disables LibreOffice and will only allow plain text
-   * and HTML import/exports.
+   * When configured, soffice handles all advanced office-format
+   * conversions (docx, pdf, odt, doc, rtf -- both directions). When
+   * null, Etherpad falls back to pure-JS in-process converters
+   * that handle docx export, pdf export, and docx import natively.
+   * odt/doc/rtf export and pdf import still require soffice.
    */
   "soffice": "${SOFFICE:null}",
 
   /*
-   * When true (the default), the "Microsoft Word" export button downloads a .docx file via
-   * LibreOffice (requires "soffice" to be set). Set to false to revert to legacy .doc output
-   * (which also requires "soffice").
+   * When true (the default), the "Microsoft Word" export button
+   * downloads a .docx file -- via soffice if it's configured, or via
+   * the in-process html-to-docx converter otherwise. Set to false to
+   * revert to legacy .doc output (.doc still requires soffice).
    */
   "docxExport": "${DOCX_EXPORT:true}",
 

--- a/settings.json.template
+++ b/settings.json.template
@@ -422,18 +422,21 @@
   "maxAge": 21600, // 60 * 60 * 6 = 6 hours
 
   /*
-   * This is the absolute path to the soffice executable.
+   * Absolute path to the soffice (LibreOffice) executable.
    *
-   * LibreOffice is used for advanced import/export of pads (docx, pdf, odt).
-   * Setting it to null disables LibreOffice and will only allow plain text
-   * and HTML import/exports.
+   * When configured, soffice handles all advanced office-format
+   * conversions (docx, pdf, odt, doc, rtf — both directions). When
+   * null, Etherpad falls back to pure-JS in-process converters
+   * that handle docx export, pdf export, and docx import natively.
+   * odt/doc/rtf export and pdf import still require soffice.
    */
   "soffice": null,
 
   /*
-   * When true (the default), the "Microsoft Word" export button downloads a .docx file via
-   * LibreOffice (requires "soffice" to be set). Set to false to revert to legacy .doc output
-   * (which also requires "soffice").
+   * When true (the default), the "Microsoft Word" export button
+   * downloads a .docx file -- via soffice if it's configured, or via
+   * the in-process html-to-docx converter otherwise. Set to false to
+   * revert to legacy .doc output (.doc still requires soffice).
    */
   "docxExport": true,
 


### PR DESCRIPTION
## Summary

Follow-up to #7568. The merged PR landed native DOCX export, PDF export, and DOCX import via pure-JS in-process converters — soffice/LibreOffice is no longer required for those three formats. Several doc comments still implied otherwise:

- `settings.json.template` and `settings.json.docker` still said "Setting [soffice] to null disables LibreOffice and will only allow plain text and HTML import/exports."
- The `docxExport` setting comment said it "requires 'soffice' to be set."
- `doc/docker.md` and `doc/docker.adoc` had a "Rebuilding including export functionality for DOC/DOCX/PDF/ODT" section telling users to install LibreOffice for DOCX export.

This PR refreshes those comments and the docker docs to reflect actual behavior:

- **soffice configured:** handles all office formats (existing behavior, unchanged).
- **soffice null:** docx export, pdf export, and docx import work natively. odt/doc/rtf export and pdf import still need soffice.

## Files

| File | Change |
|---|---|
| `settings.json.template` | rewrite `soffice` + `docxExport` JSDoc comments |
| `settings.json.docker` | same |
| `doc/docker.md` | rename section to "Office-format import/export"; clarify when soffice is needed |
| `doc/docker.adoc` | same; also align the `SOFFICE` table row with the wording already in `doc/docker.md` |

No code changes, no behavior change — documentation only.

Refs #7538.
