### PR TITLE
test(ci): probe G — install ProcDump as JIT debugger to capture __fastfail across the silent kill

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,7 +215,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) (retrigger 1) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 2) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #
@@ -474,7 +474,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) (retrigger 1) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 2) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -311,6 +311,16 @@ jobs:
           path: node-report/
           if-no-files-found: ignore
           retention-days: 7
+      - name: Upload Defender + Event Log baseline (always)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: defender-eventlog-${{ runner.os }}-node${{ matrix.node }}-${{ github.job }}-${{ github.run_attempt }}
+          path: |
+            node-report/defender-*.txt
+            node-report/event-*.txt
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Run the new vitest tests
         working-directory: src
         run: pnpm run test:vitest
@@ -482,6 +492,16 @@ jobs:
         with:
           name: node-diagnostic-report-${{ runner.os }}-node${{ matrix.node }}-${{ github.job }}
           path: node-report/
+          if-no-files-found: ignore
+          retention-days: 7
+      - name: Upload Defender + Event Log baseline (always)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: defender-eventlog-${{ runner.os }}-node${{ matrix.node }}-${{ github.job }}-${{ github.run_attempt }}
+          path: |
+            node-report/defender-*.txt
+            node-report/event-*.txt
           if-no-files-found: ignore
           retention-days: 7
       - name: Run the new vitest tests

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,6 +215,33 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
+        # PROBE G — install Sysinternals ProcDump as the system Just-In-Time
+        # debugger. When ANY process on the runner crashes, fast-fails (via
+        # int 29h), or hits an unhandled SEH exception, the OS hands it to
+        # the JIT debugger, which writes a full memory dump to the configured
+        # directory. This catches the silent-ELIFECYCLE kill class even when
+        # it bypasses every event-log path: probe A+H (PR #7855) ruled out
+        # Defender AND showed the kill produces NO entry in Application,
+        # System, or Defender Operational logs. That fingerprint matches
+        # __fastfail (int 29h) — used internally by libuv on Windows for
+        # certain TCP/pipe state-corruption assertions. ProcDump as JIT
+        # debugger is the only standard tool that captures user + kernel
+        # state across __fastfail.
+        name: Install ProcDump as JIT debugger (probe G)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Continue'
+          Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
+          Expand-Archive -Path "$env:TEMP\Procdump.zip" -DestinationPath "C:\procdump" -Force
+          New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\node-report\dumps" | Out-Null
+          # -i installs procdump as the system JIT debugger.
+          # -ma writes a full memory dump.
+          # The dump path argument tells procdump where to write the dumps.
+          & "C:\procdump\procdump64.exe" -accepteula -i -ma "${{ github.workspace }}\node-report\dumps"
+          # Sanity: confirm the AeDebug registry key now points at procdump.
+          Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
+          Get-ItemProperty "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
+      -
         name: Run the backend tests
         shell: bash
         working-directory: src
@@ -397,6 +424,33 @@ jobs:
         run: |
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
+      -
+        # PROBE G — install Sysinternals ProcDump as the system Just-In-Time
+        # debugger. When ANY process on the runner crashes, fast-fails (via
+        # int 29h), or hits an unhandled SEH exception, the OS hands it to
+        # the JIT debugger, which writes a full memory dump to the configured
+        # directory. This catches the silent-ELIFECYCLE kill class even when
+        # it bypasses every event-log path: probe A+H (PR #7855) ruled out
+        # Defender AND showed the kill produces NO entry in Application,
+        # System, or Defender Operational logs. That fingerprint matches
+        # __fastfail (int 29h) — used internally by libuv on Windows for
+        # certain TCP/pipe state-corruption assertions. ProcDump as JIT
+        # debugger is the only standard tool that captures user + kernel
+        # state across __fastfail.
+        name: Install ProcDump as JIT debugger (probe G)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Continue'
+          Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
+          Expand-Archive -Path "$env:TEMP\Procdump.zip" -DestinationPath "C:\procdump" -Force
+          New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\node-report\dumps" | Out-Null
+          # -i installs procdump as the system JIT debugger.
+          # -ma writes a full memory dump.
+          # The dump path argument tells procdump where to write the dumps.
+          & "C:\procdump\procdump64.exe" -accepteula -i -ma "${{ github.workspace }}\node-report\dumps"
+          # Sanity: confirm the AeDebug registry key now points at procdump.
+          Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
+          Get-ItemProperty "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
       -
         name: Run the backend tests
         shell: bash

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,7 +215,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) (retrigger 2) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 3) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #
@@ -474,7 +474,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) (retrigger 2) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 3) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -223,21 +223,39 @@ jobs:
         run: |
           mkdir -p "${{ github.workspace }}/node-report"
           OUT="${{ github.workspace }}/node-report"
-          # Out-of-process OS-level watcher for the silent-ELIFECYCLE flake.
-          # In-process diagnostics (diagnostics.ts heartbeat + node-report
-          # snapshots) showed that during the death window the V8 main
-          # isolate is starved — heartbeat stops firing entirely, then the
-          # process is externally terminated, bypassing all JS handlers and
-          # Node's --report-on-fatalerror. To capture state during that
-          # starvation we need a process that doesn't depend on the dying
-          # process's event loop. A bash background loop polling Windows
-          # OS state every 500 ms gives us that:
-          #   - netstat.log: localhost TCP socket states over time
-          #     (TIME_WAIT/CLOSE_WAIT accumulation, handle exhaustion)
-          #   - tasklist.log: node.exe process handle count, working set,
-          #     CPU time — captured by the OS independent of V8.
-          # Both logs are appended to node-report/ which already gets
-          # uploaded as an artifact on failure.
+
+          # ============================================================
+          # PROBE A: disable Windows Defender real-time monitoring.
+          # ------------------------------------------------------------
+          # The Windows silent-ELIFECYCLE flake (12+ captures) shows
+          # external termination with no JS-handler trace and no native
+          # abort report. That fingerprint matches Defender's behavioural-
+          # monitoring terminating processes flagged by its heuristics
+          # (rapid TCP fanout to localhost is on the suspect list). The
+          # GHA runner has Defender RT enabled by default. Disable it
+          # for the duration of this step. If kills disappear → causal;
+          # if not → Defender ruled out (it's already ruled out for the
+          # rest of the matrix where this isn't disabled).
+          # ============================================================
+          powershell -Command "Set-MpPreference -DisableRealtimeMonitoring \$true -ErrorAction SilentlyContinue; Get-MpPreference | Select-Object -Property DisableRealtimeMonitoring,DisableBehaviorMonitoring,DisableIOAVProtection,IsTamperProtected | Format-List" \
+            > "$OUT/defender-state-before.txt" 2>&1 || true
+
+          # ============================================================
+          # PROBE H (pre): clear Application + System event logs so the
+          # post-test dump contains only test-phase signal.
+          # ============================================================
+          powershell -Command "wevtutil cl Application; wevtutil cl System; Write-Host 'event logs cleared'" \
+            > "$OUT/event-clear.txt" 2>&1 || true
+
+          # ============================================================
+          # OS sidecar from PR #7846 + tasklist fix (probe I).
+          # Previous tasklist.log was empty because git-bash on Windows
+          # invoked `tasklist` in a way that produced UTF-16-LE output
+          # with a BOM. Use PowerShell's Get-CimInstance instead — clean
+          # ASCII, full process columns including HandleCount and
+          # WorkingSetSize which are the OS-side equivalents of the
+          # libuv handle table.
+          # ============================================================
           (
             while true; do
               ts=$(date '+%H:%M:%S.%3N')
@@ -247,12 +265,13 @@ jobs:
               } >> "$OUT/netstat.log"
               {
                 echo "=== $ts ==="
-                tasklist /v /fi "imagename eq node.exe" /fo csv 2>/dev/null || true
+                powershell -NoProfile -Command "Get-CimInstance -Query \"SELECT ProcessId,Name,HandleCount,ThreadCount,WorkingSetSize,PageFileUsage,KernelModeTime,UserModeTime FROM Win32_Process WHERE Name='node.exe'\" | Format-Table -AutoSize ProcessId,HandleCount,ThreadCount,WorkingSetSize,PageFileUsage,KernelModeTime,UserModeTime" 2>/dev/null || true
               } >> "$OUT/tasklist.log"
               sleep 0.5
             done
           ) &
           WATCHER_PID=$!
+
           # --exit forces process.exit(failures) after the suite completes,
           # closing the post-suite event-loop drain window where Windows +
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
@@ -263,6 +282,26 @@ jobs:
           set -e
           kill "$WATCHER_PID" 2>/dev/null || true
           wait "$WATCHER_PID" 2>/dev/null || true
+
+          # ============================================================
+          # PROBE H (post): dump event logs to the artifact directory
+          # regardless of pass/fail. On a kill we want the OS-side view
+          # of who terminated the process. On a pass we want a baseline
+          # to compare against.
+          # ============================================================
+          powershell -NoProfile -Command "Get-WinEvent -LogName Application -MaxEvents 500 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-Table -Wrap -AutoSize TimeCreated,Id,LevelDisplayName,ProviderName,Message" \
+            > "$OUT/event-application.txt" 2>&1 || true
+          powershell -NoProfile -Command "Get-WinEvent -LogName System -MaxEvents 500 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-Table -Wrap -AutoSize TimeCreated,Id,LevelDisplayName,ProviderName,Message" \
+            > "$OUT/event-system.txt" 2>&1 || true
+          powershell -NoProfile -Command "Get-WinEvent -LogName 'Microsoft-Windows-Windows Defender/Operational' -MaxEvents 200 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-Table -Wrap -AutoSize TimeCreated,Id,LevelDisplayName,Message" \
+            > "$OUT/event-defender.txt" 2>&1 || true
+          # Specifically grab process-termination / WER events
+          powershell -NoProfile -Command "Get-WinEvent -FilterHashtable @{LogName='Application';ProviderName='Application Error','Application Hang','Windows Error Reporting'} -MaxEvents 100 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-List" \
+            > "$OUT/event-app-errors.txt" 2>&1 || true
+          # Confirm Defender state at end of run (sanity: did it stay disabled?)
+          powershell -NoProfile -Command "Get-MpPreference | Select-Object DisableRealtimeMonitoring,DisableBehaviorMonitoring,DisableIOAVProtection,IsTamperProtected | Format-List" \
+            > "$OUT/defender-state-after.txt" 2>&1 || true
+
           exit $EXIT
       - name: Upload Node diagnostic reports on failure
         if: ${{ failure() }}
@@ -357,21 +396,39 @@ jobs:
         run: |
           mkdir -p "${{ github.workspace }}/node-report"
           OUT="${{ github.workspace }}/node-report"
-          # Out-of-process OS-level watcher for the silent-ELIFECYCLE flake.
-          # In-process diagnostics (diagnostics.ts heartbeat + node-report
-          # snapshots) showed that during the death window the V8 main
-          # isolate is starved — heartbeat stops firing entirely, then the
-          # process is externally terminated, bypassing all JS handlers and
-          # Node's --report-on-fatalerror. To capture state during that
-          # starvation we need a process that doesn't depend on the dying
-          # process's event loop. A bash background loop polling Windows
-          # OS state every 500 ms gives us that:
-          #   - netstat.log: localhost TCP socket states over time
-          #     (TIME_WAIT/CLOSE_WAIT accumulation, handle exhaustion)
-          #   - tasklist.log: node.exe process handle count, working set,
-          #     CPU time — captured by the OS independent of V8.
-          # Both logs are appended to node-report/ which already gets
-          # uploaded as an artifact on failure.
+
+          # ============================================================
+          # PROBE A: disable Windows Defender real-time monitoring.
+          # ------------------------------------------------------------
+          # The Windows silent-ELIFECYCLE flake (12+ captures) shows
+          # external termination with no JS-handler trace and no native
+          # abort report. That fingerprint matches Defender's behavioural-
+          # monitoring terminating processes flagged by its heuristics
+          # (rapid TCP fanout to localhost is on the suspect list). The
+          # GHA runner has Defender RT enabled by default. Disable it
+          # for the duration of this step. If kills disappear → causal;
+          # if not → Defender ruled out (it's already ruled out for the
+          # rest of the matrix where this isn't disabled).
+          # ============================================================
+          powershell -Command "Set-MpPreference -DisableRealtimeMonitoring \$true -ErrorAction SilentlyContinue; Get-MpPreference | Select-Object -Property DisableRealtimeMonitoring,DisableBehaviorMonitoring,DisableIOAVProtection,IsTamperProtected | Format-List" \
+            > "$OUT/defender-state-before.txt" 2>&1 || true
+
+          # ============================================================
+          # PROBE H (pre): clear Application + System event logs so the
+          # post-test dump contains only test-phase signal.
+          # ============================================================
+          powershell -Command "wevtutil cl Application; wevtutil cl System; Write-Host 'event logs cleared'" \
+            > "$OUT/event-clear.txt" 2>&1 || true
+
+          # ============================================================
+          # OS sidecar from PR #7846 + tasklist fix (probe I).
+          # Previous tasklist.log was empty because git-bash on Windows
+          # invoked `tasklist` in a way that produced UTF-16-LE output
+          # with a BOM. Use PowerShell's Get-CimInstance instead — clean
+          # ASCII, full process columns including HandleCount and
+          # WorkingSetSize which are the OS-side equivalents of the
+          # libuv handle table.
+          # ============================================================
           (
             while true; do
               ts=$(date '+%H:%M:%S.%3N')
@@ -381,12 +438,13 @@ jobs:
               } >> "$OUT/netstat.log"
               {
                 echo "=== $ts ==="
-                tasklist /v /fi "imagename eq node.exe" /fo csv 2>/dev/null || true
+                powershell -NoProfile -Command "Get-CimInstance -Query \"SELECT ProcessId,Name,HandleCount,ThreadCount,WorkingSetSize,PageFileUsage,KernelModeTime,UserModeTime FROM Win32_Process WHERE Name='node.exe'\" | Format-Table -AutoSize ProcessId,HandleCount,ThreadCount,WorkingSetSize,PageFileUsage,KernelModeTime,UserModeTime" 2>/dev/null || true
               } >> "$OUT/tasklist.log"
               sleep 0.5
             done
           ) &
           WATCHER_PID=$!
+
           # --exit forces process.exit(failures) after the suite completes,
           # closing the post-suite event-loop drain window where Windows +
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
@@ -397,6 +455,26 @@ jobs:
           set -e
           kill "$WATCHER_PID" 2>/dev/null || true
           wait "$WATCHER_PID" 2>/dev/null || true
+
+          # ============================================================
+          # PROBE H (post): dump event logs to the artifact directory
+          # regardless of pass/fail. On a kill we want the OS-side view
+          # of who terminated the process. On a pass we want a baseline
+          # to compare against.
+          # ============================================================
+          powershell -NoProfile -Command "Get-WinEvent -LogName Application -MaxEvents 500 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-Table -Wrap -AutoSize TimeCreated,Id,LevelDisplayName,ProviderName,Message" \
+            > "$OUT/event-application.txt" 2>&1 || true
+          powershell -NoProfile -Command "Get-WinEvent -LogName System -MaxEvents 500 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-Table -Wrap -AutoSize TimeCreated,Id,LevelDisplayName,ProviderName,Message" \
+            > "$OUT/event-system.txt" 2>&1 || true
+          powershell -NoProfile -Command "Get-WinEvent -LogName 'Microsoft-Windows-Windows Defender/Operational' -MaxEvents 200 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-Table -Wrap -AutoSize TimeCreated,Id,LevelDisplayName,Message" \
+            > "$OUT/event-defender.txt" 2>&1 || true
+          # Specifically grab process-termination / WER events
+          powershell -NoProfile -Command "Get-WinEvent -FilterHashtable @{LogName='Application';ProviderName='Application Error','Application Hang','Windows Error Reporting'} -MaxEvents 100 -ErrorAction SilentlyContinue | Sort-Object TimeCreated | Format-List" \
+            > "$OUT/event-app-errors.txt" 2>&1 || true
+          # Confirm Defender state at end of run (sanity: did it stay disabled?)
+          powershell -NoProfile -Command "Get-MpPreference | Select-Object DisableRealtimeMonitoring,DisableBehaviorMonitoring,DisableIOAVProtection,IsTamperProtected | Format-List" \
+            > "$OUT/defender-state-after.txt" 2>&1 || true
+
           exit $EXIT
       - name: Upload Node diagnostic reports on failure
         if: ${{ failure() }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,7 +215,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G — install Sysinternals ProcDump as the system Just-In-Time
+        # PROBE G (rev 2) — install Sysinternals ProcDump as the system Just-In-Time
         # debugger. When ANY process on the runner crashes, fast-fails (via
         # int 29h), or hits an unhandled SEH exception, the OS hands it to
         # the JIT debugger, which writes a full memory dump to the configured
@@ -425,7 +425,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G — install Sysinternals ProcDump as the system Just-In-Time
+        # PROBE G (rev 2) — install Sysinternals ProcDump as the system Just-In-Time
         # debugger. When ANY process on the runner crashes, fast-fails (via
         # int 29h), or hits an unhandled SEH exception, the OS hands it to
         # the JIT debugger, which writes a full memory dump to the configured

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -312,7 +312,7 @@ jobs:
           WATCHER_PID=$!
 
           # ============================================================
-          # PROBE G rev 3 — attach ProcDump to every node.exe as it
+          # PROBE G rev 3 (retrigger) — attach ProcDump to every node.exe as it
           # spawns. The JIT debugger registered above only fires for
           # AeDebug events (unhandled SEH / __fastfail / WER crashes);
           # the first rev-2 capture proved that fires NOTHING when the
@@ -571,7 +571,7 @@ jobs:
           WATCHER_PID=$!
 
           # ============================================================
-          # PROBE G rev 3 — attach ProcDump to every node.exe as it
+          # PROBE G rev 3 (retrigger) — attach ProcDump to every node.exe as it
           # spawns. The JIT debugger registered above only fires for
           # AeDebug events (unhandled SEH / __fastfail / WER crashes);
           # the first rev-2 capture proved that fires NOTHING when the

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,7 +215,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 1) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #
@@ -474,7 +474,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 1) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,30 +215,42 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 2) — install Sysinternals ProcDump as the system Just-In-Time
-        # debugger. When ANY process on the runner crashes, fast-fails (via
-        # int 29h), or hits an unhandled SEH exception, the OS hands it to
-        # the JIT debugger, which writes a full memory dump to the configured
-        # directory. This catches the silent-ELIFECYCLE kill class even when
-        # it bypasses every event-log path: probe A+H (PR #7855) ruled out
-        # Defender AND showed the kill produces NO entry in Application,
-        # System, or Defender Operational logs. That fingerprint matches
-        # __fastfail (int 29h) — used internally by libuv on Windows for
-        # certain TCP/pipe state-corruption assertions. ProcDump as JIT
-        # debugger is the only standard tool that captures user + kernel
-        # state across __fastfail.
-        name: Install ProcDump as JIT debugger (probe G)
+        # PROBE G (rev 3) — install Sysinternals ProcDump as the system
+        # Just-In-Time debugger AND additionally launch a long-running
+        # procdump that monitors all node.exe processes specifically.
+        #
+        # Rev 2's first capture (run 26511524556, Win+plugins) confirmed
+        # ProcDump was registered as AeDebug but no .dmp was produced when
+        # the kill fired. AeDebug only triggers on unhandled SEH /
+        # WER-classified crashes / __fastfail. The fact that NOTHING fired
+        # narrows the kill class significantly: it bypasses every Windows
+        # user-mode debug entry point including JIT debugger.
+        #
+        # That leaves: external TerminateProcess (Defender already ruled
+        # out by probe A), or _exit() from native code inside Node that
+        # bypasses both Node's exit hooks and Windows' debug paths.
+        #
+        # Rev 3 attacks from a different angle: instead of waiting for
+        # AeDebug, attach procdump directly to node.exe processes as they
+        # spawn, with `-e 0 -t -h` (catch first-chance exceptions, dump
+        # on terminate, dump on hang). This monitors the process from
+        # outside without depending on AeDebug — even an external
+        # TerminateProcess can be caught this way as a "Termination"
+        # event from procdump's perspective.
+        name: Install ProcDump as JIT debugger + node.exe monitor (probe G rev 3)
         shell: powershell
         run: |
           $ErrorActionPreference = 'Continue'
           Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
           Expand-Archive -Path "$env:TEMP\Procdump.zip" -DestinationPath "C:\procdump" -Force
           New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\node-report\dumps" | Out-Null
-          # -i installs procdump as the system JIT debugger.
-          # -ma writes a full memory dump.
-          # The dump path argument tells procdump where to write the dumps.
-          & "C:\procdump\procdump64.exe" -accepteula -i -ma "${{ github.workspace }}\node-report\dumps"
-          # Sanity: confirm the AeDebug registry key now points at procdump.
+          # JIT debugger registration. Use cwd at install time = the dumps
+          # directory, since procdump's -i stores cwd as -j path.
+          Push-Location "${{ github.workspace }}\node-report\dumps"
+          & "C:\procdump\procdump64.exe" -accepteula -i -ma .
+          Pop-Location
+          # Sanity: confirm the AeDebug key now points at procdump,
+          # and that the -j path is what we want.
           Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
           Get-ItemProperty "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
       -
@@ -299,6 +311,35 @@ jobs:
           ) &
           WATCHER_PID=$!
 
+          # ============================================================
+          # PROBE G rev 3 — attach ProcDump to every node.exe as it
+          # spawns. The JIT debugger registered above only fires for
+          # AeDebug events (unhandled SEH / __fastfail / WER crashes);
+          # the first rev-2 capture proved that fires NOTHING when the
+          # silent kill happens. Adding a directly-attached procdump
+          # to each node.exe catches a wider set of events, INCLUDING
+          # external TerminateProcess from another process (the kill
+          # source we can't otherwise see).
+          #
+          # Flags: -ma full memory, -t dump-on-process-termination,
+          # -n 3 dump up to 3 events per pid then detach. Output to
+          # node-report/dumps/<pid>.dmp.
+          # ============================================================
+          (
+            attached_pids=""
+            while true; do
+              for pid in $(powershell -NoProfile -Command "Get-Process node -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Id" 2>/dev/null); do
+                if [[ ",$attached_pids," != *,$pid,* ]]; then
+                  attached_pids="$attached_pids,$pid"
+                  echo "[attach-monitor] attaching procdump to pid=$pid at $(date '+%H:%M:%S.%3N')" >> "$OUT/procdump-monitor.log"
+                  /c/procdump/procdump64.exe -accepteula -ma -t -n 3 $pid "$OUT/dumps" >> "$OUT/procdump-monitor.log" 2>&1 &
+                fi
+              done
+              sleep 0.5
+            done
+          ) &
+          ATTACH_MONITOR_PID=$!
+
           # --exit forces process.exit(failures) after the suite completes,
           # closing the post-suite event-loop drain window where Windows +
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
@@ -309,6 +350,14 @@ jobs:
           set -e
           kill "$WATCHER_PID" 2>/dev/null || true
           wait "$WATCHER_PID" 2>/dev/null || true
+          kill "$ATTACH_MONITOR_PID" 2>/dev/null || true
+          wait "$ATTACH_MONITOR_PID" 2>/dev/null || true
+          # Probe G rev 3 — also harvest any .dmp files left at the
+          # workspace root (where JIT-debugger procdump may have written
+          # before rev 3's Push-Location fix) and the cwd of any attached
+          # procdump that exited.
+          find "${{ github.workspace }}" -maxdepth 3 -name '*.dmp' -print -exec cp -v {} "$OUT/dumps/" \; 2>>"$OUT/dump-harvest.log" || true
+          ls -la "$OUT/dumps/" 2>&1 >> "$OUT/dump-harvest.log"
 
           # ============================================================
           # PROBE H (post): dump event logs to the artifact directory
@@ -425,30 +474,42 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 2) — install Sysinternals ProcDump as the system Just-In-Time
-        # debugger. When ANY process on the runner crashes, fast-fails (via
-        # int 29h), or hits an unhandled SEH exception, the OS hands it to
-        # the JIT debugger, which writes a full memory dump to the configured
-        # directory. This catches the silent-ELIFECYCLE kill class even when
-        # it bypasses every event-log path: probe A+H (PR #7855) ruled out
-        # Defender AND showed the kill produces NO entry in Application,
-        # System, or Defender Operational logs. That fingerprint matches
-        # __fastfail (int 29h) — used internally by libuv on Windows for
-        # certain TCP/pipe state-corruption assertions. ProcDump as JIT
-        # debugger is the only standard tool that captures user + kernel
-        # state across __fastfail.
-        name: Install ProcDump as JIT debugger (probe G)
+        # PROBE G (rev 3) — install Sysinternals ProcDump as the system
+        # Just-In-Time debugger AND additionally launch a long-running
+        # procdump that monitors all node.exe processes specifically.
+        #
+        # Rev 2's first capture (run 26511524556, Win+plugins) confirmed
+        # ProcDump was registered as AeDebug but no .dmp was produced when
+        # the kill fired. AeDebug only triggers on unhandled SEH /
+        # WER-classified crashes / __fastfail. The fact that NOTHING fired
+        # narrows the kill class significantly: it bypasses every Windows
+        # user-mode debug entry point including JIT debugger.
+        #
+        # That leaves: external TerminateProcess (Defender already ruled
+        # out by probe A), or _exit() from native code inside Node that
+        # bypasses both Node's exit hooks and Windows' debug paths.
+        #
+        # Rev 3 attacks from a different angle: instead of waiting for
+        # AeDebug, attach procdump directly to node.exe processes as they
+        # spawn, with `-e 0 -t -h` (catch first-chance exceptions, dump
+        # on terminate, dump on hang). This monitors the process from
+        # outside without depending on AeDebug — even an external
+        # TerminateProcess can be caught this way as a "Termination"
+        # event from procdump's perspective.
+        name: Install ProcDump as JIT debugger + node.exe monitor (probe G rev 3)
         shell: powershell
         run: |
           $ErrorActionPreference = 'Continue'
           Invoke-WebRequest -Uri "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
           Expand-Archive -Path "$env:TEMP\Procdump.zip" -DestinationPath "C:\procdump" -Force
           New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\node-report\dumps" | Out-Null
-          # -i installs procdump as the system JIT debugger.
-          # -ma writes a full memory dump.
-          # The dump path argument tells procdump where to write the dumps.
-          & "C:\procdump\procdump64.exe" -accepteula -i -ma "${{ github.workspace }}\node-report\dumps"
-          # Sanity: confirm the AeDebug registry key now points at procdump.
+          # JIT debugger registration. Use cwd at install time = the dumps
+          # directory, since procdump's -i stores cwd as -j path.
+          Push-Location "${{ github.workspace }}\node-report\dumps"
+          & "C:\procdump\procdump64.exe" -accepteula -i -ma .
+          Pop-Location
+          # Sanity: confirm the AeDebug key now points at procdump,
+          # and that the -j path is what we want.
           Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
           Get-ItemProperty "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug" -ErrorAction SilentlyContinue | Format-List
       -
@@ -509,6 +570,35 @@ jobs:
           ) &
           WATCHER_PID=$!
 
+          # ============================================================
+          # PROBE G rev 3 — attach ProcDump to every node.exe as it
+          # spawns. The JIT debugger registered above only fires for
+          # AeDebug events (unhandled SEH / __fastfail / WER crashes);
+          # the first rev-2 capture proved that fires NOTHING when the
+          # silent kill happens. Adding a directly-attached procdump
+          # to each node.exe catches a wider set of events, INCLUDING
+          # external TerminateProcess from another process (the kill
+          # source we can't otherwise see).
+          #
+          # Flags: -ma full memory, -t dump-on-process-termination,
+          # -n 3 dump up to 3 events per pid then detach. Output to
+          # node-report/dumps/<pid>.dmp.
+          # ============================================================
+          (
+            attached_pids=""
+            while true; do
+              for pid in $(powershell -NoProfile -Command "Get-Process node -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Id" 2>/dev/null); do
+                if [[ ",$attached_pids," != *,$pid,* ]]; then
+                  attached_pids="$attached_pids,$pid"
+                  echo "[attach-monitor] attaching procdump to pid=$pid at $(date '+%H:%M:%S.%3N')" >> "$OUT/procdump-monitor.log"
+                  /c/procdump/procdump64.exe -accepteula -ma -t -n 3 $pid "$OUT/dumps" >> "$OUT/procdump-monitor.log" 2>&1 &
+                fi
+              done
+              sleep 0.5
+            done
+          ) &
+          ATTACH_MONITOR_PID=$!
+
           # --exit forces process.exit(failures) after the suite completes,
           # closing the post-suite event-loop drain window where Windows +
           # Node 24 hard-kills the process. Scoped to Windows so Linux/local
@@ -519,6 +609,14 @@ jobs:
           set -e
           kill "$WATCHER_PID" 2>/dev/null || true
           wait "$WATCHER_PID" 2>/dev/null || true
+          kill "$ATTACH_MONITOR_PID" 2>/dev/null || true
+          wait "$ATTACH_MONITOR_PID" 2>/dev/null || true
+          # Probe G rev 3 — also harvest any .dmp files left at the
+          # workspace root (where JIT-debugger procdump may have written
+          # before rev 3's Push-Location fix) and the cwd of any attached
+          # procdump that exited.
+          find "${{ github.workspace }}" -maxdepth 3 -name '*.dmp' -print -exec cp -v {} "$OUT/dumps/" \; 2>>"$OUT/dump-harvest.log" || true
+          ls -la "$OUT/dumps/" 2>&1 >> "$OUT/dump-harvest.log"
 
           # ============================================================
           # PROBE H (post): dump event logs to the artifact directory

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -215,7 +215,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) (retrigger 3) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 4) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #
@@ -474,7 +474,7 @@ jobs:
           powershell -Command "(gc settings.json.template) -replace '\"max\": 10', '\"max\": 10000' | Out-File -encoding ASCII settings.json.holder"
           powershell -Command "(gc settings.json.holder) -replace '\"points\": 10', '\"points\": 1000' | Out-File -encoding ASCII settings.json"
       -
-        # PROBE G (rev 3) (retrigger 3) — install Sysinternals ProcDump as the system
+        # PROBE G (rev 3) (retrigger 4) — install Sysinternals ProcDump as the system
         # Just-In-Time debugger AND additionally launch a long-running
         # procdump that monitors all node.exe processes specifically.
         #


### PR DESCRIPTION
## Summary

Install Sysinternals ProcDump as the system Just-In-Time debugger on both Windows backend matrices. When ANY process on the runner crashes or fast-fails (`int 29h`), the OS hands it to the JIT debugger, which writes a full memory dump to the artifact directory.

## Why

**Defender ruled out by #7855.** First failure on that PR (run 26470378618) with `DisableRealtimeMonitoring + DisableBehaviorMonitoring + DisableIOAVProtection` all confirmed `True` produced this evidence:

| Source | Contents at kill time |
|---|---|
| Application log | empty (cleared pre-test, zero entries during run) |
| System log | only pre-test service-stop events |
| Defender Operational | only stale 2026-05-18 provisioning events |
| Application Error/Hang/WER | zero entries |
| OS-side tasklist (node.exe) 1s before kill | HandleCount=323 stable, ThreadCount=17 stable, WS=321 MB stable, KernelModeTime + UserModeTime growing linearly — completely healthy |

Then **dead 1 second later with zero trace anywhere**.

That fingerprint — silent external termination with no event-log entry and a healthy OS-side process — is the signature of `__fastfail` (`int 29h`). libuv on Windows uses it for internal assertion failures in `uv_win.c`, `tcp-win.c`, `pipe-win.c` (TCP/pipe state-corruption checks). `__fastfail` terminates the process bypassing all user-mode notification and WER.

The only standard tool that captures state across `__fastfail` is a JIT-installed debugger.

## What this changes

New step on both Windows backend matrices, BEFORE "Run the backend tests":

```yaml
- name: Install ProcDump as JIT debugger (probe G)
  shell: powershell
  run: |
    Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -OutFile "$env:TEMP\Procdump.zip"
    Expand-Archive -Path "$env:TEMP\Procdump.zip" -DestinationPath "C:\procdump" -Force
    New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\node-report\dumps" | Out-Null
    & "C:\procdump\procdump64.exe" -accepteula -i -ma "${{ github.workspace }}\node-report\dumps"
```

- `-i` registers procdump64.exe as the AeDebug handler (system JIT debugger)
- `-ma` writes full memory dumps
- Dumps land in `node-report/dumps/` — picked up by the existing failure-artifact upload

## Built on PR #7855

Branch is on top of `probe-flake-defender-eventlog-sidecar`, so it carries the Defender-off + event-log + tasklist-fix probes too. Even though Defender's ruled out, those baselines stay useful for cross-comparison.

## Expected outcome

On the next silent ELIFECYCLE failure: a `.dmp` file in the artifact. Loadable in WinDbg with `!analyze -v` — that should name the function calling `__fastfail` and the assertion that fired.

If no `.dmp` is produced even on failure → the kill isn't going through user-mode exception handling at all → it's coming from the kernel (HVCI, CET violation, page-fault chain). Escalates to ETW tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)