### PR TITLE
perf: avoid throw-as-control-flow in SessionManager hot path (#7756)

### DIFF
--- a/src/node/db/SessionManager.ts
+++ b/src/node/db/SessionManager.ts
@@ -62,18 +62,8 @@ exports.findAuthorID = async (groupID:string, sessionCookie: string) => {
    * Also, see #3820.
    */
   const sessionIDs = sessionCookie.replace(/^"|"$/g, '').split(',');
-  const sessionInfoPromises = sessionIDs.map(async (id) => {
-    try {
-      return await exports.getSessionInfo(id);
-    } catch (err:any) {
-      if (err.message === 'sessionID does not exist') {
-        console.debug(`SessionManager getAuthorID: no session exists with ID ${id}`);
-      } else {
-        throw err;
-      }
-    }
-    return undefined;
-  });
+  const sessionInfoPromises = sessionIDs.map(async (id) =>
+      (await getSessionInfoOrNull(id)) || undefined);
   const now = Math.floor(Date.now() / 1000);
   const isMatch = (si: {
     groupID: string;
@@ -163,9 +153,20 @@ exports.createSession = async (groupID: string, authorID: string, validUntil: nu
  * @param {String} sessionID The id of the session
  * @return {Promise<Object>} the sessioninfos
  */
+// Non-throwing variant for hot-path callers. Hot path uses
+// `findAuthorID` on every CLIENT_READY and `listSessionsWithDBKey` on
+// session listing; both wrap getSessionInfo in try/catch and discard
+// "sessionID does not exist" CustomError. Profiling against develop at
+// 100-400 author sweep (ether/etherpad#7756) attributed ~6% of total
+// CPU to that throw+catch pair: ~1.8% to CustomError construction and
+// ~4% to the cascading `console.debug` call routed through log4js. A
+// null return collapses the cost to a single nullable check.
+const getSessionInfoOrNull = async (sessionID: string) =>
+  await db.get(`session:${sessionID}`);
+
 exports.getSessionInfo = async (sessionID:string) => {
   // check if the database entry of this session exists
-  const session = await db.get(`session:${sessionID}`);
+  const session = await getSessionInfoOrNull(sessionID);
 
   if (session == null) {
     // session does not exist
@@ -250,15 +251,12 @@ const listSessionsWithDBKey = async (dbkey: string) => {
 
   // iterate through the sessions and get the sessioninfos
   for (const sessionID of Object.keys(sessions || {})) {
-    try {
-      sessions[sessionID] = await exports.getSessionInfo(sessionID);
-    } catch (err:any) {
-      if (err.name === 'apierror') {
-        console.warn(`Found bad session ${sessionID} in ${dbkey}`);
-        sessions[sessionID] = null;
-      } else {
-        throw err;
-      }
+    const info = await getSessionInfoOrNull(sessionID);
+    if (info == null) {
+      console.warn(`Found bad session ${sessionID} in ${dbkey}`);
+      sessions[sessionID] = null;
+    } else {
+      sessions[sessionID] = info;
     }
   }
 


### PR DESCRIPTION
## Summary

CPU profile of the SUT at the 100→400 author dive sweep (load-test workflow run [25956384097](https://github.com/ether/etherpad-load-test/actions/runs/25956384097)) attributed **~6% of total process CPU** to the throw + catch around `getSessionInfo`:

- **~1.82%** to `new CustomError('sessionID does not exist', 'apierror')` (stack-trace capture)
- **~4.12%** downstream, via the catch block's `console.debug(...)` routed through log4js → `sendToListeners` → `sendLogEventToAppender`

Both internal callers (`findAuthorID` on every CLIENT_READY, `listSessionsWithDBKey` on session listing) caught `apierror` and discarded it. The public `exports.getSessionInfo` still has to throw for the HTTP API (returns `code: 1` for missing sessionID), so this PR introduces a private `getSessionInfoOrNull` helper that returns `null` and switches the two hot-path callers to it. `exports.getSessionInfo` becomes a thin wrapper that preserves the throw semantics.

## Profile evidence

Inverted callers of `CustomError` constructor in the profile:
```
 1.82% exports.getSessionInfo [src/node/db/SessionManager.ts]
```

Inverted (non-log4js) callers of log4js `Logger.<computed>`:
```
 4.12% exports.checkAccess [src/node/db/SecurityManager.ts]
```
(`checkAccess` is the entry point that drives `findAuthorID` → `getSessionInfo` → `console.debug`.)

## Behavior

- No behavior change for the HTTP API. `getSessionInfo` still throws \`apierror\` when the session doesn't exist; `RestAPI.ts`/`APIHandler.ts` translate that to `code: 1`.
- The two internal callers preserve their existing semantics: `findAuthorID` returns `undefined` for unknown sessions, `listSessionsWithDBKey` continues to log a warning and set `sessions[sessionID] = null`.

## Test plan

- [x] \`pnpm exec mocha tests/backend/specs/api/sessionsAndGroups.ts\` — all 32 cases pass, including \"getSessionInfo of deleted session\" (still expects code:1).
- [ ] Re-run the dive sweep with this branch as core_ref and confirm steady-state CPU% drops at the cliff (300-400 authors).

Part of [#7756](https://github.com/ether/etherpad/issues/7756). Profile capture pipeline is in etherpad-load-test#109/110/111.