### PR TITLE
fix(pad): outdated notice — resolve author from token cookie (Qodo #7804)

### DIFF
--- a/src/node/hooks/express/openapi-admin.ts
+++ b/src/node/hooks/express/openapi-admin.ts
@@ -20,7 +20,10 @@ export const generateAdminDefinition = (): any => ({
     title: 'Etherpad Admin API',
     description:
       'Authenticated administrative endpoints consumed by the Etherpad admin UI. ' +
-      'Distinct from the public /api/{version}/* surface served by /api/openapi.json.',
+      'Distinct from the public /api/{version}/* surface served by /api/openapi.json. ' +
+      'For completeness this document also includes non-admin endpoints that are ' +
+      'consumed by the pad UI itself (e.g. /api/version-status) since they share the ' +
+      'same internal route registration.',
     version: getEpVersion(),
   },
   paths: {

--- a/src/node/hooks/express/updateStatus.ts
+++ b/src/node/hooks/express/updateStatus.ts
@@ -31,31 +31,32 @@ export const firstAuthorOf = (pad: {pool?: {numToAttrib?: Record<number | string
 };
 
 /**
- * Resolve the express-session author for a plain HTTP GET. The pad-side fetch
- * is `credentials: 'same-origin'`, so the `express_sid` cookie is sent
- * automatically. The global express-session middleware should have populated
- * `req.session` already — but if not (e.g. test harness without middleware),
- * we re-invoke it ourselves. On any failure path we return null and the
- * caller treats the request as anonymous.
+ * Resolve the pad-visitor's authorID from the HttpOnly token cookie. This
+ * mirrors how Etherpad's own socket.io handshake resolves pad-visitor identity:
+ * the browser sends the `token` cookie (or `<prefix>token`) with every
+ * same-origin request, and `authorManager.getAuthorId(token, user)` maps the
+ * token to a stable authorID via the `token2author` DB key.
+ *
+ * We do NOT use `req.session.user.author` because Etherpad does not populate
+ * an authorID into the express-session `user` object for pad visitors, so that
+ * field is always undefined in production.
+ *
+ * On any failure path we return null and the caller treats the request as
+ * anonymous, resulting in an EMPTY (no-badge) response.
  */
 export const resolveRequestAuthor = async (req: any): Promise<string | null> => {
-  const readAuthor = (): string | null => {
-    const a = req?.session?.user?.author;
-    return typeof a === 'string' && a !== '' ? a : null;
-  };
-  const fromSession = readAuthor();
-  if (fromSession !== null) return fromSession;
   try {
-    const expressModule = await import('../express');
-    const mw = (expressModule as any).sessionMiddleware;
-    if (typeof mw !== 'function') return null;
-    await new Promise<void>((resolve, reject) => {
-      mw(req, {} as any, (err?: unknown) => (err ? reject(err) : resolve()));
-    });
+    const cookiePrefix = (settings as any).cookie?.prefix ?? '';
+    const token = req?.cookies?.[`${cookiePrefix}token`];
+    if (typeof token !== 'string' || token === '') return null;
+    const authorManagerMod: any = await import('../../db/AuthorManager');
+    const authorManager = authorManagerMod.default ?? authorManagerMod;
+    if (typeof authorManager.getAuthorId !== 'function') return null;
+    const authorId = await authorManager.getAuthorId(token, req?.session?.user);
+    return typeof authorId === 'string' && authorId !== '' ? authorId : null;
   } catch {
     return null;
   }
-  return readAuthor();
 };
 
 interface OutdatedResponse {

--- a/src/tests/backend-new/specs/hooks/express/updateStatus.test.ts
+++ b/src/tests/backend-new/specs/hooks/express/updateStatus.test.ts
@@ -5,12 +5,12 @@
  * (same as production), then exercised via supertest. `loadState` is mocked so
  * tests control the "latest" version without touching the filesystem.
  * `PadManager` is mocked so pad-creation doesn't require a running database.
+ * `AuthorManager` is mocked so token→authorID resolution doesn't require a DB.
  *
- * Session injection: `resolveRequestAuthor` reads `req.session.user.author`
- * directly. A simple before-route middleware sets that property on each
- * request, keyed by the `X-Test-Author` request header, so individual tests
- * can choose which author the request "belongs to" without needing real
- * session middleware.
+ * Author injection: `resolveRequestAuthor` reads the `token` cookie and calls
+ * `authorManager.getAuthorId(token, user)`. Tests set `sessionAuthor` to
+ * control which authorID the mock returns for the test token `t.alice`.
+ * `null` means "anonymous" (getAuthorId returns null / empty for the token).
  */
 
 import {describe, it, expect, vi, beforeAll, beforeEach, afterEach} from 'vitest';
@@ -38,6 +38,14 @@ vi.mock('../../../../../node/updater', () => ({
   getDetectedInstallMethod: () => 'git',
 }));
 
+// AuthorManager is dynamically imported inside resolveRequestAuthor(). Stubbing
+// it here lets tests control token→authorID resolution without a DB.
+vi.mock('../../../../../node/db/AuthorManager', () => ({
+  default: {
+    getAuthorId: vi.fn(),
+  },
+}));
+
 // PadManager is dynamically imported inside computeOutdated(). Stubbing it
 // here lets us control pad existence and author-pool contents without a DB.
 vi.mock('../../../../../node/db/PadManager', () => {
@@ -58,6 +66,7 @@ vi.mock('../../../../../node/db/PadManager', () => {
 // ---------------------------------------------------------------------------
 
 import * as stateModule from '../../../../../node/updater/state';
+import * as authorManagerModule from '../../../../../node/db/AuthorManager';
 import {
   expressCreateServer,
   _resetBadgeCacheForTests,
@@ -112,21 +121,22 @@ let app: Express;
 let request: ReturnType<typeof supertest>;
 
 /**
- * The author that the fake session middleware will inject into req.session.
- * Tests that need a specific author set this before making a request.
- * `null` means "anonymous" (no session author).
+ * The author that `authorManager.getAuthorId` will return for the test token
+ * `t.alice`. Tests set this before making a request. `null` means "anonymous"
+ * (getAuthorId returns null/empty, so resolveRequestAuthor returns null).
  */
 let sessionAuthor: string | null = null;
+
+/** Fixed test token used in every request. The cookie name has no prefix in tests. */
+const TEST_TOKEN = 't.alice';
 
 beforeAll(() => {
   app = express();
 
-  // Fake session middleware: sets req.session.user.author from our test
-  // variable, so resolveRequestAuthor() in the route sees the right identity.
+  // Inject the test token cookie so resolveRequestAuthor() sees it.
+  // The real cookie-parser middleware is not needed: we set req.cookies directly.
   app.use((req: any, _res, next) => {
-    if (sessionAuthor !== null) {
-      req.session = {user: {author: sessionAuthor}};
-    }
+    req.cookies = {token: TEST_TOKEN};
     next();
   });
 
@@ -143,6 +153,13 @@ beforeEach(() => {
   sessionAuthor = null;
   // Reset the loadState spy so each test controls its own return value.
   vi.mocked(stateModule.loadState).mockReset();
+  // Wire up the AuthorManager mock: return sessionAuthor (or null) for our test token.
+  vi.mocked((authorManagerModule as any).default.getAuthorId).mockImplementation(
+    async (token: string) => {
+      if (token === TEST_TOKEN && sessionAuthor !== null) return sessionAuthor;
+      return null;
+    },
+  );
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

Follow-up to #7804 addressing two Qodo review findings on the merged outdated-notice redesign.

### 🐞 Author lookup always null in production (CRITICAL)

`resolveRequestAuthor(req)` read `req.session.user.author`, but Etherpad never populates that field for pad visitors — pad authorship is derived from the HttpOnly `token` cookie via `authorManager.getAuthorId(token, user)` (and gated by `securityManager.checkAccess` for the socket.io handshake).

Result: in production, `resolveRequestAuthor` always returned `null`, `computeOutdated` always returned `EMPTY`, and the new gritter would never fire.

This PR replaces the helper with a token-cookie-based path that mirrors the same resolution Etherpad's own socket.io handshake uses. The route shape and gating logic are unchanged.

The 9 e2e test cases for `/api/version-status` are updated to inject `req.cookies = {token: TEST_TOKEN}` and stub `authorManager.getAuthorId`. All 9 still pass.

### 📘 `/api/version-status` documented in admin OpenAPI spec

The route is public (called from `pad_outdated_notice.ts` during pad load) but lives in `openapi-admin.ts`, whose stated purpose is admin endpoints — misleading for tooling consumers.

Fixed by clarifying the admin spec's `info.description` to acknowledge that the doc may include pad-side endpoints for completeness. A structural split (separate `openapi-public.ts`) would be larger surgery for limited benefit since the routes share a single registration site.

### ❌ Not addressed: vulnerable-below removed without deprecation WARN

Qodo flagged this as a rule violation. The removal was an intentional product decision by the maintainer (issue #7799 explicitly says "drop it"). The `vulnerable-below` directive was an internal release-notes scrape — no plugin or external system depended on it — so a deprecation period adds friction without protecting any consumer. Documented in this PR description rather than in code.

## Test plan

- [x] `pnpm --filter ep_etherpad-lite exec vitest run tests/backend-new/specs/hooks/express/updateStatus.test.ts` — 9/9 green
- [x] `pnpm --filter ep_etherpad-lite exec vitest run` — 702/703 green (the 1 failure is the unrelated `backend-tests-glob.test.ts` fresh-clone harness limitation, present on develop)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)