### PR TITLE
security(proxy-path): set Vary on public routes that echo x-proxy-path (cache poisoning)

### DIFF
--- a/src/node/hooks/express/specialpages.ts
+++ b/src/node/hooks/express/specialpages.ts
@@ -30,8 +30,15 @@ import {sanitizeProxyPath} from '../../utils/sanitizeProxyPath';
 // headers in Vary so a shared cache/CDN in front of Etherpad keys on them and
 // can't serve a proxy-path injected by one client to another (cache poisoning).
 // Mirrors the admin-route fix in admin.ts (GHSA-fjgc-3mj7-8rg8).
-const PROXY_PATH_VARY_HEADERS = ['x-proxy-path', 'x-forwarded-prefix', 'x-ingress-path'];
-const varyOnProxyPath = (res: any) => res.vary(PROXY_PATH_VARY_HEADERS);
+//
+// Only vary on the headers sanitizeProxyPath() actually consults for the
+// current config: x-proxy-path is always honored, but x-forwarded-prefix and
+// x-ingress-path are ignored unless trustProxy is enabled — varying on them
+// then would only fragment shared caches without affecting the response.
+const varyOnProxyPath = (res: any) => {
+  res.vary('x-proxy-path');
+  if (settings.trustProxy) res.vary(['x-forwarded-prefix', 'x-ingress-path']);
+};
 
 
 exports.socketio = (hookName: string, {io}: any) => {

--- a/src/node/hooks/express/specialpages.ts
+++ b/src/node/hooks/express/specialpages.ts
@@ -25,6 +25,14 @@ let ioI: { sockets: { sockets: any[]; }; } | null = null
 // rules. Reused by admin.ts so both call sites share one definition.
 import {sanitizeProxyPath} from '../../utils/sanitizeProxyPath';
 
+// Public routes echo the proxy-path headers into rendered URLs, social-preview
+// metadata, manifest links and the legacy timeslider redirect. Advertise the
+// headers in Vary so a shared cache/CDN in front of Etherpad keys on them and
+// can't serve a proxy-path injected by one client to another (cache poisoning).
+// Mirrors the admin-route fix in admin.ts (GHSA-fjgc-3mj7-8rg8).
+const PROXY_PATH_VARY_HEADERS = ['x-proxy-path', 'x-forwarded-prefix', 'x-ingress-path'];
+const varyOnProxyPath = (res: any) => res.vary(PROXY_PATH_VARY_HEADERS);
+
 
 exports.socketio = (hookName: string, {io}: any) => {
   ioI = io
@@ -173,6 +181,7 @@ const handleLiveReload = async (args: ArgsExpressType, padString: string, timeSl
       })
       setRouteHandler('/', (req: any, res: any) => {
         const proxyPath = sanitizeProxyPath(req);
+        varyOnProxyPath(res);
         const socialMetaHtml = renderSocialMeta({
           req, settings, availableLangs: i18n.availableLangs, locales: i18n.locales, kind: 'home',
           proxyPath,
@@ -202,6 +211,7 @@ const handleLiveReload = async (args: ArgsExpressType, padString: string, timeSl
         });
 
         const proxyPath = sanitizeProxyPath(req);
+        varyOnProxyPath(res);
         const socialMetaHtml = renderSocialMeta({
           req, settings, availableLangs: i18n.availableLangs, locales: i18n.locales, kind: 'pad', padName: req.params.pad,
           proxyPath,
@@ -246,6 +256,7 @@ const handleLiveReload = async (args: ArgsExpressType, padString: string, timeSl
         });
 
         const proxyPath = sanitizeProxyPath(req);
+        varyOnProxyPath(res);
         const socialMetaHtml = renderSocialMeta({
           req, settings, availableLangs: i18n.availableLangs, locales: i18n.locales, kind: 'timeslider', padName: req.params.pad,
           proxyPath,
@@ -369,6 +380,7 @@ exports.expressCreateServer = async (_hookName: string, args: ArgsExpressType, c
     // serve index.html under /
     args.app.get('/', (req: any, res: any) => {
       const proxyPath = sanitizeProxyPath(req);
+      varyOnProxyPath(res);
       const socialMetaHtml = renderSocialMeta({
         req, settings, availableLangs: i18n.availableLangs, locales: i18n.locales, kind: 'home',
         proxyPath,
@@ -389,6 +401,7 @@ exports.expressCreateServer = async (_hookName: string, args: ArgsExpressType, c
       });
 
       const proxyPath = sanitizeProxyPath(req);
+      varyOnProxyPath(res);
       const socialMetaHtml = renderSocialMeta({
         req, settings, availableLangs: i18n.availableLangs, locales: i18n.locales, kind: 'pad', padName: req.params.pad,
         proxyPath,
@@ -417,6 +430,7 @@ exports.expressCreateServer = async (_hookName: string, args: ArgsExpressType, c
         // technically well-defined but Firefox dropped a trailing-slash
         // case once that flaked the legacy-URL test (#7710).
         const proxyPath = sanitizeProxyPath(req);
+        varyOnProxyPath(res);
         return res.redirect(302, `${proxyPath}/p/${encodeURIComponent(req.params.pad)}`);
       }
       ensureAuthorTokenCookie(req, res, settings);
@@ -425,6 +439,7 @@ exports.expressCreateServer = async (_hookName: string, args: ArgsExpressType, c
       });
 
       const proxyPath = sanitizeProxyPath(req);
+      varyOnProxyPath(res);
       const socialMetaHtml = renderSocialMeta({
         req, settings, availableLangs: i18n.availableLangs, locales: i18n.locales, kind: 'timeslider', padName: req.params.pad,
         proxyPath,

--- a/src/tests/backend/specs/proxyPathVary.ts
+++ b/src/tests/backend/specs/proxyPathVary.ts
@@ -13,14 +13,18 @@
  * companion to the already-fixed admin-route variant (GHSA-fjgc-3mj7-8rg8).
  */
 
+const assert = require('assert').strict;
 const common = require('../common');
 const padManager = require('../../../node/db/PadManager');
+import settings from '../../../node/utils/Settings';
 
 let agent: any;
 
+const varyList = (res: any): string[] =>
+  String(res.headers.vary || '').toLowerCase().split(',').map((s: string) => s.trim());
+
 const assertVariesOnProxyPath = (res: any, where: string) => {
-  const vary = String(res.headers.vary || '').toLowerCase();
-  if (!vary.split(',').map((s: string) => s.trim()).includes('x-proxy-path')) {
+  if (!varyList(res).includes('x-proxy-path')) {
     throw new Error(
         `${where}: response must advertise "Vary: x-proxy-path" so a shared ` +
         `cache cannot serve a poisoned proxy-path to another user ` +
@@ -31,10 +35,16 @@ const assertVariesOnProxyPath = (res: any, where: string) => {
 describe(__filename, function () {
   this.timeout(30000);
   const padId = 'ProxyPathVaryTest';
+  let trustProxyBackup: any;
 
   before(async function () {
     agent = await common.init();
     await padManager.getPad(padId, 'test content');
+    trustProxyBackup = settings.trustProxy;
+  });
+
+  after(function () {
+    settings.trustProxy = trustProxyBackup;
   });
 
   it('sets Vary: x-proxy-path on the home page', async function () {
@@ -55,5 +65,29 @@ describe(__filename, function () {
   it('sets Vary: x-proxy-path on the legacy timeslider redirect', async function () {
     const res = await agent.get(`/p/${padId}/timeslider`).expect(302);
     assertVariesOnProxyPath(res, `GET /p/${padId}/timeslider (redirect)`);
+  });
+
+  it('does NOT vary on the trust-gated headers when trustProxy is false', async function () {
+    // sanitizeProxyPath ignores x-forwarded-prefix / x-ingress-path unless
+    // trustProxy is enabled, so varying on them would only fragment caches.
+    settings.trustProxy = false;
+    const res = await agent.get('/').expect(200);
+    const vary = varyList(res);
+    assert.ok(vary.includes('x-proxy-path'), `expected x-proxy-path, got "${res.headers.vary}"`);
+    assert.ok(!vary.includes('x-forwarded-prefix'),
+        `must not vary on x-forwarded-prefix when trustProxy=false (got "${res.headers.vary}")`);
+    assert.ok(!vary.includes('x-ingress-path'),
+        `must not vary on x-ingress-path when trustProxy=false (got "${res.headers.vary}")`);
+  });
+
+  it('varies on all proxy-path headers when trustProxy is true', async function () {
+    settings.trustProxy = true;
+    const res = await agent.get('/').expect(200);
+    const vary = varyList(res);
+    assert.ok(vary.includes('x-proxy-path'), `expected x-proxy-path, got "${res.headers.vary}"`);
+    assert.ok(vary.includes('x-forwarded-prefix'),
+        `expected x-forwarded-prefix when trustProxy=true (got "${res.headers.vary}")`);
+    assert.ok(vary.includes('x-ingress-path'),
+        `expected x-ingress-path when trustProxy=true (got "${res.headers.vary}")`);
   });
 });

--- a/src/tests/backend/specs/proxyPathVary.ts
+++ b/src/tests/backend/specs/proxyPathVary.ts
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Cache-poisoning hardening for the `x-proxy-path` header on public routes.
+ *
+ * Etherpad echoes the (sanitised) `x-proxy-path` prefix into rendered URLs,
+ * social-preview metadata, PWA manifest links, and the legacy timeslider
+ * redirect on `/`, `/p/:pad`, and `/p/:pad/timeslider`. If a shared cache /
+ * reverse proxy in front of Etherpad stores these responses keyed on URL alone,
+ * a value injected by one client is served to every other client. These
+ * responses must therefore advertise `Vary: x-proxy-path` so a conforming cache
+ * keeps prefixed and non-prefixed variants separate. Reported by `meifukun`;
+ * companion to the already-fixed admin-route variant (GHSA-fjgc-3mj7-8rg8).
+ */
+
+const common = require('../common');
+const padManager = require('../../../node/db/PadManager');
+
+let agent: any;
+
+const assertVariesOnProxyPath = (res: any, where: string) => {
+  const vary = String(res.headers.vary || '').toLowerCase();
+  if (!vary.split(',').map((s: string) => s.trim()).includes('x-proxy-path')) {
+    throw new Error(
+        `${where}: response must advertise "Vary: x-proxy-path" so a shared ` +
+        `cache cannot serve a poisoned proxy-path to another user ` +
+        `(got Vary: "${res.headers.vary || ''}")`);
+  }
+};
+
+describe(__filename, function () {
+  this.timeout(30000);
+  const padId = 'ProxyPathVaryTest';
+
+  before(async function () {
+    agent = await common.init();
+    await padManager.getPad(padId, 'test content');
+  });
+
+  it('sets Vary: x-proxy-path on the home page', async function () {
+    const res = await agent.get('/').expect(200);
+    assertVariesOnProxyPath(res, 'GET /');
+  });
+
+  it('sets Vary: x-proxy-path on the pad page', async function () {
+    const res = await agent.get(`/p/${padId}`).expect(200);
+    assertVariesOnProxyPath(res, `GET /p/${padId}`);
+  });
+
+  it('sets Vary: x-proxy-path on the timeslider embed page', async function () {
+    const res = await agent.get(`/p/${padId}/timeslider?embed=1`).expect(200);
+    assertVariesOnProxyPath(res, `GET /p/${padId}/timeslider?embed=1`);
+  });
+
+  it('sets Vary: x-proxy-path on the legacy timeslider redirect', async function () {
+    const res = await agent.get(`/p/${padId}/timeslider`).expect(302);
+    assertVariesOnProxyPath(res, `GET /p/${padId}/timeslider (redirect)`);
+  });
+});


### PR DESCRIPTION
Follow-up hardening to **GHSA-fjgc-3mj7-8rg8** (`x-proxy-path` admin XSS/open-redirect, fixed in #7784). Reported privately by **meifukun** (https://github.com/meifukun).

That advisory added `Vary: x-proxy-path` to the **admin** routes but left the **public** routes uncovered. The home page, pad page and timeslider (plus the legacy timeslider redirect) echo the sanitised `x-proxy-path` prefix into rendered URLs, social-preview metadata, manifest links and the redirect target — but advertised no `Vary`. A shared cache/CDN keyed on URL alone could store a prefix injected by one client and serve it to others.

## Scope
This is **cache-correctness hardening, not XSS/open-redirect** — the value is still passed through `sanitizeProxyPath` (quotes / angle-brackets / protocol-relative `//` / `..` already blocked by #7784). Deliberately does **not** change `x-proxy-path`'s trust model: it stays honored under `trustProxy: false` because subpath / Home-Assistant-ingress deployments rely on that default. The fix is purely additive (`Vary`).

## Change
Adds a `varyOnProxyPath(res)` helper applied at every `sanitizeProxyPath()` call site in `specialpages.ts` (both dev-watched and prod route blocks).

## Test
New `proxyPathVary.ts` asserts `Vary: x-proxy-path` on `/`, `/p/:pad`, the timeslider embed page, and the legacy redirect. Existing `proxyPathRedirect.ts` still passes; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)