### PR TITLE
fix(a11y): drop role=textbox / aria-multiline from innerdocbody (#7778)

### DIFF
--- a/src/static/js/ace.ts
+++ b/src/static/js/ace.ts
@@ -301,8 +301,12 @@ const Ace2Editor = function () {
     // <body> tag
     innerDocument.body.id = 'innerdocbody';
     innerDocument.body.classList.add('innerdocbody');
-    innerDocument.body.setAttribute('role', 'textbox');
-    innerDocument.body.setAttribute('aria-multiline', 'true');
+    // Deliberately no role="textbox" / aria-multiline: those put NVDA/JAWS
+    // into focus mode (the whole pad becomes one flat edit field), which
+    // hides links and headings from the rotor and suppresses arrow-key
+    // line navigation. contenteditable=true already tells AT this is
+    // editable; without textbox semantics AT can browse the content as a
+    // document. See #7778 / #7255.
     innerDocument.body.setAttribute('aria-label', 'Pad content');
     innerDocument.body.setAttribute('aria-describedby', 'editor-keyboard-hint');
     innerDocument.body.setAttribute('spellcheck', 'false');

--- a/src/tests/frontend-new/specs/a11y_dialogs.spec.ts
+++ b/src/tests/frontend-new/specs/a11y_dialogs.spec.ts
@@ -280,6 +280,22 @@ test('editor-keyboard-hint exists in the editor iframe with localized text (#725
   expect(text).toContain('Escape');
 });
 
+test('innerdocbody does not advertise role=textbox / aria-multiline (#7778)', async ({page}) => {
+  // role=textbox + aria-multiline force NVDA/JAWS into focus mode for the
+  // whole pad, which hides links/headings from the rotor and stops
+  // arrow-key line navigation. Keep these attributes absent so AT browses
+  // the editor as document content. The aria-label / aria-describedby
+  // (#editor-keyboard-hint) stay — they don't change AT mode.
+  const innerFrame = page.frameLocator('iframe[name="ace_outer"]')
+      .frameLocator('iframe[name="ace_inner"]');
+  const body = innerFrame.locator('body#innerdocbody');
+  await expect(body).toHaveCount(1);
+  expect(await body.getAttribute('role')).toBeNull();
+  expect(await body.getAttribute('aria-multiline')).toBeNull();
+  await expect(body).toHaveAttribute('aria-label', 'Pad content');
+  await expect(body).toHaveAttribute('aria-describedby', 'editor-keyboard-hint');
+});
+
 test('line-number sidediv is hidden from screen readers (#7255)', async ({page}) => {
   // sidediv lives in the outer ace iframe (ace_outer) — query the frame.
   const outerFrame = page.frameLocator('iframe[name="ace_outer"]');


### PR DESCRIPTION
## Summary

- Removes `role="textbox"` and `aria-multiline="true"` from `innerdocbody`
- Keeps `aria-label="Pad content"` and `aria-describedby="editor-keyboard-hint"`
- Adds Playwright regression test asserting the attrs stay absent

Lighter alternative to the AT-only read mirror originally sketched in #7778 — pure ARIA strip, no DOM restructuring, no plugin impact.

## Why

Murphy's 2026-05-16 re-test of #7255 said "you still can't cycle through the text properly line by line to press links and such". The narrower fixes in #7777 don't address that — it's the textbox role doing the damage:

- `role="textbox"` + `aria-multiline="true"` pin NVDA/JAWS into **focus mode** for the entire pad.
- In focus mode: arrow keys move the caret one character at a time, P/H/K rotor shortcuts are suppressed, links don't appear in the rotor's links list.
- That matches the reported symptoms exactly.

`contenteditable="true"` alone is enough to tell AT this is editable. Without the textbox role, NVDA/JAWS browse the content as document-mode HTML, restoring line-by-line arrow nav and rotor access to headings + links.

## Acceptance criteria from #7778 — partial

This is the cheap experiment first. If the ARIA strip alone unblocks line / link / heading navigation in real AT, the heavier mirror approach in #7778 isn't needed. If headings still feel flat, we layer `role="paragraph"` onto each `<div class="ace-line">` next.

## Test plan

- [ ] CI: new `innerdocbody does not advertise role=textbox / aria-multiline (#7778)` Playwright test passes
- [ ] CI: existing #7255 regression tests (skip-to-content, line-number sidediv hidden, keyboard-hint text) still pass
- [ ] Local manual: arrow-down through a multi-line pad in NVDA/JAWS/VoiceOver and confirm caret moves line-by-line in browse mode
- [ ] Local manual: open the rotor / elements list and confirm headings (h1-h4 from ep_headings2) + links surface
- [ ] **@StrangeGirlMurph** real-screen-reader retest of #7255 once this is on a build

Refs #7255 #7777

🤖 Generated with [Claude Code](https://claude.com/claude-code)