### PR TITLE
deps: pin ueberdb2 to 6.1.9 (fixes standalone-server startup exit) + run deb smoke on PRs

### DIFF
--- a/.github/workflows/deb-package.yml
+++ b/.github/workflows/deb-package.yml
@@ -15,6 +15,24 @@ on:
       - 'src/node/utils/run_cmd.ts'
       - 'src/static/js/pluginfw/**'
       - 'settings.json.template'
+  # Also build + smoke-test the package on PRs that touch the production
+  # footprint. The smoke step boots the packaged server and waits for /health,
+  # which is the only check that catches "server starts then exits before
+  # binding the port" startup regressions (e.g. a dependency bump whose change
+  # lets the event loop drain mid-boot). Previously this workflow ran only on
+  # push to develop, so such a regression was caught *after* merge — by which
+  # point develop was already red. Running it pre-merge blocks the PR instead.
+  # The release/apt-publish jobs are tag-guarded, so PRs run the build job only.
+  pull_request:
+    paths:
+      - 'packaging/**'
+      - '.github/workflows/deb-package.yml'
+      - 'src/package.json'
+      - 'pnpm-lock.yaml'
+      - 'src/node/server.ts'
+      - 'src/node/utils/run_cmd.ts'
+      - 'src/static/js/pluginfw/**'
+      - 'settings.json.template'
   workflow_dispatch:
     inputs:
       ref:

--- a/bin/package.json
+++ b/bin/package.json
@@ -11,7 +11,7 @@
     "log4js": "^6.9.1",
     "semver": "^7.8.4",
     "tsx": "^4.22.4",
-    "ueberdb2": "^6.1.12"
+    "ueberdb2": "6.1.9"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: ^4.22.4
         version: 4.22.4
       ueberdb2:
-        specifier: ^6.1.12
-        version: 6.1.12(@elastic/elasticsearch@9.4.2)(async@3.2.6)(cassandra-driver@4.8.0)(dirty-ts@1.1.8)(mongodb@7.3.0)(mssql@12.5.5(@azure/core-client@1.10.1))(mysql2@3.22.5(@types/node@25.9.3))(nano@11.0.5)(pg@8.21.0)(redis@6.0.0(@opentelemetry/api@1.9.1))(rethinkdb@2.4.2)(rusty-store-kv@1.3.1)(surrealdb@2.0.3(tslib@2.8.1)(typescript@6.0.3))
+        specifier: 6.1.9
+        version: 6.1.9(@elastic/elasticsearch@9.4.2)(async@3.2.6)(cassandra-driver@4.8.0)(dirty-ts@1.1.8)(mongodb@7.3.0)(mssql@12.5.5(@azure/core-client@1.10.1))(mysql2@3.22.5(@types/node@25.9.3))(nano@11.0.5)(pg@8.21.0)(redis@6.0.0(@opentelemetry/api@1.9.1))(rethinkdb@2.4.2)(rusty-store-kv@1.3.1)(surrealdb@2.0.3(tslib@2.8.1)(typescript@6.0.3))
     devDependencies:
       '@types/node':
         specifier: ^25.9.3
@@ -364,8 +364,8 @@ importers:
         specifier: 4.22.4
         version: 4.22.4
       ueberdb2:
-        specifier: ^6.1.12
-        version: 6.1.12(@elastic/elasticsearch@9.4.2)(async@3.2.6)(cassandra-driver@4.8.0)(dirty-ts@1.1.8)(mongodb@7.3.0)(mssql@12.5.5(@azure/core-client@1.10.1))(mysql2@3.22.5(@types/node@25.9.3))(nano@11.0.5)(pg@8.21.0)(redis@6.0.0(@opentelemetry/api@1.9.1))(rethinkdb@2.4.2)(rusty-store-kv@1.3.1)(surrealdb@2.0.3(tslib@2.8.1)(typescript@6.0.3))
+        specifier: 6.1.9
+        version: 6.1.9(@elastic/elasticsearch@9.4.2)(async@3.2.6)(cassandra-driver@4.8.0)(dirty-ts@1.1.8)(mongodb@7.3.0)(mssql@12.5.5(@azure/core-client@1.10.1))(mysql2@3.22.5(@types/node@25.9.3))(nano@11.0.5)(pg@8.21.0)(redis@6.0.0(@opentelemetry/api@1.9.1))(rethinkdb@2.4.2)(rusty-store-kv@1.3.1)(surrealdb@2.0.3(tslib@2.8.1)(typescript@6.0.3))
       underscore:
         specifier: 1.13.8
         version: 1.13.8
@@ -5400,8 +5400,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ueberdb2@6.1.12:
-    resolution: {integrity: sha512-LxW4He5ZWhRzSldB105T/z9L7ljPJJeQ2VkM7tAhh0hj2TZ0zz6DItdBwDA5CQPab5QhiJ7BZC1OgkDqNDL53w==}
+  ueberdb2@6.1.9:
+    resolution: {integrity: sha512-AOifNHJT0A9c52eEQqcm77d3/RUZVIvGFN1KFbXEPpfI89fa5c9lS8z7piu6m+CwBgWD+Fq5wAmP7W3LVZ4MwA==}
     engines: {node: '>=24.0.0'}
     peerDependencies:
       '@elastic/elasticsearch': ^9.0.0
@@ -11097,7 +11097,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ueberdb2@6.1.12(@elastic/elasticsearch@9.4.2)(async@3.2.6)(cassandra-driver@4.8.0)(dirty-ts@1.1.8)(mongodb@7.3.0)(mssql@12.5.5(@azure/core-client@1.10.1))(mysql2@3.22.5(@types/node@25.9.3))(nano@11.0.5)(pg@8.21.0)(redis@6.0.0(@opentelemetry/api@1.9.1))(rethinkdb@2.4.2)(rusty-store-kv@1.3.1)(surrealdb@2.0.3(tslib@2.8.1)(typescript@6.0.3)):
+  ueberdb2@6.1.9(@elastic/elasticsearch@9.4.2)(async@3.2.6)(cassandra-driver@4.8.0)(dirty-ts@1.1.8)(mongodb@7.3.0)(mssql@12.5.5(@azure/core-client@1.10.1))(mysql2@3.22.5(@types/node@25.9.3))(nano@11.0.5)(pg@8.21.0)(redis@6.0.0(@opentelemetry/api@1.9.1))(rethinkdb@2.4.2)(rusty-store-kv@1.3.1)(surrealdb@2.0.3(tslib@2.8.1)(typescript@6.0.3)):
     optionalDependencies:
       '@elastic/elasticsearch': 9.4.2
       async: 3.2.6

--- a/src/package.json
+++ b/src/package.json
@@ -87,7 +87,7 @@
     "surrealdb": "^2.0.3",
     "tinycon": "0.6.8",
     "tsx": "4.22.4",
-    "ueberdb2": "^6.1.12",
+    "ueberdb2": "6.1.9",
     "underscore": "1.13.8",
     "undici": "^8.4.1",
     "unorm": "1.6.0",


### PR DESCRIPTION
## What

- **Pin `ueberdb2` to `6.1.9`** (exact) in `src/package.json` and `bin/package.json`, regenerating `pnpm-lock.yaml`.
- **Add a `pull_request` trigger** to `.github/workflows/deb-package.yml` (scoped to the same production-footprint paths as the existing `push` trigger).

## Why — the bug

`ueberdb2` **6.1.10** rewrote `lib/CacheAndBufferLayer.ts`: the constructor's always-on, *referenced* `setInterval` flush timer was replaced by a lazily-armed `setTimeout` that is **`.unref()`'d** and only created when there are dirty keys.

On a **fresh, empty dirty DB** there are no dirty keys → no flush timer is ever armed → ueberdb2 no longer anchors Node's event loop. In the packaged (`.deb`/systemd) production boot this exposes a startup window where the loop has **no referenced handle**, so the process **exits cleanly (code 0) before `server.listen()` binds the port** — the server never serves `/health`.

Verified in isolation (dirty DB, `writeInterval > 0`):
- `6.1.9` → process stays alive (referenced `setInterval` anchors the loop)
- `6.1.12` → `PROCESS_EXIT code 0` immediately after init

### Symptom on `develop`

The **Debian-package amd64 smoke** failed on three consecutive pushes — #7966 (`ueberdb2 6.1.9→6.1.12`), then #7965, #7967 — logging the version banner then `etherpad.service: Deactivated successfully`, with the `/health` check on `:9001` never connecting. Backend / Docker / downstream-smoke stayed green because they keep the loop alive by other means; only the bare fresh-empty-dirty-DB packaged boot hits the gap.

`ueberdb2@6.1.12` is the latest published release, so there is no fixed version to roll forward to yet — hence the pin back to the last green release. A proper fix in ueberDB (keep a referenced keepalive across init, or don't `.unref()` the flush timer) + a `6.1.13` release should follow, after which this pin can be lifted.

## Why — the CI change

The deb smoke step is the **only** check that catches this "boots then exits before binding" class of regression, but `deb-package.yml` previously ran **only on push to `develop`** — i.e. *after* merge. That's exactly why a Dependabot bump turned `develop` red instead of being blocked at PR time. Running it on `pull_request` (scoped to package.json / lockfile / `server.ts` / packaging paths, which dependency bumps touch) blocks the PR instead. The `release`/`apt-publish` jobs are tag-guarded (`startsWith(github.ref, 'refs/tags/v')`), so PRs run the `build` (+ amd64 smoke) job only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)