### PR TITLE
fix(ExportHtml): preserve nested ol start across sibling ul

### DIFF
--- a/src/node/utils/ExportHtml.ts
+++ b/src/node/utils/ExportHtml.ts
@@ -470,7 +470,10 @@ const getHTMLFromAtext = async (pad:PadType, atext: AText, authorColors?: string
           // preserve counters so numbering can continue after interruptions.
           // Use 0 as sentinel (not delete) so the ol-opening logic knows this
           // level was explicitly reset and won't fall back to line.start.
-          if (diff + 1 > actualNextLevel) {
+          // Only reset when closing an ordered list — closing an unordered list
+          // at the same level must not poison the ol counter for a future
+          // unrelated ol at this level (which would still want line.start).
+          if (line.listTypeName === 'number' && diff + 1 > actualNextLevel) {
             olItemCounts[diff + 1] = 0;
           }
 


### PR DESCRIPTION
## Summary

Round-tripping `<ul>...<ul>...</ul></ul><ol><li>x<ol><li>y</li></ol></li></ol>` through `setHTML` → `getHTML` was emitting the inner `<ol>` as `<ol class=\"number\">` instead of the expected `<ol start=\"2\" class=\"number\">`.

Root cause: the depth-decrease loop in `getHTMLFromAtext` resets `olItemCounts[level] = 0` to signal \"this ol level was explicitly closed, don't fall back to `line.start` next time it reopens\" (#7470). The gate only checked depth, not list type, so closing a *bullet* `<ul>` at depth 2 was also writing `olItemCounts[2] = 0`. When a later, unrelated `<ol>` opened at depth 2, the ol-opening logic took the \"counter exists but is 0\" branch and dropped `line.start`.

Fix: only run the counter reset when the line being closed is itself a `number` list. UL closures no longer touch ol bookkeeping.

## Trade-off

The 0-sentinel design from #7470 still applies for genuine ol-close cases — if you close an ol and reopen one later at the same depth, `line.start` is still ignored (per that PR's intent). This change narrows the gate; it doesn't reverse the prior decision.

## Test plan

Backend sweep on a fresh `develop` clone (Node 24.14.0):

- Before: 6 failing — `appendTextAuthor` x1, `importexportGetPost` x2, `pad.ts` x3 (\"Get Authors of the Pad\", \"Pad with complex nested lists of different types\", \"copyPadWithoutHistory > creates a new pad with the same content as the source pad\").
- After: 4 failing — the two `pad.ts` nested-list cases now pass. The other 4 failures are unrelated (#7785, #7788, #7790) and tracked separately.
- 1438 passing, 21 pending. No regressions in `tests/backend/specs/api/` or `tests/backend/specs/admin/`.

Note: these failures are currently invisible in CI because of the broken backend test glob — see #7789, which has to land for CI to actually run these tests.

Fixes #7786
Fixes #7787

🤖 Generated with [Claude Code](https://claude.com/claude-code)