### PR TITLE
chore(release): park the non-functional ep_etherpad npm publish

### DIFF
--- a/.github/workflows/releaseEtherpad.yml
+++ b/.github/workflows/releaseEtherpad.yml
@@ -1,9 +1,33 @@
+# PARKED — npm publish of the core package is not part of the standard release.
+#
+# This workflow renames `ep_etherpad-lite` -> `ep_etherpad` and publishes
+# `./src` to npm. As of 2026-06, that publish serves no load-bearing purpose:
+#   - `ep_etherpad` has 0 dependents on npm and nothing in this repo depends on it;
+#   - plugins import `ep_etherpad-lite` resolved from the LOCAL core install,
+#     and plugin CI clones `ether/etherpad` rather than `npm install`-ing core;
+#   - Etherpad is run via git clone / Docker / zip / snap, never `npm install`.
+# The publish has been failing (E404 PUT — the `ep_etherpad` package has no OIDC
+# trusted publisher configured on npmjs.com), which is why npm is stuck at 2.5.0
+# while 3.x shipped fine without it.
+#
+# It is therefore gated behind an explicit `confirm: true` dispatch input so a
+# stray run fails fast with a clear message instead of a confusing 404. To
+# actually publish, the npm owner of `ep_etherpad` (samtv12345) must first
+# configure a trusted publisher: npmjs.com -> ep_etherpad -> Settings ->
+# Trusted Publisher -> repo `ether/etherpad`, workflow `releaseEtherpad.yml`.
+# Decision pending: finish that config, or remove this workflow. See AGENTS.MD.
 name: releaseEtherpad.yaml
 permissions:
   contents: read
   id-token: write   # for npm OIDC trusted publishing
 on:
   workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'PARKED — publish ep_etherpad to npm? Requires a trusted publisher configured on npmjs.com first (see workflow header). Set true only if that is done.'
+        required: true
+        default: false
+        type: boolean
 
 env:
   PNPM_HOME: ~/.pnpm-store
@@ -12,6 +36,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+        - name: Guard — refuse unless explicitly confirmed
+          if: ${{ inputs.confirm != true }}
+          run: |
+            echo "::error::releaseEtherpad is PARKED. The ep_etherpad npm publish is non-functional"
+            echo "::error::(no trusted publisher configured on npmjs.com; 0 dependents on npm)."
+            echo "::error::Re-run with confirm=true only after the owner configures a trusted"
+            echo "::error::publisher. See the workflow header / AGENTS.MD 'Releasing' section."
+            exit 1
         - name: Checkout repository
           uses: actions/checkout@v6
         - uses: actions/setup-node@v6

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -231,7 +231,7 @@ Releases are driven almost entirely by GitHub Actions. A maintainer dispatches *
    - `handleRelease.yml` → builds Etherpad, extracts the matching changelog section via `generateChangelog` (`bin/generateReleaseNotes.ts`), and publishes the **GitHub Release** (`make_latest: true`);
    - `docker.yml` → builds & pushes the Docker images;
    - `snap-publish.yml` → publishes the snap.
-5. **npm publish is a separate manual step:** dispatch **"releaseEtherpad.yaml"** (`workflow_dispatch`), which runs `npm publish --provenance --access public` via npm **OIDC trusted publishing**. It is *not* fired by the tag.
+5. **npm publish — PARKED, not part of the release.** `releaseEtherpad.yaml` publishes the core as `ep_etherpad` to npm, but that package is **not load-bearing**: it has 0 dependents, nothing depends on it (plugins import `ep_etherpad-lite` from the *local* core install; plugin CI clones the repo), and Etherpad is run via clone/Docker/zip/snap — never `npm install`. The publish currently fails with `E404` because `ep_etherpad` has no OIDC trusted publisher configured on npmjs.com, which is why npm sits at 2.5.0 while 3.x shipped fine without it. The workflow is gated behind a `confirm: true` input so it can't run by accident. **Skip it for a normal release.** To revive it, the npm owner of `ep_etherpad` (`samtv12345`) configures a trusted publisher (npmjs.com → ep_etherpad → Settings → Trusted Publisher → repo `ether/etherpad`, workflow `releaseEtherpad.yml`); otherwise the workflow can be removed. Decision pending.
 
 ### Documentation
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Park ep_etherpad npm publish workflow behind explicit confirm input
<code>⚙️ Configuration changes</code> <code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Why

While cutting **3.3.0** the npm-publish step (`releaseEtherpad.yaml`) failed with `E404 PUT https://registry.npmjs.org/ep_etherpad`. Investigating *why we publish it at all*, the answer is: **no functional reason.**

- `ep_etherpad` has **0 dependents** on npm, and nothing in this repo depends on it.
- Plugins import **`ep_etherpad-lite`** resolved from the **local** core install; plugin CI **clones `ether/etherpad`** rather than `npm install`-ing core.
- Etherpad is run via git clone / Docker / zip / snap — never `npm install`.
- The publish has been failing because `ep_etherpad` has **no OIDC trusted publisher** configured on npmjs.com, which is why npm is stuck at **2.5.0** while 3.0/3.1/3.2/**3.3** all shipped fine without it.

The 3.3.0 release itself is complete (GitHub Release, tags, docs, Docker, snap); only this orphaned publish was "failing".

## What this does

Rather than chase a trusted-publisher setup for a publish nobody consumes, **park** the workflow:

- Gate the job behind an explicit **`confirm: true`** dispatch input, with a guard step that **fails fast with a clear message** instead of the confusing 404.
- Document the status in the workflow header and the **AGENTS.MD → Releasing** section (npm publish marked PARKED / skip for a normal release).

Nothing is deleted — this is the package owner's call. **@samtv12345**, since you own the `ep_etherpad` npm package: do you want to (a) finish the trusted-publisher config (npmjs.com → ep_etherpad → Settings → Trusted Publisher → repo `ether/etherpad`, workflow `releaseEtherpad.yml`) to revive it, or (b) drop the workflow entirely? Parked pending your decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Gate the ep_etherpad npm publish workflow behind an explicit <b><i>confirm: true</i></b> input.
• Fail fast with a clear “PARKED” message when confirmation is not provided.
• Document that npm publish is not part of the standard release process.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Maintainer"] --> B["releaseEtherpad workflow_dispatch"] --> C{"confirm=true?"}
  C -- "No" --> D["Guard step: fail fast"]
  C -- "Yes" --> E["Publish steps"] --> F[("npm registry: ep_etherpad")]

  subgraph Legend
    direction LR
    _actor["Actor"] ~~~ _dec{"Decision"} ~~~ _ext[("External system")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Configure npm OIDC trusted publisher and keep publishing</b></summary>

- ➕ Restores parity between GitHub releases and npm package versions
- ➕ Keeps an option for consumers that might rely on npm in the future
- ➖ Requires npm package owner action and ongoing maintenance
- ➖ Still publishes a package that currently has no demonstrated consumers

</details>

<details>
<summary><b>2. Remove the workflow entirely</b></summary>

- ➕ Eliminates a recurring failure mode and maintenance overhead
- ➕ Clarifies release process by removing dead steps
- ➖ Harder to reintroduce quickly if an external consumer appears
- ➖ Loses historical/intent context unless documented elsewhere

</details>

<details>
<summary><b>3. Move publish behind an environment protection gate (in addition to confirm)</b></summary>

- ➕ Adds a second, auditable safeguard (required reviewers)
- ➕ Prevents accidental runs even if confirm is toggled
- ➖ More GitHub configuration complexity
- ➖ Still doesn’t solve the trusted-publisher prerequisite

</details>

**Recommendation:** Parking behind an explicit `confirm: true` input is the best interim approach: it prevents accidental failures while preserving the workflow pending the npm owner’s decision. Longer-term, either (a) complete trusted-publisher setup if npm publish is desired, or (b) remove the workflow to reduce release surface area.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>AGENTS.MD</strong> <code>Document npm publish as parked and skippable for normal releases</code> <code>+1/-1</code></summary>

<br/>

>Document npm publish as parked and skippable for normal releases
>
><pre>
>• Updates the release checklist to state that npm publishing the core as &#x27;ep_etherpad&#x27; is parked, non-load-bearing, and currently fails due to missing trusted publisher configuration. Provides clear instructions to skip it for normal releases and notes how to revive or remove it.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7922/files#diff-2e7d278cb4a2bad1de30725a7d02b20d44e88891396f51ac046711923ba51409'>AGENTS.MD</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>releaseEtherpad.yml</strong> <code>Mark workflow as parked and require explicit confirm to run publish</code> <code>+32/-0</code></summary>

<br/>

>Mark workflow as parked and require explicit confirm to run publish
>
><pre>
>• Adds a prominent header explaining why the ep_etherpad npm publish is non-functional and not part of standard releases. Introduces a required boolean &#x27;confirm&#x27; workflow_dispatch input and a guard step that fails fast with a clear error message unless explicitly confirmed.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7922/files#diff-65379e76896c05ce692578aefd54ad8b36b1da68ad9dd3df31273294abca6394'>.github/workflows/releaseEtherpad.yml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>