### PR TITLE
ci: swap deprecated ep_readonly_guest for ep_guest in plugin matrix

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -146,7 +146,7 @@ jobs:
           ep_hash_auth
           ep_headings2
           ep_markdown
-          ep_readonly_guest
+          ep_guest
           ep_set_title_on_pad
           ep_spellcheck
           ep_subscript_and_superscript
@@ -289,7 +289,7 @@ jobs:
           ep_hash_auth
           ep_headings2
           ep_markdown
-          ep_readonly_guest
+          ep_guest
           ep_set_title_on_pad
           ep_spellcheck
           ep_subscript_and_superscript

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -219,7 +219,7 @@ jobs:
           ep_hash_auth
           ep_headings2
           ep_markdown
-          ep_readonly_guest
+          ep_guest
           ep_set_title_on_pad
           ep_spellcheck
           ep_subscript_and_superscript
@@ -308,7 +308,7 @@ jobs:
           ep_hash_auth
           ep_headings2
           ep_markdown
-          ep_readonly_guest
+          ep_guest
           ep_set_title_on_pad
           ep_spellcheck
           ep_subscript_and_superscript

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -93,7 +93,7 @@ jobs:
           ep_hash_auth
           ep_headings2
           ep_markdown
-          ep_readonly_guest
+          ep_guest
           ep_set_title_on_pad
           ep_spellcheck
           ep_subscript_and_superscript

--- a/.github/workflows/upgrade-from-latest-release.yml
+++ b/.github/workflows/upgrade-from-latest-release.yml
@@ -76,7 +76,7 @@ jobs:
           ep_hash_auth
           ep_headings2
           ep_markdown
-          ep_readonly_guest
+          ep_guest
           ep_set_title_on_pad
           ep_spellcheck
           ep_subscript_and_superscript

--- a/src/tests/backend/specs/admin/anonymizeAuthorSocket.ts
+++ b/src/tests/backend/specs/admin/anonymizeAuthorSocket.ts
@@ -62,17 +62,21 @@ const ask = (socket: any, evt: string, payload: any, replyEvt: string) =>
     });
 
 // adminSocket() depends on Etherpad's default plain-text password check for
-// settings.users[name].password. Plugins like ep_hash_auth replace the
-// authenticate hook to expect hashed credentials, so the basic-auth probe
-// returns no admin session, /settings's connection handler returns without
+// settings.users[name].password. Any authenticate-hook plugin that claims
+// the request before the built-in basic-auth fallback can block this:
+// the historical offender was ep_readonly_guest, whose authenticate hook
+// sorts itself first and silently swaps req.session.user with a guest
+// (#7795); ep_hash_auth-style plugins that expect hashed credentials
+// would do the same. When that happens the basic-auth probe returns no
+// admin session, /settings's connection handler returns without
 // registering listeners (see src/node/hooks/express/adminsettings.ts:25),
 // and every socket.emit() afterwards waits forever for a reply that
 // nothing will ever send. The socket itself still connects when admin
 // session is missing, so the probe has to run at the application layer:
-// emit a known `/settings` event (`load`) and wait for the matching reply
-// (`settings`). If it doesn't arrive within the budget, skip — much
-// cheaper than letting mocha's 120s per-test timeout absorb 7 stalled
-// tests. Tracked in #7795.
+// emit a known `/settings` event (`authorLoad`) and wait for the matching
+// reply (`results:authorLoad`). If it doesn't arrive within the budget,
+// skip — much cheaper than letting mocha's 120s per-test timeout absorb
+// 7 stalled tests.
 const PROBE_BUDGET_MS = 15000;
 const adminSocketWithProbe = async (budgetMs: number): Promise<{
   ok: true; socket: any;
@@ -135,8 +139,9 @@ describe(__filename, function () {
     if (!probe.ok) {
       console.warn(
           `[anonymizeAuthorSocket] admin socket probe failed (${probe.reason}); ` +
-          'skipping suite — likely an authenticate-hook plugin (e.g. ep_hash_auth) ' +
-          'rejecting the test\'s plain-text admin credentials. Tracked in #7795.');
+          'skipping suite — an authenticate-hook plugin (e.g. ep_readonly_guest, ' +
+          'or an ep_hash_auth-style plugin requiring hashed credentials) is ' +
+          'rejecting the test\'s plain-text admin credentials.');
       this.skip();
       return;
     }


### PR DESCRIPTION
## Summary

`ep_readonly_guest` is archived (read-only on GitHub) and its `authenticate` hook unconditionally swaps `req.session.user` with a read-only guest, even when the request carries an HTTP `Authorization` header. That silently demoted admin login attempts and stalled the `anonymizeAuthorSocket` tests for 14 min/run on every with-plugins CI matrix (#7795).

The pre-fix theory in #7795 blamed `ep_hash_auth.handleMessage` — that's a red herring. The hook is only invoked by `PadMessageHandler.ts:559` and never fires on the `/settings` namespace. The deprecation warning in the issue trace came from an unrelated earlier test (rate-limited by `warnDeprecated`'s 10-min stack dedupe in `pad_utils.ts:141`).

## Root cause

`ep_readonly_guest/index.js:31-39`:

```js
exports.authenticate = (hookName, {req}, cb) => {
  if (req.path === endpoint('forceauth')) return cb([]);
  req.session.user = user;            // guest, is_admin=false
  return cb([true]);                  // hard-claims auth
};
```

Plus it `sort`s itself to **run first** in `expressCreateServer`. So when the test does `GET /admin/` with `Authorization: Basic …`, `ep_readonly_guest` runs first, ignores the header, sets the guest session, returns `[true]`. The Set-Cookie returned to the test is for a guest. Socket connects to `/settings`; `adminsettings.ts:25` checks `is_admin` → false → handler bails without binding `socket.on('authorLoad', …)`. Every subsequent `emit()` has no listener → mocha 60s timeout × 7.

## Fix

`ep_guest@1.0.72` (the maintained successor by the same authors) already defers when the request targets `/admin*` or carries an `Authorization` header — see its `index.js:50-51`, added in response to its own issue #85. Swapping `ep_readonly_guest` → `ep_guest` in the plugin matrix unblocks `anonymizeAuthorSocket` on Linux, Windows, and the upgrade-from-latest-release workflow.

The runtime probe added in #7796 stays in place — it still catches any other authenticate-hook plugin that rejects the test's plain-text credentials (e.g. a future `ep_hash_auth`-style hashed-only plugin). Its comment is reattributed so future readers don't chase the `ep_hash_auth` red herring.

## Verification

Reproduced in a worktree off `develop@f6ab8561a` (Node 24) with the exact CI plugin list:

- **Before:** all 7 `anonymizeAuthorSocket` tests skip via the probe (`Successful authentication … for user guest` in logs).
- **After swap:** all 7 pass in ~12s.
- Full `tests/backend/specs/admin` + `tests/backend/specs/api` under the swapped matrix: **321 passing, 13 pending, 0 failing**.

## Files

- `.github/workflows/backend-tests.yml` — Linux + Windows with-plugins matrices
- `.github/workflows/frontend-tests.yml` — UI + admin with-plugins matrices
- `.github/workflows/upgrade-from-latest-release.yml`
- `.github/workflows/load-test.yml`
- `src/tests/backend/specs/admin/anonymizeAuthorSocket.ts` — reattribute the probe-skip warning so it points at `ep_readonly_guest` (the historical offender) instead of `ep_hash_auth`.

Closes #7795.

## Test plan

- [ ] Linux with Plugins matrix is green
- [ ] Windows with Plugins matrix is green
- [ ] Upgrade from latest release passes (it installs the same plugin set)
- [ ] Frontend with Plugins matrices stay green (no behavior change in the guest plugin from the user's POV — ep_guest is a drop-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)