### PR TITLE
fix: include images in HTML export

### DIFF
--- a/src/node/utils/ExportHtml.ts
+++ b/src/node/utils/ExportHtml.ts
@@ -222,11 +222,19 @@ const getHTMLFromAtext = async (pad:PadType, atext: AText, authorColors?: string
       for (const o of ops) {
         const usedAttribs:string[] = [];
 
-        // mark all attribs as used
+        // mark all attribs as used; also collect image attributes
+        let imageUrl: string | null = null;
+        let imageWidth: string | null = null;
+        let imageHeight: string | null = null;
         for (const a of attributes.decodeAttribString(o.attribs)) {
           if (a in anumMap) {
             usedAttribs.push(String(anumMap[a])); // i = 0 => bold, etc.
           }
+          const attr = apool.numToAttrib[a];
+          if (!attr) continue;
+          if (attr[0] === 'image' && attr[1]) imageUrl = decodeURIComponent(attr[1]);
+          if (attr[0] === 'image-width' && attr[1]) imageWidth = attr[1];
+          if (attr[0] === 'image-height' && attr[1]) imageHeight = attr[1];
         }
         let outermostTag = -1;
         // find the outer most open tag that is no longer used
@@ -259,10 +267,18 @@ const getHTMLFromAtext = async (pad:PadType, atext: AText, authorColors?: string
 
         let s = taker.take(chars);
 
-        // form feed (0x0C) is a legacy control char with no meaning in HTML
-        s = s.replace(String.fromCharCode(12), '');
-
-        assem.append(_encodeWhitespace(Security.escapeHTML(s)));
+        if (imageUrl) {
+          // Emit an <img> tag for image attributes (e.g. from ep_image_upload)
+          let imgStyle = '';
+          if (imageWidth) imgStyle += `width:${imageWidth};`;
+          if (imageHeight) imgStyle += `height:${imageHeight};`;
+          const styleAttr = imgStyle ? ` style="${Security.escapeHTMLAttribute(imgStyle)}"` : '';
+          assem.append(`<img src="${Security.escapeHTMLAttribute(imageUrl)}"${styleAttr}>`);
+        } else {
+          // form feed (0x0C) is a legacy control char with no meaning in HTML
+          s = s.replace(String.fromCharCode(12), '');
+          assem.append(_encodeWhitespace(Security.escapeHTML(s)));
+        }
       } // end iteration over spans in line
 
       // close all the tags that are open after the last op


### PR DESCRIPTION
## Problem

Images inserted via image plugins (e.g. ep_image_upload) store their URL in the attribute pool under the `image` key (URL-encoded), with optional `image-width` and `image-height` attributes.

Previously `ExportHtml.ts` had no handling for the `image` attribute: the placeholder character was output as escaped text, silently dropping every image from the exported HTML.

## Fix

Detects `image`, `image-width`, and `image-height` attributes on each op inside `processNextChars`. When an image URL is present the placeholder character is consumed and an `<img>` tag is emitted instead, with inline width/height styles when available.

The URL is decoded with `decodeURIComponent` and sanitized with `Security.escapeHTMLAttribute` before output.

## Testing

Tested with pads containing:
- Base64-embedded images (`data:image/png;base64,...`)
- Server-path images (`/static/images/padname/uuid.png`)
