### PR TITLE
feat(settings): default settings.enablePluginPadOptions to true

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -267,15 +267,16 @@ below.
 ### Runtime flag
 
 The passthrough is gated by `settings.enablePluginPadOptions`, default
-`false`. Operators must opt in via `settings.json`:
+`true`. Operators who want to lock plugins out of pad-wide state can flip
+it in `settings.json`:
 
 ```json
 {
-  "enablePluginPadOptions": true
+  "enablePluginPadOptions": false
 }
 ```
 
-When enabled, the server reflects the value to every client via
+When enabled (the default), the server reflects the value to every client via
 `clientVars.enablePluginPadOptions` so plugins can detect both *capable*
 (static) and *active* (per-pad request) at the same point.
 

--- a/settings.json.template
+++ b/settings.json.template
@@ -853,11 +853,11 @@
     * accepting pad-wide values under plugin-namespaced keys matching
     * /^ep_[a-z0-9_]+$/ (e.g. ep_table_of_contents). Values are validated
     * (JSON-safe, 64 KB per key, 256 KB total) and broadcast to every
-    * connected client just like native pad-wide toggles. Disabled by
-    * default; flip to true once your plugins (e.g. ep_plugin_helpers'
-    * padToggle) require it. See doc/plugins.md.
+    * connected client just like native pad-wide toggles. Enabled by
+    * default; set to false to lock plugins out of pad-wide state. See
+    * doc/plugins.md.
     **/
-    "enablePluginPadOptions": "${ENABLE_PLUGIN_PAD_OPTIONS:false}",
+    "enablePluginPadOptions": "${ENABLE_PLUGIN_PAD_OPTIONS:true}",
 
   /*
    * Optional privacy banner shown once the pad loads. Disabled by default.

--- a/src/node/utils/PluginCapabilities.ts
+++ b/src/node/utils/PluginCapabilities.ts
@@ -12,7 +12,7 @@
 
 // True when applyPadSettings (client + server) preserves keys matching
 // /^ep_[a-z0-9_]+$/ on pad.padOptions. The runtime gate is
-// settings.enablePluginPadOptions (default false), mirrored to clients via
+// settings.enablePluginPadOptions (default true), mirrored to clients via
 // clientVars.enablePluginPadOptions. See doc/plugins.md for the full
 // contract (key namespace, validation, size caps).
 export const padOptionsPluginPassthrough = true;

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -434,11 +434,11 @@ const settings: SettingsType = {
   updateServer: "https://static.etherpad.org",
   enableDarkMode: true,
   enablePadWideSettings: true,
-  // New plugin-padOption passthrough is opt-in per AGENTS.MD §52 ("New
-  // features should be placed behind feature flags and disabled by
-  // default"). Flip to true to let plugins (e.g. ep_plugin_helpers'
-  // padToggle) ride the existing padoptions broadcast/persist rail.
-  enablePluginPadOptions: false,
+  // Lets plugins (e.g. ep_plugin_helpers' padToggle / padSelect) ride the
+  // existing padoptions broadcast/persist rail to store pad-wide options
+  // under ep_* keys. Operators who want to lock plugin-driven pad-wide
+  // state out can set this to false in settings.json.
+  enablePluginPadOptions: true,
   allowPadDeletionByAllUsers: false,
   privacyBanner: {
     enabled: false,

--- a/src/tests/backend/specs/Pad.ts
+++ b/src/tests/backend/specs/Pad.ts
@@ -214,7 +214,7 @@ describe(__filename, function () {
     });
     afterEach(function () { console.warn = warnSpy; });
 
-    describe('with enablePluginPadOptions = true', function () {
+    describe('with enablePluginPadOptions = true (default)', function () {
       before(function () { settings.enablePluginPadOptions = true; });
 
       it('preserves ep_* keys verbatim so plugins can ride padoptions', function () {
@@ -285,10 +285,10 @@ describe(__filename, function () {
       });
     });
 
-    describe('with enablePluginPadOptions = false (default)', function () {
+    describe('with enablePluginPadOptions = false (operator opt-out)', function () {
       before(function () { settings.enablePluginPadOptions = false; });
 
-      it('drops every ep_* key — feature flag is opt-in', function () {
+      it('drops every ep_* key — operator has opted out of plugin pad-wide state', function () {
         const ps: any = Pad.Pad.normalizePadSettings({
           ep_table_of_contents: {enabled: true},
           ep_font_color: 'red',


### PR DESCRIPTION
## Note to Sam: This is more of a fix than a feat, it's the pad wide setting for plugins enabled by default as I intended but messed it up :)
## Summary
- Flip `settings.enablePluginPadOptions` default from `false` → `true`. Matches the original intent of shipping the `ep_*` passthrough in 3.0.0 (PR #7698): let plugins like `ep_plugin_helpers`' `padToggle` / `padSelect` ride the existing `padoptions` broadcast/persist rail out of the box.
- Updates `Settings.ts`, `settings.json.template` (env-var default), `PluginCapabilities.ts` comment, and `doc/plugins.md` (now describes the flag as opt-out instead of opt-in).
- Backend test describe-blocks relabeled — `true` is now `(default)`, `false` is now `(operator opt-out)`. Same matrix; both branches still pass.

## Why now
- ether/ep_comments_page#422 (and sibling per-plugin reports discussed on Discord) — stock 3.x deployments `console.warn` on every pad load because `ep_plugin_helpers` detects `clientVars.enablePluginPadOptions === false` and tells the admin to flip it. With the flag default-true, the warning stops firing on fresh installs while still surfacing for operators who have explicitly opted out.
- Plugins on `ep_plugin_helpers >= 0.6` already expect pad-wide options to work; default-false silently no-op'd `pad.changePadOption('ep_*', …)` and made the helper UI inert.

## Compat
- Deployments with an explicit `"enablePluginPadOptions": false` in `settings.json` keep that value — no migration.
- `clientVars` shape is unchanged; older clients only read `enablePluginPadOptions` and keep working.

## Follow-up
- ether/ep_plugin_helpers: README and warning comments still describe the flag as opt-in. Separate PR queued.

Closes ether/ep_comments_page#422 (warning suppression for stock deployments).

## Test plan
- [x] `mocha tests/backend/specs/Pad.ts` — 31 passing, both `(default)` and `(operator opt-out)` branches green
- [ ] Full backend suite via CI
- [ ] Smoke a fresh `settings.json` (env-var path) to confirm `clientVars.enablePluginPadOptions === true` on default deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)