### PR TITLE
fix(pad): suppress deletion-token modal when allowPadDeletionByAllUsers is on (#7926)

### DIFF
--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -1287,9 +1287,15 @@ const handleClientReady = async (socket:any, message: ClientReadyMessage) => {
     // once. Readonly sessions never see it.
     const isCreator =
         !sessionInfo.readonly && sessionInfo.author === await pad.getRevisionAuthor(0);
-    // Skip token issuance when requireAuthentication is on: every creator has a
-    // stable identity so the cookie/identity path is sufficient.
-    const padDeletionToken = isCreator && !settings.requireAuthentication
+    // Skip token issuance — and so the client never shows the "Save your pad
+    // deletion token" modal (issue #7926) — when the token cannot help:
+    //   - requireAuthentication: every creator already has a stable identity, so
+    //     the cookie/identity path is sufficient.
+    //   - allowPadDeletionByAllUsers: anyone can delete the pad with no token at
+    //     all (see handlePadDelete's flagOk branch), so a recovery token is noise
+    //     and the modal only overwhelms users who will never need it.
+    const padDeletionToken =
+        isCreator && !settings.requireAuthentication && !settings.allowPadDeletionByAllUsers
         ? await padDeletionManager.createDeletionTokenIfAbsent(sessionInfo.padId)
         : null;
 

--- a/src/tests/backend/specs/socketio.ts
+++ b/src/tests/backend/specs/socketio.ts
@@ -34,7 +34,7 @@ describe(__filename, function () {
       plugins.hooks[hookName] = [];
     }
     backups.settings = {};
-    for (const setting of ['editOnly', 'requireAuthentication', 'requireAuthorization', 'users', 'enablePadWideSettings']) {
+    for (const setting of ['editOnly', 'requireAuthentication', 'requireAuthorization', 'users', 'enablePadWideSettings', 'allowPadDeletionByAllUsers']) {
       // @ts-ignore
       backups.settings[setting] = settings[setting];
     }
@@ -489,6 +489,49 @@ describe(__filename, function () {
       const cvB = await common.handshake(socketB, 'foo');
       assert.equal(cvB.data.canEditPadSettings, true,
           'same author across tabs is one identity, both are the creator');
+    });
+  });
+
+  describe('Pad deletion token issuance (#7926)', function () {
+    const removeIfExists = async (padId: string) => {
+      if (await padManager.doesPadExist(padId)) {
+        const p = await padManager.getPad(padId);
+        await p.remove();
+      }
+    };
+
+    beforeEach(async function () {
+      // @ts-ignore - public setting toggled per test
+      settings.allowPadDeletionByAllUsers = false;
+      await removeIfExists('pad');
+    });
+    afterEach(async function () {
+      if (socket) socket.close();
+      socket = null;
+      await removeIfExists('pad');
+    });
+
+    it('anonymous creator receives a deletion token by default', async function () {
+      const res = await agent.get('/p/pad').expect(200);
+      socket = await common.connect(res);
+      const cv: any = await common.handshake(socket, 'pad');
+      assert.equal(cv.type, 'CLIENT_VARS');
+      assert.equal(typeof cv.data.padDeletionToken, 'string',
+          'creator should get a token so the client can show the save-token modal');
+      assert.ok(cv.data.padDeletionToken.length >= 32);
+    });
+
+    it('no token (and so no modal) when allowPadDeletionByAllUsers is true', async function () {
+      // @ts-ignore - public setting
+      settings.allowPadDeletionByAllUsers = true;
+      const res = await agent.get('/p/pad').expect(200);
+      socket = await common.connect(res);
+      const cv: any = await common.handshake(socket, 'pad');
+      assert.equal(cv.type, 'CLIENT_VARS');
+      // A null token means showDeletionTokenModalIfPresent() returns early on the
+      // client, so the "Save your pad deletion token" modal never appears. Anyone
+      // can already delete the pad without a token in this configuration.
+      assert.equal(cv.data.padDeletionToken, null);
     });
   });
 


### PR DESCRIPTION
## Problem

Closes #7926.

The one-time **pad deletion token** is minted for the creator on their first visit, and the client pops a *"Save your pad deletion token"* modal. As the reporter notes, for many users (children/students, less technical teachers) this modal is confusing and overwhelming.

When an instance sets **`allowPadDeletionByAllUsers: true`**, the token is pointless: *anyone* can already delete the pad with no token at all (`handlePadDelete`'s `flagOk` branch). So in that configuration the modal is pure noise.

## Change

Gate token issuance on `!settings.allowPadDeletionByAllUsers` in `handleClientReady`:

```ts
const padDeletionToken =
    isCreator && !settings.requireAuthentication && !settings.allowPadDeletionByAllUsers
    ? await padDeletionManager.createDeletionTokenIfAbsent(sessionInfo.padId)
    : null;
```

With no token in `clientVars`, the client's `showDeletionTokenModalIfPresent()` returns early and the modal never appears. This implements the reporter's first (preferred) option — it derives automatically from the existing setting, **no new setting required**.

This PR is intentionally minimal and unconditionally safe (a token is never needed when everyone can delete). A follow-up PR will handle the related ideas discussed on the issue — suppressing the token for authenticated/OIDC sessions that carry a durable cross-device identity, and the deletion-button naming.

## Test

`src/tests/backend/specs/socketio.ts` — new *"Pad deletion token issuance (#7926)"* block:
- anonymous creator still receives a token by default (≥32 chars);
- **no token** in `clientVars` when `allowPadDeletionByAllUsers` is true.

Full `socketio.ts` suite: 41 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)