### PR TITLE
feat(metrics): 3 Prometheus counters for scaling dive (#7756)

### DIFF
--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -47,6 +47,7 @@ const accessLogger = log4js.getLogger('access');
 const hooks = require('../../static/js/pluginfw/hooks');
 const stats = require('../stats')
 const assert = require('assert').strict;
+import {recordChangesetApply, recordSocketEmit} from '../prom-instruments';
 import {RateLimiterMemory} from 'rate-limiter-flexible';
 import {ChangesetRequest, PadUserInfo, SocketClientRequest} from "../types/SocketClientRequest";
 import {APool, AText, PadAuthor, PadType} from "../types/PadType";
@@ -113,6 +114,20 @@ function getActivePadCountFromSessionInfos() {
   return padIds.size;
 }
 exports.getActivePadCountFromSessionInfos = getActivePadCountFromSessionInfos;
+
+// Per-pad user counts derived on demand from sessioninfos. Used by
+// prometheus.ts to populate `etherpad_pad_users{padId}` so the #7756
+// scaling-dive harness can confirm the pad it's pointing at actually
+// has the expected concurrency.
+function getPadUsersMap(): Map<string, number> {
+  const out = new Map<string, number>();
+  for (const {padId} of Object.values(sessioninfos)) {
+    if (!padId) continue;
+    out.set(padId, (out.get(padId) ?? 0) + 1);
+  }
+  return out;
+}
+exports.getPadUsersMap = getPadUsersMap;
 
 /**
  * Build a sanitized copy of the plugins registry suitable for sending to the
@@ -591,6 +606,7 @@ exports.handleCustomObjectMessage = (msg: CustomMessage, sessionID: string) => {
     } else {
       // broadcast to all clients on this pad
       socketio.sockets.in(msg.data.payload.padId).emit('message', msg);
+      recordSocketEmit(msg.data.type);
     }
   }
 };
@@ -611,6 +627,7 @@ exports.handleCustomMessage = (padID: string, msgString:string) => {
     },
   };
   socketio.sockets.in(padID).emit('message', msg);
+  recordSocketEmit(msg.data.type);
 };
 
 /**
@@ -651,6 +668,7 @@ exports.sendChatMessageToPadClients = async (mt: ChatMessage|number, puId: strin
     type: 'COLLABROOM',
     data: {type: 'CHAT_MESSAGE', message},
   });
+  recordSocketEmit('CHAT_MESSAGE');
   await promise;
 };
 
@@ -770,6 +788,7 @@ const handleUserChanges = async (socket:any, message: {
 
   // Measure time to process edit
   const stopWatch = stats.timer('edits').start();
+  const stopHistogram = recordChangesetApply();
   try {
     const {data: {baseRev, apool, changeset}} = message;
     if (baseRev == null) throw new Error('missing baseRev');
@@ -882,6 +901,7 @@ const handleUserChanges = async (socket:any, message: {
                        `(socket ${socket.id}) on pad ${thisSession.padId}: ${err.stack || err}`);
   } finally {
     stopWatch.end();
+    stopHistogram();
   }
 };
 
@@ -934,6 +954,7 @@ exports.updatePadClients = async (pad: PadType) => {
       };
       try {
         socket.emit('message', msg);
+        recordSocketEmit('NEW_CHANGES');
       } catch (err:any) {
         messageLogger.error(`Failed to notify user of new revision: ${err.stack || err}`);
         return;

--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -786,9 +786,14 @@ const handleUserChanges = async (socket:any, message: {
   // if the session was valid when the message arrived in the first place
   if (!thisSession) throw new Error('client disconnected');
 
-  // Measure time to process edit
+  // Measure time to process edit. stats.timer('edits') spans the full handler
+  // (apply + fan-out) for backwards-compat; the new Prometheus histogram below
+  // wraps only the apply path so the scaling-dive harness can distinguish
+  // "apply is slow" from "fan-out is slow". Failed applies do not call the
+  // stopper — leaving the timer un-observed keeps the success-path
+  // distribution clean.
   const stopWatch = stats.timer('edits').start();
-  const stopHistogram = recordChangesetApply();
+  const stopApplyHistogram = recordChangesetApply();
   try {
     const {data: {baseRev, apool, changeset}} = message;
     if (baseRev == null) throw new Error('missing baseRev');
@@ -890,6 +895,10 @@ const handleUserChanges = async (socket:any, message: {
     // The client assumes that ACCEPT_COMMIT and NEW_CHANGES messages arrive in order. Make sure we
     // have already sent any previous ACCEPT_COMMIT and NEW_CHANGES messages.
     assert.equal(thisSession.rev, r);
+    // End of the apply path. The Prometheus histogram observes here so that
+    // fan-out (socket emit + updatePadClients) does NOT inflate the apply
+    // duration. Failed applies are deliberately not recorded.
+    stopApplyHistogram();
     socket.emit('message', {type: 'COLLABROOM', data: {type: 'ACCEPT_COMMIT', newRev}});
     thisSession.rev = newRev;
     if (newRev !== r) thisSession.time = await pad.getRevisionDate(newRev);
@@ -901,7 +910,6 @@ const handleUserChanges = async (socket:any, message: {
                        `(socket ${socket.id}) on pad ${thisSession.padId}: ${err.stack || err}`);
   } finally {
     stopWatch.end();
-    stopHistogram();
   }
 };
 

--- a/src/node/prom-instruments.ts
+++ b/src/node/prom-instruments.ts
@@ -1,0 +1,36 @@
+// Prometheus instruments referenced from the hot path (PadMessageHandler).
+//
+// Defined in a separate file so that PadMessageHandler can import the
+// recording helpers without creating a circular import with prometheus.ts
+// (which already requires PadMessageHandler to read sessioninfos).
+//
+// The metrics themselves are added to the central Registry by prometheus.ts.
+
+import client from 'prom-client';
+
+export const changesetApplyDuration = new client.Histogram({
+  name: 'etherpad_changeset_apply_duration_seconds',
+  help: 'Time spent applying an incoming USER_CHANGES message on the server',
+  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 5],
+});
+
+export const socketEmitsTotal = new client.Counter({
+  name: 'etherpad_socket_emits_total',
+  help: 'Number of socket.io broadcast emits, bucketed by message type',
+  labelNames: ['type'],
+});
+
+export const padUsersGauge = new client.Gauge({
+  name: 'etherpad_pad_users',
+  help: 'Active users connected to a pad, keyed by padId',
+  labelNames: ['padId'],
+});
+
+/** Start a timer for the changeset apply path. Call the returned function when done. */
+export const recordChangesetApply = (): (() => void) =>
+  changesetApplyDuration.startTimer();
+
+/** Increment the socket-emit counter for the given message type. */
+export const recordSocketEmit = (type: string | undefined): void => {
+  socketEmitsTotal.labels(type || 'unknown').inc();
+};

--- a/src/node/prom-instruments.ts
+++ b/src/node/prom-instruments.ts
@@ -5,12 +5,20 @@
 // (which already requires PadMessageHandler to read sessioninfos).
 //
 // The metrics themselves are added to the central Registry by prometheus.ts.
+//
+// Everything here is gated behind settings.scalingDiveMetrics (default false).
+// When the flag is off the recording helpers short-circuit to no-ops and the
+// metrics are never registered, so production deployments don't pay for
+// instrumentation they don't use.
 
 import client from 'prom-client';
+import settings from './utils/Settings';
+
+export const enabled = (): boolean => settings.scalingDiveMetrics === true;
 
 export const changesetApplyDuration = new client.Histogram({
   name: 'etherpad_changeset_apply_duration_seconds',
-  help: 'Time spent applying an incoming USER_CHANGES message on the server',
+  help: 'Time spent applying an incoming USER_CHANGES message on the server (apply path only, excludes fan-out to other clients)',
   buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 5],
 });
 
@@ -26,11 +34,34 @@ export const padUsersGauge = new client.Gauge({
   labelNames: ['padId'],
 });
 
-/** Start a timer for the changeset apply path. Call the returned function when done. */
-export const recordChangesetApply = (): (() => void) =>
-  changesetApplyDuration.startTimer();
+// Allowlist of message-type label values. Anything outside this set is rolled
+// into 'other' so a misbehaving plugin or HTTP-API caller passing a
+// user-controlled msgString cannot explode prom-client's internal label-cardinality
+// state.
+const KNOWN_TYPES = new Set([
+  'NEW_CHANGES',
+  'ACCEPT_COMMIT',
+  'CHAT_MESSAGE',
+  'CLIENT_VARS',
+  'CLIENT_MESSAGE',
+  'CUSTOM',
+  'USER_NEWINFO',
+  'USERINFO_UPDATE',
+  'USER_LEAVE',
+]);
 
-/** Increment the socket-emit counter for the given message type. */
+/** Start a timer for the changeset apply path. Call the returned function when done.
+ *  Returns a no-op stopper when the feature flag is off. */
+export const recordChangesetApply = (): (() => void) => {
+  if (!enabled()) return () => {};
+  return changesetApplyDuration.startTimer();
+};
+
+/** Increment the socket-emit counter for the given message type.
+ *  No-op when the feature flag is off. Unknown/missing types are bucketed as
+ *  'other' to keep label cardinality bounded. */
 export const recordSocketEmit = (type: string | undefined): void => {
-  socketEmitsTotal.labels(type || 'unknown').inc();
+  if (!enabled()) return;
+  const label = type && KNOWN_TYPES.has(type) ? type : 'other';
+  socketEmitsTotal.labels(label).inc();
 };

--- a/src/node/prometheus.ts
+++ b/src/node/prometheus.ts
@@ -23,6 +23,15 @@ const activePadsGauge = new client.Gauge({
 });
 register.registerMetric(activePadsGauge);
 
+// Added for the #7756 scaling dive: lets the load-test harness attribute
+// where time goes (apply path vs. fan-out) and confirm per-pad concurrency.
+// The metric handles live in prom-instruments.ts to avoid a circular import
+// with PadMessageHandler (which records into them on the hot path).
+import {padUsersGauge, changesetApplyDuration, socketEmitsTotal} from './prom-instruments';
+register.registerMetric(padUsersGauge);
+register.registerMetric(changesetApplyDuration);
+register.registerMetric(socketEmitsTotal);
+
 client.collectDefaultMetrics({register});
 
 const monitor = async function () {
@@ -32,6 +41,11 @@ const monitor = async function () {
   }
   activePadsGauge.set(PadMessageHandler.getActivePadCountFromSessionInfos());
   totalUsersGauge.set(PadMessageHandler.getTotalActiveUsers());
+  // Per-pad concurrency: reset to avoid stale labels for pads that drained.
+  padUsersGauge.reset();
+  for (const [padId, count] of PadMessageHandler.getPadUsersMap()) {
+    padUsersGauge.set({padId}, count);
+  }
   return register;
 };
 

--- a/src/node/prometheus.ts
+++ b/src/node/prometheus.ts
@@ -27,10 +27,14 @@ register.registerMetric(activePadsGauge);
 // where time goes (apply path vs. fan-out) and confirm per-pad concurrency.
 // The metric handles live in prom-instruments.ts to avoid a circular import
 // with PadMessageHandler (which records into them on the hot path).
-import {padUsersGauge, changesetApplyDuration, socketEmitsTotal} from './prom-instruments';
-register.registerMetric(padUsersGauge);
-register.registerMetric(changesetApplyDuration);
-register.registerMetric(socketEmitsTotal);
+// Gated behind settings.scalingDiveMetrics so production deployments don't
+// pay for the instrumentation by default.
+import {padUsersGauge, changesetApplyDuration, socketEmitsTotal, enabled as scalingDiveMetricsEnabled} from './prom-instruments';
+if (scalingDiveMetricsEnabled()) {
+  register.registerMetric(padUsersGauge);
+  register.registerMetric(changesetApplyDuration);
+  register.registerMetric(socketEmitsTotal);
+}
 
 client.collectDefaultMetrics({register});
 
@@ -41,10 +45,12 @@ const monitor = async function () {
   }
   activePadsGauge.set(PadMessageHandler.getActivePadCountFromSessionInfos());
   totalUsersGauge.set(PadMessageHandler.getTotalActiveUsers());
-  // Per-pad concurrency: reset to avoid stale labels for pads that drained.
-  padUsersGauge.reset();
-  for (const [padId, count] of PadMessageHandler.getPadUsersMap()) {
-    padUsersGauge.set({padId}, count);
+  if (scalingDiveMetricsEnabled()) {
+    // Per-pad concurrency: reset to avoid stale labels for pads that drained.
+    padUsersGauge.reset();
+    for (const [padId, count] of PadMessageHandler.getPadUsersMap()) {
+      padUsersGauge.set({padId}, count);
+    }
   }
   return register;
 };

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -271,6 +271,7 @@ export type SettingsType = {
   ipLogging: 'full' | 'truncated' | 'anonymous',
   automaticReconnectionTimeout: number,
   loadTest: boolean,
+  scalingDiveMetrics: boolean,
   dumpOnUncleanExit: boolean,
   indentationOnNewLine: boolean,
   logconfig: any | null,
@@ -650,6 +651,13 @@ const settings: SettingsType = {
    * Disable Load Testing
    */
   loadTest: false,
+  /**
+   * Expose extra Prometheus metrics designed for the scaling-dive load-test harness
+   * (ether/etherpad#7756): etherpad_pad_users{padId}, etherpad_changeset_apply_duration_seconds,
+   * etherpad_socket_emits_total{type}. Default false — enable only when running the harness so
+   * production deployments aren't paying for instrumentation they don't use.
+   */
+  scalingDiveMetrics: false,
   /**
    * Disable dump of objects preventing a clean exit
    */

--- a/src/tests/backend-new/specs/prom-instruments.test.ts
+++ b/src/tests/backend-new/specs/prom-instruments.test.ts
@@ -1,8 +1,10 @@
 // Smoke test for the Prometheus instruments added for #7756. Verifies the
 // recording helpers actually move the underlying metrics so the load-test
-// harness can rely on them.
+// harness can rely on them, AND that the settings.scalingDiveMetrics flag
+// gates everything off when disabled.
 
-import {describe, it, expect, beforeEach} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import settings from '../../../node/utils/Settings';
 import {
   recordChangesetApply,
   recordSocketEmit,
@@ -10,12 +12,17 @@ import {
   socketEmitsTotal,
 } from '../../../node/prom-instruments';
 
+const originalFlag = settings.scalingDiveMetrics;
+
 beforeEach(() => {
   socketEmitsTotal.reset();
   changesetApplyDuration.reset();
+  settings.scalingDiveMetrics = true;
 });
 
-describe('recordSocketEmit', () => {
+afterEach(() => { settings.scalingDiveMetrics = originalFlag; });
+
+describe('recordSocketEmit (flag enabled)', () => {
   it('increments etherpad_socket_emits_total keyed by message type', async () => {
     recordSocketEmit('NEW_CHANGES');
     recordSocketEmit('NEW_CHANGES');
@@ -27,21 +34,45 @@ describe('recordSocketEmit', () => {
     expect(byType['CHAT_MESSAGE']).toBe(1);
   });
 
-  it('falls back to "unknown" when type is missing', async () => {
+  it('buckets unknown / user-supplied label values as "other" to keep cardinality bounded', async () => {
     recordSocketEmit(undefined);
+    recordSocketEmit('attacker-supplied-string-1');
+    recordSocketEmit('attacker-supplied-string-2');
     const values = await socketEmitsTotal.get();
-    expect(values.values.some((v) => v.labels.type === 'unknown')).toBe(true);
+    const byType: Record<string, number> = {};
+    for (const v of values.values) byType[v.labels.type as string] = v.value;
+    expect(byType['other']).toBe(3);
+    // No labels for the attacker strings — proves the allowlist is enforced.
+    expect(Object.keys(byType)).not.toContain('attacker-supplied-string-1');
+    expect(Object.keys(byType)).not.toContain('attacker-supplied-string-2');
   });
 });
 
-describe('recordChangesetApply', () => {
+describe('recordChangesetApply (flag enabled)', () => {
   it('observes a duration in etherpad_changeset_apply_duration_seconds', async () => {
     const end = recordChangesetApply();
     await new Promise((r) => setTimeout(r, 5));
     end();
     const values = await changesetApplyDuration.get();
-    // Histogram exposes `_sum` and `_count` rows. We only need to confirm count > 0.
     const countRow = values.values.find((v) => v.metricName === 'etherpad_changeset_apply_duration_seconds_count');
     expect(countRow?.value).toBeGreaterThan(0);
+  });
+});
+
+describe('feature flag (disabled by default)', () => {
+  beforeEach(() => { settings.scalingDiveMetrics = false; });
+
+  it('recordSocketEmit is a no-op', async () => {
+    recordSocketEmit('NEW_CHANGES');
+    const values = await socketEmitsTotal.get();
+    expect(values.values.length).toBe(0);
+  });
+
+  it('recordChangesetApply returns a no-op stopper that does not observe', async () => {
+    const end = recordChangesetApply();
+    end();
+    const values = await changesetApplyDuration.get();
+    const countRow = values.values.find((v) => v.metricName === 'etherpad_changeset_apply_duration_seconds_count');
+    expect(countRow?.value ?? 0).toBe(0);
   });
 });

--- a/src/tests/backend-new/specs/prom-instruments.test.ts
+++ b/src/tests/backend-new/specs/prom-instruments.test.ts
@@ -1,0 +1,47 @@
+// Smoke test for the Prometheus instruments added for #7756. Verifies the
+// recording helpers actually move the underlying metrics so the load-test
+// harness can rely on them.
+
+import {describe, it, expect, beforeEach} from 'vitest';
+import {
+  recordChangesetApply,
+  recordSocketEmit,
+  changesetApplyDuration,
+  socketEmitsTotal,
+} from '../../../node/prom-instruments';
+
+beforeEach(() => {
+  socketEmitsTotal.reset();
+  changesetApplyDuration.reset();
+});
+
+describe('recordSocketEmit', () => {
+  it('increments etherpad_socket_emits_total keyed by message type', async () => {
+    recordSocketEmit('NEW_CHANGES');
+    recordSocketEmit('NEW_CHANGES');
+    recordSocketEmit('CHAT_MESSAGE');
+    const values = await socketEmitsTotal.get();
+    const byType: Record<string, number> = {};
+    for (const v of values.values) byType[v.labels.type as string] = v.value;
+    expect(byType['NEW_CHANGES']).toBe(2);
+    expect(byType['CHAT_MESSAGE']).toBe(1);
+  });
+
+  it('falls back to "unknown" when type is missing', async () => {
+    recordSocketEmit(undefined);
+    const values = await socketEmitsTotal.get();
+    expect(values.values.some((v) => v.labels.type === 'unknown')).toBe(true);
+  });
+});
+
+describe('recordChangesetApply', () => {
+  it('observes a duration in etherpad_changeset_apply_duration_seconds', async () => {
+    const end = recordChangesetApply();
+    await new Promise((r) => setTimeout(r, 5));
+    end();
+    const values = await changesetApplyDuration.get();
+    // Histogram exposes `_sum` and `_count` rows. We only need to confirm count > 0.
+    const countRow = values.values.find((v) => v.metricName === 'etherpad_changeset_apply_duration_seconds_count');
+    expect(countRow?.value).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds three Prometheus rows to \`/stats/prometheus\` so the load-test harness for #7756 can attribute *where* time goes on the server, not just the gauge headline (CPU / event-loop / memory):

- \`etherpad_pad_users{padId}\` — gauge derived from \`sessioninfos\` on scrape. Lets the harness confirm a target pad actually has the expected concurrency.
- \`etherpad_changeset_apply_duration_seconds\` — histogram observed inside \`handleUserChanges\`. Separates \"apply path is slow\" from \"fan-out is slow\" when latency rises.
- \`etherpad_socket_emits_total{type}\` — counter at the broadcast emit sites (\`handleCustomObjectMessage\`, \`handleCustomMessage\`, \`sendChatMessageToPadClients\`) and the per-socket \`NEW_CHANGES\` loop in \`updatePadClients\`. Bucketed by message type so the harness can measure the amplification factor of each lever (especially the fan-out batching lever).

Metric handles live in a new \`src/node/prom-instruments.ts\` rather than \`prometheus.ts\` itself, to avoid a circular import — \`prometheus.ts\` already \`require\`s \`PadMessageHandler\` to read \`sessioninfos\`.

This is the follow-up PR planned in section 6 of \`docs/superpowers/specs/2026-05-15-scaling-dive-design.md\` (in \`ether/etherpad-load-test\`). The load-test harness already tolerates these metrics' absence, so it ships unblocked; this PR just makes the next dive run more informative.

## Test Plan

- [ ] Backend test \`src/tests/backend-new/specs/prom-instruments.test.ts\` passes (3/3 locally) — verifies the recording helpers move the underlying counter/histogram.
- [ ] Existing backend test suite remains green.
- [ ] After merge, \`curl http://your-etherpad/stats/prometheus | grep etherpad_\` shows the three new rows.
- [ ] Trigger the [Scaling dive workflow](https://github.com/ether/etherpad-load-test/actions/workflows/scaling-dive.yml) with \`core_ref\` pointing at this branch or develop-post-merge; verify the harness reports include \`etherpad_socket_emits_total{type=NEW_CHANGES}\` and \`etherpad_changeset_apply_duration_seconds_count\` in the JSON snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)