### PR TITLE
fix(pad): URL view-option params lost to padeditor.init race (#7840)

### DIFF
--- a/src/static/js/pad.ts
+++ b/src/static/js/pad.ts
@@ -720,9 +720,26 @@ const pad = {
       pad.refreshPadSettingsControls();
       pad.applyOptionsChange();
       pad.refreshMyViewControls();
+      // The following view overrides MUST run inside postAceInit (after
+      // padeditor.init resolves), not in the synchronous tail of
+      // _afterHandshake. Running them sync queues a setProperty in the
+      // Ace2Editor pending-init queue; the queue is flushed when ace
+      // finishes loading, but padeditor.init's own
+      // setViewOptions(initialViewOptions) call runs immediately *after*
+      // that flush and clobbers the URL-driven value. See #7464 for the
+      // RTL incarnation of this race (now generalised here for #7840).
       if (settings.rtlIsExplicit) {
         // URL or server config explicitly set RTL — takes priority over cookie
         pad.changeViewOption('rtlIsTrue', settings.rtlIsTrue === true);
+      }
+      if (settings.LineNumbersDisabled === true) {
+        pad.changeViewOption('showLineNumbers', false);
+      }
+      if (settings.noColors === true) {
+        pad.changeViewOption('noColors', true);
+      }
+      if (settings.useMonospaceFontGlobal === true) {
+        pad.changeViewOption('padFontFamily', 'RobotoMono');
       }
 
       // Prevent sticky chat or chat and users to be checked for mobiles
@@ -809,24 +826,6 @@ const pad = {
       ace.ace_setEditable(!window.clientVars.readonly);
     });
 
-    // If the LineNumbersDisabled value is set to true then we need to hide the Line Numbers
-    if (settings.LineNumbersDisabled === true) {
-      this.changeViewOption('showLineNumbers', false);
-    }
-
-    // If the noColors value is set to true then we need to
-    // hide the background colors on the ace spans
-    if (settings.noColors === true) {
-      this.changeViewOption('noColors', true);
-    }
-
-    // RTL override is applied in postAceInit (after padeditor.init resolves)
-    // to avoid a race where setViewOptions(initialViewOptions) overwrites it.
-
-    // If the Monospacefont value is set to true then change it to monospace.
-    if (settings.useMonospaceFontGlobal === true) {
-      this.changeViewOption('padFontFamily', 'RobotoMono');
-    }
     // if the globalUserName value is set we need to tell the server and
     // the client about the new authorname
     if (settings.globalUserName !== false) {

--- a/src/tests/frontend-new/specs/url_view_options.spec.ts
+++ b/src/tests/frontend-new/specs/url_view_options.spec.ts
@@ -1,0 +1,49 @@
+import {expect, test} from '@playwright/test';
+import {goToNewPad} from '../helper/padHelper';
+
+// Covers the URL-param view overrides that share the same _afterHandshake
+// race as rtl=false (fixed in #7464). Each test loads a pad with the URL
+// param in the initial navigation so the race actually fires, instead of
+// applying the param via a second goto on an already-initialized pad.
+
+test.beforeEach(async ({context}) => {
+  await context.clearCookies();
+});
+
+const navigateWithParam = async (page, padId, param) => {
+  await page.goto(`http://localhost:9001/p/${padId}?${param}`);
+  await page.waitForSelector('iframe[name="ace_outer"]');
+  await page.waitForSelector('#editorcontainer.initialized');
+};
+
+test.describe('URL-param view options apply on initial load (race-free)', function () {
+  test('?showLineNumbers=false hides the line-number gutter on first paint', async function ({page}) {
+    const padId = await goToNewPad(page);
+    await navigateWithParam(page, padId, 'showLineNumbers=false');
+
+    const outerBody = page.frameLocator('iframe[name="ace_outer"]').locator('body');
+    await expect(outerBody).toHaveClass(/line-numbers-hidden/);
+    await expect(page.locator('#options-linenoscheck')).not.toBeChecked();
+  });
+
+  test('?showLineNumbers=true keeps the gutter visible (no regression)', async function ({page}) {
+    const padId = await goToNewPad(page);
+    await navigateWithParam(page, padId, 'showLineNumbers=true');
+
+    const outerBody = page.frameLocator('iframe[name="ace_outer"]').locator('body');
+    await expect(outerBody).not.toHaveClass(/line-numbers-hidden/);
+    await expect(page.locator('#options-linenoscheck')).toBeChecked();
+  });
+
+  test('?useMonospaceFont=true applies monospace on first paint', async function ({page}) {
+    const padId = await goToNewPad(page);
+    await navigateWithParam(page, padId, 'useMonospaceFont=true');
+
+    // padFontFamily=RobotoMono is mirrored onto the inner body via
+    // setProperty('textface', ...) AND onto the #viewfontmenu select;
+    // the same race that drops showLineNumbers also drops the select
+    // value back to empty when the param fires before padeditor.init
+    // resolves.
+    await expect(page.locator('#viewfontmenu')).toHaveValue('RobotoMono');
+  });
+});

--- a/src/tests/frontend-new/specs/url_view_options.spec.ts
+++ b/src/tests/frontend-new/specs/url_view_options.spec.ts
@@ -1,4 +1,4 @@
-import {expect, test} from '@playwright/test';
+import {expect, Page, test} from '@playwright/test';
 import {goToNewPad} from '../helper/padHelper';
 
 // Covers the URL-param view overrides that share the same _afterHandshake
@@ -10,7 +10,7 @@ test.beforeEach(async ({context}) => {
   await context.clearCookies();
 });
 
-const navigateWithParam = async (page, padId, param) => {
+const navigateWithParam = async (page: Page, padId: string, param: string) => {
   await page.goto(`http://localhost:9001/p/${padId}?${param}`);
   await page.waitForSelector('iframe[name="ace_outer"]');
   await page.waitForSelector('#editorcontainer.initialized');


### PR DESCRIPTION
## Summary

Closes #7840. `?showLineNumbers=false` (and `?useMonospaceFont=true`) on an iframe-embedded pad get re-applied to the server default a few hundred ms after pad boot. Same race that affected `?rtl=false` before #7464 — generalises that fix to the neighbouring URL view-toggles.

## Why the iframe reporter sees it and direct users don't

The race always fires, but it only becomes *observable* when the value `padeditor.init`'s deferred `setViewOptions(initialViewOptions)` call re-applies disagrees with the URL param. `initialViewOptions` is built from `cookie pref ?? server default`:

- Direct-browser users typically have a `prefs` cookie from a prior in-pad toggle that matches what they're asking for via URL → no observable race.
- Cross-context iframe embeds with no cookie → server default `showLineNumbers:true` fights the URL `false` → URL preference visibly lost.

## What the race looks like

1. `_afterHandshake` → `getParams()` sets `settings.LineNumbersDisabled = true`.
2. `_afterHandshake` calls `padeditor.init(view).then(postAceInit)` — async; ace iframes still loading.
3. Sync tail of `_afterHandshake` hits the URL-param block: `changeViewOption('showLineNumbers', false)` → queues `setProperty('showslinenumbers', false)` in `Ace2Editor.actionsPendingInit` (loaded=false).
4. `ace.init` resolves → `loaded=true` → queue flushes → URL-driven `false` applied.
5. `padeditor.init` resumes past its own `await` and runs `self.setViewOptions(initialViewOptions)` — `initialViewOptions.showLineNumbers === true` (server default) → `setProperty('showslinenumbers', true)` runs against `loaded=true` and immediately re-shows the gutter.

#7464 spotted this for RTL and moved the override into `postAceInit`. The neighbouring blocks for `showLineNumbers` / `noColors` / `useMonospaceFontGlobal` at the same synchronous-tail site never got the same treatment. This PR generalises that fix.

## Test plan

- [x] New spec \`src/tests/frontend-new/specs/url_view_options.spec.ts\`:
  - \`?showLineNumbers=false\` → outer body has \`.line-numbers-hidden\` on first paint
  - \`?showLineNumbers=true\` no-regression
  - \`?useMonospaceFont=true\` → \`#viewfontmenu\` value is \`RobotoMono\` on first paint
- [x] Verified the three race cases fail on \`develop\` before the fix.
- [x] Verified \`rtl_url_param.spec.ts\`, \`timeslider_line_numbers.spec.ts\`, \`pad_settings.spec.ts\`, \`embed_value.spec.ts\`, \`hide_menu_right.spec.ts\` still pass (26/26 green together).

## Not in scope

- The \`?noColors=true\` URL path turns out to be unaffected for the inner-body \`authorColors\` class (the override at \`pad_editor.ts:268-270\` always wins). The colorscheck checkbox UI doesn't reflect \`settings.noColors\` in either the racy or fixed state — that's a pre-existing cosmetic mismatch independent of this race and worth its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)