### PR TITLE
test(ci): OS-level sidecar watcher for the Windows silent ELIFECYCLE

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -222,11 +222,48 @@ jobs:
           NODE_OPTIONS: "--report-on-fatalerror --report-uncaught-exception --report-on-signal --report-compact --report-directory=${{ github.workspace }}/node-report"
         run: |
           mkdir -p "${{ github.workspace }}/node-report"
+          OUT="${{ github.workspace }}/node-report"
+          # Out-of-process OS-level watcher for the silent-ELIFECYCLE flake.
+          # In-process diagnostics (diagnostics.ts heartbeat + node-report
+          # snapshots) showed that during the death window the V8 main
+          # isolate is starved — heartbeat stops firing entirely, then the
+          # process is externally terminated, bypassing all JS handlers and
+          # Node's --report-on-fatalerror. To capture state during that
+          # starvation we need a process that doesn't depend on the dying
+          # process's event loop. A bash background loop polling Windows
+          # OS state every 500 ms gives us that:
+          #   - netstat.log: localhost TCP socket states over time
+          #     (TIME_WAIT/CLOSE_WAIT accumulation, handle exhaustion)
+          #   - tasklist.log: node.exe process handle count, working set,
+          #     CPU time — captured by the OS independent of V8.
+          # Both logs are appended to node-report/ which already gets
+          # uploaded as an artifact on failure.
+          (
+            while true; do
+              ts=$(date '+%H:%M:%S.%3N')
+              {
+                echo "=== $ts ==="
+                netstat -an 2>/dev/null | grep -E "TCP\s+(127\.0\.0\.1|\[::1\])" || true
+              } >> "$OUT/netstat.log"
+              {
+                echo "=== $ts ==="
+                tasklist /v /fi "imagename eq node.exe" /fo csv 2>/dev/null || true
+              } >> "$OUT/tasklist.log"
+              sleep 0.5
+            done
+          ) &
+          WATCHER_PID=$!
           # --exit forces process.exit(failures) after the suite completes,
           # closing the post-suite event-loop drain window where Windows +
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
           # runs still surface real handle leaks via natural drain.
+          set +e
           pnpm test -- --exit
+          EXIT=$?
+          set -e
+          kill "$WATCHER_PID" 2>/dev/null || true
+          wait "$WATCHER_PID" 2>/dev/null || true
+          exit $EXIT
       - name: Upload Node diagnostic reports on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
@@ -319,11 +356,48 @@ jobs:
           NODE_OPTIONS: "--report-on-fatalerror --report-uncaught-exception --report-on-signal --report-compact --report-directory=${{ github.workspace }}/node-report"
         run: |
           mkdir -p "${{ github.workspace }}/node-report"
+          OUT="${{ github.workspace }}/node-report"
+          # Out-of-process OS-level watcher for the silent-ELIFECYCLE flake.
+          # In-process diagnostics (diagnostics.ts heartbeat + node-report
+          # snapshots) showed that during the death window the V8 main
+          # isolate is starved — heartbeat stops firing entirely, then the
+          # process is externally terminated, bypassing all JS handlers and
+          # Node's --report-on-fatalerror. To capture state during that
+          # starvation we need a process that doesn't depend on the dying
+          # process's event loop. A bash background loop polling Windows
+          # OS state every 500 ms gives us that:
+          #   - netstat.log: localhost TCP socket states over time
+          #     (TIME_WAIT/CLOSE_WAIT accumulation, handle exhaustion)
+          #   - tasklist.log: node.exe process handle count, working set,
+          #     CPU time — captured by the OS independent of V8.
+          # Both logs are appended to node-report/ which already gets
+          # uploaded as an artifact on failure.
+          (
+            while true; do
+              ts=$(date '+%H:%M:%S.%3N')
+              {
+                echo "=== $ts ==="
+                netstat -an 2>/dev/null | grep -E "TCP\s+(127\.0\.0\.1|\[::1\])" || true
+              } >> "$OUT/netstat.log"
+              {
+                echo "=== $ts ==="
+                tasklist /v /fi "imagename eq node.exe" /fo csv 2>/dev/null || true
+              } >> "$OUT/tasklist.log"
+              sleep 0.5
+            done
+          ) &
+          WATCHER_PID=$!
           # --exit forces process.exit(failures) after the suite completes,
           # closing the post-suite event-loop drain window where Windows +
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
           # runs still surface real handle leaks via natural drain.
+          set +e
           pnpm test -- --exit
+          EXIT=$?
+          set -e
+          kill "$WATCHER_PID" 2>/dev/null || true
+          wait "$WATCHER_PID" 2>/dev/null || true
+          exit $EXIT
       - name: Upload Node diagnostic reports on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Adds a bash background loop to both Windows backend-test steps (with- and without-plugins) that polls Windows OS state every 500 ms and writes to the existing `node-report/` artifact directory:

- `netstat.log` — localhost TCP socket states (ESTABLISHED / TIME_WAIT / CLOSE_WAIT / FIN_WAIT) per tick.
- `tasklist.log` — `node.exe` process handle count, working set, CPU time per tick.

## Why

Eleven captured silent-ELIFECYCLE deaths from the merged in-process diagnostics (#7838, #7842) all share the same shape: the V8 main isolate goes event-loop-starved for 200–400 ms (5 Hz heartbeat falls silent), then the process is externally terminated bypassing all JS handlers, `--report-on-fatalerror`, and `--report-uncaught-exception`. The libuv handle list in our pre-kill `node-report` snapshots is nominal — but libuv only knows about handles Node currently owns. The kernel can hold many more sockets in disposal states (TIME_WAIT etc.) that we never see.

To capture state during the starvation window we need a probe whose scheduling doesn't depend on the dying process's event loop. A bash background loop is the simplest such probe — its scheduling is the runner's bash, not the Node isolate.

## What this changes

Workflow-only — no code changes. Both Windows steps now wrap `pnpm test -- --exit` like this:

```bash
( while true; do
    ts=$(date '+%H:%M:%S.%3N')
    { echo "=== $ts ==="; netstat -an | grep TCP ...; } >> "$OUT/netstat.log"
    { echo "=== $ts ==="; tasklist /v /fi "imagename eq node.exe" /fo csv; } >> "$OUT/tasklist.log"
    sleep 0.5
done ) &
WATCHER_PID=$!
set +e; pnpm test -- --exit; EXIT=$?; set -e
kill "$WATCHER_PID" 2>/dev/null || true
exit $EXIT
```

Linux jobs are untouched (the flake is Windows-only).

## Expected next capture

On the next silent ELIFECYCLE Win+plugins failure we'll get, for the first time:
- 500 ms-resolution external snapshots of localhost TCP state across the death window
- Node process handle count from the OS view independent of V8 responsiveness

Either signal can be the smoking gun (or rule out a class of hypotheses, e.g. TIME_WAIT exhaustion).

## Risk

`netstat -an` and `tasklist` are cheap. The sleep loop runs in its own bash process so it doesn't compete with Node for the event loop. 500 ms cadence keeps CPU overhead negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)