### PR TITLE
fix(a11y): action Qodo review on merged #7758

### DIFF
--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -328,18 +328,39 @@ const Ace2Editor = function () {
     });
     debugLog('Ace2Editor.init() Ace2Inner.init() returned');
 
-    // Screen-reader-only keyboard hint, target of the body's
-    // aria-describedby. We park it in <head> instead of <body> because
-    // Ace2Inner manages body children via its line model — anything
-    // unrelated inserted into body gets wiped by line splices. The ARIA
-    // spec allows the description target to live anywhere in the same
-    // document, and screen readers resolve it by ID; rendering doesn't
-    // matter because aria-describedby fetches the element's text.
+    // Screen-reader-only keyboard hint, target of the inner body's
+    // aria-describedby. Three things matter for AT to actually announce it:
+    //
+    //   1. Position: appended to the inner document's <head>. Anything in
+    //      <body> gets wiped by Ace2Inner's line-model rebuild during the
+    //      queued setBaseText/importText calls below. The ARIA spec lets
+    //      aria-describedby resolve to any ID in the same document, so
+    //      head placement is valid — screen readers look up by ID and
+    //      read text content, rendering position doesn't matter.
+    //   2. Exposure: NOT `hidden`. The HTML `hidden` attribute removes the
+    //      node from the accessibility tree, so aria-describedby would
+    //      resolve to a node with no exposed name. We leave the element
+    //      visible in markup but unrendered (head children don't paint).
+    //   3. Localization: html10n.get() returns undefined when translations
+    //      are still loading (and Ace2Editor.init() races with that load),
+    //      so seed with a hardcoded English fallback and re-pull the
+    //      translated string on every html10n `localized` event — that
+    //      keeps the text right both on first paint and on runtime
+    //      language changes.
+    const HINT_FALLBACK_EN =
+        'Press Escape to exit the editor. Press Alt+F9 to access the toolbar.';
     const hint = innerDocument.createElement('div');
     hint.id = 'editor-keyboard-hint';
-    hint.hidden = true;
-    hint.textContent = html10n.get('pad.editor.keyboardHint');
+    const refreshHint = () => {
+      const localized = html10n.get('pad.editor.keyboardHint');
+      hint.textContent =
+          (typeof localized === 'string' && localized) ? localized : HINT_FALLBACK_EN;
+    };
+    refreshHint();
     innerDocument.head.appendChild(hint);
+    if (html10n && typeof html10n.bind === 'function') {
+      html10n.bind('localized', refreshHint);
+    }
 
     loaded = true;
     doActionsPendingInit();

--- a/src/tests/frontend-new/specs/a11y_dialogs.spec.ts
+++ b/src/tests/frontend-new/specs/a11y_dialogs.spec.ts
@@ -163,14 +163,38 @@ test('skip-to-content link bypasses toolbar (WCAG 2.4.1, #7255)', async ({page})
 });
 
 test('skip link is the first Tab target from a fresh page (WCAG 2.4.1, #7255)', async ({page}) => {
-  // Pre-condition: pad.ts no longer auto-focuses the editor on load
-  // (that previously trapped Tab inside the editor iframe and left the
-  // skip link unreachable from the URL bar). Initial focus is on <body>.
-  const initialTag = await page.evaluate(() => document.activeElement?.tagName);
-  expect(initialTag).toBe('BODY');
+  // Don't assert what happens to be focused after page load — plugins,
+  // banners, or the privacy-token modal can grab focus before the test
+  // runs, and the actual invariant we care about is tab order, not the
+  // starting point. Defocus first, then press Tab from a known state.
+  await page.evaluate(() => {
+    const a = document.activeElement as HTMLElement | null;
+    if (a && a !== document.body && typeof a.blur === 'function') a.blur();
+  });
   await page.keyboard.press('Tab');
   const afterTabId = await page.evaluate(() => document.activeElement?.id || '');
   expect(afterTabId).toBe('skip-to-content');
+});
+
+test('editor-keyboard-hint exists in the editor iframe with localized text (#7255)', async ({page}) => {
+  // Regression: PR #7451 added #editor-keyboard-hint as the target of the
+  // editor body's aria-describedby. The hint was being wiped by
+  // Ace2Inner.init()'s body management before it could be announced;
+  // PR #7758 reworked the insertion to run after doActionsPendingInit().
+  // Assert here that the hint actually exists post-init and carries the
+  // localized string — without this test, future ace internals changes
+  // could silently reintroduce the wipe.
+  const innerFrame = page.frameLocator('iframe[name="ace_outer"]')
+      .frameLocator('iframe[name="ace_inner"]');
+  const hint = innerFrame.locator('#editor-keyboard-hint');
+  await expect(hint).toHaveCount(1);
+  // html10n may take a moment to populate; toHaveText polls. The string is
+  // mandatory (mandatory English fallback in ace.ts), so neither '' nor
+  // 'undefined' is acceptable.
+  const text = await hint.textContent();
+  expect(text && text.length > 0).toBe(true);
+  expect(text).not.toBe('undefined');
+  expect(text).toContain('Escape');
 });
 
 test('line-number sidediv is hidden from screen readers (#7255)', async ({page}) => {


### PR DESCRIPTION
Follow-up to #7758 (merged before Qodo's review was applied). Addresses two `Action required` Qodo findings on commit c4ea12d and one test-flake risk.

## Summary
- **Hint not announced to AT** — `editor-keyboard-hint` was created with `hidden=true`, which removes it from the accessibility tree, so the inner body's `aria-describedby` pointer resolved to a node with no exposed name. Removed `hidden`; the element lives in the inner document's `<head>` where it isn't painted anyway, so there's no visual cost.
- **Hint could be `undefined` forever** — `html10n.get()` returns `undefined` when translations haven't finished loading, and `Ace2Editor.init()` races with that load. Seed with a hardcoded English fallback so the hint is always usable, and re-pull translated text on every `html10n.bind('localized', …)` event (also fixes stale-language bug after runtime language switch).
- **Brittle Tab test precondition** — replaced the `activeElement === <body>` precondition with an explicit blur, so the assertion is purely about tab order and isn't broken by load-time focus grabbers.

Qodo's remaining "feature-flag the skip link" suggestion is intentionally declined — a WCAG 2.4.1 compliance fix shouldn't be opt-in.

Refs #7255.

## Test plan
- [x] `pnpm exec playwright test a11y_dialogs.spec.ts` locally — passes
- [ ] CI Frontend + Backend + Playwright suites green
- [ ] Manual: VoiceOver / NVDA announces the keyboard hint when focus enters the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)