### PR TITLE
fix(i18n): reuse translated settings title in pad dialog (#7884)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -266,7 +266,6 @@
   "pad.noCookie": "Cookie could not be found. Please allow cookies in your browser!  Your session and settings will not be saved between visits.  This may be due to Etherpad being included in an iFrame in some Browsers.  Please ensure Etherpad is on the same subdomain/domain as the parent iFrame",
   "pad.permissionDenied": "You do not have permission to access this pad",
 
-  "pad.settings.title": "Settings",
   "pad.settings.padSettings": "Pad-wide Settings",
   "pad.settings.userSettings": "User Settings",
   "pad.settings.myView": "My View",

--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -222,7 +222,7 @@
       <!------------------------------------------------------------->
 
       <div id="settings" class="popup" role="dialog" aria-modal="true" aria-labelledby="settings-title"><div class="popup-content">
-          <h1 id="settings-title" data-l10n-id="pad.settings.title">Settings</h1>
+          <h1 id="settings-title" data-l10n-id="pad.toolbar.settings.title">Settings</h1>
           <div class="settings-sections">
             <div id="user-settings-section" class="settings-section">
             <% e.begin_block("mySettings"); %>

--- a/src/tests/backend/specs/settingsModalHeading.ts
+++ b/src/tests/backend/specs/settingsModalHeading.ts
@@ -10,7 +10,10 @@ const common = require('../common');
 // `enablePadWideSettings: false` the template used to render
 // `data-l10n-id="pad.settings.padSettings"` ("Pad-wide Settings") for every
 // user, even though no pad-wide controls were rendered in that mode. The fix
-// removes the conditional and always uses `pad.settings.title` ("Settings").
+// removes the conditional and always uses the neutral "Settings" title. We
+// reuse the existing, already-translated `pad.toolbar.settings.title` key
+// rather than a dedicated `pad.settings.title` duplicate, so the title is
+// localised in every locale without waiting for new TranslateWiki strings.
 describe(__filename, function () {
   this.timeout(30000);
   let agent: any;
@@ -31,15 +34,15 @@ describe(__filename, function () {
     return m ? m[1] : null;
   };
 
-  it('uses pad.settings.title with the feature enabled', async function () {
+  it('uses pad.toolbar.settings.title with the feature enabled', async function () {
     settings.enablePadWideSettings = true;
     const res = await agent.get('/p/headingTest').expect(200);
-    assert.equal(titleH1(res.text), 'pad.settings.title');
+    assert.equal(titleH1(res.text), 'pad.toolbar.settings.title');
   });
 
-  it('uses pad.settings.title with the feature disabled (no misleading "Pad-wide" label)', async function () {
+  it('uses pad.toolbar.settings.title with the feature disabled (no misleading "Pad-wide" label)', async function () {
     settings.enablePadWideSettings = false;
     const res = await agent.get('/p/headingTest').expect(200);
-    assert.equal(titleH1(res.text), 'pad.settings.title');
+    assert.equal(titleH1(res.text), 'pad.toolbar.settings.title');
   });
 });


### PR DESCRIPTION
Closes part of #7884.

## Problem

In v3.x the pad **Settings** dialog title renders untranslated on non-English UIs (the "title not translated left" in the issue's German screenshot), even though the gear-button tooltip right above it *is* translated.

Root cause: PR #7545 introduced a dedicated `pad.settings.title` l10n key for the dialog `<h1>`. That value (`"Settings"`) is identical to the long-standing `pad.toolbar.settings.title` key used by the toolbar gear button. Because `pad.settings.title` was brand new, TranslateWiki volunteers hadn't translated it for most locales yet — so the dialog title fell back to English while the identical, already-translated toolbar key sat unused.

## Fix

Point the dialog `<h1>` at the existing `pad.toolbar.settings.title` key and delete the duplicate `pad.settings.title` from `en.json`. No new strings to translate — the title is immediately localised in the **111 locales** that already carry the toolbar key (including German → "Einstellungen").

I verified there is **no regression**: every locale that had translated the old `pad.settings.title` also has `pad.toolbar.settings.title` translated, so no locale loses its dialog title.

The `settingsModalHeading` backend regression spec is updated to assert the reused key. It still guards the original intent (a neutral "Settings" title regardless of `enablePadWideSettings`, never the misleading "Pad-wide Settings" label).

## Scope note

The other untranslated labels in the German screenshot (Disable Chat, Dark mode, Enforce settings, Fade inactive author colors, User Settings, and the deletion-token strings) are **genuinely new strings** from #7545/#7554 and the deletion-token feature — they have no existing translated key to reuse, so they're left to the normal TranslateWiki flow rather than hand-seeded. The dual User-Settings / Pad-wide-Settings panels are intentional (per maintainer note on the issue).

## Test

```
$ NODE_ENV=production npx mocha --import=tsx tests/backend/specs/settingsModalHeading.ts
  ✔ uses pad.toolbar.settings.title with the feature enabled
  ✔ uses pad.toolbar.settings.title with the feature disabled (no misleading "Pad-wide" label)
  2 passing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)