### PR TITLE
fix(import): correct outdated import-format help message (#7988)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -314,7 +314,7 @@
   "pad.importExport.exportworda.title": "Export as Microsoft Word",
   "pad.importExport.exportpdfa.title": "Export as PDF",
   "pad.importExport.exportopena.title": "Export as ODF (Open Document Format)",
-  "pad.importExport.noConverter.innerHTML": "You can only import from plain text or HTML formats. For more advanced import features, please <a href=\"https://github.com/ether/etherpad-lite/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-AbiWord\">install LibreOffice</a>.",
+  "pad.importExport.noConverter.innerHTML": "You can import plain text, HTML, Microsoft Word (.docx) and Etherpad files directly. To import other formats such as PDF, ODT, DOC or RTF, please <a href=\"https://github.com/ether/etherpad/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-AbiWord\">install LibreOffice</a>.",
 
   "pad.modals.connected": "Connected.",
   "pad.modals.reconnecting": "Reconnecting to your pad…",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -314,7 +314,7 @@
   "pad.importExport.exportworda.title": "Export as Microsoft Word",
   "pad.importExport.exportpdfa.title": "Export as PDF",
   "pad.importExport.exportopena.title": "Export as ODF (Open Document Format)",
-  "pad.importExport.noConverter.innerHTML": "You can import plain text, HTML, Microsoft Word (.docx) and Etherpad files directly. To import other formats such as PDF, ODT, DOC or RTF, please <a href=\"https://github.com/ether/etherpad/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-AbiWord\">install LibreOffice</a>.",
+  "pad.importExport.noConverter.innerHTML": "You can import plain text, HTML, Microsoft Word (.docx) and Etherpad files directly. To import other formats such as PDF, ODT, DOC or RTF, please <a href=\"https://github.com/ether/etherpad/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-LibreOffice\">install LibreOffice</a>.",
 
   "pad.modals.connected": "Connected.",
   "pad.modals.reconnecting": "Reconnecting to your pad…",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -314,7 +314,7 @@
   "pad.importExport.exportworda.title": "Export as Microsoft Word",
   "pad.importExport.exportpdfa.title": "Export as PDF",
   "pad.importExport.exportopena.title": "Export as ODF (Open Document Format)",
-  "pad.importExport.noConverter.innerHTML": "You can import plain text, HTML, Microsoft Word (.docx) and Etherpad files directly. To import other formats such as PDF, ODT, DOC or RTF, please <a href=\"https://github.com/ether/etherpad/wiki/How-to-enable-importing-and-exporting-different-file-formats-with-LibreOffice\">install LibreOffice</a>.",
+  "pad.importExport.noConverter.innerHTML": "You can import plain text, HTML, Microsoft Word (.docx) and Etherpad files directly. To import other formats such as PDF, ODT, DOC or RTF, the server administrator needs to install LibreOffice — see the <a href=\"https://docs.etherpad.org/\">Etherpad documentation</a>.",
 
   "pad.modals.connected": "Connected.",
   "pad.modals.reconnecting": "Reconnecting to your pad…",


### PR DESCRIPTION
## Problem

Closes #7988.

The import/export dialog's "no converter" notice (shown when `soffice`/LibreOffice is **not** configured) read:

> You can only import from plain text or HTML formats. For more advanced import features, please [install LibreOffice](https://github.com/ether/etherpad-lite/wiki/...-with-AbiWord).

Two problems:
- **(a)** Inaccurate — Etherpad imports several formats natively without LibreOffice, so users were told to install LibreOffice for files that already work.
- **(b)** The help link pointed at the legacy `ether/etherpad-lite` wiki, and the target AbiWord wiki pages turned out to be vandalized/empty. The wiki is being retired, so we shouldn't link to it at all.

## What works without LibreOffice

From `src/node/handler/ImportHandler.ts`:

| Extension | No LibreOffice |
|---|---|
| `.txt`, `.html`/`.htm` | native |
| `.etherpad` | native (direct DB import) |
| `.docx` | native via `mammoth` (`ImportDocxNative`) |
| `.pdf`, `.odt`, `.doc`, `.rtf` | requires `soffice` (`SOFFICE_ONLY_IMPORT_FORMATS`) |

## Change

Single-string update to `pad.importExport.noConverter.innerHTML` in `src/locales/en.json`:

> You can import plain text, HTML, Microsoft Word (.docx) and Etherpad files directly. To import other formats such as PDF, ODT, DOC or RTF, the server administrator needs to install LibreOffice — see the [Etherpad documentation](https://docs.etherpad.org/).

- Lists the natively-supported formats and scopes the LibreOffice ask to the formats that genuinely need it.
- Drops the wiki link entirely (wiki is being retired); points at the documentation site instead.

Only the English source string is edited; translations re-sync via TranslateWiki.