### PR TITLE
fix(API): hide SYSTEM_AUTHOR_ID from listAuthorsOfPad

### DIFF
--- a/doc/api/http_api.adoc
+++ b/doc/api/http_api.adoc
@@ -654,6 +654,8 @@ _Example returns:_
 
 returns an array of authors who contributed to this pad
 
+The synthetic `a.etherpad-system` author (used internally when content is inserted without an explicit `authorId` — HTTP API `setText`/`appendText`/`setHTML` calls without `authorId`, server-side imports, plugins like `ep_post_data`) is omitted from the returned list.
+
 _Example returns:_
 
   * `{code: 0, message:"ok", data: {authorIDs : ["a.s8oes9dhwrvt0zif", "a.akf8finncvomlqva"]}`

--- a/doc/api/http_api.md
+++ b/doc/api/http_api.md
@@ -698,6 +698,8 @@ return true of false
 
 returns an array of authors who contributed to this pad
 
+The synthetic `a.etherpad-system` author (used internally when content is inserted without an explicit `authorId` — HTTP API `setText`/`appendText`/`setHTML` calls without `authorId`, server-side imports, plugins like `ep_post_data`) is omitted from the returned list.
+
 *Example returns:*
 * `{code: 0, message:"ok", data: {authorIDs : ["a.s8oes9dhwrvt0zif", "a.akf8finncvomlqva"]}`
 * `{code: 1, message:"padID does not exist", data: null}`

--- a/src/node/db/API.ts
+++ b/src/node/db/API.ts
@@ -831,7 +831,13 @@ Example returns:
 exports.listAuthorsOfPad = async (padID: string) => {
   // get the pad
   const pad = await getPadSafe(padID, true);
-  const authorIDs = pad.getAllAuthors();
+  // Pad.SYSTEM_AUTHOR_ID is the synthetic author Etherpad attributes inserts to
+  // when no authorId is supplied (HTTP API setText/appendText/setHTML without
+  // authorId, server-side import flows, plugins like ep_post_data). It is an
+  // implementation detail of changeset bookkeeping, not a real contributor, so
+  // it should not surface through this public API.
+  const {Pad} = require('./Pad');
+  const authorIDs = pad.getAllAuthors().filter((id: string) => id !== Pad.SYSTEM_AUTHOR_ID);
   return {authorIDs};
 };
 


### PR DESCRIPTION
## Summary

`Pad.SYSTEM_AUTHOR_ID` (`'a.etherpad-system'`) is the synthetic author Etherpad attributes inserts to whenever the HTTP API or an internal flow inserts content without supplying an `authorId` — `setText`/`setHTML`/`appendText` without `authorId`, server-side imports, plugins like `ep_post_data`. The reason is that the changeset's text and attribs must stay in sync; without *any* author attribute, `pad.atext` drifts and clients fail `setDocAText` reconciliation when loading the pad. See `Pad.ts:96-105` for the full rationale.

That implementation detail was leaking through `listAuthorsOfPad`. A pad whose only \"contributor\" is the system author was reporting one authorID, which the existing tests in `pad.ts` and `appendTextAuthor.ts` (and presumably any external caller using `listAuthorsOfPad` to count real users) treat as a real participant.

Fix: filter `SYSTEM_AUTHOR_ID` at the public API surface. `getAllAuthors()` and downstream callers (copy, anonymize, atext verification) keep seeing the synthetic id — this only narrows the `listAuthorsOfPad` response.

## Why filter, not change attribution

I considered changing `Pad.appendCoreMsg` / `appendText` / `setText` to skip attribution when no `authorId` is supplied. That would break the changeset's text/attribs invariant — `Pad.ts:96-105` is explicit that the system author exists precisely to avoid that drift. The bug is in *exposing* the synthetic id, not in attributing to it.

## Test plan

Full backend sweep on a fresh develop clone (Node 24.14.0):

- Before: 6 failing (`appendTextAuthor` ×1, `importexportGetPost` ×2, `pad.ts` ×3).
- After: 4 failing (the 4 are #7786, #7787, #7788 — tracked separately).
- The two author-count failures are now green:
  - `pad.ts > Get Authors of the Pad`
  - `appendTextAuthor.ts > appendText without authorId does not attribute to any author`
- 1438 passing, 21 pending. No regressions in any other spec.

Note: these failures are invisible in CI today because of the broken backend-test glob — see #7789. Merging that is what makes CI actually run the affected tests.

Fixes #7785
Fixes #7790

🤖 Generated with [Claude Code](https://claude.com/claude-code)