### PR TITLE
fix(admin): restore SearchField + sorting modules used by AuthorPage

### DIFF
--- a/admin/src/components/SearchField.tsx
+++ b/admin/src/components/SearchField.tsx
@@ -1,0 +1,14 @@
+import {ChangeEventHandler, FC} from "react";
+import {Search} from 'lucide-react'
+export type SearchFieldProps = {
+  value: string,
+  onChange:  ChangeEventHandler<HTMLInputElement>,
+  placeholder?: string
+}
+
+export const SearchField:FC<SearchFieldProps> = ({onChange,value, placeholder})=>{
+  return <span className="search-field">
+    <input value={value} onChange={onChange} placeholder={placeholder}/>
+    <Search/>
+  </span>
+}

--- a/admin/src/utils/sorting.ts
+++ b/admin/src/utils/sorting.ts
@@ -1,0 +1,6 @@
+export const determineSorting = (sortBy: string, ascending: boolean, currentSymbol: string) => {
+  if (sortBy === currentSymbol) {
+    return ascending ? 'sort up' : 'sort down';
+  }
+  return 'sort none';
+}

--- a/src/tests/backend-new/specs/admin-i18n-source-lint.test.ts
+++ b/src/tests/backend-new/specs/admin-i18n-source-lint.test.ts
@@ -84,16 +84,26 @@ describe('admin i18n source lint', () => {
       "SearchParams['sortBy'] still includes 'downloads'").toBe(false);
   });
 
-  it('orphan modules from pre-rework admin are gone', () => {
-    // SearchField.tsx and sorting.ts were imported by the pre-rework admin
-    // pages but the rework dropped both. Delete-then-grep here so a future
-    // unrelated import accidentally re-adding them fails review.
+  it('SearchField + sorting modules exist and are consumed by AuthorPage', () => {
+    // History: PR #7716 (admin design rework) dropped the last consumer of
+    // these helpers, then PR #7736 deleted both modules calling them
+    // "orphans". PR #7667 (GDPR author-erasure) merged afterwards from an
+    // older base and reintroduced imports of SearchField + determineSorting
+    // in admin/src/pages/AuthorPage.tsx, breaking the admin build on
+    // develop. The files have been restored; this test pins both the file
+    // presence and the AuthorPage consumption so a future "orphan" sweep
+    // cannot quietly remove them again without also updating AuthorPage.
     const fs = require('fs');
     const join = require('path').join;
     expect(fs.existsSync(join(repoRoot, 'admin/src/components/SearchField.tsx')),
-      'admin/src/components/SearchField.tsx is dead code from pre-rework admin').toBe(false);
+      'admin/src/components/SearchField.tsx is missing — AuthorPage imports it').toBe(true);
     expect(fs.existsSync(join(repoRoot, 'admin/src/utils/sorting.ts')),
-      'admin/src/utils/sorting.ts is dead code from pre-rework admin').toBe(false);
+      'admin/src/utils/sorting.ts is missing — AuthorPage imports determineSorting from it').toBe(true);
+    const authorPage = read('admin/src/pages/AuthorPage.tsx');
+    expect(authorPage.includes("from \"../components/SearchField.tsx\""),
+      'AuthorPage no longer imports SearchField — delete SearchField.tsx too').toBe(true);
+    expect(authorPage.includes("from \"../utils/sorting.ts\""),
+      'AuthorPage no longer imports determineSorting — delete sorting.ts too').toBe(true);
   });
 
   it('PadPage sort dropdown is paired with a direction toggle', () => {


### PR DESCRIPTION
## Summary
- Restores `admin/src/components/SearchField.tsx` and `admin/src/utils/sorting.ts`, which #7736 deleted as "orphan modules" before #7667 (GDPR admin AuthorPage) merged and reintroduced the imports.
- Without these files develop's admin build fails with `TS2307: Cannot find module '../components/SearchField.tsx'` (and a knock-on `TS7006` implicit-any on the SearchField onChange callback), which is what's currently breaking **Backend tests**, **Frontend admin tests**, **Docker** (build-test / build-test-local-plugin / build-test-db-drivers), **rate limit**, and **Upgrade from latest release** on develop.

## Why this happened
1. #7716 (admin design rework) restructured admin pages and removed the last consumer of `SearchField` / `determineSorting`.
2. #7736 noticed the orphans and deleted both files on 2026-05-12.
3. #7667 (GDPR author-erasure UI) — written off an older base — merged *after* #7736 and added `admin/src/pages/AuthorPage.tsx`, which still imports `SearchField` and `determineSorting`.

Develop now has an `AuthorPage.tsx` whose imports point at deleted files. Every CI job that runs `pnpm --filter admin run build-copy` (directly or transitively through Docker / Backend tests / Frontend admin tests) fails at the `tsc` step.

## The fix
Restore both files verbatim from `ff7c4d531^`. This is the minimum change needed to make develop's admin build pass again. Inlining the two helpers into `AuthorPage.tsx` (or deleting them again together with their consumers) can be done as follow-up cleanup.

## Test plan
- [x] `cd admin && pnpm exec tsc --noEmit` — no errors
- [x] `cd admin && pnpm exec tsc && pnpm exec vite build` — built in 545ms; admin bundle written to `src/templates/admin`
- [ ] CI: Backend tests, Frontend admin tests, Docker, rate limit, Upgrade from latest release all back to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)