### PR TITLE
Env-var overrides for offline/air-gapped installs (update check, plugin catalog, updater)

### DIFF
--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -102,9 +102,9 @@ The notice auto-fades after 8 seconds and can be dismissed immediately. The publ
 
 ## Disabling everything
 
-Set `updates.tier` to `"off"`. No HTTP request will leave the instance and no banner or badge will render.
+Set `updates.tier` to `"off"`. The self-updater goes silent — no request to the GitHub Releases API leaves the instance and no banner or badge renders. Note this does **not** cover the separate legacy version check in `UpdateCheck.ts`, which still fetches `${updateServer}/info.json` until you also set `privacy.updateCheck` to `false` (see [PRIVACY.md](../../PRIVACY.md)).
 
-On Docker / air-gapped installs you can do this without editing `settings.json` inside the image by setting `UPDATES_TIER=off` (and, to also drop the separate `updateServer` version check, `PRIVACY_UPDATE_CHECK=false`). See the [Updates & privacy](../docker.md#updates--privacy-offline--air-gapped) table in the Docker docs for the full set of environment variables.
+On Docker / air-gapped installs you can do both without editing `settings.json` inside the image by setting `UPDATES_TIER=off` **and** `PRIVACY_UPDATE_CHECK=false` (add `PRIVACY_PLUGIN_CATALOG=false` to also disable the admin plugin browser's catalogue fetch). See the [Updates & privacy](../docker.md#updates--privacy-offline--air-gapped) table in the Docker docs for the full set of environment variables.
 
 ## Privacy
 

--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -104,6 +104,8 @@ The notice auto-fades after 8 seconds and can be dismissed immediately. The publ
 
 Set `updates.tier` to `"off"`. No HTTP request will leave the instance and no banner or badge will render.
 
+On Docker / air-gapped installs you can do this without editing `settings.json` inside the image by setting `UPDATES_TIER=off` (and, to also drop the separate `updateServer` version check, `PRIVACY_UPDATE_CHECK=false`). See the [Updates & privacy](../docker.md#updates--privacy-offline--air-gapped) table in the Docker docs for the full set of environment variables.
+
 ## Privacy
 
 The version check sends no telemetry. Etherpad fetches the public GitHub Releases API (`api.github.com/repos/<repo>/releases/latest`) with `If-None-Match` to be cache-friendly. The only metadata GitHub sees is the same as any other GitHub API client — your IP and a `User-Agent: etherpad-self-update` header. No instance ID, no version, no identifiers travel upstream.

--- a/doc/admin/updates.md
+++ b/doc/admin/updates.md
@@ -102,7 +102,7 @@ The notice auto-fades after 8 seconds and can be dismissed immediately. The publ
 
 ## Disabling everything
 
-Set `updates.tier` to `"off"`. The self-updater goes silent — no request to the GitHub Releases API leaves the instance and no banner or badge renders. Note this does **not** cover the separate legacy version check in `UpdateCheck.ts`, which still fetches `${updateServer}/info.json` until you also set `privacy.updateCheck` to `false` (see [PRIVACY.md](../../PRIVACY.md)).
+Set `updates.tier` to `"off"`. The self-updater goes silent — no request to the GitHub Releases API leaves the instance and no banner or badge renders. Note this does **not** cover the separate legacy version check in `UpdateCheck.ts`, which still fetches `${updateServer}/info.json` until you also set `privacy.updateCheck` to `false` (see [PRIVACY.md](https://github.com/ether/etherpad/blob/develop/PRIVACY.md)).
 
 On Docker / air-gapped installs you can do both without editing `settings.json` inside the image by setting `UPDATES_TIER=off` **and** `PRIVACY_UPDATE_CHECK=false` (add `PRIVACY_PLUGIN_CATALOG=false` to also disable the admin plugin browser's catalogue fetch). See the [Updates & privacy](../docker.md#updates--privacy-offline--air-gapped) table in the Docker docs for the full set of environment variables.
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -118,6 +118,25 @@ The `settings.json.docker` available by default allows to control almost every s
 | `USER_PASSWORD`    | the password for the first user `user` (leave unspecified if you do not want to create it) |                                                                                                                                                                                                                                     |
 
 
+### Updates & privacy (offline / air-gapped)
+
+Etherpad makes a small number of outbound calls (a periodic version check and the admin plugin catalogue). In an air-gapped or firewalled deployment these can be disabled entirely without editing `settings.json` inside the image — set the variables below. See [doc/privacy.md](privacy.md) and [doc/admin/updates.md](admin/updates.md) for what each call sends.
+
+| Variable                          | Description                                                                                                  | Default                          |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `PRIVACY_UPDATE_CHECK`            | Set to `false` to disable the hourly version check (`UpdateCheck.ts`).                                       | `true`                           |
+| `PRIVACY_PLUGIN_CATALOG`          | Set to `false` to disable the admin plugin browser (manual install-by-name via CLI still works).            | `true`                           |
+| `UPDATES_TIER`                    | Self-updater tier: `off` \| `notify` \| `manual` \| `auto` \| `autonomous`. Set to `off` to suppress the GitHub Releases check entirely. | `notify`                         |
+| `UPDATES_SOURCE`                  | Where update metadata is fetched from.                                                                       | `github`                         |
+| `UPDATES_CHANNEL`                 | Release channel to track.                                                                                    | `stable`                         |
+| `UPDATES_CHECK_INTERVAL_HOURS`    | How often (hours) the updater polls when not `off`.                                                          | `6`                              |
+| `UPDATES_GITHUB_REPO`             | Repository the updater checks for releases.                                                                  | `ether/etherpad`                 |
+| `UPDATES_REQUIRE_ADMIN_FOR_STATUS`| Lock `/admin/update/status` to authenticated admins.                                                         | `false`                          |
+| `UPDATE_SERVER`                   | Endpoint backing the version check. Point elsewhere (or disable the check above) for offline installs.       | `https://etherpad.org/ep_infos`  |
+
+> **Fully offline:** set `UPDATES_TIER=off`, `PRIVACY_UPDATE_CHECK=false`, and `PRIVACY_PLUGIN_CATALOG=false`. The version check is fire-and-forget and already fails closed (a blocked endpoint is caught and logged, it does not prevent startup), but disabling it removes the outbound attempt and the log noise.
+
+
 ### Database
 
 | Variable      | Description                                                    | Default                                                               |

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -120,7 +120,7 @@ The `settings.json.docker` available by default allows to control almost every s
 
 ### Updates & privacy (offline / air-gapped)
 
-Etherpad makes a small number of outbound calls (a periodic version check and the admin plugin catalogue). In an air-gapped or firewalled deployment these can be disabled entirely without editing `settings.json` inside the image — set the variables below. See [doc/privacy.md](privacy.md) and [doc/admin/updates.md](admin/updates.md) for what each call sends.
+Etherpad makes a small number of outbound calls (a periodic version check and the admin plugin catalogue). In an air-gapped or firewalled deployment these can be disabled entirely without editing `settings.json` inside the image — set the variables below. See [PRIVACY.md](../PRIVACY.md) and [doc/admin/updates.md](admin/updates.md) for what each call sends.
 
 | Variable                          | Description                                                                                                  | Default                          |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------- |

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -120,7 +120,7 @@ The `settings.json.docker` available by default allows to control almost every s
 
 ### Updates & privacy (offline / air-gapped)
 
-Etherpad makes a small number of outbound calls (a periodic version check and the admin plugin catalogue). In an air-gapped or firewalled deployment these can be disabled entirely without editing `settings.json` inside the image — set the variables below. See [PRIVACY.md](../PRIVACY.md) and [doc/admin/updates.md](admin/updates.md) for what each call sends.
+Etherpad makes a small number of outbound calls (a periodic version check and the admin plugin catalogue). In an air-gapped or firewalled deployment these can be disabled entirely without editing `settings.json` inside the image — set the variables below. See [PRIVACY.md](https://github.com/ether/etherpad/blob/develop/PRIVACY.md) and [doc/admin/updates.md](admin/updates.md) for what each call sends.
 
 | Variable                          | Description                                                                                                  | Default                          |
 | --------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------- |

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -210,15 +210,17 @@
    * tier: "off" | "notify" | "manual" | "auto" | "autonomous"
    * Default "notify" shows a banner when an update is available.
    * Docker installs are read-only — tiers above "notify" are not applied even if requested.
+   * Air-gapped / offline deployments should set UPDATES_TIER=off to suppress the
+   * periodic check against the GitHub Releases API entirely.
    */
   "updates": {
-    "tier": "notify",
-    "source": "github",
-    "channel": "stable",
+    "tier": "${UPDATES_TIER:notify}",
+    "source": "${UPDATES_SOURCE:github}",
+    "channel": "${UPDATES_CHANNEL:stable}",
     "installMethod": "docker",
-    "checkIntervalHours": 6,
-    "githubRepo": "ether/etherpad",
-    "requireAdminForStatus": false,
+    "checkIntervalHours": "${UPDATES_CHECK_INTERVAL_HOURS:6}",
+    "githubRepo": "${UPDATES_GITHUB_REPO:ether/etherpad}",
+    "requireAdminForStatus": "${UPDATES_REQUIRE_ADMIN_FOR_STATUS:false}",
     "preApplyGraceMinutes": 0,
     "drainSeconds": 60,
     "rollbackHealthCheckSeconds": 60,
@@ -321,7 +323,19 @@
    *  https://etherpad.org/ep_infos
    */
 
-  "updateServer": "https://etherpad.org/ep_infos",
+  "updateServer": "${UPDATE_SERVER:https://etherpad.org/ep_infos}",
+
+  /*
+   * Outbound network calls. See doc/privacy.md for what each one sends.
+   *  - PRIVACY_UPDATE_CHECK=false   : disables the hourly version check (UpdateCheck.ts)
+   *  - PRIVACY_PLUGIN_CATALOG=false : disables the admin plugin browser
+   *                                   (manual install-by-name via CLI still works)
+   * Air-gapped / firewalled deployments should set both to false.
+   */
+  "privacy": {
+    "updateCheck": "${PRIVACY_UPDATE_CHECK:true}",
+    "pluginCatalog": "${PRIVACY_PLUGIN_CATALOG:true}"
+  },
 
   /*
    * The type of the database.

--- a/settings.json.docker
+++ b/settings.json.docker
@@ -326,7 +326,7 @@
   "updateServer": "${UPDATE_SERVER:https://etherpad.org/ep_infos}",
 
   /*
-   * Outbound network calls. See doc/privacy.md for what each one sends.
+   * Outbound network calls. See PRIVACY.md for what each one sends.
    *  - PRIVACY_UPDATE_CHECK=false   : disables the hourly version check (UpdateCheck.ts)
    *  - PRIVACY_PLUGIN_CATALOG=false : disables the admin plugin browser
    *                                   (manual install-by-name via CLI still works)

--- a/settings.json.template
+++ b/settings.json.template
@@ -446,7 +446,7 @@
   "updateServer": "${UPDATE_SERVER:https://etherpad.org/ep_infos}",
 
   /*
-   * Outbound network calls. See doc/privacy.md for what each one sends.
+   * Outbound network calls. See PRIVACY.md for what each one sends.
    *  - updateCheck=false  : disables hourly version check (UpdateCheck.ts)
    *  - pluginCatalog=false: disables admin plugin browser
    *                        (manual install-by-name via CLI still works)

--- a/settings.json.template
+++ b/settings.json.template
@@ -216,7 +216,7 @@
    * Default "notify" shows a banner when an update is available. "off" disables the version check.
    */
   "updates": {
-    "tier": "notify",
+    "tier": "${UPDATES_TIER:notify}",
     "source": "github",
     "channel": "stable",
     "installMethod": "auto",
@@ -443,17 +443,19 @@
    *  https://etherpad.org/ep_infos
    */
 
-  "updateServer": "https://etherpad.org/ep_infos",
+  "updateServer": "${UPDATE_SERVER:https://etherpad.org/ep_infos}",
 
   /*
-   * Outbound network calls. See PRIVACY.md for what each one sends.
+   * Outbound network calls. See doc/privacy.md for what each one sends.
    *  - updateCheck=false  : disables hourly version check (UpdateCheck.ts)
    *  - pluginCatalog=false: disables admin plugin browser
    *                        (manual install-by-name via CLI still works)
+   * Air-gapped / firewalled deployments should set both PRIVACY_UPDATE_CHECK and
+   * PRIVACY_PLUGIN_CATALOG to false (or UPDATES_TIER=off, which covers the version check).
    */
   "privacy": {
-    "updateCheck": true,
-    "pluginCatalog": true
+    "updateCheck": "${PRIVACY_UPDATE_CHECK:true}",
+    "pluginCatalog": "${PRIVACY_PLUGIN_CATALOG:true}"
   },
 
   /*

--- a/src/tests/backend/specs/settings.ts
+++ b/src/tests/backend/specs/settings.ts
@@ -197,4 +197,85 @@ describe(__filename, function () {
       assert.strictEqual(settings.padOptions.fadeInactiveAuthorColors, true);
     });
   });
+
+  // Regression test for ether/etherpad#7911.
+  // Air-gapped / firewalled deployments must be able to disable Etherpad's
+  // outbound calls (version check + plugin catalogue + self-updater) purely
+  // via environment variables, without editing settings.json inside the image.
+  // These assertions parse the *shipped* settings.json.docker so a future edit
+  // that drops the ${ENV} placeholders fails loudly here.
+  describe('offline / air-gapped env overrides (issue #7911)', function () {
+    const dockerSettings = path.join(__dirname, '../../../../settings.json.docker');
+    const templateSettings = path.join(__dirname, '../../../../settings.json.template');
+    const envVars = [
+      'PRIVACY_UPDATE_CHECK', 'PRIVACY_PLUGIN_CATALOG', 'UPDATES_TIER',
+      'UPDATES_SOURCE', 'UPDATES_CHANNEL', 'UPDATES_CHECK_INTERVAL_HOURS',
+      'UPDATES_GITHUB_REPO', 'UPDATES_REQUIRE_ADMIN_FOR_STATUS', 'UPDATE_SERVER',
+    ];
+    const saved: {[k: string]: string | undefined} = {};
+
+    before(function () { for (const v of envVars) saved[v] = process.env[v]; });
+    afterEach(function () {
+      for (const v of envVars) {
+        if (saved[v] == null) delete process.env[v];
+        else process.env[v] = saved[v];
+      }
+    });
+
+    it('keeps shipped defaults when no env vars are set', function () {
+      for (const v of envVars) delete process.env[v];
+      const s = exportedForTestingOnly.parseSettings(dockerSettings, true);
+      assert.strictEqual(s!.privacy.updateCheck, true);
+      assert.strictEqual(s!.privacy.pluginCatalog, true);
+      assert.strictEqual(s!.updates.tier, 'notify');
+      assert.strictEqual(s!.updates.checkIntervalHours, 6);
+      assert.strictEqual(s!.updateServer, 'https://etherpad.org/ep_infos');
+    });
+
+    it('disables all outbound calls when the offline env vars are set', function () {
+      process.env.PRIVACY_UPDATE_CHECK = 'false';
+      process.env.PRIVACY_PLUGIN_CATALOG = 'false';
+      process.env.UPDATES_TIER = 'off';
+      const s = exportedForTestingOnly.parseSettings(dockerSettings, true);
+      // Coerced to real booleans, not the strings "false".
+      assert.strictEqual(s!.privacy.updateCheck, false);
+      assert.strictEqual(s!.privacy.pluginCatalog, false);
+      assert.strictEqual(s!.updates.tier, 'off');
+    });
+
+    it('honours the remaining updates.* and updateServer overrides', function () {
+      process.env.UPDATES_SOURCE = 'gitlab';
+      process.env.UPDATES_CHANNEL = 'beta';
+      process.env.UPDATES_CHECK_INTERVAL_HOURS = '24';
+      process.env.UPDATES_GITHUB_REPO = 'acme/etherpad-fork';
+      process.env.UPDATES_REQUIRE_ADMIN_FOR_STATUS = 'true';
+      process.env.UPDATE_SERVER = 'https://mirror.internal/ep_infos';
+      const s = exportedForTestingOnly.parseSettings(dockerSettings, true);
+      assert.strictEqual(s!.updates.source, 'gitlab');
+      assert.strictEqual(s!.updates.channel, 'beta');
+      assert.strictEqual(s!.updates.checkIntervalHours, 24); // numeric coercion
+      assert.strictEqual(s!.updates.githubRepo, 'acme/etherpad-fork');
+      assert.strictEqual(s!.updates.requireAdminForStatus, true); // boolean coercion
+      assert.strictEqual(s!.updateServer, 'https://mirror.internal/ep_infos');
+    });
+
+    // The source-install template carries the same placeholders so non-Docker
+    // deployments get the offline knobs too.
+    it('settings.json.template exposes the same offline overrides', function () {
+      for (const v of envVars) delete process.env[v];
+      const dflt = exportedForTestingOnly.parseSettings(templateSettings, true);
+      assert.strictEqual(dflt!.privacy.updateCheck, true);
+      assert.strictEqual(dflt!.privacy.pluginCatalog, true);
+      assert.strictEqual(dflt!.updates.tier, 'notify');
+      assert.strictEqual(dflt!.updateServer, 'https://etherpad.org/ep_infos');
+
+      process.env.UPDATES_TIER = 'off';
+      process.env.PRIVACY_UPDATE_CHECK = 'false';
+      process.env.PRIVACY_PLUGIN_CATALOG = 'false';
+      const over = exportedForTestingOnly.parseSettings(templateSettings, true);
+      assert.strictEqual(over!.updates.tier, 'off');
+      assert.strictEqual(over!.privacy.updateCheck, false);
+      assert.strictEqual(over!.privacy.pluginCatalog, false);
+    });
+  });
 });


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add env-var overrides to disable update checks &amp; plugin catalog for offline installs
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>📝 Documentation</code> <code>🧪 Tests</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What

Addresses **item 2 of #7911**: air-gapped / firewalled deployments could not disable Etherpad's outbound calls purely via environment variables — `settings.json.docker` hardcoded `updates.tier` and shipped **no `privacy` block at all**, so operators had to edit `settings.json` inside the image.

This wires the relevant keys through the **existing** `${ENV:default}` substitution (`Settings.ts` `lookupEnvironmentVariables`) in both shipped settings files. No code changes — config + docs + tests only.

### New environment variables

| Variable | Setting | Default |
| --- | --- | --- |
| `PRIVACY_UPDATE_CHECK` | `privacy.updateCheck` | `true` |
| `PRIVACY_PLUGIN_CATALOG` | `privacy.pluginCatalog` | `true` |
| `UPDATES_TIER` | `updates.tier` (`off` = no calls) | `notify` |
| `UPDATES_SOURCE` | `updates.source` | `github` |
| `UPDATES_CHANNEL` | `updates.channel` | `stable` |
| `UPDATES_CHECK_INTERVAL_HOURS` | `updates.checkIntervalHours` | `6` |
| `UPDATES_GITHUB_REPO` | `updates.githubRepo` | `ether/etherpad` |
| `UPDATES_REQUIRE_ADMIN_FOR_STATUS` | `updates.requireAdminForStatus` | `false` |
| `UPDATE_SERVER` | `updateServer` | `https://etherpad.org/ep_infos` |

**Fully offline:** `UPDATES_TIER=off`, `PRIVACY_UPDATE_CHECK=false`, `PRIVACY_PLUGIN_CATALOG=false`.

## Docs

- New **"Updates & privacy (offline / air-gapped)"** section in `doc/docker.md`.
- Cross-link + Docker note added to `doc/admin/updates.md` "Disabling everything".

## Tests

Added backend regression tests (`src/tests/backend/specs/settings.ts`) that parse the **shipped** `settings.json.docker` and `settings.json.template` and assert the overrides apply with correct boolean/numeric coercion — so a future edit that drops the `${ENV}` placeholders fails loudly. `30 passing`.

## Scope note

This is **item 2 only**. Item 1 (the `packageManager`/corepack startup-failure claim) does not reproduce on the official Docker image on `develop` — it already installs pnpm via `npm` (corepack was dropped for Node 25) and runs `node` directly, with no package manager invoked at startup. Awaiting the reporter's confirmation of whether they hit it on the official image vs. a source build before touching anything there. See discussion on #7911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Expose update/privacy settings as env-var overrides for Docker and template installs.
• Add offline/air-gapped documentation and cross-links for disabling all outbound calls.
• Add regression tests to ensure shipped settings keep ${ENV:default} placeholders and type
  coercion.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Environment variables"] --> B["settings.json.docker"] --> D["Settings loader (parseSettings)"] --> E["Update check"]
  A --> C["settings.json.template"] --> D --> F["Plugin catalog"]
  D --> G["Self-updater"]
  H["Docs: docker/admin"] --> A
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Single OFFLINE/AIRGAPPED mode flag</b></summary>

- ➕ Simpler operator experience (one variable to set).
- ➕ Avoids partial configurations (e.g., disabling tier but not plugin catalog).
- ➖ Adds new semantics/branching in settings parsing or runtime code.
- ➖ Less flexible for users who want some calls but not others.

</details>

<details>
<summary><b>2. Docker entrypoint rewrites settings.json at startup</b></summary>

- ➕ Keeps settings.json.docker free of placeholders and env parsing concerns.
- ➕ Can validate values more strictly before writing config.
- ➖ More moving parts and maintenance burden in container startup scripts.
- ➖ Harder to keep parity with non-Docker installs (template).

</details>

**Recommendation:** The chosen approach (adding ${ENV:default} placeholders to shipped settings templates and enforcing them via regression tests) is the best fit: it reuses the existing Settings.ts substitution/coercion logic, avoids runtime behavior changes, and works consistently for both Docker and source installs. A single OFFLINE flag could be considered later as a convenience wrapper, but the current granular env vars are more flexible and lower-risk.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>settings.ts</strong> <code>Add regression tests for offline env overrides in shipped settings files</code> <code>+81/-0</code></summary>

<br/>

>Add regression tests for offline env overrides in shipped settings files
>
><pre>
>• Adds tests that parse the repository&#x27;s shipped settings.json.docker and settings.json.template and assert env-var overrides apply as expected. Verifies boolean/numeric coercion and protects against future removal of ${ENV} placeholders.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7917/files#diff-ab955e4986399b2a06b0481681c67ec25ffbef1b155dcf64d7b3a47a4717285c'>src/tests/backend/specs/settings.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>updates.md</strong> <code>Document Docker env vars for disabling update checks</code> <code>+2/-0</code></summary>

<br/>

>Document Docker env vars for disabling update checks
>
><pre>
>• Adds guidance for Docker/air-gapped deployments to disable update-related outbound calls via environment variables (not editing settings inside the image). Links readers to the new Docker docs table for the full variable set.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7917/files#diff-993df0850e5480094511a1c746ab9bfbb6de4fe114d6691500529991f07bba6d'>doc/admin/updates.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>docker.md</strong> <code>Add offline/air-gapped update &amp; privacy env-var reference table</code> <code>+19/-0</code></summary>

<br/>

>Add offline/air-gapped update &amp; privacy env-var reference table
>
><pre>
>• Introduces a dedicated section describing Etherpad&#x27;s outbound update/plugin-catalog calls and how to disable them in air-gapped deployments. Documents all new environment variables and provides a &#x27;fully offline&#x27; recommended combination.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7917/files#diff-335c79f91b55c3bed8b6a75b79e1cae5804bff04c6c53d5f7c18ac704560c0d2'>doc/docker.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>settings.json.docker</strong> <code>Make updates/privacy settings overridable via env vars (Docker image)</code> <code>+21/-7</code></summary>

<br/>

>Make updates/privacy settings overridable via env vars (Docker image)
>
><pre>
>• Replaces hardcoded updates.* values with ${ENV:default} placeholders and makes updateServer configurable via UPDATE_SERVER. Adds a privacy block with env-var toggles for update checks and plugin catalog access, enabling fully offline behavior without editing the image.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7917/files#diff-a2d04bd4c9335eb53e500de1e9ceb908f9f752c665413098d48ffe6568576227'>settings.json.docker</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>settings.json.template</strong> <code>Expose offline update/privacy env vars in source-install template</code> <code>+7/-5</code></summary>

<br/>

>Expose offline update/privacy env vars in source-install template
>
><pre>
>• Adds ${UPDATES_TIER:notify} and ${UPDATE_SERVER:...} placeholders and wires privacy.updateCheck/pluginCatalog through env vars. Updates comments to point to doc/privacy.md and to describe air-gapped configuration.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7917/files#diff-2b14e66ffa839924b6dbfbfc79dc4c3fe89f44a936c70b03a3b55bac9a93e58e'>settings.json.template</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>