### PR TITLE
fix(bin): port importSqlFile & migrateDirtyDBtoRealDB to ueberdb2 promise API

### DIFF
--- a/bin/importSqlFile.ts
+++ b/bin/importSqlFile.ts
@@ -2,7 +2,6 @@
 
 // As of v14, Node.js does not exit when there is an unhandled Promise rejection. Convert an
 // unhandled rejection into an uncaught exception, which does cause Node.js to exit.
-import util from "node:util";
 import fs from 'node:fs';
 import log4js from 'log4js';
 import readline from 'readline';
@@ -69,8 +68,7 @@ const unescape = (val: string) => {
   if (!sqlFile) throw new Error('Use: node importSqlFile.js $SQLFILE');
 
   log('initializing db');
-  const initDb = await util.promisify(db.init.bind(db));
-  await initDb(null);
+  await db.init();
   log('done');
 
   log(`Opening ${sqlFile}...`);
@@ -86,8 +84,7 @@ const unescape = (val: string) => {
       value = value.substring(0, value.length - 2);
       console.log(`key: ${key} val: ${value}`);
       console.log(`unval: ${unescape(value)}`);
-      // @ts-ignore
-      db.set(key, unescape(value), null);
+      await db.set(key, unescape(value));
       keyNo++;
       if (keyNo % 1000 === 0) log(` ${keyNo}`);
     }
@@ -96,9 +93,7 @@ const unescape = (val: string) => {
   process.stdout.write('done. waiting for db to finish transaction. ' +
                        'depended on dbms this may take some time..\n');
 
-  const closeDB = util.promisify(db.close.bind(db));
-  // @ts-ignore
-  await closeDB(null);
+  await db.close();
   log(`finished, imported ${keyNo} keys.`);
   process.exit(0)
 })();

--- a/bin/migrateDirtyDBtoRealDB.ts
+++ b/bin/migrateDirtyDBtoRealDB.ts
@@ -35,26 +35,16 @@ process.on('unhandledRejection', (err) => { throw err; });
   const keys = await dirty.findKeys('*', '')
 
   console.log(`Found ${keys.length} records, processing now.`);
-  const p: Promise<void>[] = [];
   let numWritten = 0;
   for (const key of keys) {
-    let value = await dirty.get(key);
-    let bcb, wcb;
-    p.push(new Promise((resolve, reject) => {
-      bcb = (err:any) => { if (err != null) return reject(err); };
-      wcb = (err:any) => {
-        if (err != null) return reject(err);
-        if (++numWritten % 100 === 0) console.log(`Wrote record ${numWritten} of ${length}`);
-        resolve();
-      };
-    }));
-    db.set(key, value, bcb, wcb);
+    const value = await dirty.get(key);
+    await db.set(key, value);
+    if (++numWritten % 100 === 0) console.log(`Wrote record ${numWritten} of ${keys.length}`);
   }
-  await Promise.all(p);
   console.log(`Wrote all ${numWritten} records`);
 
-  await db.close(null);
-  await dirty.close(null);
+  await db.close();
+  await dirty.close();
   console.log('Finished.');
   process.exit(0)
 })();


### PR DESCRIPTION
## Problem

Two `bin/` maintenance scripts still call the pre-v6 **callback-style** ueberdb2 API, which no longer exists in ueberdb2 6.x (now promise-based: `set(key, value)`, `init()`, `close()` — no callbacks/extra args). This produces `tsc` errors, some of which were masked with `// @ts-ignore`:

```
importSqlFile.ts(73)            initDb(null)            Expected 0 arguments, but got 1
migrateDirtyDBtoRealDB.ts(51)   db.set(k, v, bcb, wcb)  Expected 2 arguments, but got 4
migrateDirtyDBtoRealDB.ts(56)   db.close(null)          Expected 0 arguments, but got 1
migrateDirtyDBtoRealDB.ts(57)   dirty.close(null)       Expected 0 arguments, but got 1
```

(Spotted while fixing #7982 — the type-checker flagged these neighbouring scripts.)

## Fix

- **importSqlFile.ts** — drop the now-unused `util` import and the `util.promisify` wrappers; call `await db.init()`, `await db.set(...)`, `await db.close()` directly. Removes two `// @ts-ignore` comments that were hiding the broken calls.
- **migrateDirtyDBtoRealDB.ts** — replace the `bcb`/`wcb` callback + `Promise.all` machinery with a straightforward `await db.set(key, value)` in the loop, and call `close()` with no args. Also fixes the progress log, which referenced an undefined `length` instead of `keys.length`.

Pure type/correctness cleanup — behaviour is unchanged (writes are now awaited, which is equivalent or safer than the old fire-and-forget). `tsc --noEmit` on the `bin` package is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)