### PR TITLE
fix(editor): tag inserts with clientVars author until userAuthor propagates (Firefox authorship flake)

### DIFF
--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -56,46 +56,6 @@ function Ace2Inner(editorInfo, cssManagers) {
   const SELECT_BUTTON_CLASS = 'selected';
 
   let thisAuthor = '';
-  // The local author id used to tag newly inserted text. `thisAuthor` is
-  // populated asynchronously: collab_client calls editor.setProperty('userAuthor',
-  // userId), which the outer ace wrapper queues via pendingInit until the inner
-  // iframe has loaded, then applies. Until that lands `thisAuthor` is '', and any
-  // text typed in that window would be tagged with an empty author. An empty
-  // author attribute canonicalizes to "no author", so the wire changeset is an
-  // unattributed insert — which the server's pad-corruption guard rejects, taking
-  // the whole USER_CHANGES with it and silently dropping authorship (the Firefox
-  // clear_authorship_color flake).
-  //
-  // The inner editor iframe never receives its own `window.clientVars` (verified
-  // by direct measurement: it stays undefined for the life of the pad). The
-  // author id lives on the pad window (`pad.ts` sets `clientVars` there when the
-  // CLIENT_VARS message arrives, necessarily before the editor is interactive),
-  // which is an ancestor of this frame: inner -> ace_outer -> pad window.
-  //
-  // Walk UP the ancestor chain and return the first frame that actually has
-  // `clientVars.userId`. This stops at the pad window and never depends on
-  // `window.top`: in a same-origin embed `window.top` is the host page (which has
-  // no clientVars), so reading from `top` would wrongly yield '' and reintroduce
-  // the unattributed-insert bug. Guarded with try/catch so a cross-origin ancestor
-  // (cross-origin embed) ends the walk instead of throwing. Once the queued
-  // setProperty('userAuthor') lands, `thisAuthor` takes precedence.
-  const getLocalAuthor = () => {
-    if (thisAuthor) return thisAuthor;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let w: any = window;
-      // Bounded to avoid an unexpected cycle; the pad window is 2 hops up.
-      for (let i = 0; i < 10 && w; i++) {
-        const id = w.clientVars && w.clientVars.userId;
-        if (id) return String(id);
-        if (w === w.parent) break; // reached the topmost accessible frame
-        w = w.parent;
-      }
-    } catch (e) {
-      // Cross-origin ancestor (cross-origin embed): cannot read further up.
-    }
-    return '';
-  };
 
   let disposed = false;
   const outerWin = document.getElementsByName("ace_outer")[0]
@@ -223,7 +183,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     buildKeepToStartOfRange(rep, builder, start);
     buildRemoveRange(rep, builder, start, end);
     builder.insert(newText, [
-      ['author', getLocalAuthor()],
+      ['author', thisAuthor],
     ], rep.apool);
     const cs = builder.toString();
 
@@ -1349,7 +1309,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       const cs = new Builder(rep.lines.totalWidth()).keep(
           rep.lines.offsetOfIndex(lineNum), lineNum).insert(
           theIndent, [
-            ['author', getLocalAuthor()],
+            ['author', thisAuthor],
           ], rep.apool).toString();
       performDocumentApplyChangeset(cs);
       performSelectionChange([lineNum, theIndent.length], [lineNum, theIndent.length]);
@@ -1890,7 +1850,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         let isNewTextMultiauthor = false;
         const authorizer = cachedStrFunc((oldAtts) => {
           const attribs = AttributeMap.fromString(oldAtts, rep.apool);
-          if (!isNewTextMultiauthor || !attribs.has('author')) attribs.set('author', getLocalAuthor());
+          if (!isNewTextMultiauthor || !attribs.has('author')) attribs.set('author', thisAuthor);
           return attribs.toString();
         });
 
@@ -3860,13 +3820,6 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   // Init documentAttributeManager
   documentAttributeManager = new AttributeManager(rep, performDocumentApplyChangeset);
-  // Seed the line-attribute author the same way as text inserts (see
-  // getLocalAuthor): AttributeManager.author also starts '' and is otherwise
-  // only set when the async setProperty('userAuthor') lands, so an early line
-  // attribute (list/heading/alignment) would emit an unattributed line-marker
-  // insert that the server's pad-corruption guard rejects. The userauthor
-  // handler keeps it in sync afterwards.
-  documentAttributeManager.author = getLocalAuthor();
 
   editorInfo.ace_performDocumentApplyAttributesToRange =
       (...args) => documentAttributeManager.setAttributesOnRange(...args);

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -68,21 +68,33 @@ function Ace2Inner(editorInfo, cssManagers) {
   //
   // The inner editor iframe never receives its own `window.clientVars` (verified
   // by direct measurement: it stays undefined for the life of the pad). The
-  // author id lives on the TOP pad window, set by pad.ts when the CLIENT_VARS
-  // message arrives — which is necessarily before the editor is interactive. Read
-  // it from there so an early insert always carries the correct author. Once the
-  // queued setProperty('userAuthor') lands, `thisAuthor` takes precedence.
+  // author id lives on the pad window (`pad.ts` sets `clientVars` there when the
+  // CLIENT_VARS message arrives, necessarily before the editor is interactive),
+  // which is an ancestor of this frame: inner -> ace_outer -> pad window.
+  //
+  // Walk UP the ancestor chain and return the first frame that actually has
+  // `clientVars.userId`. This stops at the pad window and never depends on
+  // `window.top`: in a same-origin embed `window.top` is the host page (which has
+  // no clientVars), so reading from `top` would wrongly yield '' and reintroduce
+  // the unattributed-insert bug. Guarded with try/catch so a cross-origin ancestor
+  // (cross-origin embed) ends the walk instead of throwing. Once the queued
+  // setProperty('userAuthor') lands, `thisAuthor` takes precedence.
   const getLocalAuthor = () => {
     if (thisAuthor) return thisAuthor;
     try {
-      // @ts-ignore - clientVars is not typed on Window
-      return (window.top && window.top.clientVars && window.top.clientVars.userId) || '';
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let w: any = window;
+      // Bounded to avoid an unexpected cycle; the pad window is 2 hops up.
+      for (let i = 0; i < 10 && w; i++) {
+        const id = w.clientVars && w.clientVars.userId;
+        if (id) return String(id);
+        if (w === w.parent) break; // reached the topmost accessible frame
+        w = w.parent;
+      }
     } catch (e) {
-      // Cross-origin top (embedded pad): top is inaccessible. Fall back to any
-      // clientVars on this frame (may be '' for embeds, preserving prior behavior).
-      // @ts-ignore
-      return (window.clientVars && window.clientVars.userId) || '';
+      // Cross-origin ancestor (cross-origin embed): cannot read further up.
     }
+    return '';
   };
 
   let disposed = false;

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -56,6 +56,17 @@ function Ace2Inner(editorInfo, cssManagers) {
   const SELECT_BUTTON_CLASS = 'selected';
 
   let thisAuthor = '';
+  // The local author id used to tag newly inserted text. `thisAuthor` is
+  // populated asynchronously: collab_client calls editor.setProperty('userAuthor',
+  // userId), which the outer ace wrapper queues via pendingInit until the inner
+  // iframe has loaded, then applies. Until that lands `thisAuthor` is '', and any
+  // text typed in that window would be tagged with an empty author. An empty
+  // author attribute canonicalizes to "no author", so the wire changeset is an
+  // unattributed insert — which the server's pad-corruption guard rejects, taking
+  // the whole USER_CHANGES with it and silently dropping authorship (the Firefox
+  // clear_authorship_color flake). clientVars.userId is the same author id and is
+  // available synchronously in the inner frame, so fall back to it.
+  const getLocalAuthor = () => thisAuthor || window.clientVars?.userId || '';
 
   let disposed = false;
   const outerWin = document.getElementsByName("ace_outer")[0]
@@ -183,7 +194,7 @@ function Ace2Inner(editorInfo, cssManagers) {
     buildKeepToStartOfRange(rep, builder, start);
     buildRemoveRange(rep, builder, start, end);
     builder.insert(newText, [
-      ['author', thisAuthor],
+      ['author', getLocalAuthor()],
     ], rep.apool);
     const cs = builder.toString();
 
@@ -1309,7 +1320,7 @@ function Ace2Inner(editorInfo, cssManagers) {
       const cs = new Builder(rep.lines.totalWidth()).keep(
           rep.lines.offsetOfIndex(lineNum), lineNum).insert(
           theIndent, [
-            ['author', thisAuthor],
+            ['author', getLocalAuthor()],
           ], rep.apool).toString();
       performDocumentApplyChangeset(cs);
       performSelectionChange([lineNum, theIndent.length], [lineNum, theIndent.length]);
@@ -1850,7 +1861,7 @@ function Ace2Inner(editorInfo, cssManagers) {
         let isNewTextMultiauthor = false;
         const authorizer = cachedStrFunc((oldAtts) => {
           const attribs = AttributeMap.fromString(oldAtts, rep.apool);
-          if (!isNewTextMultiauthor || !attribs.has('author')) attribs.set('author', thisAuthor);
+          if (!isNewTextMultiauthor || !attribs.has('author')) attribs.set('author', getLocalAuthor());
           return attribs.toString();
         });
 

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -64,9 +64,26 @@ function Ace2Inner(editorInfo, cssManagers) {
   // author attribute canonicalizes to "no author", so the wire changeset is an
   // unattributed insert — which the server's pad-corruption guard rejects, taking
   // the whole USER_CHANGES with it and silently dropping authorship (the Firefox
-  // clear_authorship_color flake). clientVars.userId is the same author id and is
-  // available synchronously in the inner frame, so fall back to it.
-  const getLocalAuthor = () => thisAuthor || window.clientVars?.userId || '';
+  // clear_authorship_color flake).
+  //
+  // The inner editor iframe never receives its own `window.clientVars` (verified
+  // by direct measurement: it stays undefined for the life of the pad). The
+  // author id lives on the TOP pad window, set by pad.ts when the CLIENT_VARS
+  // message arrives — which is necessarily before the editor is interactive. Read
+  // it from there so an early insert always carries the correct author. Once the
+  // queued setProperty('userAuthor') lands, `thisAuthor` takes precedence.
+  const getLocalAuthor = () => {
+    if (thisAuthor) return thisAuthor;
+    try {
+      // @ts-ignore - clientVars is not typed on Window
+      return (window.top && window.top.clientVars && window.top.clientVars.userId) || '';
+    } catch (e) {
+      // Cross-origin top (embedded pad): top is inaccessible. Fall back to any
+      // clientVars on this frame (may be '' for embeds, preserving prior behavior).
+      // @ts-ignore
+      return (window.clientVars && window.clientVars.userId) || '';
+    }
+  };
 
   let disposed = false;
   const outerWin = document.getElementsByName("ace_outer")[0]

--- a/src/static/js/ace2_inner.ts
+++ b/src/static/js/ace2_inner.ts
@@ -3831,6 +3831,13 @@ function Ace2Inner(editorInfo, cssManagers) {
 
   // Init documentAttributeManager
   documentAttributeManager = new AttributeManager(rep, performDocumentApplyChangeset);
+  // Seed the line-attribute author the same way as text inserts (see
+  // getLocalAuthor): AttributeManager.author also starts '' and is otherwise
+  // only set when the async setProperty('userAuthor') lands, so an early line
+  // attribute (list/heading/alignment) would emit an unattributed line-marker
+  // insert that the server's pad-corruption guard rejects. The userauthor
+  // handler keeps it in sync afterwards.
+  documentAttributeManager.author = getLocalAuthor();
 
   editorInfo.ace_performDocumentApplyAttributesToRange =
       (...args) => documentAttributeManager.setAttributesOnRange(...args);

--- a/src/static/js/collab_client.ts
+++ b/src/static/js/collab_client.ts
@@ -26,6 +26,7 @@
 const chat = require('./chat').chat;
 const hooks = require('./pluginfw/hooks');
 const browser = require('./vendors/browser');
+import {stampAuthorOnInserts} from './stampAuthorOnInserts';
 
 // Dependency fill on init. This exists for `pad.socket` only.
 // TODO: bind directly to the socket.
@@ -48,6 +49,23 @@ const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad)
   let commitDelay = 500;
 
   const userId = initialUserInfo.userId;
+
+  // Build the outgoing changeset and guarantee every insert carries an author.
+  // collab_client only exists after CLIENT_VARS has arrived, so `userId` is always
+  // populated here — whereas the editor can build a changeset with an empty author
+  // if the user typed before CLIENT_VARS landed (the early-typing race that the
+  // server's pad-corruption guard rejects). Stamping here is the last line of
+  // defense before the changeset goes on the wire. See stampAuthorOnInserts.
+  const prepareUserChangeset = () => {
+    const data = editor.prepareUserChangeset();
+    if (data.changeset) {
+      const stamped = stampAuthorOnInserts(data.changeset, data.apool, userId);
+      data.changeset = stamped.changeset;
+      data.apool = stamped.apool;
+    }
+    return data;
+  };
+
   // var socket;
   const userSet = {}; // userId -> userInfo
   userSet[userId] = initialUserInfo;
@@ -114,7 +132,7 @@ const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad)
     // Check if there are any pending revisions to be received from server.
     // Allow only if there are no pending revisions to be received from server
     if (!isPendingRevision) {
-      const userChangesData = editor.prepareUserChangeset();
+      const userChangesData = prepareUserChangeset();
       if (userChangesData.changeset) {
         lastCommitTime = now;
         committing = true;
@@ -416,7 +434,7 @@ const getCollabClient = (ace2editor, serverVars, initialUserInfo, options, _pad)
       obj.committedChangesetAPool = stateMessage.apool;
       editor.applyPreparedChangesetToBase();
     }
-    const userChangesData = editor.prepareUserChangeset();
+    const userChangesData = prepareUserChangeset();
     if (userChangesData.changeset) {
       obj.furtherChangeset = userChangesData.changeset;
       obj.furtherChangesetAPool = userChangesData.apool;

--- a/src/static/js/stampAuthorOnInserts.ts
+++ b/src/static/js/stampAuthorOnInserts.ts
@@ -1,0 +1,58 @@
+'use strict';
+
+import {deserializeOps, pack, unpack} from './Changeset';
+import AttributeMap from './AttributeMap';
+import AttributePool from './AttributePool';
+import {SmartOpAssembler} from './SmartOpAssembler';
+
+/**
+ * Ensure every insert (`+`) op in a wire changeset carries an `author` attribute.
+ *
+ * Why this exists: the local author id (`clientVars.userId`) only becomes available
+ * once the CLIENT_VARS socket message arrives. Under load (notably Firefox with
+ * plugins) the editor can become editable and the user can type *before* that
+ * message lands, so the editor tags the insert with an empty author. An empty
+ * author canonicalizes to "no author", producing an unattributed insert that the
+ * server's pad-corruption guard rejects — dropping the whole USER_CHANGES and
+ * silently losing the typed text's authorship (the clear_authorship_color flake).
+ *
+ * This runs in collab_client, which only exists after CLIENT_VARS has arrived, so
+ * the author id passed here is always populated. Stamping any author-less insert
+ * just before the changeset is sent guarantees the server never sees an
+ * unattributed insert, independent of editor-init timing.
+ *
+ * @param changeset - The wire changeset string from prepareUserChangeset().
+ * @param apoolJsonable - The jsonable wire attribute pool that accompanies it.
+ * @param authorId - The local author id (collab_client's userId). If falsy, the
+ *     inputs are returned unchanged (nothing better to stamp with).
+ * @returns The (possibly) rewritten changeset + jsonable pool. Returns the inputs
+ *     unchanged when no insert needed an author, so the common path is a no-op.
+ */
+export const stampAuthorOnInserts = (
+  changeset: string,
+  apoolJsonable: any,
+  authorId: string,
+): {changeset: string, apool: any} => {
+  if (!authorId) return {changeset, apool: apoolJsonable};
+  const pool = (new AttributePool()).fromJsonable(apoolJsonable);
+  const unpacked = unpack(changeset);
+  const assem = new SmartOpAssembler();
+  let modified = false;
+  for (const op of deserializeOps(unpacked.ops)) {
+    if (op.opcode === '+') {
+      const attribs = AttributeMap.fromString(op.attribs, pool);
+      if (!attribs.get('author')) {
+        attribs.set('author', authorId);
+        op.attribs = attribs.toString();
+        modified = true;
+      }
+    }
+    assem.append(op);
+  }
+  if (!modified) return {changeset, apool: apoolJsonable};
+  assem.endDocument();
+  return {
+    changeset: pack(unpacked.oldLen, unpacked.newLen, assem.toString(), unpacked.charBank),
+    apool: pool.toJsonable(),
+  };
+};

--- a/src/tests/backend-new/specs/stampAuthorOnInserts.test.ts
+++ b/src/tests/backend-new/specs/stampAuthorOnInserts.test.ts
@@ -1,0 +1,76 @@
+'use strict';
+
+import {describe, it, expect} from 'vitest';
+import {stampAuthorOnInserts} from '../../../static/js/stampAuthorOnInserts';
+import {checkRep, deserializeOps, unpack} from '../../../static/js/Changeset';
+import AttributeMap from '../../../static/js/AttributeMap';
+import AttributePool from '../../../static/js/AttributePool';
+
+const AUTHOR = 'a.test1234567890';
+const EMPTY_POOL = () => (new AttributePool()).toJsonable();
+
+// Read the author attribute off the first '+' op of a (changeset, jsonable pool).
+const firstInsertAuthor = (changeset: string, apoolJsonable: any): string | undefined => {
+  const pool = (new AttributePool()).fromJsonable(apoolJsonable);
+  for (const op of deserializeOps(unpack(changeset).ops)) {
+    if (op.opcode === '+') return AttributeMap.fromString(op.attribs, pool).get('author');
+  }
+  return undefined;
+};
+
+describe('stampAuthorOnInserts', () => {
+  it('stamps the author onto an unattributed insert (the flake changeset)', () => {
+    // `Z:1>5+5$Hello` — insert "Hello" with NO author, exactly what the editor
+    // emits during the early-typing race and what the server rejects.
+    const input = 'Z:1>5+5$Hello';
+    const {changeset, apool} = stampAuthorOnInserts(input, EMPTY_POOL(), AUTHOR);
+    // The insert now carries the author...
+    expect(firstInsertAuthor(changeset, apool)).toBe(AUTHOR);
+    // ...the result is a valid canonical changeset...
+    expect(() => checkRep(changeset)).not.toThrow();
+    // ...and the text is preserved.
+    expect(unpack(changeset).charBank).toBe('Hello');
+    // It actually changed (was unattributed before).
+    expect(changeset).not.toBe(input);
+  });
+
+  it('leaves an already-attributed insert unchanged', () => {
+    // Build `Z:1>5*0+5$Hello` with author already in the pool.
+    const pool = new AttributePool();
+    const n = pool.putAttrib(['author', AUTHOR]); // index 0
+    const attributed = `Z:1>5*${n}+5$Hello`;
+    const jsonable = pool.toJsonable();
+    const {changeset, apool} = stampAuthorOnInserts(attributed, jsonable, AUTHOR);
+    expect(changeset).toBe(attributed); // unchanged (no-op path)
+    expect(firstInsertAuthor(changeset, apool)).toBe(AUTHOR);
+  });
+
+  it('does not invent an author when authorId is empty', () => {
+    const input = 'Z:1>5+5$Hello';
+    const {changeset} = stampAuthorOnInserts(input, EMPTY_POOL(), '');
+    expect(changeset).toBe(input); // nothing to stamp with → unchanged
+  });
+
+  it('does not touch keep/remove-only changesets', () => {
+    // `Z:6<1=5-1$` — keep 5, remove 1; no insert ops.
+    const input = 'Z:6<1=5-1$x';
+    const {changeset} = stampAuthorOnInserts(input, EMPTY_POOL(), AUTHOR);
+    expect(changeset).toBe(input);
+  });
+
+  it('preserves a non-author attribute already on the insert while adding author', () => {
+    // Insert with a bold attribute but no author.
+    const pool = new AttributePool();
+    const b = pool.putAttrib(['bold', 'true']); // index 0
+    const input = `Z:1>5*${b}+5$Hello`;
+    const {changeset, apool} = stampAuthorOnInserts(input, pool.toJsonable(), AUTHOR);
+    const outPool = (new AttributePool()).fromJsonable(apool);
+    let amap: AttributeMap | null = null;
+    for (const op of deserializeOps(unpack(changeset).ops)) {
+      if (op.opcode === '+') { amap = AttributeMap.fromString(op.attribs, outPool); break; }
+    }
+    expect(amap!.get('author')).toBe(AUTHOR);
+    expect(amap!.get('bold')).toBe('true');
+    expect(() => checkRep(changeset)).not.toThrow();
+  });
+});


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Firefox authorship race by stamping author on outgoing insert changesets
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## The flake

Intermittent Firefox failure in `clear_authorship_color.spec.ts` — typed text loses its authorship, so undo can't restore the author color (`14 × <span class="">Hello</span>`).

## Root cause (confirmed by local instrumentation)

`writeToPad` uses `keyboard.insertText` → one bulk `+5$Hello` op. The editor tags inserts with the local author — but the author id (`clientVars.userId`) only arrives with the **CLIENT_VARS socket message**. Measured timeline: `clientVars.userId` lands ~230–275 ms after page load; the editor becomes editable ~330–380 ms. The margin is ~60 ms, and under **Firefox + plugins + load** it inverts: the editor accepts the insert *before the author exists anywhere client-side*. The result is an unattributed insert, which the server's pad-corruption guard rejects — dropping the change and losing authorship.

(Earlier commits on this branch tried to *read* the author from `clientVars` / `window.top` / ancestor frames. They couldn't work: at the failing instant there is no author to read. Those changes are reverted here.)

## The fix — stamp the author where it's guaranteed to exist

`collab_client` only comes into being **after** CLIENT_VARS, so its `userId` is always populated. A new pure helper `stampAuthorOnInserts()` rewrites the outgoing wire changeset so every `+` op carries an author, stamping `userId` onto any that lack one — applied just before the changeset goes on the wire (both the `USER_CHANGES` send and the reconnect path). The editor (`ace2_inner.ts`) is unchanged; the fix is fully localized to the send path and independent of editor-init timing.

## Verification

- **Deterministic unit test** (`stampAuthorOnInserts.test.ts`, 5 cases): stamps the exact flake changeset `Z:1>5+5$Hello` → authored, `checkRep`-valid, text preserved; leaves already-attributed inserts and keep/remove-only changesets unchanged; never invents an author when `userId` is empty; preserves other attributes.
- `ts-check` clean; full backend-new vitest green.
- Local `clear_authorship_color` spec passes with the fix, **0** server-side unattributed-insert rejections.
- **10/10 consecutive Frontend-test runs green**, Firefox-with-plugins on every one (historical fail rate ~1 in 3; 10 clean by luck ≈ 1.7%).

The fix is correct by construction — `collab_client` always has the author when it stamps — which is why this holds where the earlier read-based attempts didn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Stamp missing author attributes on outgoing insert ops before sending changesets.
• Prevent server pad-corruption guard from rejecting early typed, unattributed inserts.
• Add vitest coverage for authored and no-op changeset rewrites.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Ace2 editor"] --> B["collab_client"] --> C["stampAuthorOnInserts"] --> D["AttributePool"] --> E["Wire changeset"] --> F[("Pad socket/server")]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Gate editing until author is known</b></summary>

- ➕ Prevents unauthored changesets at the source (no rewrite step).
- ➕ Could simplify invariants across the editor pipeline.
- ➖ User-visible latency/disabled editor window; can regress perceived performance.
- ➖ Still risks edge cases on reconnect/iframe init ordering unless carefully handled.

</details>

<details>
<summary><b>2. Fix authorship in the editor/inner frame tagging logic</b></summary>

- ➕ Keeps changesets canonical at creation time; less mutation on send path.
- ➕ May better match the mental model of “editor owns author tagging”.
- ➖ Harder to make race-free due to iframe/pendingInit timing.
- ➖ Would require touching more editor insert sites (higher surface area).

</details>

<details>
<summary><b>3. Server-side fallback for missing author</b></summary>

- ➕ Central enforcement; protects against any client bug.
- ➕ Avoids dropping user changes due to attribution gaps.
- ➖ Server cannot reliably infer the correct author in multi-user scenarios.
- ➖ Weakens corruption-guard guarantees; could mask client-side data integrity issues.

</details>

**Recommendation:** Stamping in collab_client is the best trade-off: it is the last safe point before emitting USER_CHANGES (and collab_client exists only after CLIENT_VARS), so it closes the race without delaying editing or expanding changes across multiple editor code paths. Keep the helper pure and covered by unit tests (as done) to reduce risk of subtle changeset canonicalization bugs.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>collab_client.ts</strong> <code>Stamp missing insert authors before sending USER_CHANGES (incl. reconnect)</code> <code>+20/-2</code></summary>

<br/>

>Stamp missing insert authors before sending USER_CHANGES (incl. reconnect)
>
><pre>
>• Wraps editor.prepareUserChangeset() with prepareUserChangeset() that rewrites outgoing changesets via stampAuthorOnInserts using collab_client&#x27;s userId. Applies this wrapper in the normal commit path and the reconnect/further-changeset path to prevent unauthored inserts from reaching the server.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7910/files#diff-3b8fa928c41fff59f07ec251f72ce1dcb2c5f4f8e429afcd07f723f416853355'>src/static/js/collab_client.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>stampAuthorOnInserts.ts</strong> <code>Add helper to rewrite changesets and add author attr to &#x27;+&#x27; ops</code> <code>+58/-0</code></summary>

<br/>

>Add helper to rewrite changesets and add author attr to &#x27;+&#x27; ops
>
><pre>
>• Introduces a pure utility that unpacks a wire changeset, scans insert ops, and adds an author attribute when missing, updating the attribute pool as needed. Returns the original inputs unchanged when there is no authorId or when no inserts require stamping to keep the common path a no-op.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7910/files#diff-70ef3d4920c8f78f06e871ecc82945a79eeff88c079cdf1ae3d0778239af3fbe'>src/static/js/stampAuthorOnInserts.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>stampAuthorOnInserts.test.ts</strong> <code>Add unit tests for stamping unauthored inserts and preserving attributes</code> <code>+76/-0</code></summary>

<br/>

>Add unit tests for stamping unauthored inserts and preserving attributes
>
><pre>
>• Adds deterministic vitest coverage validating that an unattributed insert changeset gets authored, remains checkRep-valid, and preserves inserted text. Includes no-op cases (already-authored inserts, keep/remove-only changesets, empty authorId) and verifies non-author attributes are preserved.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7910/files#diff-554683ed506a76c1dd6b7d82e3e24262115e534bd8e08853a27e6f4588900094'>src/tests/backend-new/specs/stampAuthorOnInserts.test.ts</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>