### PR TITLE
fix(pad): show detected language in settings dropdown (#7925)

### DIFF
--- a/src/static/js/pad.ts
+++ b/src/static/js/pad.ts
@@ -581,7 +581,10 @@ const pad = {
     $('#padsettings-options-linenoscheck').prop('checked', view.showLineNumbers !== false);
     $('#padsettings-options-rtlcheck').prop('checked', !!view.rtlIsTrue);
     $('#padsettings-viewfontmenu').val(view.padFontFamily || '');
-    $('#padsettings-languagemenu').val(padOptions.lang || 'en');
+    // When no pad-wide lang is set, reflect the language html10n actually
+    // detected and rendered (e.g. from the browser) instead of defaulting the
+    // dropdown to English while the UI is in another language. See #7925.
+    $('#padsettings-languagemenu').val(padOptions.lang || html10n.getLanguage() || 'en');
     $('#padsettings-enforcecheck').prop('checked', !!padOptions.enforceSettings);
     $('#padsettings-options-stickychat, #padsettings-options-chatandusers')
         .prop('disabled', padOptions.showChat === false);
@@ -599,7 +602,10 @@ const pad = {
     $('#options-linenoscheck').prop('checked', effectiveOptions.view?.showLineNumbers !== false);
     $('#options-rtlcheck').prop('checked', !!effectiveOptions.view?.rtlIsTrue);
     $('#viewfontmenu').val(effectiveOptions.view?.padFontFamily || '');
-    $('#languagemenu').val(effectiveOptions.lang || 'en');
+    // Fall back to the detected language rather than hardcoded English when the
+    // user has not explicitly chosen one, so the dropdown matches the rendered
+    // UI language. See #7925.
+    $('#languagemenu').val(effectiveOptions.lang || html10n.getLanguage() || 'en');
     $('#settings input[id^="options-"]').prop('disabled', disabled);
     $('#viewfontmenu, #languagemenu').prop('disabled', disabled);
     $('#options-stickychat, #options-chatandusers')

--- a/src/tests/frontend-new/specs/language.spec.ts
+++ b/src/tests/frontend-new/specs/language.spec.ts
@@ -101,9 +101,10 @@ test.describe('Language select and change', function () {
     try {
       await goToNewPad(page)
 
-      // The toolbar should have rendered in German (detection works) ...
-      await page.locator('.buttonicon-bold').evaluate((el) =>
-          el.parentElement!.title === 'Fett (Strg-B)')
+      // The toolbar should have rendered in German (detection works) — the
+      // bold button's parent <li> carries the localized German tooltip.
+      await expect(page.locator('.buttonicon-bold').locator('..'))
+          .toHaveAttribute('title', 'Fett (Strg-B)')
 
       // ... and the language dropdown must show the detected language, not
       // English, even though it was never explicitly selected.

--- a/src/tests/frontend-new/specs/language.spec.ts
+++ b/src/tests/frontend-new/specs/language.spec.ts
@@ -90,4 +90,27 @@ test.describe('Language select and change', function () {
     await page.waitForSelector('html[dir="ltr"]')
 
   });
+
+  // Regression test for #7925: when the UI language is auto-detected from the
+  // browser (no language cookie, no pad-wide lang set), the language dropdown
+  // must reflect the detected language instead of defaulting to English.
+  test('dropdown reflects the browser-detected language', async function ({browser}) {
+    const context = await browser.newContext({locale: 'de-DE'})
+    await context.clearCookies()
+    const page = await context.newPage()
+    try {
+      await goToNewPad(page)
+
+      // The toolbar should have rendered in German (detection works) ...
+      await page.locator('.buttonicon-bold').evaluate((el) =>
+          el.parentElement!.title === 'Fett (Strg-B)')
+
+      // ... and the language dropdown must show the detected language, not
+      // English, even though it was never explicitly selected.
+      await showSettings(page)
+      await expect(langDropdown(page).locator('.current')).toHaveText('Deutsch')
+    } finally {
+      await context.close()
+    }
+  });
 });


### PR DESCRIPTION
## Problem

Fixes #7925 (follow-up to #7586).

The pad UI correctly auto-detects the browser language and renders in it (e.g. German), but the **Language dropdown** in Settings still shows **English**.

## Root cause

Two code paths set the dropdown value and disagree when the language is *auto-detected* (no `language` cookie, no pad-wide `lang`):

- `pad_editor.ts` (on html10n's `localized` event) correctly sets both dropdowns to `html10n.getLanguage()` (e.g. `de`).
- `pad.ts` `refreshMyViewControls()` / `refreshPadSettingsControls()` set them to `effectiveOptions.lang || 'en'` / `padOptions.lang || 'en'`. When nothing is explicitly chosen, `getMyViewOverrides()` deletes `overrides.lang`, so the value is `undefined` and the dropdown falls back to hardcoded **`'en'`**. These refreshes run *after* the `localized` handler (during handshake), clobbering the correct value back to English.

## Fix

Fall back to the detected language before `'en'`:

```js
$('#languagemenu').val(effectiveOptions.lang || html10n.getLanguage() || 'en');
$('#padsettings-languagemenu').val(padOptions.lang || html10n.getLanguage() || 'en');
```

`getLanguage()` returns the matched lowercase locale key, which matches the `<option value>` keys built from the available locales — so the right option is selected. An explicit user choice (cookie/pad option) still takes precedence.

## Testing

Added a regression test that loads a pad under a `de-DE` browser locale and asserts the dropdown reads **"Deutsch"** with no manual selection.

RED-green verified against a running server:
- **Without the fix:** the new test fails — dropdown shows `English` (reproduces #7925).
- **With the fix:** all 5 `language.spec.ts` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)