### PR TITLE
fix(tests): unblock CI — Windows updater paths + admin-plugins row count

### DIFF
--- a/src/tests/backend-new/specs/updater/RollbackHandler.test.ts
+++ b/src/tests/backend-new/specs/updater/RollbackHandler.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {checkPendingVerification, performRollback, RollbackDeps} from '../../../../node/updater/RollbackHandler';
 import {EMPTY_STATE} from '../../../../node/updater/types';
@@ -120,8 +121,8 @@ describe('performRollback', () => {
     };
     await performRollback(state, deps);
     expect(deps.copyFile).toHaveBeenCalledWith(
-      '/srv/etherpad/var/update-backup/pnpm-lock.yaml',
-      '/srv/etherpad/pnpm-lock.yaml',
+      path.join(deps.backupDir, 'pnpm-lock.yaml'),
+      path.join(deps.repoDir, 'pnpm-lock.yaml'),
     );
     const lastSave = (deps.saveState as any).mock.calls.at(-1)[0];
     expect(lastSave.execution.status).toBe('rolled-back');

--- a/src/tests/backend-new/specs/updater/UpdateExecutor.test.ts
+++ b/src/tests/backend-new/specs/updater/UpdateExecutor.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {executeUpdate, ExecutorDeps} from '../../../../node/updater/UpdateExecutor';
 import {EMPTY_STATE, UpdateState} from '../../../../node/updater/types';
@@ -64,7 +65,10 @@ describe('executeUpdate', () => {
     const r = await executeUpdate(deps);
     expect(r).toEqual({outcome: 'pending-verification'});
     expect(copies).toEqual([
-      {src: '/srv/etherpad/pnpm-lock.yaml', dst: '/srv/etherpad/var/update-backup/pnpm-lock.yaml'},
+      {
+        src: path.join(deps.repoDir, 'pnpm-lock.yaml'),
+        dst: path.join(deps.backupDir, 'pnpm-lock.yaml'),
+      },
     ]);
     expect(states.at(-1)?.execution.status).toBe('pending-verification');
     expect((states.at(-1)?.execution as any).fromSha).toBe('abc123');

--- a/src/tests/frontend-new/admin-spec/adminupdateplugins.spec.ts
+++ b/src/tests/frontend-new/admin-spec/adminupdateplugins.spec.ts
@@ -48,23 +48,22 @@ test.describe('Plugins page',  ()=> {
 
         // Select Installation button
         await pluginRow.locator('td').nth(4).locator('button').first().click()
-        await page.waitForTimeout(100)
         await page.waitForSelector('table tbody')
+
+        // The installed-plugins table can grow by more than one row if the
+        // installed plugin pulls in transitive plugin deps (e.g.
+        // ep_set_title_on_pad depends on ep_plugin_helpers as of 0.7.2), so
+        // assert by name rather than by row count.
         const installedPlugins = page.locator('table tbody').first()
-        const installedPluginsRows = installedPlugins.locator('tr')
-        await expect(installedPluginsRows).toHaveCount(2, {
-            timeout: 15000
-        })
+        const installedPluginRow = installedPlugins.locator('tr', {hasText: 'ep_set_title_on_pad'})
+        await expect(installedPluginRow).toHaveCount(1, {timeout: 15000})
 
-        const installedPluginRow = installedPluginsRows.nth(1)
-
-        await expect(installedPluginRow).toContainText('ep_set_title_on_pad')
         await installedPluginRow.locator('td').nth(2).locator('button').first().click()
 
-        // Wait for the uninstallation to complete
-        await expect(installedPluginsRows).toHaveCount(1, {
-            timeout: 15000
-        })
+        // Wait for the uninstallation to complete: the row for
+        // ep_set_title_on_pad should disappear. Other installed plugins
+        // (etherpad-lite itself, transitive plugin deps) may stay.
+        await expect(installedPluginRow).toHaveCount(0, {timeout: 15000})
         await page.waitForTimeout(5000)
     })
 })


### PR DESCRIPTION
## Summary
- The Windows backend test job has been red on develop since #7607 merged (run [25623510470](https://github.com/ether/etherpad/actions/runs/25623510470)). Two new vitest specs assert hardcoded POSIX paths against `copyFile` calls, but the production code builds the same paths via `path.join` — which emits backslashes on Windows. So the tests pass on Linux/macOS only by coincidence.
- Switches the expected values in `RollbackHandler.test.ts` and `UpdateExecutor.test.ts` to `path.join(deps.repoDir, …)` / `path.join(deps.backupDir, …)`, so the assertions track whatever the implementation produces on the host platform.
- No production code changes; this is test-only and unblocks every PR currently red against develop's Windows backend job (e.g. #7710).

## Test plan
- [x] `pnpm exec vitest run tests/backend-new/specs/updater/RollbackHandler.test.ts tests/backend-new/specs/updater/UpdateExecutor.test.ts` passes locally on Linux (17/17).
- [ ] Windows backend tests pass on CI for this branch.
- [ ] After merge, the same job on develop @ HEAD goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)