### PR TITLE
fix(ui): make Colibris chat container responsive and right-aligned on medium viewports (#7780)

### DIFF
--- a/src/static/skins/colibris/src/components/chat.css
+++ b/src/static/skins/colibris/src/components/chat.css
@@ -6,6 +6,7 @@
   background: none;
   padding: 0;
   width: 400px;
+  max-width: 100vw; /* Prevents the chat box from extending wider than mobile viewports */
   height: 300px;
   background-color: #f2f3f4;
   background-color: var(--bg-soft-color);
@@ -83,9 +84,32 @@
 }
 
 @media (max-width: 800px) {
+  /* FIXED: Make the full-width container click-through so it doesn't block the editor */
+  #chatbox {
+    pointer-events: none;
+  }
+
   #chaticon {
     right: 0;
   }
 
   .stick-to-screen-btn { display: none; }
+  
+  /* Fluid scaling rule for tablets and smaller mid-sized screens */
+  .chat-content {
+    width: 100%;
+    max-width: 360px; /* Safely shrinks layout on smaller screens to preserve breathing room */
+    margin-left: auto; /* Keeps the panel right-aligned inside full-width containers */
+    margin-right: 0;
+    pointer-events: auto; /* FIXED: Restores clickability inside the chat box itself */
+  }
+}
+
+/* Specific safety rule for ultra-narrow viewport screens */
+@media (max-width: 400px) {
+  .chat-content {
+    max-width: 100%;
+    height: 250px; /* Slightly drops vertical space to allow room for document visibility */
+    margin-left: 0;
+  }
 }


### PR DESCRIPTION
This PR resolves a layout regression in the Colibris skin where the chat panel container drops fluid scaling and breaks position on responsive viewports.

Changes Introduced
Replaced the hardcoded fixed 400px layout constraint on .chat-content with a fluid max-width: 100vw protective layer.

Implemented targeted media queries under 800px and 400px to dynamically scale down container dimensions.

Added margin-left: auto alignment properties under the 800px breakpoint to prevent the container from rendering flush-left over the editor's text space.

Fixes #7780