### PR TITLE
fix(pad): keep menu_right visible on readonly pads by default

### DIFF
--- a/src/static/js/pad.ts
+++ b/src/static/js/pad.ts
@@ -91,10 +91,12 @@ const getParameters = [
   },
   {
     // showMenuRight accepts 'true' or 'false'. Explicit 'false' hides the
-    // right-side toolbar (import/export/timeslider/settings/share/users);
-    // explicit 'true' forces it visible, overriding the readonly
-    // auto-hide applied further down (issue #5182). Any other value is
-    // a no-op — the menu stays in its default state.
+    // right-side toolbar (import/export/timeslider/settings/embed/home/
+    // users) — useful for iframe-embedded readonly pads where the menu
+    // is just chrome (issue #5182). Explicit 'true' forces the menu
+    // visible (a no-op against the default, kept for symmetry and for
+    // overriding any future caller-applied hide). Any other value is a
+    // no-op — the menu stays in its default state.
     name: 'showMenuRight',
     checkVal: null,
     callback: (val) => {
@@ -787,14 +789,18 @@ const pad = {
       $('#chaticon').hide();
       $('#options-chatandusers').parent().hide();
       $('#options-stickychat').parent().hide();
-      // Hide the right-side toolbar on readonly pads — import/export,
-      // timeslider, settings, share, users are all noise for viewers
-      // who can't interact with the pad. Callers who need those
-      // controls visible on a readonly pad can force them back via
-      // `?showMenuRight=true`, which runs in getParameters() above.
-      if (getUrlVars().get('showMenuRight') !== 'true') {
-        $('#editbar .menu_right').hide();
-      }
+      // The right-side toolbar stays visible on readonly pads. The
+      // server-side `toolbar.menu(buttons, isReadOnly)` (see
+      // src/node/utils/toolbar.ts) already strips `savedrevision`, and
+      // `.readonly .acl-write { display: none }` hides the Import column
+      // inside the import/export popup, so the remaining controls
+      // (export, timeslider, settings, embed, home, showusers) are all
+      // safe for readonly viewers — and the userlist is the surface that
+      // plugins like ep_guest hang their "Log In" button off, so hiding
+      // it traps guests in readonly with no way out. Iframe-embed use
+      // cases that want a clean look (issue #5182) opt in to the hide
+      // via `?showMenuRight=false`, or hide the whole editbar via
+      // `?showControls=false`.
     } else if (!settings.hideChat) { $('#chaticon').show(); }
 
     $('body').addClass(window.clientVars.readonly ? 'readonly' : 'readwrite');

--- a/src/tests/frontend-new/specs/hide_menu_right.spec.ts
+++ b/src/tests/frontend-new/specs/hide_menu_right.spec.ts
@@ -44,9 +44,24 @@ test.describe('showMenuRight URL parameter', function () {
     return url;
   };
 
-  test('readonly pad hides .menu_right by default', async function ({page}) {
+  test('readonly pad shows .menu_right by default', async function ({page}) {
+    // The server-side toolbar.menu(..., isReadOnly) strips `savedrevision`
+    // and `.readonly .acl-write { display: none }` hides the Import
+    // column of the import/export popup, so the remaining controls
+    // (export, timeslider, settings, embed, home, showusers) are safe
+    // for readonly viewers — and ep_guest / other auth plugins depend
+    // on the userlist being reachable to surface their Log In button.
     const readonlyUrl = await getReadonlyUrl(page);
     await page.goto(readonlyUrl);
+    await page.waitForSelector('#editorcontainer.initialized');
+    await expect(page.locator('#editbar .menu_right')).toBeVisible();
+  });
+
+  test('readonly pad with showMenuRight=false hides the menu', async function ({page}) {
+    // Iframe-embed use case (issue #5182): the embedder opts in to the
+    // hide via the URL parameter when they want a clean look.
+    const readonlyUrl = await getReadonlyUrl(page);
+    await page.goto(`${readonlyUrl}?showMenuRight=false`);
     await page.waitForSelector('#editorcontainer.initialized');
     await expect(page.locator('#editbar .menu_right')).toBeHidden();
   });


### PR DESCRIPTION
## Summary

The client-side \`\$('#editbar .menu_right').hide()\` introduced for issue #5182 hides the userlist toggle alongside import/export when a pad is readonly. That breaks any auth plugin that hangs a "Log In" button off the userlist popup (notably **ep_guest**, which injects its button into \`#myuser\`): the readOnly guest user can see the pad but has no way to escape readOnly mode because the very button they need is hidden.

It also throws useful chrome (settings, embed, home, timeslider, userlist) out with the truly write-only stuff (savedrevision, import) — none of those are write-only, and the server already strips the ones that are.

## Root cause

Two server-side mechanisms already handle readonly correctly:

- \`src/node/utils/toolbar.ts:282-290\` — \`toolbar.menu(..., isReadOnly)\` removes \`savedrevision\` from the right toolbar for readonly pads.
- \`src/static/css/pad/popup_import_export.css:1\` — \`.readonly .acl-write { display: none }\` hides the **Import** column of the import/export popup; export stays visible and is legitimately useful in readonly.

The blanket client-side hide is redundant against both and only serves the iframe-embed clean-chrome use case from #5182 — which is already served by the explicit \`?showMenuRight=false\` opt-out (handler at \`src/static/js/pad.ts:91-107\`), or by \`?showControls=false\` which hides the entire editbar.

## Change

- Remove the auto-hide at \`pad.ts:783\`. Readonly pads now show \`.menu_right\` by default.
- Update the comment on the \`showMenuRight\` URL parameter handler to reflect that hiding is now opt-in via \`?showMenuRight=false\` (was: opt-out of an auto-hide via \`?showMenuRight=true\`).

The \`?showMenuRight=true\` and \`?showMenuRight=false\` overrides still work; iframe-embed deployments switch from \`?showMenuRight=true\` (no-op now) to \`?showMenuRight=false\` (still hides).

## Tests

\`src/tests/frontend-new/specs/hide_menu_right.spec.ts\`:

- ✏️ Inverted \`readonly pad hides .menu_right by default\` → \`readonly pad shows .menu_right by default\`.
- ➕ Added \`readonly pad with showMenuRight=false hides the menu\` to cover the iframe-embed opt-out.
- ✅ \`readonly pad with showMenuRight=true keeps the menu visible\` still passes.

## Test plan

- [ ] Frontend tests green (the test file is rewritten to match the new behaviour)
- [ ] Backend tests green
- [ ] Manual: install ep_guest, set the guest user to \`readOnly: true\`, visit a pad unauth; the **Log In** button is reachable from the userlist popup.
- [ ] Manual: visit a readonly pad with \`?showMenuRight=false\`; the right toolbar is still hidden (issue #5182 iframe-embed case still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)