### PR TITLE
fix(skin): paint root canvas so iOS dark mode has no white status bar (#7606)

### DIFF
--- a/src/static/skins/colibris/src/pad-variants.css
+++ b/src/static/skins/colibris/src/pad-variants.css
@@ -133,6 +133,22 @@
   box-shadow: 0 0 14px 0px var(--super-dark-color);
 }
 
+/* == Root canvas / iOS status-bar safe area (issue #7606) == */
+/* The variant rules above only paint inner containers, leaving the <html> root
+   transparent. iOS Safari fills the status-bar safe area above the page from
+   the ROOT canvas background (not `theme-color`), so a dark-mode pad showed a
+   white strip above the dark toolbar. Paint the root with the TOOLBAR colour
+   (matching `theme-color` and the OP's request that the bar match the toolbar)
+   so the safe area, toolbar, and address bar are one seamless colour. The
+   colours mirror toolbarColorForTokens / skin_toolbar_colors.ts. `color-scheme`
+   keeps UA-painted chrome (overscroll, scrollbars, form controls) in step. */
+html.super-light-toolbar, html.light-toolbar { color-scheme: light; }
+html.super-dark-toolbar, html.dark-toolbar { color-scheme: dark; }
+html.super-light-toolbar { background-color: var(--super-light-color); }
+html.light-toolbar { background-color: var(--light-color); }
+html.super-dark-toolbar { background-color: var(--super-dark-color); }
+html.dark-toolbar { background-color: var(--dark-color); }
+
 
 
 

--- a/src/tests/frontend-new/specs/theme_color_dark_mode.spec.ts
+++ b/src/tests/frontend-new/specs/theme_color_dark_mode.spec.ts
@@ -59,4 +59,18 @@ test.describe('dark color scheme', () => {
       // before pad.css so it takes effect at first paint.
       await expect(page.locator('html')).toHaveClass(/super-dark-editor/);
     });
+
+  test('root canvas matches the toolbar so the iOS status-bar area is not white',
+    async ({page}) => {
+      await goToNewPad(page);
+      // The <html> root must carry the toolbar colour as its background — iOS
+      // Safari paints the status-bar safe area from the root canvas, not from
+      // theme-color, so leaving it transparent produced a white strip above
+      // the dark pad (issue #7606). #485365 == --super-dark-color, the dark
+      // toolbar colour.
+      await expect
+        .poll(() => page.evaluate(() =>
+          getComputedStyle(document.documentElement).backgroundColor))
+        .toBe('rgb(72, 83, 101)');
+    });
 });


### PR DESCRIPTION
## Problem

Follow-up to #7909 (merged). The OP confirmed Android Chrome/Firefox now look correct, but **iOS Safari still shows a white strip at the very top** in dark mode — the status-bar area above the dark toolbar. Screenshot: dark toolbar + dark pad, but a white band behind the iOS status bar (clock/battery).

## Root cause

`theme-color` only tints the address-bar **chrome**. The status-bar **safe area** at the top is painted by iOS Safari from the page's **root canvas background** — not from `theme-color`. (Android tints its chrome from `theme-color`, which is why it looked fine there but iOS didn't.)

In the colibris skin the background variants only colour inner containers (`#editorcontainerbox`, `body` descendants); `<html>` and `<body>` stay transparent. Measured in a mobile dark-mode viewport on the merged build:

```
htmlBg: rgba(0, 0, 0, 0)   bodyBg: rgba(0, 0, 0, 0)   colorScheme: normal
```

Transparent root + `color-scheme: normal` → the UA canvas falls back to the light default (white) → white status-bar strip.

## Fix

Paint the `<html>` root per toolbar variant with the **toolbar colour** (matching `theme-color` and the OP's original request that the bar match the toolbar), and set `color-scheme` so the safe area, toolbar, and address bar are one seamless colour. Colours mirror `skin_toolbar_colors.ts`.

```css
html.super-light-toolbar, html.light-toolbar { color-scheme: light; }
html.super-dark-toolbar,  html.dark-toolbar  { color-scheme: dark; }
html.super-light-toolbar { background-color: var(--super-light-color); }
html.light-toolbar       { background-color: var(--light-color); }
html.super-dark-toolbar  { background-color: var(--super-dark-color); }
html.dark-toolbar        { background-color: var(--dark-color); }
```

## Verification (mobile viewport, this branch)

- **Dark OS:** root `background-color` is now `rgb(72, 83, 101)` (`#485365`, == toolbar == `theme-color`), `color-scheme: dark`.
- **Light OS:** root stays `rgb(255, 255, 255)`, `color-scheme: light` — unchanged.
- Frontend regression test added asserting the dark root canvas matches the toolbar.

> The remaining real-device iOS confirmation is the OP re-testing on pad-dev once this deploys; the white strip is iOS chrome that headless engines can't render, but the root-canvas colour is the documented mechanism and is now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)