### PR TITLE
perf: don't log settings.loadTest warning per-message (#7756)

### DIFF
--- a/src/node/db/SecurityManager.ts
+++ b/src/node/db/SecurityManager.ts
@@ -76,11 +76,11 @@ exports.checkAccess = async (padID:string, sessionCookie:string, token:string, u
 
   // Authentication and authorization checks.
   // settings.loadTest just short-circuits authn/authz; the user-facing
-  // warning about this configuration choice fires once at startup, not
-  // per request (see Settings.ts). Re-logging it here was costing
-  // ~4% of process CPU in the 100-400 author dive sweep (#7756): the
-  // routed-console-warn went through log4js's clustering dispatch on
-  // every message.
+  // warning about this configuration choice is logged from Settings.ts
+  // during settings load/reload, not on every request. Re-logging it
+  // here was costing ~4% of process CPU in the 100-400 author dive
+  // sweep (#7756): the routed-console-warn went through log4js's
+  // clustering dispatch on every message.
   if (!settings.loadTest && settings.requireAuthentication) {
     if (userSettings == null) {
       authLogger.debug('access denied: authentication is required');

--- a/src/node/db/SecurityManager.ts
+++ b/src/node/db/SecurityManager.ts
@@ -75,10 +75,13 @@ exports.checkAccess = async (padID:string, sessionCookie:string, token:string, u
   }
 
   // Authentication and authorization checks.
-  if (settings.loadTest) {
-    console.warn(
-        'bypassing socket.io authentication and authorization checks due to settings.loadTest');
-  } else if (settings.requireAuthentication) {
+  // settings.loadTest just short-circuits authn/authz; the user-facing
+  // warning about this configuration choice fires once at startup, not
+  // per request (see Settings.ts). Re-logging it here was costing
+  // ~4% of process CPU in the 100-400 author dive sweep (#7756): the
+  // routed-console-warn went through log4js's clustering dispatch on
+  // every message.
+  if (!settings.loadTest && settings.requireAuthentication) {
     if (userSettings == null) {
       authLogger.debug('access denied: authentication is required');
       return DENY;

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -1195,8 +1195,9 @@ export const reloadSettings = () => {
 
     if (settings.loadTest) {
       logger.warn(
-          'settings.loadTest is true: socket.io authentication and authorization checks ' +
-          'will be bypassed for every connection. Do NOT enable this in production.');
+        'settings.loadTest is true: SecurityManager.checkAccess() will bypass ' +
+        'authentication and authorization for both HTTP and socket.io requests. ' +
+        'Do NOT enable this in production.');
     }
 
     if (!settings.skinName) {

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -1193,6 +1193,12 @@ export const reloadSettings = () => {
     logger.warn("logLayoutType: " + settings.logLayoutType);
     initLogging(settings.logconfig);
 
+    if (settings.loadTest) {
+      logger.warn(
+          'settings.loadTest is true: socket.io authentication and authorization checks ' +
+          'will be bypassed for every connection. Do NOT enable this in production.');
+    }
+
     if (!settings.skinName) {
         logger.warn('No "skinName" parameter found. Please check out settings.json.template and ' +
             'update your settings.json. Falling back to the default "colibris".');


### PR DESCRIPTION
## Summary

A fresh CPU profile of the dive SUT (etherpad-load-test workflow [run 25957515210](https://github.com/ether/etherpad-load-test/actions/runs/25957515210), against open PR #7775's branch to remove the throw-cascade noise) revealed that **~4% of total process CPU was spent in log4js inside `SecurityManager.checkAccess`** — *and it wasn't from the throw chain at all*. Tracing the actual log call exposes this line:

\`\`\`ts
// SecurityManager.checkAccess, line 78-81
if (settings.loadTest) {
  console.warn(
      'bypassing socket.io authentication and authorization checks due to settings.loadTest');
}
\`\`\`

When \`settings.loadTest\` is true (used by the dive harness, by some local dev rigs, and by anyone benchmarking), this \`console.warn\` fires on **every** \`checkAccess\` call — once per inbound socket.io message. With \`log4js.replaceConsole\` + cluster-mode dispatch (default), each warning allocates a LogEvent, formats it, and walks the \`sendToListeners\` → \`sendLogEventToAppender\` chain. The profile attributes ~4% of total CPU to that path.

\`settings.loadTest\` is a configuration choice, not a per-request condition. Move the warning to startup (Settings.ts init, next to the other config-time warnings), and drop the per-message branch. The loadTest short-circuit (bypassing the \`else if (settings.requireAuthentication)\` block) still applies — just silently.

## Profile evidence

Inverted-caller analysis of \`log4js.Logger.<computed>\` in the perf-branch profile (CPU.20260516.083843.2623.0.001.cpuprofile, 100→400 author sweep, ~103s wall, 65% on-CPU):

\`\`\`
 4.08% exports.checkAccess [src/node/db/SecurityManager.ts]
 0.19% _getLocked              [nm/ueberdb2]
 0.19% _setLocked              [nm/ueberdb2]
 0.09% handleRequest           [nm/router/lib/layer.js]
 0.07% (anon)                  [src/node/handler/SocketIORouter.ts]
\`\`\`

After PR #7775 removed the \`getSessionInfo\` throw cascade, this number was *unchanged*, which is what surfaced the real root cause.

## Test plan

- [x] \`tests/backend/specs/api/sessionsAndGroups.ts\` — 32 passing
- [x] \`tests/backend/specs/socketio.ts\` — 39 passing (handleMessage success + error paths)
- [ ] Re-run dive sweep with this branch as core_ref and verify the log4js cost drops out of the profile.

## Relationship to #7775

Independent. \#7775 removes the throw-as-control-flow pattern (CustomError construction is real CPU, ~1.8%); this PR removes the per-message warning logging (~4% in dive measurements with \`loadTest: true\`). Both should land. Together they hit the actionable parts of the per-message logger cost the profile flagged.