### PR TITLE
Support Node 25

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         # PRs: test on latest Node only. Push to develop: full matrix.
-        node: ${{ github.event_name == 'pull_request' && fromJSON('[24]') || fromJSON('[22, 24, 25]') }}
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[25]') || fromJSON('[22, 24, 25]') }}
     steps:
       -
         name: Checkout repository
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ${{ github.event_name == 'pull_request' && fromJSON('[24]') || fromJSON('[22, 24, 25]') }}
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[25]') || fromJSON('[22, 24, 25]') }}
     steps:
       -
         name: Checkout repository

--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       - name: Setup Pages
         if: github.event_name == 'push'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
           cache-dependency-path: etherpad/pnpm-lock.yaml
       -

--- a/.github/workflows/frontend-admin-tests.yml
+++ b/.github/workflows/frontend-admin-tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # PRs: single Node version. Push: full matrix.
-        node: ${{ github.event_name == 'pull_request' && fromJSON('[24]') || fromJSON('[22, 24, 25]') }}
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[25]') || fromJSON('[22, 24, 25]') }}
 
     steps:
       -

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       -
         name: Install all dependencies and symlink for ep_etherpad-lite
@@ -114,7 +114,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       - name: Install all dependencies and symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile
@@ -190,7 +190,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       - name: Install all dependencies and symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile
@@ -291,7 +291,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       - name: Install all dependencies and symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/handleRelease.yml
+++ b/.github/workflows/handleRelease.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       - name: Install all dependencies and symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/installer-test.yml
+++ b/.github/workflows/installer-test.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Pre-install pnpm (avoid sudo prompt in the installer)
         run: npm install -g pnpm
@@ -50,8 +50,8 @@ jobs:
       - name: Run bin/installer.sh against this commit
         env:
           ETHERPAD_DIR: ${{ runner.temp }}/etherpad-installer-test
-          ETHERPAD_REPO: ${{ github.server_url }}/${{ github.repository }}.git
-          ETHERPAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          ETHERPAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }}
+          ETHERPAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           NO_COLOR: "1"
         run: sh ./bin/installer.sh
 
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Pre-install pnpm
         run: npm install -g pnpm
@@ -113,8 +113,8 @@ jobs:
         shell: pwsh
         env:
           ETHERPAD_DIR: ${{ runner.temp }}\etherpad-installer-test
-          ETHERPAD_REPO: ${{ github.server_url }}/${{ github.repository }}.git
-          ETHERPAD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          ETHERPAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.clone_url || format('{0}/{1}.git', github.server_url, github.repository) }}
+          ETHERPAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
           NO_COLOR: "1"
         run: ./bin/installer.ps1
 

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       -
         name: Install all dependencies and symlink for ep_etherpad-lite
@@ -77,7 +77,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       -
         name: Install etherpad-load-test
@@ -140,7 +140,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       -
         name: Install all dependencies and symlink for ep_etherpad-lite

--- a/.github/workflows/perform-type-check.yml
+++ b/.github/workflows/perform-type-check.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
       - name: Install all dependencies and symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/rate-limit.yml
+++ b/.github/workflows/rate-limit.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
 
       -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
           cache: pnpm
           cache-dependency-path: etherpad/pnpm-lock.yaml
       - name: Install dependencies ether.github.com

--- a/.github/workflows/releaseEtherpad.yml
+++ b/.github/workflows/releaseEtherpad.yml
@@ -17,9 +17,8 @@ jobs:
         - uses: actions/setup-node@v6
           with:
             # OIDC trusted publishing needs npm >= 11.5.1, which requires
-            # Node >= 22.9.0. setup-node's `22` resolves to the latest
-            # 22.x, which satisfies that.
-            node-version: 22
+            # Node >= 22.9.0. Node 25 satisfies that and matches the rest of CI.
+            node-version: 25
             registry-url: https://registry.npmjs.org/
         - name: Upgrade npm to >=11.5.1 (required for trusted publishing)
           run: npm install -g npm@latest

--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
 
       - name: Install bin dependencies
         working-directory: ./bin

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -28,13 +28,16 @@ jobs:
       fail-fast: false
       matrix:
         # PRs: single Node version. Push: full matrix.
-        node: ${{ github.event_name == 'pull_request' && fromJSON('[24]') || fromJSON('[22, 24, 25]') }}
+        node: ${{ github.event_name == 'pull_request' && fromJSON('[25]') || fromJSON('[22, 24, 25]') }}
     steps:
       -
         name: Check out latest release
         uses: actions/checkout@v6
         with:
-          ref: develop #FIXME change to master when doing release
+          fetch-depth: 0
+      -
+        name: Check out latest release tag
+        run: git checkout "$(git tag --list 'v*' --sort=-version:refname | head -n1)"
       - uses: actions/cache@v5
         name: Cache pnpm store
         with:
@@ -84,13 +87,10 @@ jobs:
       -
         name: Install all dependencies and symlink for ep_etherpad-lite
         run: pnpm install --frozen-lockfile
-      # Because actions/checkout@v6 is called with "ref: master" and without
-      # "fetch-depth: 0", the local clone does not have the ${GITHUB_SHA}
-      # commit. Fetch ${GITHUB_REF} to get the ${GITHUB_SHA} commit. Note that a
-      # plain "git fetch" only fetches "normal" references (refs/heads/* and
-      # refs/tags/*), and for pull requests none of the normal references
-      # include ${GITHUB_SHA}, so we have to explicitly tell Git to fetch
-      # ${GITHUB_REF}.
+      # The job starts from the latest release tag, so fetch the pull-request
+      # ref explicitly before checking out ${GITHUB_SHA}. A plain "git fetch"
+      # only brings "normal" references (refs/heads/* and refs/tags/*), and for
+      # pull requests none of those include the synthetic merge commit.
       -
         name: Fetch the new Git commits
         run: git fetch --depth=1 origin "${GITHUB_REF}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+### Breaking changes
+
+- **Node 25 is now the default development and CI target.** `packageManager` is now `pnpm@11.1.2` and `engines.pnpm` requires `>=11.1.2`. Node 25 [stopped shipping Corepack](https://github.com/nodejs/node/pull/57617); install pnpm directly with `npm install -g pnpm` (or follow the existing `bin/installer.sh` one-liner, which does this for you).
+
 ### Notable enhancements
 
 - **Self-update subsystem — Tier 2 (manual click).**
@@ -60,7 +64,7 @@
 
 - The HTTP client in the backend has been migrated from `axios` to the built-in `fetch` API, dropping a dependency now that Node 22 ships a stable fetch.
 - `admin/` and `ui/` workspaces moved from `rolldown-vite` to upstream **Vite 8**.
-- Build and CI moved to **pnpm 11** (`packageManager: "pnpm@11.0.6"`); the `Dockerfile`, snap, and all GitHub workflows are aligned. pnpm overrides have been migrated from `package.json` to `pnpm-workspace.yaml` to match pnpm 11's expectations.
+- Build and CI moved to **pnpm 11** (`packageManager: "pnpm@11.1.2"`); the `Dockerfile`, snap, and all GitHub workflows are aligned. pnpm overrides have been migrated from `package.json` to `pnpm-workspace.yaml` to match pnpm 11's expectations.
 - All client modules have been converted to ESM.
 - The CI matrix tests Node 22, 24, and 25; on PRs the matrix is reduced to a single Node version to keep feedback fast.
 - Frontend Playwright tests now run against the `/ether` plugin set, with feature-tag based skips so plugin-incompatible specs are excluded automatically.

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "ui": "link:ui"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.13.0",
+    "pnpm": ">=11.1.2"
   },
-  "packageManager": "pnpm@11.0.6",
+  "packageManager": "pnpm@11.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ether/etherpad.git"


### PR DESCRIPTION
## Summary

Bumps the workflow Node version to 25 and the pinned pnpm to 11.1.2.

**Corepack is gone from the diff.** Node 25 [stopped distributing Corepack](https://github.com/nodejs/node/pull/57617), and the earlier approach in #7741 (`corepack pnpm` everywhere + dynamic resolver + bootstrap helpers) was over-engineering. End-users install pnpm with `npm install -g pnpm` exactly as before — that's all that's needed.

### What this changes (16 files, +42/-38)

- All workflows move to Node 25 on PR runs; push runs keep the full `[22, 24, 25]` matrix.
- `packageManager` → `pnpm@11.1.2`, `engines.pnpm` → `>=11.1.2`.
- `upgrade-from-latest-release.yml` now checks out the **latest release tag** instead of `ref: develop #FIXME`, finally exercising what its name implies.
- `installer-test.yml` resolves `ETHERPAD_REPO` / `ETHERPAD_BRANCH` from the PR head when running on a fork, so the installer smoke test runs against the PR branch.

### What this does NOT change

- No `src/` changes. No new files. No corepack shimming. The runtime updater, plugin migration, `bin/installDeps.sh`, `bin/run.sh`, package.json scripts — all untouched vs develop.

### Verification

End-to-end test in real `node:25-bookworm-slim` (confirmed no `corepack` on PATH):

```
=== Node + npm + no corepack ===
v25.9.0 / 11.12.1 / (no corepack)
=== npm install -g pnpm → 11.1.2 ===
=== pnpm i → Done in 10.4s ===
=== pnpm run build:etherpad → admin SPA + OIDC built ===
OK: admin SPA built
=== pnpm run prod → HTTP server listening for connections ===
```

Local tests: `ts-check`, `test-utils` (mocha) 20/20, vitest 598/598, `updater-integration` 5/5, `updater-scheduler-integration` 2/2.

Closes #7741.
