### PR TITLE
fix(deps): force @opentelemetry/core >=2.8.0 (CVE-2026-54285)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@babel/core@<7.29.6': '>=7.29.6'
+  '@opentelemetry/core@<2.8.0': '>=2.8.0'
   basic-ftp@<5.3.1: '>=5.3.1 <6.0.0'
   brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
@@ -1143,8 +1144,8 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/core@2.7.1':
-    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+  '@opentelemetry/core@2.8.0':
+    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -6239,7 +6240,7 @@ snapshots:
   '@elastic/transport@9.3.6':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       debug: 4.4.3(supports-color@8.1.1)
       hpagent: 1.2.0
       ms: 2.1.3
@@ -6540,7 +6541,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ strictDepBuilds: false
 # is no longer read). Force-bump transitive deps with known CVEs.
 overrides:
   '@babel/core@<7.29.6': '>=7.29.6'
+  '@opentelemetry/core@<2.8.0': '>=2.8.0'
   basic-ftp@<5.3.1: '>=5.3.1 <6.0.0'
   brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'


### PR DESCRIPTION
Resolves Dependabot alert [#205](https://github.com/ether/etherpad/security/dependabot/205) — **GHSA-8988-4f7v-96qf / CVE-2026-54285** (medium, CVSS 5.3).

### The vulnerability
`W3CBaggagePropagator.extract()` in `@opentelemetry/core` < 2.8.0 does not enforce the W3C Baggage size limits (8,192 bytes / 180 entries) on **inbound** `baggage` headers — limits were only applied on `inject()`. Parsing oversized baggage allocates memory proportional to the header size with no cap ([CWE-770](https://cwe.mitre.org/data/definitions/770.html)). Fixed in 2.8.0.

### Dependency chain (transitive, runtime)
```
src/package.json -> @elastic/elasticsearch@^9.4.2
                 -> @elastic/transport@9.3.6
                 -> @opentelemetry/core@2.7.1   <- vulnerable
```

### Practical reachability in Etherpad: low
- `@elastic/elasticsearch` is only exercised by the optional Elasticsearch ueberdb backend.
- The vulnerable path is `extract()` on **inbound** baggage headers; Etherpad's ES client makes **outbound** requests to a trusted, operator-configured ES server — there is no attacker-controlled inbound baggage reaching the propagator.
- Node's default `--max-http-header-size` (16 KB) independently caps the vector; the advisory itself rates availability impact as "limited".

Still worth patching to clear the alert and harden non-HTTP/raised-limit deployments.

### The fix
`@elastic/transport@9.3.6` declares its dep as `@opentelemetry/core: 2.x`, so **2.8.0 satisfies the existing range** — no parent bump needed. 2.8.0's peer range (`@opentelemetry/api >=1.0.0 <1.10.0`) is satisfied by the `1.9.1` already in the tree.

Added a `>=2.8.0` override to `pnpm-workspace.yaml` alongside the other CVE force-bumps (pnpm 11 no longer reads root `package.json` `pnpm.overrides`). Lockfile diff is surgical: only the override line and the `2.7.1 -> 2.8.0` resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)