### PR TITLE
fix(l10n): silence spurious 'could not translate element content' warning on form controls

### DIFF
--- a/src/static/js/vendors/html10n.ts
+++ b/src/static/js/vendors/html10n.ts
@@ -680,6 +680,16 @@ export class Html10n {
       // @ts-ignore
       node[prop] = str.str!
       populateAriaLabel()
+    } else if (node.tagName === 'SELECT' || node.tagName === 'INPUT' ||
+               node.tagName === 'TEXTAREA') {
+      // Form-controllable elements carry their accessible name on aria-label
+      // rather than as text content — a <select>'s text is its <option>
+      // labels, not its own name. Plugins that put `data-l10n-id` on a
+      // <select> (ep_headings2, ep_align, ep_font_size, …) used to trigger a
+      // spurious "could not translate element content" warning here because
+      // the text-node hunt below finds nothing to write. Short-circuit and
+      // just localize aria-label. See ether/ep_align#182 review.
+      populateAriaLabel()
     } else {
       let children = node.childNodes,
         found = false
@@ -696,17 +706,6 @@ export class Html10n {
       }
       if (!found) {
         console.warn('Unexpected error: could not translate element content for key '+str.id, node)
-      }
-      // Form-controllable elements (<select>, <input>, <textarea>) carry their
-      // accessible name on aria-label rather than as text content (a <select>'s
-      // text is its <option> labels, not its own name). The textContent branch
-      // above doesn't fall through to populateAriaLabel(), so plugins that put
-      // data-l10n-id on a <select> and rely on the auto-population (introduced
-      // in #7584) end up with no accessible name. Populate aria-label here so
-      // those controls stay localized too. See ether/ep_align#182 review.
-      const tag = node.tagName;
-      if (tag === 'SELECT' || tag === 'INPUT' || tag === 'TEXTAREA') {
-        populateAriaLabel()
       }
     }
   }

--- a/src/tests/frontend-new/specs/html10n_form_controls_aria.spec.ts
+++ b/src/tests/frontend-new/specs/html10n_form_controls_aria.spec.ts
@@ -65,15 +65,21 @@ test('no "could not translate element content" warning for <select data-l10n-id>
   // <option> element children — the text-node hunt in translateNode finds
   // nothing and used to warn before the SELECT/INPUT/TEXTAREA short-circuit
   // landed. The accessible name still ends up on aria-label.
+  //
+  // To actually exercise the bug path the key must default `prop` to
+  // textContent (i.e. the suffix after the last `.` must NOT be one of
+  // title|innerHTML|alt|textContent|value|placeholder, see
+  // html10n.translateNode). `pad.loading` is a stable pad-bundle key that
+  // satisfies that.
   const warnings: string[] = [];
   page.on('console', (msg) => {
     if (msg.type() === 'warning') warnings.push(msg.text());
   });
 
-  await page.evaluate(() => {
+  await page.evaluate(() => new Promise<void>((res) => {
     const sel = document.createElement('select');
     sel.id = 'html10n-test-no-warn';
-    sel.setAttribute('data-l10n-id', 'pad.toolbar.bold.title');
+    sel.setAttribute('data-l10n-id', 'pad.loading');
     for (const v of ['a', 'b', 'c']) {
       const opt = document.createElement('option');
       opt.value = v;
@@ -81,16 +87,18 @@ test('no "could not translate element content" warning for <select data-l10n-id>
       sel.appendChild(opt);
     }
     document.body.appendChild(sel);
+    // localize completes asynchronously inside a build() callback; wait
+    // on the `localized` event instead of a fixed timeout so the test
+    // is deterministic on slow CI runners.
+    // @ts-ignore window.html10n is exposed by pad.ts
+    window.html10n.mt.bind('localized', () => res());
     // @ts-ignore
     window.html10n.localize(['en']);
-  });
-
-  // Give html10n a tick to run.
-  await page.waitForTimeout(50);
+  }));
 
   const offending = warnings.filter((m) =>
       m.includes('could not translate element content') &&
-      m.includes('pad.toolbar.bold.title'));
+      m.includes('pad.loading'));
   expect(offending).toEqual([]);
 });
 

--- a/src/tests/frontend-new/specs/html10n_form_controls_aria.spec.ts
+++ b/src/tests/frontend-new/specs/html10n_form_controls_aria.spec.ts
@@ -59,6 +59,41 @@ test('html10n auto-populates aria-label on <textarea> with data-l10n-id', async 
   await expect(ta).toHaveAttribute('data-l10n-aria-label', 'true');
 });
 
+test('no "could not translate element content" warning for <select data-l10n-id>', async ({page}) => {
+  // Regression: thm reported the warning on Etherpad 3.1.0 because the
+  // <select data-l10n-id="ep_headings.style"> in ep_headings2 has only
+  // <option> element children — the text-node hunt in translateNode finds
+  // nothing and used to warn before the SELECT/INPUT/TEXTAREA short-circuit
+  // landed. The accessible name still ends up on aria-label.
+  const warnings: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'warning') warnings.push(msg.text());
+  });
+
+  await page.evaluate(() => {
+    const sel = document.createElement('select');
+    sel.id = 'html10n-test-no-warn';
+    sel.setAttribute('data-l10n-id', 'pad.toolbar.bold.title');
+    for (const v of ['a', 'b', 'c']) {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v.toUpperCase();
+      sel.appendChild(opt);
+    }
+    document.body.appendChild(sel);
+    // @ts-ignore
+    window.html10n.localize(['en']);
+  });
+
+  // Give html10n a tick to run.
+  await page.waitForTimeout(50);
+
+  const offending = warnings.filter((m) =>
+      m.includes('could not translate element content') &&
+      m.includes('pad.toolbar.bold.title'));
+  expect(offending).toEqual([]);
+});
+
 test('an author-supplied aria-label on a form control is preserved', async ({page}) => {
   // Mirror the existing semantics for non-form-control elements: if the
   // template author wrote their own aria-label, html10n must not


### PR DESCRIPTION
## Summary
- `<select data-l10n-id="…">` with `<option>` element children (ep_headings2, ep_align, ep_font_size, ep_font_family, …) used to print `Unexpected error: could not translate element content for key …` on every pad load. The textContent branch in `html10n.translateNode` hunted for a text-node child, found none, and warned — even though the existing SELECT/INPUT/TEXTAREA aria-label fallback further down still set the accessible name correctly.
- Move the form-control case into its own `else if`, before the text-node hunt. `aria-label` is the only sensible localization target for `<select>`/`<input>`/`<textarea>` (their text is on `<option>` / `value`, not directly on the control).
- Add a regression test that injects a `<select data-l10n-id>` and asserts no `could not translate element content` warning is emitted.

Reported by thm on Etherpad 3.1.0:
> console also says: padbootstrap-…js:1 Unexpected error: could not translate element content for key ep_headings.style \<select id="heading-selection" aria-label="Stil" data-l10n-id="ep_headings.style" data-l10n-aria-label="true" style="display: none;">…\</select>

Existing aria-label population (PR #7584) is unchanged in observable behaviour; the new test alongside it locks in that the warning stays silent.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] CI: full backend + frontend playwright
- [ ] New spec: `html10n_form_controls_aria.spec.ts → 'no "could not translate element content" warning for <select data-l10n-id>'`
- [ ] Pre-existing specs in `html10n_form_controls_aria.spec.ts` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)