### PR TITLE
fix(ci): stop installer smoke test hanging for 6h

### DIFF
--- a/.github/workflows/installer-test.yml
+++ b/.github/workflows/installer-test.yml
@@ -70,13 +70,30 @@ jobs:
 
       - name: Smoke test - start Etherpad and curl /api
         shell: bash
+        # Hard backstop: if teardown ever fails to reap the server the step
+        # fails in minutes instead of burning to GitHub's 6h job ceiling.
+        timeout-minutes: 8
         env:
           ETHERPAD_DIR: ${{ runner.temp }}/etherpad-installer-test
         run: |
           set -eu
+          # Enable job control so the backgrounded launcher gets its own
+          # process group, letting us reap the whole pnpm -> node tree below.
+          set -m
           cd "$ETHERPAD_DIR"
           pnpm run prod >/tmp/etherpad.log 2>&1 &
           PID=$!
+          # `pnpm run prod` is a nested launcher (pnpm -> pnpm --filter -> node),
+          # so killing $PID alone orphans the node server, which keeps the step's
+          # output pipe open and hangs CI. Kill the entire process group, with a
+          # SIGKILL fallback in case SIGTERM is swallowed (e.g. a live flush timer
+          # keeping the event loop alive), so the step always exits cleanly.
+          reap() {
+            kill -TERM "-$PID" 2>/dev/null || true
+            sleep 5
+            kill -KILL "-$PID" 2>/dev/null || true
+          }
+          trap reap EXIT
           # Wait up to 60s for the API to come up.
           ok=0
           for i in $(seq 1 60); do
@@ -90,11 +107,8 @@ jobs:
           if [ "$ok" != "1" ]; then
             echo "Etherpad did not start within 60s. Last 200 lines of log:" >&2
             tail -200 /tmp/etherpad.log >&2 || true
-            kill "$PID" 2>/dev/null || true
             exit 1
           fi
-          kill "$PID" 2>/dev/null || true
-          wait "$PID" 2>/dev/null || true
 
   installer-windows:
     name: end-to-end install (windows-latest)
@@ -131,6 +145,7 @@ jobs:
 
       - name: Smoke test - start Etherpad and curl /api
         shell: pwsh
+        timeout-minutes: 8
         env:
           ETHERPAD_DIR: ${{ runner.temp }}\etherpad-installer-test
         run: |


### PR DESCRIPTION
## Problem

The **Installer test** workflow has hung for ~6 hours and been cancelled on **every** ubuntu/macos run since **v3.2.0 (2026-05-22)**. It last passed on 2026-05-17 (3.1.0) in ~9 min. Because the workflow is path-triggered on `.github/workflows/installer-test.yml`, this turns every PR that touches that file red — most recently the Dependabot `actions/checkout` v6→v7 bump (#7977), which had nothing to do with the failure.

## Root cause

The *"Smoke test - start Etherpad and curl /api"* step starts the server in the background, confirms `/api` answers (it does, in ~6s), then tears down with:

```bash
kill "$PID"
wait "$PID"
```

`pnpm run prod` is a nested launcher — `pnpm` → `pnpm --filter ep_etherpad-lite run prod` → `node node/server.ts` — so `$PID` is only the **outer** pnpm. The script then `wait`s on it. If the node server doesn't actually exit on SIGTERM (a live `setInterval`/flush timer keeping the event loop alive is the suspected regression), the `wait` blocks forever, the step never releases its output pipe, and the job runs to GitHub's 6h ceiling. Windows passed because it uses `Stop-Process -Force`.

There was also **no `timeout-minutes`**, so a hung step can only end at the 6h cap.

## Fix

Make teardown robust regardless of the server's shutdown behaviour:

- `set -m` so the backgrounded launcher gets its **own process group**
- a trap that kills the **whole group** — `SIGTERM`, then a `SIGKILL` fallback — so the entire `pnpm`→`node` tree is reaped and the step exits cleanly
- drop the blocking `wait`
- add `timeout-minutes: 8` to both the POSIX and Windows smoke steps as a hard backstop, so any future hang fails in minutes instead of 6 hours

Verified locally that `set -m` + `kill -TERM "-$PID"` reaps the full process group, and the script passes `bash -n`.

## Follow-up (not in this PR)

This only fixes CI robustness. The underlying bug — the production server not terminating cleanly on SIGTERM, likely the ueberDB flush-timer `setInterval` keeping the event loop alive — should be fixed separately so `node node/server.ts` shuts down gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)