### PR TITLE
fix: RTL content option no longer flips the whole page (#7900)

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -683,7 +683,11 @@ function Ace2Inner(editorInfo, cssManagers) {
       rtlistrue: (value) => {
         targetBody.classList.toggle('rtl', value);
         targetBody.classList.toggle('ltr', !value);
-        document.documentElement.dir = value ? 'rtl' : 'ltr';
+        // Apply the base direction to the inner editor document only. Using the
+        // top-level `document` here would flip the whole page (toolbar, chrome)
+        // even though this is a per-pad content option — see issue #7900. The
+        // page direction is governed solely by the UI language (see l10n.ts).
+        targetDoc.documentElement.dir = value ? 'rtl' : 'ltr';
       },
       fadeinactiveauthorcolors: (value) => {
         fadeInactiveAuthorColors = `${value}` !== 'false';

--- a/src/tests/frontend-new/specs/rtl_url_param.spec.ts
+++ b/src/tests/frontend-new/specs/rtl_url_param.spec.ts
@@ -36,18 +36,28 @@ test.describe('RTL URL parameter', function () {
   });
 
   test('rtl content option flips only the pad inner contents, not the whole page', {tag: '@feature:rtl-toggle'}, async function ({page}) {
+    // The top-level page direction is owned by the UI language, not the pad's
+    // RTL content option. Capture whatever the language chose so the assertion
+    // is locale-independent (it could legitimately be rtl on an RTL locale).
+    const html = page.locator('html');
+    await expect(html).toHaveAttribute('dir', /^(ltr|rtl)$/);
+    const initialPageDir = await html.getAttribute('dir');
+
     await appendQueryParams(page, {rtl: 'true'});
     await expect(page.locator('#options-rtlcheck')).toBeChecked();
 
-    // The inner editor document is flipped to RTL...
-    const innerBody = page.frame('ace_inner')!.locator('#innerdocbody');
+    // The inner editor document is flipped to RTL. Use a frameLocator chain so
+    // Playwright auto-waits for the nested iframes/body to be ready.
+    const innerBody = page
+      .frameLocator('iframe[name="ace_outer"]')
+      .frameLocator('iframe[name="ace_inner"]')
+      .locator('#innerdocbody');
     await expect(innerBody).toHaveClass(/\brtl\b/);
-    const innerDirection = await innerBody.evaluate((el) =>
-      el.ownerDocument.defaultView!.getComputedStyle(el).direction);
-    expect(innerDirection).toBe('rtl');
+    await expect.poll(() => innerBody.evaluate((el) =>
+      el.ownerDocument.defaultView!.getComputedStyle(el).direction)).toBe('rtl');
 
-    // ...but the top-level page (toolbar, chrome) is governed by the UI
-    // language, not the pad's RTL content option, and must stay LTR.
-    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    // ...but the top-level page (toolbar, chrome) is unaffected: its dir is
+    // whatever the UI language set and must not change when the pad flips.
+    await expect(html).toHaveAttribute('dir', initialPageDir!);
   });
 });

--- a/src/tests/frontend-new/specs/rtl_url_param.spec.ts
+++ b/src/tests/frontend-new/specs/rtl_url_param.spec.ts
@@ -34,4 +34,20 @@ test.describe('RTL URL parameter', function () {
     await page.waitForSelector('#editorcontainer.initialized');
     await expect(page.locator('#options-rtlcheck')).not.toBeChecked();
   });
+
+  test('rtl content option flips only the pad inner contents, not the whole page', {tag: '@feature:rtl-toggle'}, async function ({page}) {
+    await appendQueryParams(page, {rtl: 'true'});
+    await expect(page.locator('#options-rtlcheck')).toBeChecked();
+
+    // The inner editor document is flipped to RTL...
+    const innerBody = page.frame('ace_inner')!.locator('#innerdocbody');
+    await expect(innerBody).toHaveClass(/\brtl\b/);
+    const innerDirection = await innerBody.evaluate((el) =>
+      el.ownerDocument.defaultView!.getComputedStyle(el).direction);
+    expect(innerDirection).toBe('rtl');
+
+    // ...but the top-level page (toolbar, chrome) is governed by the UI
+    // language, not the pad's RTL content option, and must stay LTR.
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+  });
 });


### PR DESCRIPTION
Fixes #7900.

> Note: the related "enforce settings" override bug discovered during testing has been split into #7902.

## Problem

Enabling the pad's **RTL** content option flips the **entire page** — the toolbar and surrounding chrome — not just the pad's inner text contents, which is all a per-pad content option should affect.

## Root cause

The `rtlistrue` setter in `src/static/js/ace2_inner.ts` wrote the base direction to `document.documentElement`. In that file `document` resolves to the **top-level pad page** (the editor iframes are derived from it via `document.getElementsByName("ace_outer")`), so toggling RTL content overwrote the whole page's `dir` attribute.

The page direction is owned solely by the **UI language** — `src/static/js/l10n.ts` sets `document.documentElement.dir = html10n.getDirection()`. The content option must not clobber it.

## Fix

Apply the content direction to the **inner editor document** (`targetDoc.documentElement`) instead of the top-level `document`. The inner body already gets the `.rtl`/`.ltr` class; this keeps the `dir` attribute on the inner `<html>` where it belongs, so the toolbar/chrome stay governed by the UI language.

## Test

Added a frontend test (`rtl_url_param.spec.ts`) asserting that with `rtl=true` the inner editor body flips to RTL while the top-level `<html>` `dir` stays `ltr`. Verified red→green: the test fails against the old code (top-level `<html dir="rtl">`) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
