### PR TITLE
test(ci): drain event loop with setImmediate after every test (mitigation hypothesis)

### DIFF
--- a/src/tests/backend/diagnostics.ts
+++ b/src/tests/backend/diagnostics.ts
@@ -253,10 +253,32 @@ export const mochaHooks = {
       }
     }
   },
-  afterEach(this: any) {
+  async afterEach(this: any) {
     if (this.currentTest) {
       lastFinishedTest = this.currentTest.fullTitle();
       currentTest = '<no test running>';
     }
+    // Mitigation experiment for the Windows-backend silent ELIFECYCLE
+    // flake. PR #7842 captured nine deaths showing a consistent shape:
+    // 200-400 ms after a test starts, the event loop stops servicing
+    // timers (heartbeat goes silent) and the process is terminated
+    // shortly after — with no JS-handler trace, no native abort report,
+    // and no obvious anomaly in the pre-kill libuv state. The pattern
+    // suggests cumulative event-loop pressure: rapid sequential
+    // supertest TCP roundtrips + socket.io connections + DOCX export
+    // I/O queue up enough work that something in libuv's IOCP path
+    // (Windows-specific) eventually triggers an external kill.
+    //
+    // Insert a single setImmediate yield after every test so the event
+    // loop drains queued I/O callbacks at a deterministic boundary
+    // rather than letting them stack across tests. If the kill rate
+    // drops materially on Windows backend matrices after this lands
+    // we have strong evidence the trigger is cumulative; if it
+    // doesn't, we rule out cumulative pressure and look elsewhere
+    // (specific test paths, native module bugs, etc.).
+    //
+    // Cost: ~600 tests × 1 setImmediate = ~600 µs total wall-clock,
+    // negligible compared to the multi-minute backend test phase.
+    await new Promise((r) => setImmediate(r));
   },
 };


### PR DESCRIPTION
## Summary

Insert a single `setImmediate` yield in the mocha root `afterEach` so the event loop drains queued I/O callbacks at every test boundary. Pure mitigation hypothesis test — no other changes.

## Why

Ten captured deaths on the merged diagnostic infrastructure (#7838, #7842) show a consistent shape:

- 200–400 ms after a test starts, the 5 Hz heartbeat `setInterval` goes silent for the entire death window (no timer events at all).
- The process is then externally terminated, bypassing `unhandledRejection`, `uncaughtException`, `--report-on-fatalerror`, `--report-uncaught-exception`, and all signal handlers.
- Pre-kill state in the libuv handle trace is nominal (3–7 handles, no leak, no spike).
- Dying tests span supertest+JWT HTTP, socket.io connect bursts, and DOCX export round-trips — different surface code, same fingerprint.

The common substrate across all 10 deaths is rapid loopback TCP and queued I/O across test boundaries. This experiment tests one specific hypothesis: **cumulative event-loop pressure across tests** is the trigger. A `setImmediate` yield in `afterEach` forces a deterministic drain at every boundary instead of letting work stack across tests.

## Expected outcome

| Result | Conclusion |
|---|---|
| Win+plugins flake rate drops materially | Cumulative I/O pressure is the trigger; this is a working mitigation. Promote to permanent. |
| Flake rate unchanged | Cumulative pressure ruled out. Move on to per-test pathologies (jose CNG, Express middleware, native modules). |

## Cost

`~600 tests × 1 setImmediate yield ≈` negligible compared to the multi-minute backend test phase. Locally verified — a 3-test probe runs cleanly with the new async `afterEach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)