### PR TITLE
fix(tests): close socket.io clients in lowerCasePadIds spec

### DIFF
--- a/src/tests/backend/specs/lowerCasePadIds.ts
+++ b/src/tests/backend/specs/lowerCasePadIds.ts
@@ -17,6 +17,15 @@ describe(__filename, function () {
     }));
   };
   let backup:any;
+  // Track every socket.io-client we open so afterEach can disconnect each
+  // one. Without this, the client's 5s reconnect timer stays armed after
+  // the test server tears down, keeping the event loop alive past mocha's
+  // "passing" output and tripping the unclean-exit force-quit (see the
+  // diagnostics.ts comment block about the Windows + Node 24 backend-test
+  // flake; this spec was responsible for 3 of the 3 leaked timers seen
+  // in the wtfnode dump).
+  const openedSockets: any[] = [];
+  const trackSocket = (s: any) => { openedSockets.push(s); return s; };
 
   before(async function () {
     backup = settings.lowerCasePadIds;
@@ -27,6 +36,10 @@ describe(__filename, function () {
   });
   afterEach(async function () {
     await cleanUpPads();
+    while (openedSockets.length) {
+      const s = openedSockets.pop();
+      try { s.disconnect(); } catch { /* socket may already be torn down */ }
+    }
   });
   after(async function () {
     settings.lowerCasePadIds = backup;
@@ -65,13 +78,13 @@ describe(__filename, function () {
       });
 
       const oldPad = await agent.get('/p/ALREADYexistingPad').expect(200);
-      const oldPadSocket = await common.connect(oldPad);
+      const oldPadSocket = trackSocket(await common.connect(oldPad));
       const oldPadHandshake = await common.handshake(oldPadSocket, 'ALREADYexistingPad');
       assert.equal(oldPadHandshake.data.padId, 'ALREADYexistingPad');
       assert.equal(oldPadHandshake.data.collab_client_vars.initialAttributedText.text, 'oldpad\n');
 
       const newPad = await agent.get('/p/alreadyexistingpad').expect(200);
-      const newPadSocket = await common.connect(newPad);
+      const newPadSocket = trackSocket(await common.connect(newPad));
       const newPadHandshake = await common.handshake(newPadSocket, 'alreadyexistingpad');
       assert.equal(newPadHandshake.data.padId, 'alreadyexistingpad');
       assert.equal(newPadHandshake.data.collab_client_vars.initialAttributedText.text, 'newpad\n');
@@ -81,7 +94,7 @@ describe(__filename, function () {
       await padManager.getPad('maliciousattempt', 'attempt');
 
       const newPad = await agent.get('/p/maliciousattempt').expect(200);
-      const newPadSocket = await common.connect(newPad);
+      const newPadSocket = trackSocket(await common.connect(newPad));
       const newPadHandshake = await common.handshake(newPadSocket, 'MaliciousAttempt');
 
       assert.equal(newPadHandshake.data.collab_client_vars.initialAttributedText.text, 'attempt\n');


### PR DESCRIPTION
## Summary

`tests/backend/specs/lowerCasePadIds.ts` opened three socket.io-client connections (for `ALREADYexistingPad`, `alreadyexistingpad`, `maliciousattempt`) but never closed them. Each leaked client kept a 5s reconnect timer armed in `socket.io-client/manager.js` past mocha's "passing" output, tripping the unclean-exit force-quit in `server.ts:287` and exiting the process with code 1.

This is the root cause of the Windows + Node 24 backend-test flake the team has been chasing (see the comment block at the top of `src/tests/backend/diagnostics.ts`, added in #7663). The flake reproduces 100% on Linux + Node 24 too — it just happens to bite Windows + Node 24 more often because of slightly different timing.

## Verification

I patched the unclean-exit handler to always call `wtfnode.dump()`. On `origin/develop` HEAD without this fix:

```
[WTF Node?] open handles:
- Timers:
  - (5000 ~ 5 s) (anonymous) @ socket.io-client@4.8.3/.../manager.js:375
  - (5000 ~ 5 s) (anonymous) @ socket.io-client@4.8.3/.../manager.js:375
  - (2363 ~ 2.4 s) (anonymous) @ socket.io-client@4.8.3/.../manager.js:375
[ERROR] server - Forcing an unclean exit...
[diag +28856ms] exit code=1
```

With this fix on the same branch:

```
1115 passing (1m)
8 pending
[diag +67905ms] beforeExit code=0 exitCode=undefined
[diag +67905ms] exit code=0
```

No force-exit, no leaked timers, no `wtfnode` dump, clean `process.exit(0)`.

## Test plan

- [x] `mocha tests/backend/specs/lowerCasePadIds.ts` — 4 passing, exit 0.
- [x] Full backend suite via `mocha --recursive tests/backend/specs/**.ts` — 1115 passing, exit 0.
- [x] Verified `wtfnode` dump is empty after teardown.

## Notes

The leak was triggered by `common.connect()` returning a socket.io-client `Socket` that callers are expected to close. This spec was the only outlier — every other spec that calls `common.connect()` already disconnects (`messages.ts`, `clientvar_rev_consistency.ts`, `chat.ts`, `undo_clear_authorship.ts`) or its callers do.

`socketio.ts` has 45 `common.connect()` calls and only 8 closes, but most of those connections are deliberately short-lived inside `it` blocks and the helper used there appears to clean up via the test's own `afterEach`. wtfnode confirmed only 3 timers were leaking, all matching this spec's pad names.

Once this lands, follow-up PR #7720 (Tier 3 auto-update) should see Windows-24 go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)