### PR TITLE
ci(rate-limit): wait for etherpad readiness before running test

### DIFF
--- a/.github/workflows/rate-limit.yml
+++ b/.github/workflows/rate-limit.yml
@@ -58,7 +58,7 @@ jobs:
         name: run docker images
         run: |
           docker run --name etherpad-docker -p 9000:9001 --rm --network ep_net --ip 172.23.42.2 -e 'TRUST_PROXY=true' epl-debian-slim &
-          docker run -p 8081:80 --rm --network ep_net --ip 172.23.42.1 -d nginx-latest
+          docker run --name nginx-docker -p 8081:80 --rm --network ep_net --ip 172.23.42.1 -d nginx-latest
           docker run --rm --network ep_net --ip 172.23.42.3 --name anotherip -dt anotherip
       -
         name: install dependencies and create symlink for ep_etherpad-lite
@@ -71,14 +71,20 @@ jobs:
         # stops returning 5xx.
         name: Wait for etherpad behind nginx to be ready
         run: |
-          for i in $(seq 1 60); do
-            if curl -fsS -o /dev/null --max-time 2 http://127.0.0.1:8081/; then
+          # ~60s budget: 30 iterations × (1s curl timeout + 1s sleep).
+          # Cold-start of the etherpad container is well under that.
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null --max-time 1 http://127.0.0.1:8081/; then
               echo "etherpad is ready behind nginx"
               exit 0
             fi
-            sleep 2
+            sleep 1
           done
           echo "ERROR: etherpad behind nginx did not become ready in time"
+          echo "--- docker ps ---"
+          docker ps -a || true
+          echo "--- nginx-docker logs ---"
+          docker logs nginx-docker || true
           echo "--- etherpad-docker logs ---"
           docker logs etherpad-docker || true
           exit 1

--- a/.github/workflows/rate-limit.yml
+++ b/.github/workflows/rate-limit.yml
@@ -64,6 +64,25 @@ jobs:
         name: install dependencies and create symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile
       -
+        # The etherpad container is started in the background above; without
+        # this wait the test step can hit nginx before etherpad is listening
+        # and nginx returns 502, failing the run on a cold cache. Poll the
+        # nginx-proxied endpoint (which is also what the test hits) until it
+        # stops returning 5xx.
+        name: Wait for etherpad behind nginx to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS -o /dev/null --max-time 2 http://127.0.0.1:8081/; then
+              echo "etherpad is ready behind nginx"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: etherpad behind nginx did not become ready in time"
+          echo "--- etherpad-docker logs ---"
+          docker logs etherpad-docker || true
+          exit 1
+      -
         name: run rate limit test
         run: |
           cd src/tests/ratelimit


### PR DESCRIPTION
## Summary
- Adds a readiness poll on \`http://127.0.0.1:8081/\` between \`run docker images\` and the test step in \`.github/workflows/rate-limit.yml\`.
- Eliminates the race where the etherpad container started with \`&\` isn't yet listening when the test fires, causing nginx to return 502 and the workflow to fail.

## Why
Developments three most recent runs of this workflow — all on README-only commits (#7723, #7724, #7725) — failed with the same 502 from nginx upstream. PR #7721 also tripped it three reruns in a row. With a warm pnpm-store, \`pnpm install --frozen-lockfile\` finishes faster than etherpad can boot inside the container, so the test starts before the upstream is responsive. Polling until nginx stops returning 5xx makes the run deterministic.

## Test plan
- [x] CI's \`rate limit\` job passes on this PR (the failure mode it fixes).
- [x] Polling step output shows "etherpad is ready behind nginx" within ~30s on a normal run.
- [x] If etherpad fails to come up, the new step prints \`docker logs etherpad-docker\` so future failures are easier to triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)