### PR TITLE
perf: room-broadcast NEW_CHANGES fan-out for steady-state clients behind feature flag (#7780)

### DIFF
--- a/settings.json.docker
+++ b/settings.json.docker
@@ -684,7 +684,7 @@
   "socketTransportProtocols" : ["websocket", "polling"],
 
   /*
-   * Performance experiment (#7780): room-broadcast NEW_CHANGES to steady-state
+   * room-broadcast NEW_CHANGES to steady-state
    * recipients, keep per-socket catch-up for stragglers.
    */
   "roomBroadcastNewChanges": "${ROOM_BROADCAST_NEW_CHANGES:false}",

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -683,6 +683,12 @@
    */
   "socketTransportProtocols" : ["websocket", "polling"],
 
+  /*
+   * Performance experiment (#7780): room-broadcast NEW_CHANGES to steady-state
+   * recipients, keep per-socket catch-up for stragglers.
+   */
+  "roomBroadcastNewChanges": "${ROOM_BROADCAST_NEW_CHANGES:false}",
+
   "socketIo": {
     /*
      * Maximum permitted client message size (in bytes). This controls the

--- a/settings.json.template
+++ b/settings.json.template
@@ -765,6 +765,15 @@
    */
   "socketTransportProtocols" : ["websocket", "polling"],
 
+  /*
+   * Performance experiment (#7780): use room-broadcast NEW_CHANGES fan-out for
+   * steady-state recipients (clients at head-1), while stragglers still catch
+   * up via per-socket emits.
+   *
+   * Keep disabled unless explicitly benchmarking or validating this behavior.
+   */
+  "roomBroadcastNewChanges": false,
+
   "socketIo": {
     /*
      * Maximum permitted client message size (in bytes). This controls the

--- a/settings.json.template
+++ b/settings.json.template
@@ -766,7 +766,7 @@
   "socketTransportProtocols" : ["websocket", "polling"],
 
   /*
-   * Performance experiment (#7780): use room-broadcast NEW_CHANGES fan-out for
+   * use room-broadcast NEW_CHANGES fan-out for
    * steady-state recipients (clients at head-1), while stragglers still catch
    * up via per-socket emits.
    *

--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -1046,7 +1046,6 @@ exports.updatePadClients = async (pad: PadType) => {
       }
     }
 
-    // Broadcast the latest revision once for all steady-state recipients (head-1).
     if (syncedSocketIds.length > 0 && headRev >= 0) {
       const revision = await getRevision(headRev);
       const author = revision.meta.author;
@@ -1073,7 +1072,6 @@ exports.updatePadClients = async (pad: PadType) => {
           ns.to(pad.id).emit('message', msg);
         }
       } else {
-        // Fallback to direct socket emits if namespace is unavailable.
         for (const socketId of syncedSocketIds) {
           const socket = roomSockets.find((s) => s.id === socketId);
           if (socket != null) socket.emit('message', msg);
@@ -1089,7 +1087,6 @@ exports.updatePadClients = async (pad: PadType) => {
       }
     }
 
-    // Stragglers still need per-socket catch-up to preserve rev+1 semantics.
     await Promise.all(stragglerSockets.map(async (socket) => {
       const sessioninfo = sessioninfos[socket.id];
       if (sessioninfo == null) return;

--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -1010,6 +1010,122 @@ exports.updatePadClients = async (pad: PadType) => {
   // benefits of running this in parallel,
   // but benefit of reusing cached revision object is HUGE
   const revCache:MapArrayType<any> = {};
+  const forWireCache:MapArrayType<any> = {};
+
+  const getRevision = async (rev: any) => {
+    let revision = revCache[rev];
+    if (!revision) {
+      revision = await pad.getRevision(rev);
+      revCache[rev] = revision;
+    }
+    return revision;
+  };
+
+  const getForWire = (rev: number, revision: any) => {
+    let forWire = forWireCache[rev];
+    if (!forWire) {
+      forWire = prepareForWire(revision.changeset, pad.pool);
+      forWireCache[rev] = forWire;
+    }
+    return forWire;
+  };
+
+  if (settings.roomBroadcastNewChanges) {
+    const headRev = pad.getHeadRevisionNumber();
+    const syncedSocketIds: string[] = [];
+    const stragglerSockets: any[] = [];
+
+    for (const socket of roomSockets) {
+      const sessioninfo = sessioninfos[socket.id];
+      // The user might have disconnected since _getRoomSockets() was called.
+      if (sessioninfo == null) continue;
+      if (sessioninfo.rev === headRev - 1) {
+        syncedSocketIds.push(socket.id);
+      } else {
+        stragglerSockets.push(socket);
+      }
+    }
+
+    // Broadcast the latest revision once for all steady-state recipients (head-1).
+    if (syncedSocketIds.length > 0 && headRev >= 0) {
+      const revision = await getRevision(headRev);
+      const author = revision.meta.author;
+      const currentTime = revision.meta.timestamp;
+      const forWire = getForWire(headRev, revision);
+      const exemplarSession = sessioninfos[syncedSocketIds[0]];
+      const msg = {
+        type: 'COLLABROOM',
+        data: {
+          type: 'NEW_CHANGES',
+          newRev: headRev,
+          changeset: forWire.translated,
+          apool: forWire.pool,
+          author,
+          currentTime,
+          timeDelta: currentTime - exemplarSession.time,
+        },
+      };
+      const ns = socketio?.sockets;
+      if (ns != null) {
+        if (stragglerSockets.length > 0) {
+          ns.to(pad.id).except(stragglerSockets.map((s) => s.id)).emit('message', msg);
+        } else {
+          ns.to(pad.id).emit('message', msg);
+        }
+      } else {
+        // Fallback to direct socket emits if namespace is unavailable.
+        for (const socketId of syncedSocketIds) {
+          const socket = roomSockets.find((s) => s.id === socketId);
+          if (socket != null) socket.emit('message', msg);
+        }
+      }
+      recordSocketEmit('NEW_CHANGES');
+
+      for (const socketId of syncedSocketIds) {
+        const sessioninfo = sessioninfos[socketId];
+        if (sessioninfo == null || sessioninfo.rev !== headRev - 1) continue;
+        sessioninfo.time = currentTime;
+        sessioninfo.rev = headRev;
+      }
+    }
+
+    // Stragglers still need per-socket catch-up to preserve rev+1 semantics.
+    await Promise.all(stragglerSockets.map(async (socket) => {
+      const sessioninfo = sessioninfos[socket.id];
+      if (sessioninfo == null) return;
+
+      while (sessioninfo.rev < pad.getHeadRevisionNumber()) {
+        const r = sessioninfo.rev + 1;
+        const revision = await getRevision(r);
+        const author = revision.meta.author;
+        const currentTime = revision.meta.timestamp;
+        const forWire = getForWire(r, revision);
+
+        const msg = {
+          type: 'COLLABROOM',
+          data: {
+            type: 'NEW_CHANGES',
+            newRev: r,
+            changeset: forWire.translated,
+            apool: forWire.pool,
+            author,
+            currentTime,
+            timeDelta: currentTime - sessioninfo.time,
+          },
+        };
+        try {
+          socket.emit('message', msg);
+          recordSocketEmit('NEW_CHANGES');
+        } catch (err:any) {
+          messageLogger.error(`Failed to notify user of new revision: ${err.stack || err}`);
+          return;
+        }
+        sessioninfo.time = currentTime;
+        sessioninfo.rev = r;
+      }
+    }));
+    return;
+  }
 
   await Promise.all(roomSockets.map(async (socket) => {
     const sessioninfo = sessioninfos[socket.id];
@@ -1018,17 +1134,11 @@ exports.updatePadClients = async (pad: PadType) => {
 
     while (sessioninfo.rev < pad.getHeadRevisionNumber()) {
       const r = sessioninfo.rev + 1;
-      let revision = revCache[r];
-      if (!revision) {
-        revision = await pad.getRevision(r);
-        revCache[r] = revision;
-      }
+      const revision = await getRevision(r);
 
       const author = revision.meta.author;
-      const revChangeset = revision.changeset;
       const currentTime = revision.meta.timestamp;
-
-      const forWire = prepareForWire(revChangeset, pad.pool);
+      const forWire = getForWire(r, revision);
       const msg = {
         type: 'COLLABROOM',
         data: {

--- a/src/node/utils/Settings.ts
+++ b/src/node/utils/Settings.ts
@@ -275,6 +275,7 @@ export type SettingsType = {
   ipLogging: 'full' | 'truncated' | 'anonymous',
   automaticReconnectionTimeout: number,
   loadTest: boolean,
+  roomBroadcastNewChanges: boolean,
   scalingDiveMetrics: boolean,
   dumpOnUncleanExit: boolean,
   indentationOnNewLine: boolean,
@@ -698,6 +699,11 @@ const settings: SettingsType = {
    * Disable Load Testing
    */
   loadTest: false,
+  /**
+   * Use room-broadcast for steady-state NEW_CHANGES fan-out. Disabled by default so this
+   * optimization can be A/B tested safely.
+   */
+  roomBroadcastNewChanges: false,
   /**
    * Expose extra Prometheus metrics designed for the scaling-dive load-test harness
    * (ether/etherpad#7756): etherpad_pad_users{padId}, etherpad_changeset_apply_duration_seconds,

--- a/src/tests/backend-new/specs/roomBroadcastNewChanges-defaults.test.ts
+++ b/src/tests/backend-new/specs/roomBroadcastNewChanges-defaults.test.ts
@@ -1,0 +1,8 @@
+import {describe, it, expect} from 'vitest';
+import settings from '../../../node/utils/Settings';
+
+describe('room broadcast NEW_CHANGES defaults', () => {
+  it('roomBroadcastNewChanges defaults to false', () => {
+    expect(settings.roomBroadcastNewChanges).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #7780.

This PR implements Shape A for room fan-out in src/node/handler/PadMessageHandler.ts:

- broadcast NEW_CHANGES once to steady-state recipients at head - 1
- keep per-socket rev + 1 catch-up for stragglers
- gate the behavior behind settings.roomBroadcastNewChanges, default false

Goal: reduce per-recipient packet construction overhead in the steady-state path without changing client protocol behavior.

## Why each change is necessary

- src/node/handler/PadMessageHandler.ts  
  Introduces split-path fan-out:
  - steady-state sockets use room broadcast for the latest revision
  - stragglers keep per-socket incremental catch-up  
  This is necessary because a naive latest-only broadcast would be dropped by lagging clients that enforce rev + 1 semantics.

- src/node/utils/Settings.ts  
  Adds roomBroadcastNewChanges to settings type and default.  
  This is required so the optimization can be A/B tested safely and remain off by default.

- settings.json.template  
  Documents the new flag and intended usage.  
  This is required so operators can enable the experiment intentionally and understand scope.

- settings.json.docker  
  Adds ROOM_BROADCAST_NEW_CHANGES env mapping.  
  This is required for containerized benchmark and rollout workflows.

- src/tests/backend-new/specs/roomBroadcastNewChanges-defaults.test.ts  
  Verifies default remains false.  
  This guards the acceptance requirement that the change is feature-flagged and opt-in.

## Compatibility and risk

- Default behavior is unchanged when the flag is false.
- No client-side protocol changes.
- Straggler path preserves current correctness guarantees.

## Validation

- TypeScript check passed
- Backend-new Vitest suite passed
- New defaults test passed

## N=3 measurement

Run setup used for this branch measurement:
- Duration: 10 seconds
- Authors: 5
- N=3 per mode, same host, fresh run per sample

Results:

| mode | run | cpu_delta_sec | NEW_CHANGES_emits_delta |
|---|---:|---:|---:|
| off | 1 | 0.9375 | 396 |
| off | 2 | 1.0625 | 404 |
| off | 3 | 1.0312 | 400 |
| on  | 1 | 1.1875 | 102 |
| on  | 2 | 1.0156 | 100 |
| on  | 3 | 0.9531 | 99 |

Averages:
- avg off cpu_delta_sec: 1.0104
- avg on cpu_delta_sec: 1.0521
- cpu change: +4.12%
- avg off NEW_CHANGES emits delta: 400.0000
- avg on NEW_CHANGES emits delta: 100.3333
- emits change: -74.92%

Notes:
- The expected emit reduction is clearly visible.
- CPU improvement is not visible at this small workload; likely below noise floor.
- If preferred, I can add a follow-up measurement block with a heavier profile matching CI-style load settings.
