### PR TITLE
test(ci): probe — drop mocha --exit on Windows backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -258,7 +258,7 @@ jobs:
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
           # runs still surface real handle leaks via natural drain.
           set +e
-          pnpm test -- --exit
+          pnpm test
           EXIT=$?
           set -e
           kill "$WATCHER_PID" 2>/dev/null || true
@@ -392,7 +392,7 @@ jobs:
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
           # runs still surface real handle leaks via natural drain.
           set +e
-          pnpm test -- --exit
+          pnpm test
           EXIT=$?
           set -e
           kill "$WATCHER_PID" 2>/dev/null || true

--- a/src/tests/backend-new/specs/backend-tests-flake-mitigation.test.ts
+++ b/src/tests/backend-new/specs/backend-tests-flake-mitigation.test.ts
@@ -45,14 +45,17 @@ describe('backend-tests flake mitigation (PR #7748)', () => {
       .toBe(runStepCount);
   });
 
-  it('Windows backend-test steps invoke pnpm test with --exit', () => {
-    // --exit is the Windows-only mitigation. Linux still runs natural-drain
-    // so leaked-handle regressions stay visible there.
+  it.skip('Windows backend-test steps invoke pnpm test with --exit (PROBE: temporarily disabled)', () => {
+    // PROBE branch only — see PR #7856. The original assertion enforced
+    // that the post-suite-drain mitigation from PR #7748 stays in place.
+    // This probe deliberately drops --exit to see whether (a) the original
+    // post-suite hard-kill bug still reproduces on current Node 24.x, or
+    // (b) --exit was also masking signal from the mid-suite silent flake.
+    // The .skip is REQUIRED for the probe branch to run; if this is in a
+    // PR targeted at develop, revert it before merge.
     const exitCount = (workflow.match(/pnpm test -- --exit/g) || []).length;
     expect(exitCount, 'Windows × 2 jobs must pass --exit to pnpm test')
       .toBe(2);
-    // Negative check: Linux jobs must NOT use --exit so handle-leak
-    // detection stays alive on the natural-drain platforms.
     expect(workflow.includes('runs-on: ubuntu-latest'),
       'workflow no longer has any Linux jobs (sanity check)').toBe(true);
   });


### PR DESCRIPTION
## Summary

One-line workflow probe on a separate branch from #7855: remove the `--exit` flag from `pnpm test` on both Windows backend matrices.

## Why

The current workflow has been invoking `pnpm test -- --exit` on Windows since PR #7762, with the comment:

> `--exit` forces `process.exit(failures)` after the suite completes, closing the post-suite event-loop drain window where Windows + Node 24 hard-kills the process.

That's a direct admission of a known post-suite kill bug on Windows + Node 24, and `--exit` was added as **a mitigation that hides it**. The current silent-ELIFECYCLE flake fires *mid-suite*, but `--exit` is still in play after the dying test and may also be masking earlier signal.

Drop it on a separate probe branch. Either:
- Tests still complete cleanly via natural drain → the original kill from #7762 is no longer reproducible on current Node 24.x and we've been carrying the workaround for nothing.
- A fresh hard-kill appears at post-suite drain → second data point distinct from the mid-suite flake, comparable to it via the merged diagnostic infra (#7838 + #7842 + #7846).
- The mid-suite flake fires → does mocha emit additional output that `--exit`'s `process.exit()` was suppressing?

Any of these is data we don't currently have.

## Test plan

- [ ] Linux ± plugins must pass (no change there)
- [ ] Windows backend matrices: fail, pass, or unchanged — all three outcomes are informative
- [ ] Run alongside #7855 in parallel to maximise data per CI window

🤖 Generated with [Claude Code](https://claude.com/claude-code)