### PR TITLE
fix(bin): close DBs in migrateDB so it flushes and exits

### DIFF
--- a/bin/migrateDB.ts
+++ b/bin/migrateDB.ts
@@ -74,10 +74,20 @@ const handleSync = async ()=>{
   }
 }
 
-handleSync().then(()=>{
+handleSync().then(async ()=>{
+  // Closing flushes any buffered writes to the target DB and clears
+  // ueberdb2's keep-alive timer (added in 6.1.x). Without this the migrated
+  // data may not be fully persisted and the process would hang forever
+  // instead of exiting once the sync is done.
+  await ueberdb2.close()
+  await ueberdb1.close()
   console.log("Done syncing dbs")
-}).catch(e=>{
+  process.exit(0)
+}).catch(async e=>{
   console.log(`Error syncing db ${e}`)
+  await ueberdb2.close().catch(()=>{})
+  await ueberdb1.close().catch(()=>{})
+  process.exit(1)
 })
 
 


### PR DESCRIPTION
## Problem

`bin/migrateDB.ts` opens a source and target `ueberdb2` `Database`, copies every key across, then resolves the promise **without closing either connection or calling `process.exit()`**:

```ts
handleSync().then(()=>{
  console.log("Done syncing dbs")
}).catch(e=>{
  console.log(`Error syncing db ${e}`)
})
```

With `ueberdb2` 6.1.x this has two consequences:

1. **Hangs forever.** 6.1.x keeps an internal keep-alive timer (`setInterval(() => {}, 2**31-1)`) running until `close()` is called, specifically so a `Database` with buffered writes can't exit early. So after printing `Done syncing dbs` the migration process never exits. (Before 6.1.x an open DB didn't hold the event loop, so the script exited on its own.)
2. **Risk of an incomplete migration.** Target writes are buffered and only guaranteed flushed to disk on `close()`/`flush()`. An operator who sees `Done syncing dbs` and Ctrl-Cs the apparently-finished (but actually hung) process can be left with a partially-written target DB.

I confirmed the keep-alive behaviour directly: a 6.1.13 `Database` left open keeps Node alive indefinitely, while calling `close()` lets the process exit cleanly. 6.0.3 (the version shipped before this surfaced) exits immediately with the DB still open.

## Fix

Close the target then the source on both the success and error paths — which flushes buffered writes and clears the keep-alive timer — and exit with an explicit status code. This matches the pattern already used in `bin/migrateDirtyDBtoRealDB.ts`.

## Notes

- `tsc` on the `bin` package is clean for this file. There are pre-existing, unrelated type errors in other bin scripts (`importSqlFile.ts`, `migrateDirtyDBtoRealDB.ts` calling `close(null)` against the 0-arg `close()` signature) which are out of scope here.
- Related: the parallel CI fix in #7981 (the installer smoke test was hanging 6h for the same family of reason — a process kept alive by the ueberdb2 keep-alive timer not being released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)