### PR TITLE
fix(deb): bump nodejs Depends to >= 25; install Node 25 in smoke test

### DIFF
--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -128,16 +128,16 @@ jobs:
         run: |
           set -eux
           # Ubuntu's default apt nodejs is 18 — too old for our
-          # `Depends: nodejs (>= 22)`. Add NodeSource's apt repo
+          # `Depends: nodejs (>= 25)`. Add NodeSource's apt repo
           # explicitly (key + sources.list) instead of `curl | sudo bash`
           # so we don't execute network-fetched code as root.
-          NODE_MAJOR=24
+          NODE_MAJOR=25
           # GitHub runner images often ship a NodeSource node_20.x list
           # preinstalled (sometimes as a .sources deb822 file). Wipe any
           # existing nodesource entries so the only Node candidate apt sees
-          # is our node_24.x repo. Otherwise `apt-get install -y nodejs`
+          # is our node_25.x repo. Otherwise `apt-get install -y nodejs`
           # picks the higher-version 20.x build that's already cached and
-          # `dpkg -i` then fails on `Depends: nodejs (>= 22)`.
+          # `dpkg -i` then fails on `Depends: nodejs (>= 25)`.
           sudo rm -f /etc/apt/sources.list.d/nodesource.list \
                      /etc/apt/sources.list.d/nodesource.sources \
                      /etc/apt/preferences.d/nodesource \
@@ -147,7 +147,7 @@ jobs:
             | sudo gpg --dearmor --yes -o "${KEYRING}"
           echo "deb [signed-by=${KEYRING}] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
             | sudo tee /etc/apt/sources.list.d/nodesource.list
-          # Pin nodejs to the 24.x line so neither Ubuntu's noble-updates
+          # Pin nodejs to the 25.x line so neither Ubuntu's noble-updates
           # 20.x nor any leftover NodeSource cache can win the resolver.
           printf 'Package: nodejs\nPin: version %s.*\nPin-Priority: 1001\n' "${NODE_MAJOR}" \
             | sudo tee /etc/apt/preferences.d/nodesource >/dev/null

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -88,12 +88,18 @@ sudo systemctl start etherpad
 curl http://localhost:9001/health
 ```
 
-`apt` will pull in `nodejs (>= 22)` (matches Etherpad's `engines.node`).
-Recommended runtime is the current Node.js LTS (24); on distros without a
-new enough Node, add NodeSource first:
+`apt` will pull in `nodejs (>= 25)` (matches Etherpad's `engines.node`).
+Most distro repos don't yet ship Node.js 25, so on most systems you
+will need to add NodeSource's `node_25.x` apt repo before
+`apt install`:
 
 ```sh
-curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+KEYRING=/usr/share/keyrings/nodesource.gpg
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  | sudo gpg --dearmor --yes -o "${KEYRING}"
+echo "deb [signed-by=${KEYRING}] https://deb.nodesource.com/node_25.x nodistro main" \
+  | sudo tee /etc/apt/sources.list.d/nodesource.list
+sudo apt-get update
 ```
 
 ## Configuration

--- a/packaging/bin/etherpad
+++ b/packaging/bin/etherpad
@@ -11,7 +11,7 @@ export NODE_ENV
 export ETHERPAD_PRODUCTION=true
 
 # Resolve `node` explicitly to the apt-installed binary (the .deb declares
-# `Depends: nodejs (>= 22)`, which always lands at /usr/bin/node). Relying
+# `Depends: nodejs (>= 25)`, which always lands at /usr/bin/node). Relying
 # on PATH would let a stray /usr/local/bin/node — e.g. an older nvm or
 # toolcache install — shadow the version we actually require, and the
 # server would crash on startup with "Node 20.x is not supported".

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -20,7 +20,7 @@ homepage: https://etherpad.org
 license: Apache-2.0
 
 depends:
-  - nodejs (>= 22)
+  - nodejs (>= 25)
   - adduser
   - ca-certificates
 
@@ -110,11 +110,11 @@ scripts:
 overrides:
   deb:
     depends:
-      - nodejs (>= 22)
+      - nodejs (>= 25)
       - ca-certificates
   rpm:
     depends:
-      - nodejs >= 22
+      - nodejs >= 25
       - shadow-utils
       - ca-certificates
 


### PR DESCRIPTION
## Summary
Follow-up to #7752 that finishes the Node 25 floor migration where I left it half-done. #7752 raised \`src/package.json\` engines.node to \`>=25.0.0\` but missed three places still encoding the old Node 22+ floor, so the **Debian package** workflow broke on develop (run [25912914571](https://github.com/ether/etherpad/actions/runs/25912914571), sha [33b616b9](https://github.com/ether/etherpad/commit/33b616b9)).

## What broke
- \`packaging/nfpm.yaml\` declared \`Depends: nodejs (>= 22)\`, so the produced .deb installs cleanly on Node 22-or-24 systems.
- \`.github/workflows/deb-package.yml\` smoke test then *did* install Node 24 (\`NODE_MAJOR=24\`).
- \`dpkg -i\` succeeded, \`systemctl start etherpad\` crashlooped with:

  ```
  [ERROR] settings - Running Etherpad on Node v24.15.0 is not supported.
    Please upgrade at least to Node 25.0.0
  ```

  (The \`ENOENT: ... lstat '/opt/etherpad/.git'\` line above it is a benign WARN from \`getGitCommit()\` inside a try/catch — *not* the cause; it's been there since deb installs first existed.)

## What changes here
- \`packaging/nfpm.yaml\`: top-level \`depends:\` and the deb / rpm overrides bumped from \`nodejs (>= 22)\` → \`nodejs (>= 25)\` (3 occurrences).
- \`.github/workflows/deb-package.yml\`: smoke-test \`NODE_MAJOR=24\` → \`25\`; surrounding comments updated to match.
- \`packaging/README.md\`: user-facing install doc points at the NodeSource \`node_25.x\` apt repo, since Node 25 isn't yet in most distro repos and the previous \`setup_lts.x\` shortcut would land on Node 24.
- \`packaging/bin/etherpad\`: the comment explaining the apt Depends matches the new pin.

No source code changes — Etherpad's existing \`NodeVersion\` check (\`src/node/utils/NodeVersion.ts\`) already reads \`engines.node\` from \`src/package.json\` and rejects anything older, which is exactly what produced the original failure.

## Test plan
- [ ] Debian package workflow goes green on this PR (Linux runner installs Node 25, deb installs, \`etherpad.service\` starts, smoke assertions pass).
- [x] \`grep -rnE 'nodejs.*22|node_24' packaging/ .github/workflows/\` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)