### PR TITLE
fix(release): sync src + bin package.json to 3.2.0 so release ships 3.3.0

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bin",
-  "version": "3.3.0",
+  "version": "3.2.0",
   "description": "",
   "main": "checkAllPads.js",
   "directories": {

--- a/src/package.json
+++ b/src/package.json
@@ -163,6 +163,6 @@
     "debug:socketio": "cross-env DEBUG=socket.io* node --require tsx/cjs node/server.ts",
     "test:vitest": "vitest"
   },
-  "version": "3.3.0",
+  "version": "3.2.0",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix release workflow by syncing src/bin package versions back to 3.2.0
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Why the release workflow is failing

The last two **Release etherpad** dispatches (2026-06-07, 2026-06-08) both failed at the **Prepare release** step:

```
Error: No changelog record for 3.4.0, please create changelog record
    at bin/release.ts:146
```

## Root cause

3.3.0 was **never released** — the latest tag/release is `v3.2.0` (2026-05-22). The repo already carries a complete `# 3.3.0` changelog section, and the intent is to ship **3.3.0** next.

A prior commit (`d09227b1`, "3.2.0") reverted **root** and **admin/** `package.json` back to `3.2.0` to set up a clean `3.2.0 → 3.3.0` minor bump — but missed **`src/package.json`** and **`bin/package.json`**, which were left at `3.3.0`:

| file | before | after |
|------|--------|-------|
| `package.json` (root) | 3.2.0 | 3.2.0 |
| `admin/package.json` | 3.2.0 | 3.2.0 |
| `src/package.json` | **3.3.0** | **3.2.0** |
| `bin/package.json` | **3.3.0** | **3.2.0** |

`bin/release.ts` reads the current version from **`src/package.json`**, so it computed `minor(3.3.0) = 3.4.0` and aborted on the missing `# 3.4.0` changelog entry.

## Fix

Sync `src/package.json` and `bin/package.json` back to `3.2.0` so all four package.json files agree. The next `minor` dispatch then computes `3.2.0 → 3.3.0`, which satisfies the existing changelog guard (`CHANGELOG.md` opens with `# 3.3.0`).

Verified locally: `CHANGELOG.md` starts with `# 3.3.0\n` ✓, and `release.ts` will overwrite all four package.jsons to `3.3.0` during the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Set src/ and bin/ package.json versions to 3.2.0 to match root/admin.
• Prevent release.ts from computing an incorrect next minor version (3.4.0).
• Unblock the next minor release dispatch to ship 3.3.0 using existing changelog.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
flowchart TD
  A(["Release dispatch"]) --> B["bin/release.ts"] --> C["src/package.json"] --> D{"Compute version"}
  D --> E["CHANGELOG.md"] --> F{"Changelog guard"}
  F --> G(["Write via jq"]) --> H["package.json files"]

  subgraph Legend
    direction LR
    _proc(["Process step"]) ~~~ _file["File"] ~~~ _dec{"Decision"}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Make release.ts read root package.json as version source</b></summary>

- ➕ Aligns version source with the most obvious top-level manifest
- ➕ Reduces risk of workspace subpackage drift affecting releases
- ➖ May conflict with existing conventions if src/ is intended as the canonical package
- ➖ Does not by itself prevent other package.json files from drifting

</details>

<details>
<summary><b>2. Add a preflight version consistency check across all package.json files</b></summary>

- ➕ Fails fast with a clear error when versions diverge
- ➕ Prevents this class of release breakage from recurring
- ➖ Slightly more release-script complexity
- ➖ Still requires someone to resolve the mismatch when it occurs

</details>

<details>
<summary><b>3. Centralize versioning via a single source + generation step</b></summary>

- ➕ Eliminates manual multi-file version edits
- ➕ Makes releases more deterministic
- ➖ Higher change surface area than needed for the immediate unblock
- ➖ May require tooling/process changes for maintainers

</details>

**Recommendation:** The PR’s approach is the right minimal unblock: syncing src/bin back to 3.2.0 restores the intended 3.2.0 → 3.3.0 minor bump and satisfies the existing changelog guard. Consider a small follow-up to add a preflight consistency check in bin/release.ts so mismatched package.json versions fail with an actionable error before computing a wrong target version.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>package.json</strong> <code>Downgrade src package version to 3.2.0 (release version source)</code> <code>+1/-1</code></summary>

<br/>

>Downgrade src package version to 3.2.0 (release version source)
>
><pre>
>• Sets the src workspace package version from 3.3.0 back to 3.2.0. This fixes the release script’s currentVersion input, preventing it from computing a 3.4.0 target and failing the changelog guard.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7919/files#diff-cc5a2f170768969f124108ad3be7fdbcbed774c11774d99a87a3a78fef4ab97b'>src/package.json</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>package.json</strong> <code>Downgrade bin package version to 3.2.0 for release consistency</code> <code>+1/-1</code></summary>

<br/>

>Downgrade bin package version to 3.2.0 for release consistency
>
><pre>
>• Sets the bin workspace package version from 3.3.0 back to 3.2.0. This aligns it with the repository’s expected pre-release state so the release bump logic targets 3.3.0 next.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7919/files#diff-004d6bcaaf69265184337d3c9b2c00b24a5962747e290d0cb4f7f5eb329ae8b9'>bin/package.json</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>