### PR TITLE
ci: enable downstream client smoke (pad/cli/desktop) — Phase 2

### DIFF
--- a/.github/workflows/downstream-smoke.yml
+++ b/.github/workflows/downstream-smoke.yml
@@ -88,19 +88,16 @@ jobs:
       - name: Generate canonical wire-vectors
         run: cd src && pnpm run vectors:gen
 
+      # Rust toolchain for the `rust`-kind client (etherpad-pad). Other kinds
+      # use the node+pnpm already set up above.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Run enabled downstream clients
-        run: |
-          ENABLED=$(node -e 'const c=require("./src/tests/downstream/clients.json").filter(x=>x.enabled); process.stdout.write(JSON.stringify(c))')
-          if [ "$ENABLED" = "[]" ]; then
-            echo "No downstream clients enabled yet (Phase 1 harness only). Skipping."
-            exit 0
-          fi
-          # Phase 2 implements per-`kind` clone @ pinned ref + toolchain setup +
-          # vector injection (cp src/tests/fixtures/wire-vectors.json into the
-          # client) + `vectorTest` + `smokeCmd` against http://localhost:9003,
-          # iterating the entries in $ENABLED. Until a client is enabled this is
-          # a no-op so the harness lands green on its own.
-          echo "$ENABLED"
+        env:
+          SMOKE_URL: http://localhost:9003
+          SMOKE_APIKEY: ${{ env.APIKEY }}
+        run: bash src/tests/downstream/run-clients.sh
 
       - name: Teardown (by PID, never pkill)
         if: always()

--- a/src/tests/downstream/clients.json
+++ b/src/tests/downstream/clients.json
@@ -2,27 +2,27 @@
   {
     "name": "etherpad-pad",
     "repo": "https://github.com/ether/pad.git",
-    "ref": "31176d64ce746d45349e58ee6c0bb043052c6e66",
+    "ref": "ada8cafd33b4ab31206226b4c3db80b2aa00125a",
     "kind": "rust",
-    "enabled": false,
+    "enabled": true,
     "vectorTest": "cargo test --test vectors",
     "smokeCmd": "cargo test --test smoke -- --ignored"
   },
   {
     "name": "etherpad-cli-client",
     "repo": "https://github.com/ether/etherpad-cli-client.git",
-    "ref": "edbe0bb70971e54514ebea672e4ad9b51fc55bff",
+    "ref": "e4b4643c7185c2059375c430e07ca2e65d01999a",
     "kind": "node",
-    "enabled": false,
+    "enabled": true,
     "vectorTest": "pnpm run test:vectors",
     "smokeCmd": "pnpm run test:smoke"
   },
   {
     "name": "etherpad-desktop",
     "repo": "https://github.com/ether/etherpad-desktop.git",
-    "ref": "ad273c119f1926a8390c9908fc91f62fa2cf740f",
+    "ref": "9e02fd06b2be3f0eeb91d636b7bddc547210399d",
     "kind": "desktop",
-    "enabled": false,
+    "enabled": true,
     "vectorTest": "pnpm run test:vectors",
     "smokeCmd": "pnpm run test:smoke"
   }

--- a/src/tests/downstream/run-clients.sh
+++ b/src/tests/downstream/run-clients.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Runs each enabled downstream client from clients.json against an already-booted
+# Etherpad: clone @ pinned ref, set up its toolchain, point it at core's freshly
+# generated wire-vectors fixture, then run the client's vectorTest + smokeCmd.
+#
+# The fixture is injected via $ETHERPAD_WIRE_VECTORS (absolute) so clients test
+# against CURRENT core's serialization, not their vendored snapshot. The smoke
+# reaches the server via $ETHERPAD_SMOKE_URL + $ETHERPAD_SMOKE_APIKEY.
+#
+# Env (all optional except APIKEY):
+#   SMOKE_URL      default http://localhost:9003
+#   SMOKE_APIKEY   required for the live smoke (clients skip cleanly without it)
+#   MANIFEST       default src/tests/downstream/clients.json (relative to repo root)
+#   WIRE_VECTORS   default <repo>/src/tests/fixtures/wire-vectors.json
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+MANIFEST="${MANIFEST:-$REPO_ROOT/src/tests/downstream/clients.json}"
+WIRE_VECTORS="${WIRE_VECTORS:-$REPO_ROOT/src/tests/fixtures/wire-vectors.json}"
+SMOKE_URL="${SMOKE_URL:-http://localhost:9003}"
+SMOKE_APIKEY="${SMOKE_APIKEY:-}"
+
+[ -f "$WIRE_VECTORS" ] || { echo "::error::fixture not found: $WIRE_VECTORS"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+MANIFEST="$MANIFEST" node -e '
+  const c = require(process.env.MANIFEST).filter((x) => x.enabled);
+  for (const x of c) {
+    process.stdout.write([x.name, x.repo, x.ref, x.kind, x.vectorTest, x.smokeCmd].join("\t") + "\n");
+  }
+' > "$WORK/clients.tsv"
+
+if [ ! -s "$WORK/clients.tsv" ]; then
+  echo "No downstream clients enabled. Nothing to run."
+  exit 0
+fi
+
+export ETHERPAD_WIRE_VECTORS="$WIRE_VECTORS"
+export ETHERPAD_SMOKE_URL="$SMOKE_URL"
+export ETHERPAD_SMOKE_APIKEY="$SMOKE_APIKEY"
+
+fail=0
+while IFS=$'\t' read -r name repo ref kind vectorTest smokeCmd; do
+  echo "::group::$name ($kind) @ ${ref:0:12}"
+  dir="$WORK/$name"
+  git clone --quiet "$repo" "$dir"
+  # Fetch the exact pinned commit (works even when it is not a branch tip).
+  git -C "$dir" fetch --quiet origin "$ref" 2>/dev/null || true
+  git -C "$dir" checkout --quiet "$ref"
+
+  (
+    cd "$dir"
+    case "$kind" in
+      rust)
+        eval "$vectorTest"
+        eval "$smokeCmd"
+        ;;
+      node|desktop)
+        pnpm install
+        eval "$vectorTest"
+        eval "$smokeCmd"
+        ;;
+      *)
+        echo "::error::unknown client kind: $kind"; exit 1
+        ;;
+    esac
+  ) || { echo "::error::downstream client '$name' failed"; fail=1; }
+  echo "::endgroup::"
+done < "$WORK/clients.tsv"
+
+exit "$fail"


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

CI: enable live downstream client smoke gate for pad/cli/desktop
<code>🧪 Tests</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Builds on #7923 (Phase 1). Turns on the **live** downstream-smoke gate now that each client has its Phase 2 vector + smoke tests.

## What this adds
- **`src/tests/downstream/run-clients.sh`** — per-`kind` orchestration: for each enabled manifest entry, clone the client @ its pinned ref, set up its toolchain, point it at core's freshly generated fixture via `ETHERPAD_WIRE_VECTORS`, then run the client's `vectorTest` + `smokeCmd` against the booted server (`ETHERPAD_SMOKE_URL` + `ETHERPAD_SMOKE_APIKEY`). Clients test against **current core's** serialization, not a vendored snapshot.
- **`clients.json`** — all three flipped to `enabled:true`, pinned to the commits carrying their Phase 2 tests.
- **`downstream-smoke.yml`** — adds the Rust toolchain and calls the runner with the smoke env.

## The three client PRs (each adds vendored fixture + `vectorTest` + live `smokeCmd`)
- ether/pad#1 (Rust crate: changeset decode vectors + `PadSession` round-trip)
- ether/etherpad-cli-client#136 (repo's first test runner; reuses its own Changeset/AttributePool)
- ether/etherpad-desktop#78 (fixture-integrity guard + headless-light HTTP roundtrip)

## Verification
Ran the **full orchestration locally against a real core** — clone @ pinned SHA → inject fixture → vectors + live smoke — all green:
- etherpad-pad: vectors ✓, smoke ✓
- etherpad-cli-client: vectors 5/5 ✓, live USER_CHANGES round-trip ✓
- etherpad-desktop: vectors 22/22 ✓, smoke ✓

## Follow-up
Once the three client PRs squash-merge, bump their `ref`s in `clients.json` to the merge commits (the pinned pre-merge SHAs stay fetchable, so the gate keeps working until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Enable Phase 2 downstream-smoke gate to run real client vector + smoke tests.
• Add a per-client orchestrator that clones pinned refs, injects core vectors, and runs tests.
• Turn on pad/cli/desktop clients and install Rust toolchain in the workflow.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  wf["downstream-smoke.yml"] --> srv(["Booted core server"]) --> vec["Generate vectors"] --> fx["wire-vectors.json"] --> runner["run-clients.sh"] --> clients[["Downstream clients"]]
  manifest["clients.json"] --> runner
  clients --> srv

  subgraph Legend
    direction LR
    _cfg["Config/File"] ~~~ _svc(["Service"]) ~~~ _ext[["External component"]]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. GitHub Actions matrix (one job per client kind/name)</b></summary>

- ➕ Runs clients in parallel, reducing wall-clock time
- ➕ Clearer isolation/logging per client, easier to retry a single client
- ➕ Can tailor toolchain/caching per client kind (cargo/pnpm)
- ➖ More workflow complexity (matrix generation, passing vectors/artifacts)
- ➖ Needs careful artifact handling for wire-vectors.json and server URL/apikey

</details>

<details>
<summary><b>2. Package runner as a composite action / reusable workflow</b></summary>

- ➕ Reuses orchestration across repos/branches with a stable interface
- ➕ Simplifies the main workflow YAML and centralizes maintenance
- ➖ Adds indirection and versioning overhead
- ➖ Still needs the same cloning/toolchain logic internally

</details>

<details>
<summary><b>3. Avoid full clones (shallow fetch pinned commit)</b></summary>

- ➕ Less network/disk usage in CI; faster checkout of large clients
- ➖ More git edge cases around fetching non-tip SHAs; needs careful commands

</details>

**Recommendation:** The current approach (single runner script + manifest) is a good Phase 2 activation step: it’s straightforward, keeps client config data-driven, and makes local reproduction easy. If CI duration becomes an issue, consider moving to a matrix workflow for parallelism and better per-client isolation; also consider shallow-fetching pinned SHAs to reduce checkout cost.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>downstream-smoke.yml</strong> <code>Install Rust toolchain and invoke Phase 2 downstream client runner</code> <code>+9/-12</code></summary>

<br/>

>Install Rust toolchain and invoke Phase 2 downstream client runner
>
><pre>
>• Adds a Rust toolchain setup step for the rust-kind downstream client and replaces the previous placeholder logic with a call to the new run-clients.sh orchestrator. Passes SMOKE_URL and SMOKE_APIKEY env vars into the runner so downstream clients can execute live smoke tests against the booted server.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7924/files#diff-4c691445564db685f38e77cac688f937dc977922c6bd43f02514b2403956039c'>.github/workflows/downstream-smoke.yml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>clients.json</strong> <code>Enable pad/cli/desktop downstream clients and update pinned refs</code> <code>+6/-6</code></summary>

<br/>

>Enable pad/cli/desktop downstream clients and update pinned refs
>
><pre>
>• Flips etherpad-pad, etherpad-cli-client, and etherpad-desktop to enabled=true and updates each entry to a pinned commit ref that contains their Phase 2 vector + smoke tests. Keeps per-client kind and command configuration in the manifest for the orchestrator.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7924/files#diff-e7558e1d8ef9a9bfe89a164c911291d553753967829320bbc8c2b5cc4f7ca37c'>src/tests/downstream/clients.json</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>run-clients.sh</strong> <code>Add per-kind downstream client orchestrator (clone, inject vectors, run tests)</code> <code>+74/-0</code></summary>

<br/>

>Add per-kind downstream client orchestrator (clone, inject vectors, run tests)
>
><pre>
>• Introduces a bash runner that reads enabled clients from clients.json, clones each repo at its pinned ref into a temp workspace, exports ETHERPAD_WIRE_VECTORS/ETHERPAD_SMOKE_URL/ETHERPAD_SMOKE_APIKEY, and runs the configured vector + smoke commands. Handles kind-specific setup (pnpm install for node/desktop; relies on Rust toolchain for rust) and aggregates failures while continuing to run subsequent clients.
></pre>
>
><a href='https://github.com/ether/etherpad/pull/7924/files#diff-37c232efc2c62f77eaba46adfb664dd3b49c2a7b43d7f0d4b041cd6e7f5f0d7c'>src/tests/downstream/run-clients.sh</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>