### PR TITLE
test(ci): schedule a mid-test snapshot 150ms after every beforeEach

### DIFF
--- a/src/tests/backend/diagnostics.ts
+++ b/src/tests/backend/diagnostics.ts
@@ -66,9 +66,15 @@ const diag = (msg: string): void => {
 diag('diagnostics loaded');
 
 // Heartbeat. unref()'d so it never holds the event loop open by itself —
-// it only fires if mocha is otherwise alive. The interval cadence (1Hz) is
-// the trade-off between log noise (~60-120 extra lines per run) and how
-// tightly we can bracket the kill timestamp.
+// it only fires if mocha is otherwise alive. Bumped from 1 Hz to 5 Hz
+// after run 26402211271 caught a death (messages.ts > USER_CHANGES >
+// retransmission, kill +425 ms post-test-start) where the setTimeout-based
+// mid-test snapshot didn't fire — likely Windows event-loop scheduling
+// delaying setTimeout under load. setInterval has been firing reliably
+// at 1 Hz throughout the investigation, so 200 ms (5 Hz) should land
+// inside any death window ≥200 ms. writeReport on the Windows runner
+// completed in <1 ms per the log timestamps, so the cadence cost is
+// negligible compared to the precision gain.
 //
 // When the backend-test workflow has `--report-directory` set (only the
 // Windows jobs do at time of writing), every heartbeat also writes a Node
@@ -134,9 +140,9 @@ const heartbeat = setInterval(() => {
     `rss=${Math.round(mem.rss / 1024 / 1024)}M ` +
     `heap=${Math.round(mem.heapUsed / 1024 / 1024)}M ` +
     `handles=${handles} requests=${requests}`);
-  // Heartbeat always writes — its 1Hz cadence is the floor.
+  // Heartbeat always writes — its cadence is the floor for snapshot density.
   tryWriteReport('hb', 0);
-}, 1000);
+}, 200);
 heartbeat.unref();
 
 process.on('unhandledRejection', (reason: any) => {

--- a/src/tests/backend/diagnostics.ts
+++ b/src/tests/backend/diagnostics.ts
@@ -204,6 +204,24 @@ export const mochaHooks = {
       // boundary writes for any test whose neighbour fired ≥100 ms ago,
       // including the socketio tests in the dying-test pattern.
       tryWriteReport('be', 100);
+      // Mid-test snapshot. Run 26401801404 captured the dying test's
+      // beforeEach write but no further state — the kill landed 321 ms
+      // into the test body, between the 1 Hz heartbeat ticks, and the
+      // 100 ms boundary-throttle prevented additional beforeEach writes
+      // inside a single test. Schedule an unref'd setTimeout that fires
+      // 150 ms after the test entered: if it's still the running test
+      // at that point (i.e. slow enough that the death window applies),
+      // capture a snapshot from INSIDE the test body — where the TCP
+      // traffic and socket.io activity that precedes the kill happens.
+      // Fast tests (<150 ms) skip the write because currentTest will
+      // have already been cleared in afterEach.
+      const enteredTest = currentTest;
+      const midSnapshot = setTimeout(() => {
+        if (currentTest === enteredTest) {
+          tryWriteReport('mt', 0);
+        }
+      }, 150);
+      midSnapshot.unref();
     }
   },
   afterEach(this: any) {

--- a/src/tests/backend/diagnostics.ts
+++ b/src/tests/backend/diagnostics.ts
@@ -105,16 +105,28 @@ const canWriteReport =
   && !!((process as any).report?.directory
     || (process.env.NODE_OPTIONS || '').includes('--report-directory='));
 let reportCounter = 0;
-let lastReportT = 0;
+// Throttle state is scoped to boundary (`be`) writes only. Heartbeat (`hb`)
+// and mid-test (`mt`) writes use minGapMs=0 and pass `updateThrottle=false`,
+// so they never bump the boundary timestamp — otherwise a slow test's
+// `mt` write could land <100 ms before the next test's `beforeEach` and
+// suppress that test's own `be` snapshot, exactly the boundary coverage
+// the throttle is meant to preserve.
+let lastBoundaryT = 0;
 
-// Shared writer used by both the heartbeat tick and the beforeEach hook.
-// Throttled by minGapMs so a burst of fast tests doesn't produce hundreds of
-// reports — we just need dense enough coverage to bracket the kill.
-const tryWriteReport = (prefix: string, minGapMs: number): void => {
+// Shared writer used by the heartbeat tick, the beforeEach hook, and the
+// mid-test setTimeout. minGapMs throttles `be` writes against the previous
+// boundary write so a burst of fast tests doesn't produce hundreds of
+// reports; `hb` and `mt` writes pass 0 + updateThrottle=false to bypass
+// and not affect the throttle window.
+const tryWriteReport = (
+  prefix: string,
+  minGapMs: number,
+  updateThrottle = true,
+): void => {
   if (!canWriteReport) return;
   const now = Date.now();
-  if (now - lastReportT < minGapMs) return;
-  lastReportT = now;
+  if (now - lastBoundaryT < minGapMs) return;
+  if (updateThrottle) lastBoundaryT = now;
   reportCounter += 1;
   const safeTest = currentTest
     .replace(/[^a-zA-Z0-9._-]+/g, '_')
@@ -141,7 +153,9 @@ const heartbeat = setInterval(() => {
     `heap=${Math.round(mem.heapUsed / 1024 / 1024)}M ` +
     `handles=${handles} requests=${requests}`);
   // Heartbeat always writes — its cadence is the floor for snapshot density.
-  tryWriteReport('hb', 0);
+  // updateThrottle=false so the heartbeat tick doesn't suppress the next
+  // beforeEach `be` write.
+  tryWriteReport('hb', 0, false);
 }, 200);
 heartbeat.unref();
 
@@ -221,13 +235,22 @@ export const mochaHooks = {
       // traffic and socket.io activity that precedes the kill happens.
       // Fast tests (<150 ms) skip the write because currentTest will
       // have already been cleared in afterEach.
-      const enteredTest = currentTest;
-      const midSnapshot = setTimeout(() => {
-        if (currentTest === enteredTest) {
-          tryWriteReport('mt', 0);
-        }
-      }, 150);
-      midSnapshot.unref();
+      //
+      // Gated on canWriteReport: skipping the schedule entirely when
+      // node-report can't be written saves a setTimeout per test on
+      // runs without --report-directory (local mocha runs and the
+      // Linux backend matrix), which would otherwise churn timers for
+      // no possible diagnostic output.
+      if (canWriteReport) {
+        const enteredTest = currentTest;
+        const midSnapshot = setTimeout(() => {
+          // updateThrottle=false so this snapshot doesn't push out the
+          // next test's `be` write — the boundary report is still the
+          // primary record of which test the kill struck.
+          if (currentTest === enteredTest) tryWriteReport('mt', 0, false);
+        }, 150);
+        midSnapshot.unref();
+      }
     }
   },
   afterEach(this: any) {


### PR DESCRIPTION
## Summary

Follow-up to #7838. Schedule an unref'd `setTimeout` from `beforeEach` that fires 150 ms after a test enters: if it's still the running test at fire time (i.e. slow enough that the death window applies), capture a node-report from INSIDE the test body.

## Why

Run [26401801404](https://github.com/ether/etherpad/actions/runs/26401801404) captured the dying test's `beforeEach` node-report — `be-0258`, written 75 ms after `socketio.ts > Pad-wide settings creator gate different browsers` entered — but no further state. The kill landed 321 ms into the test body, between 1 Hz heartbeat ticks, and the 100 ms boundary throttle prevented further `beforeEach` writes inside the same test. The report we have shows only the listening server socket; the connections that the test body creates (and that presumably precede the kill) never get snapshotted.

## What this changes

Pure diagnostic. No behavior change on successful runs.

- `mochaHooks.beforeEach` schedules `setTimeout(150ms)` and captures `currentTest` in closure.
- Timer is `unref()`-d so it never holds the loop open.
- On fire, if `currentTest === enteredTest`, write a node-report (prefix `mt-`). Fast tests (<150 ms) have already moved on — afterEach cleared the pointer — so the write is skipped.

## Expected result on next reproduction of the kill pattern

```
be-NNNN report  +75 ms   (beforeEach, body not yet started)
mt-MMMM report  +150 ms  (mid-test, body in flight, before kill at +320 ms)
kill            +320 ms  (no further reports)
```

The mt-MMMM snapshot is the V8 stack + libuv handle snapshot we've been chasing — the one with the open TCP / socket.io connections that the kill correlates with.

## Cost

Only slow tests (>150 ms) generate an `mt-` report, so artifact growth is bounded by the count of slow tests — typically a small minority. Most tests fire-and-skip.

## Locally verified

3-test probe (10 ms, 300 ms, 5 ms tests):

```
[diag +9ms]   test start: fast (10ms)
[diag +46ms]  test start: slow (300ms)
[diag +347ms] test start: fast 2

--- files ---
be-0001-fast_10ms.json
mt-0002-slow_300ms.json   ← only the slow test triggered the mid-test write
be-0003-fast_2.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)