### PR TITLE
fix(backend-tests): un-skip api/ and admin/ subdirectory specs

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -147,7 +147,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "cross-env NODE_ENV=production mocha --import=tsx --require ./tests/backend/diagnostics.ts --timeout 120000 --recursive tests/backend/specs/**.ts ../node_modules/ep_*/static/tests/backend/specs/**",
+    "test": "cross-env NODE_ENV=production mocha --import=tsx --require ./tests/backend/diagnostics.ts --timeout 120000 --extension ts --recursive tests/backend/specs ../node_modules/ep_*/static/tests/backend/specs",
     "test-utils": "cross-env NODE_ENV=production mocha --import=tsx --timeout 5000 --recursive tests/backend/specs/*utils.ts",
     "test-container": "mocha --import=tsx --timeout 5000 tests/container/specs/api",
     "dev": "cross-env NODE_ENV=development  node --require tsx/cjs node/server.ts",

--- a/src/tests/backend-new/specs/backend-tests-glob.test.ts
+++ b/src/tests/backend-new/specs/backend-tests-glob.test.ts
@@ -1,0 +1,54 @@
+'use strict';
+
+// Regression check for the `pnpm test` glob. The previous spec script
+// `tests/backend/specs/**.ts` only matched files at depth 1 under
+// tests/backend/specs/, silently skipping every spec under api/ and
+// admin/ — including the failures filed in #7785–#7788, #7790. This
+// test asserts that mocha (running the exact arguments from
+// src/package.json's "test" script) still discovers a representative
+// file in each of those subdirectories.
+//
+// If the glob is ever narrowed again, this test fails loudly instead
+// of letting the affected specs slip out of CI.
+
+import {execFileSync} from 'child_process';
+import {readFileSync} from 'fs';
+import {join} from 'path';
+import {describe, it, expect} from 'vitest';
+
+const srcRoot = join(__dirname, '..', '..', '..');
+const pkg = JSON.parse(readFileSync(join(srcRoot, 'package.json'), 'utf8'));
+
+// Strip `cross-env NAME=value` prefixes and the leading binary name so we
+// can pass the remaining tokens straight to npx mocha --dry-run.
+const tokens = String(pkg.scripts.test).split(/\s+/);
+while (tokens[0] && /^[A-Z_][A-Z0-9_]*=/.test(tokens[0])) tokens.shift();
+if (tokens[0] === 'cross-env') {
+  tokens.shift();
+  while (tokens[0] && /^[A-Z_][A-Z0-9_]*=/.test(tokens[0])) tokens.shift();
+}
+// Drop the binary itself (mocha) — npx will re-add it.
+if (tokens[0] === 'mocha') tokens.shift();
+
+const REQUIRED = [
+  'tests/backend/specs/api/pad.ts',
+  'tests/backend/specs/api/importexportGetPost.ts',
+  'tests/backend/specs/admin/authorSearch.ts',
+];
+
+describe('backend test glob', () => {
+  it('discovers nested specs under tests/backend/specs/{api,admin}/', () => {
+    const out = execFileSync(
+        'npx', ['mocha', '--dry-run', '--list-files', ...tokens],
+        {cwd: srcRoot, encoding: 'utf8', env: {...process.env, NODE_ENV: 'production'}},
+    );
+    // mocha --list-files prints absolute paths. Normalise to repo-relative.
+    const seen = out.split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((l) => l.replace(`${srcRoot}/`, ''));
+    for (const required of REQUIRED) {
+      expect(seen, `mocha test glob missed ${required}`).toContain(required);
+    }
+  }, 60000);
+});


### PR DESCRIPTION
## Summary

`pnpm test` (in `src/`) has been silently skipping every backend spec under `tests/backend/specs/api/` and `tests/backend/specs/admin/`. The glob `tests/backend/specs/**.ts` only resolves to files at depth 1 — `**` without a slash separator is treated like `*` by both bash and minimatch, and the shell pre-expands the pattern before mocha sees it, so `--recursive` has nothing to recurse into.

Confirmed against the most recent green CI run on develop (b96e262, run id 25970235389):
- No mention of `pad.ts`, `importexportGetPost.ts`, `listAuthorsOfPad`, `copyPadWithoutHistory`, or any other test name from the api/admin subdirs.
- No other workflow runs `tests/backend/specs/api/**` either.

The fix passes the directories to mocha with `--extension ts --recursive` so mocha does its own walk.

## What this surfaces

After the fix, mocha picks up 74 spec files instead of 53. The 16 newly-discovered files contain 6 failing tests:

| File | Test | Filed as |
| --- | --- | --- |
| `tests/backend/specs/api/pad.ts` | `Get Authors of the Pad` | #7785 |
| `tests/backend/specs/api/pad.ts` | `Pad with complex nested lists of different types` | #7786 |
| `tests/backend/specs/api/pad.ts` | `copyPadWithoutHistory > creates a new pad with the same content as the source pad` | #7787 |
| `tests/backend/specs/api/importexportGetPost.ts` | `txt request rev test1 is 403` | #7788 |
| `tests/backend/specs/api/importexportGetPost.ts` | `html request rev test1 results in 500 response` | #7788 |
| `tests/backend/specs/api/appendTextAuthor.ts` | `appendText without authorId does not attribute to any author` | **not yet filed** — same shape as #7785 |

All `admin/` specs pass.

Two tests listed in #7786's body (`ugly HTML`, `white space between list items`) and one in #7787 (`attribute pools are independent`) **do not** reproduce as failures on develop HEAD; the issue bodies are slightly stale there.

## Trade-off

This change will make the next CI run red until #7785–#7788 (and the new `appendTextAuthor.ts` failure) are fixed. That's the point — those tests have been silently broken. Merging this is what makes them visible.

## Test plan

- [x] Local run on a fresh clone of develop (b96e262) with Node 24.14.0 reproduces the 6 failures listed above.
- [x] Dry-run with the new glob enumerates 74 spec files (up from 53).
- [ ] CI will turn red on this PR — that's expected; track the 5 follow-up fixes against the issues above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)