### PR TITLE
security: escape numbered-list `start` attribute (stored XSS, GHSA-f7h5-v9hm-548j)

### DIFF
--- a/src/static/js/domline.ts
+++ b/src/static/js/domline.ts
@@ -102,12 +102,21 @@ domline.createDomLine = (nonEmpty, doesWrap, optBrowser, optDocument) => {
             postHtml = `</li></ul>${postHtml}`;
           } else {
             if (start) { // is it a start of a list with more than one item in?
-              if (Number.parseInt(start[1]) === 1) { // if its the first one at this level?
+              // The `start` value comes verbatim from the attribute pool (which
+              // an attacker can populate via a crafted `.etherpad` import), so it
+              // must never be interpolated raw into the markup. An <ol> start is
+              // only ever an integer: coerce it and HTML-escape it defensively so
+              // a value such as `1><svg/onload=...>` cannot break out of the tag.
+              const startNum = Number.parseInt(start[1]);
+              if (startNum === 1) { // if its the first one at this level?
                 // Add start class to DIV node
                 lineClass = `${lineClass} ` + `list-start-${listType}`;
               }
+              const startAttr = Number.isNaN(startNum)
+                ? ''
+                : ` start="${Security.escapeHTMLAttribute(String(startNum))}"`;
               preHtml +=
-                `<ol start=${start[1]} class="list-${Security.escapeHTMLAttribute(listType)}"><li>`;
+                `<ol${startAttr} class="list-${Security.escapeHTMLAttribute(listType)}"><li>`;
             } else {
               // Handles pasted contents into existing lists
               preHtml += `<ol class="list-${Security.escapeHTMLAttribute(listType)}"><li>`;

--- a/src/tests/backend/specs/domline_list_start.ts
+++ b/src/tests/backend/specs/domline_list_start.ts
@@ -1,0 +1,62 @@
+'use strict';
+
+/*
+ * Regression test for GHSA-f7h5-v9hm-548j.
+ *
+ * The numbered-list branch of `domline.appendSpan` used to interpolate the
+ * line's `start` attribute value into an `<ol start=...>` tag unquoted and
+ * unescaped, then assign the result to `node.innerHTML`. The value comes
+ * verbatim from the attribute pool, which an attacker can populate via a
+ * crafted `.etherpad` import, so a value such as `1><svg/onload=alert(1)>`
+ * broke out of the tag and produced a live element -> stored XSS for every
+ * viewer of the pad/timeslider.
+ */
+
+const assert = require('assert').strict;
+const domline = require('../../../static/js/domline').domline;
+const {lineAttributeMarker} = require('../../../static/js/linestylefilter');
+import jsdom from 'jsdom';
+
+// Build the per-span class string exactly as linestylefilter would for a
+// numbered-list line marker carrying the given `start` value.
+const listCls = (start: string) =>
+  `${lineAttributeMarker} list:number1 start:${start}`;
+
+// Render a single line-marker span through the real domline sink and return
+// the resulting DOM node.
+const renderLine = (cls: string) => {
+  const {window} = new jsdom.JSDOM('<!DOCTYPE html><html><body></body></html>');
+  const node = domline.createDomLine(true, false, window, window.document);
+  node.clearSpans();
+  node.appendSpan('*', cls);
+  node.finishUpdate();
+  return node.node as HTMLElement;
+};
+
+describe(__filename, function () {
+  it('does not create a live element from a malicious start value', async function () {
+    // Space-free payload: satisfies the `\S+` capture the sink matches on.
+    const node = renderLine(listCls('1><svg/onload=alert(document.domain)>'));
+    assert.equal(node.querySelector('svg'), null,
+      'malicious start value must not be parsed into a live <svg> element');
+    assert.ok(!node.innerHTML.includes('<svg'),
+      `rendered markup must not contain a raw <svg> tag: ${node.innerHTML}`);
+    // The numbered list itself still renders; only the bogus value is dropped.
+    assert.ok(node.querySelector('ol'), 'a numbered list should still render');
+  });
+
+  it('renders a legitimate integer start value safely', async function () {
+    const node = renderLine(listCls('2'));
+    const ol = node.querySelector('ol');
+    assert.ok(ol, 'a numbered list should render');
+    assert.equal(ol!.getAttribute('start'), '2');
+  });
+
+  it('coerces a non-integer start value away instead of emitting it', async function () {
+    const node = renderLine(listCls('notanumber'));
+    const ol = node.querySelector('ol');
+    assert.ok(ol, 'a numbered list should still render');
+    assert.equal(ol!.getAttribute('start'), null,
+      'a non-integer start value must not reach the <ol> start attribute');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **GHSA-f7h5-v9hm-548j** — a stored XSS in the numbered-list render path.

`domline.appendSpan` built the `<ol start=...>` tag by interpolating the line's `start` attribute value **unquoted and unescaped**, then assigned the result to `node.innerHTML`:

```js
// before
preHtml += `<ol start=${start[1]} class="list-${Security.escapeHTMLAttribute(listType)}"><li>`;
```

The neighbouring `listType` is escaped — only `start` was missed. The value comes verbatim from the attribute pool, which an attacker can populate via a crafted `.etherpad` import: `ImportEtherpad.setPadRaw` validates attribute *keys* (and only warns on unknown ones) but never validates attribute *values*. On a default install (`requireAuthentication: false`, import enabled, `.etherpad` a built-in extension) `POST /p/:pad/import` needs only ordinary write access, so a space-free value like `1><svg/onload=...>` breaks out of the tag and executes in the pad's origin for every later viewer of the pad or `/timeslider` — including admins.

This is the same root-cause family as #7905 (unescaped attribute-pool values reaching an HTML context), but a **distinct, client-side sink** that #7905 did not touch.

## Fix

An `<ol>` start is only ever an integer, so at the sink in `src/static/js/domline.ts`:

- coerce the value with `Number.parseInt`,
- omit the attribute entirely when it is not a number,
- HTML-escape **and** quote it via `Security.escapeHTMLAttribute` — the same treatment the sibling `listType` already gets and that #7905 applied to the export sink.

```js
// after
const startNum = Number.parseInt(start[1]);
const startAttr = Number.isNaN(startNum)
  ? '' : ` start="${Security.escapeHTMLAttribute(String(startNum))}"`;
preHtml += `<ol${startAttr} class="list-${Security.escapeHTMLAttribute(listType)}"><li>`;
```

## Test

Adds `src/tests/backend/specs/domline_list_start.ts`, which drives the **real** `domline` render path through jsdom and asserts:

- a malicious `start` value cannot produce a live element (the unpatched code parses it into a live `SVGSVGElement`; the test fails without this fix),
- a legitimate integer start (`2`) still renders as `<ol start="2">`,
- a non-integer start is dropped rather than emitted.

Verified red→green against the unpatched sink, and the existing `export_list` numbered-list round-trip specs still pass.

Credit: 5ud0 / Tarmo Technologies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)