### PR TITLE
fix(tests): retry rmdir to clear Windows EBUSY flake in updater-integration

### DIFF
--- a/src/tests/backend/specs/updater-integration.ts
+++ b/src/tests/backend/specs/updater-integration.ts
@@ -12,6 +12,12 @@ import {EMPTY_STATE, UpdateState} from '../../../node/updater/types';
 const sh = (cmd: string, opts: any = {}) =>
   execSync(cmd, {stdio: 'pipe', ...opts}).toString().trim();
 
+// On Windows, git's child processes can briefly hold file handles after exit
+// (NTFS lazy-release / antivirus / pack files), so an immediate rmdir on the
+// temp repo hits EBUSY. fs.rm's built-in retry clears the flake.
+const cleanupTmp = (dir: string) =>
+  fs.rm(dir, {recursive: true, force: true, maxRetries: 10, retryDelay: 100});
+
 const buildTmpRepo = async (): Promise<{dir: string; v1Sha: string; v2Sha: string}> => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'updater-it-'));
   sh('git init -b main', {cwd: dir});
@@ -94,7 +100,7 @@ describe(__filename, function () {
       // The fromSha recorded in state matches the v0.0.1 SHA.
       assert.equal((states.at(-1)!.execution as {fromSha: string}).fromSha, v1Sha);
     } finally {
-      await fs.rm(dir, {recursive: true, force: true});
+      await cleanupTmp(dir);
     }
   });
 
@@ -140,7 +146,7 @@ describe(__filename, function () {
       const lock = await fs.readFile(path.join(dir, 'pnpm-lock.yaml'), 'utf8');
       assert.match(lock, /lockfileVersion: x/);
     } finally {
-      await fs.rm(dir, {recursive: true, force: true});
+      await cleanupTmp(dir);
     }
   });
 
@@ -182,7 +188,7 @@ describe(__filename, function () {
       assert.equal(states.at(-1)!.execution.status, 'rolled-back');
       assert.equal(sh('git rev-parse HEAD', {cwd: dir}), v1Sha);
     } finally {
-      await fs.rm(dir, {recursive: true, force: true});
+      await cleanupTmp(dir);
     }
   });
 
@@ -225,7 +231,7 @@ describe(__filename, function () {
       assert.equal(sh('git rev-parse HEAD', {cwd: dir}), v1Sha);
       assert.equal(exitedWith, 75);
     } finally {
-      await fs.rm(dir, {recursive: true, force: true});
+      await cleanupTmp(dir);
     }
   });
 
@@ -259,7 +265,7 @@ describe(__filename, function () {
       assert.equal(states.at(-1)!.lastResult!.outcome, 'rollback-failed');
       assert.equal(exitedWith, 75);
     } finally {
-      await fs.rm(dir, {recursive: true, force: true});
+      await cleanupTmp(dir);
     }
   });
 });

--- a/src/tests/backend/specs/updater-integration.ts
+++ b/src/tests/backend/specs/updater-integration.ts
@@ -225,8 +225,17 @@ describe(__filename, function () {
         rollbackHealthCheckSeconds: 60,
       });
       assert.equal(r.armed, false);
-      // Wait for the fire-and-forget rollback to finish.
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      // Poll for the fire-and-forget rollback to land in its terminal state.
+      // A flat sleep here was racy on Windows (git checkout + spawned-process
+      // bookkeeping can push past several hundred ms).
+      const deadline = Date.now() + 10_000;
+      while (
+        states.at(-1)?.execution.status !== 'rolled-back' &&
+        states.at(-1)?.execution.status !== 'rollback-failed' &&
+        Date.now() < deadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
       assert.equal(states.at(-1)!.execution.status, 'rolled-back');
       assert.equal(sh('git rev-parse HEAD', {cwd: dir}), v1Sha);
       assert.equal(exitedWith, 75);


### PR DESCRIPTION
## Summary

- The Windows backend-test job has been intermittently red since #7607 with `EBUSY: resource busy or locked, rmdir` against the temp-repo dirs created in `src/tests/backend/specs/updater-integration.ts`. Failing case most often: *"crash-loop guard: bootCount=3 forces immediate rollback"* — but every `it()` in the file is exposed.
- Each test builds a tmp git repo via `execSync('git …')` and cleans up in `try…finally` with `fs.rm(dir, {recursive: true, force: true})`. On Windows, git child processes can briefly hold file handles after exit (NTFS lazy-release / antivirus scan / pack files), so the first rmdir hits `EBUSY`. `fs.rm`'s default `maxRetries` is 0 — no recovery, test errors.
- Hoist cleanup to a single `cleanupTmp()` helper that passes `maxRetries: 10, retryDelay: 100`. Built-in `fs.rm` capability since Node 14.14. On Linux/macOS it is a no-op (nothing to retry); on Windows it absorbs the transient lock.
- No production code touched.

## Test plan

- [x] `cd src && npx mocha --import=tsx --timeout 120000 tests/backend/specs/updater-integration.ts` → 5/5 pass locally on Linux.
- [x] `pnpm ts-check` reports no new errors for this file (pre-existing plugin_packages errors unrelated).
- [ ] CI: Windows backend-test job (with + without plugins, Node 22/24/25) clean across a few runs to confirm the flake is gone.

## Notes

The brief also flagged a separate "shutdown hook leak" line that prints right after the rmdir error. That message is a *consequence* of the assertion failure propagating before the test's own server shuts down cleanly; once the rmdir succeeds, the leak warning goes away. Separate investigation deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)