### PR TITLE
fix: don't log a missing-author error for the reserved system author (#8044)

### DIFF
--- a/src/node/db/API.ts
+++ b/src/node/db/API.ts
@@ -25,9 +25,9 @@ import ChatMessage from '../../static/js/ChatMessage';
 import {Builder} from "../../static/js/Builder";
 import {Attribute} from "../../static/js/types/Attribute";
 
-// Mirror of `Pad.SYSTEM_AUTHOR_ID`. Inlined to avoid a circular load
+// Not `Pad.SYSTEM_AUTHOR_ID`: importing Pad here would be a circular load
 // (API <-> Pad) at module init time.
-const SYSTEM_AUTHOR_ID = 'a.etherpad-system';
+import {SYSTEM_AUTHOR_ID, isSystemAuthor} from '../utils/SystemAuthor';
 import settings from '../utils/Settings';
 const CustomError = require('../utils/customError');
 const padManager = require('./PadManager');
@@ -867,8 +867,7 @@ exports.listAuthorsOfPad = async (padID: string) => {
   // authorId, server-side import flows, plugins like ep_post_data). It is an
   // implementation detail of changeset bookkeeping, not a real contributor, so
   // it should not surface through this public API.
-  const {Pad} = require('./Pad');
-  const authorIDs = pad.getAllAuthors().filter((id: string) => id !== Pad.SYSTEM_AUTHOR_ID);
+  const authorIDs = pad.getAllAuthors().filter((id: string) => !isSystemAuthor(id));
   return {authorIDs};
 };
 

--- a/src/node/db/Pad.ts
+++ b/src/node/db/Pad.ts
@@ -23,6 +23,7 @@ const groupManager = require('./GroupManager');
 const CustomError = require('../utils/customError');
 import readOnlyManager from './ReadOnlyManager';
 import randomString from '../utils/randomstring';
+import {SYSTEM_AUTHOR_ID} from '../utils/SystemAuthor';
 const hooks = require('../../static/js/pluginfw/hooks');
 import pad_utils from "../../static/js/pad_utils";
 import {SmartOpAssembler} from "../../static/js/SmartOpAssembler";
@@ -101,8 +102,12 @@ class Pad {
    * setDocAText reconciliation in ace2_inner.ts when loading the pad. Using
    * a fixed system author keeps the AText well-formed without requiring
    * every plugin to allocate its own author up-front.
+   *
+   * Kept as a static for plugin compatibility; the canonical definition (and
+   * the one modules with a circular dependency on Pad must use) lives in
+   * ../utils/SystemAuthor.
    */
-  static readonly SYSTEM_AUTHOR_ID = 'a.etherpad-system';
+  static readonly SYSTEM_AUTHOR_ID = SYSTEM_AUTHOR_ID;
 
   /**
    * Validate that every `+` (insert) op in `aChangeset` carries an

--- a/src/node/handler/PadMessageHandler.ts
+++ b/src/node/handler/PadMessageHandler.ts
@@ -38,6 +38,7 @@ import settings, {
 } from '../utils/Settings';
 import {anonymizeIp} from '../utils/anonymizeIp';
 import {isAcceptingConnections} from '../updater/SessionDrainer';
+import {SYSTEM_AUTHOR_ID, isSystemAuthor} from '../utils/SystemAuthor';
 const logIp = (ip: string | null | undefined) => anonymizeIp(ip, settings.ipLogging);
 const securityManager = require('../db/SecurityManager');
 const plugins = require('../../static/js/pluginfw/plugin_defs');
@@ -937,12 +938,12 @@ const handleUserChanges = async (socket:any, message: {
       // op that names it is either a confused client or an attempt to
       // launder writes through a reserved attribution slot. Either way,
       // refuse.
-      // Hardcoded mirror of `Pad.SYSTEM_AUTHOR_ID` from src/node/db/Pad.ts.
-      // A `const {Pad} = require('../db/Pad')` at module scope returned
-      // a partially-initialized class here (circular load via padManager),
-      // so the static-field access ended up undefined and short-circuited
-      // the check at runtime. Inline literal is the simplest fix.
-      if (opAuthorId === 'a.etherpad-system') {
+      // `SYSTEM_AUTHOR_ID` comes from the leaf module rather than
+      // `Pad.SYSTEM_AUTHOR_ID`: a `const {Pad} = require('../db/Pad')` at
+      // module scope returned a partially-initialized class here (circular
+      // load via padManager), so the static-field access ended up undefined
+      // and short-circuited the check at runtime.
+      if (opAuthorId === SYSTEM_AUTHOR_ID) {
         throw new Error(`Author ${thisSession.author} attempted to submit changes as the ` +
                         `reserved system author ${opAuthorId} in changeset ${changeset}`);
       }
@@ -1172,7 +1173,13 @@ const handleClientReady = async (socket:any, message: ClientReadyMessage) => {
   }
 
   // these db requests all need the pad object (timestamp of latest revision, author data)
-  const authors = pad.getAllAuthors();
+  //
+  // The reserved system author is changeset bookkeeping, not a contributor, and
+  // has no `globalAuthor:` record by design — every pad created with default
+  // content carries it in the pool forever (#7885), so looking it up like a real
+  // author logged a spurious ERROR on every pad open (#8044). Skip it here, the
+  // same way listAuthorsOfPad keeps it out of the public API.
+  const authors = pad.getAllAuthors().filter((id: string) => !isSystemAuthor(id));
 
   // get timestamp of latest revision needed for timeslider
   const currentTime = await pad.getRevisionDate(pad.getHeadRevisionNumber());

--- a/src/node/types/PadType.ts
+++ b/src/node/types/PadType.ts
@@ -11,6 +11,7 @@ export type PadType = {
   getRevisionAuthor: (rev: number)=>Promise<string>,
   getRevision: (rev?: string)=>Promise<any>,
   head: number,
+  getAllAuthors: ()=>string[],
   getAllAuthorColors: ()=>Promise<MapArrayType<string>>,
   remove: ()=>Promise<void>,
   text: ()=>string,

--- a/src/node/utils/ImportEtherpad.ts
+++ b/src/node/utils/ImportEtherpad.ts
@@ -32,10 +32,10 @@ const supportedElems = require('../../static/js/contentcollector').supportedElem
 
 const logger = log4js.getLogger('ImportEtherpad');
 
-// Mirror of `Pad.SYSTEM_AUTHOR_ID`. Inlined to avoid a circular import
-// (ImportEtherpad -> Pad -> ImportEtherpad via padManager) at module
-// init time.
-const SYSTEM_AUTHOR_ID = 'a.etherpad-system';
+// Not `Pad.SYSTEM_AUTHOR_ID`: that would be a circular import
+// (ImportEtherpad -> Pad -> ImportEtherpad via padManager) at module init
+// time.
+import {SYSTEM_AUTHOR_ID} from './SystemAuthor';
 
 // A `+` op is "pure newline" (and therefore exempt from the author
 // requirement) iff every character in the op is a newline. The wire-

--- a/src/node/utils/ImportHtml.ts
+++ b/src/node/utils/ImportHtml.ts
@@ -23,9 +23,9 @@ import jsdom from 'jsdom';
 import {PadType} from "../types/PadType";
 import {Builder} from "../../static/js/Builder";
 
-// Mirror of `Pad.SYSTEM_AUTHOR_ID`. Imported as a literal to avoid a
-// circular require between Pad and ImportHtml during module init.
-const SYSTEM_AUTHOR_ID = 'a.etherpad-system';
+// Not `Pad.SYSTEM_AUTHOR_ID`: importing Pad here would create a circular
+// require between Pad and ImportHtml during module init.
+import {SYSTEM_AUTHOR_ID} from './SystemAuthor';
 
 const apiLogger = log4js.getLogger('ImportHtml');
 let processor:any;

--- a/src/node/utils/SystemAuthor.ts
+++ b/src/node/utils/SystemAuthor.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Stable author id used to attribute inserts coming from internal callers
+ * (HTTP API setText/appendText/setHTML with no authorId, the default pad
+ * content written on pad creation, server-side import flows, plugins like
+ * ep_post_data). Without ANY author attribute, pad.atext.text and
+ * pad.atext.attribs drift out of sync — clients then fail setDocAText
+ * reconciliation in ace2_inner.ts when loading the pad.
+ *
+ * It is changeset bookkeeping, not a real contributor: there is deliberately
+ * no `globalAuthor:a.etherpad-system` record in the database, so callers that
+ * resolve pool authors to author records must skip it (see
+ * `Pad.getAllAuthors()` consumers) rather than reporting it as missing.
+ *
+ * This lives in its own leaf module because `Pad.SYSTEM_AUTHOR_ID` cannot be
+ * imported from the modules that need it without a circular require at module
+ * init time (Pad -> padManager -> ImportEtherpad/ImportHtml -> Pad, and
+ * PadMessageHandler -> padManager -> Pad), which previously forced each of
+ * them to duplicate the literal.
+ */
+export const SYSTEM_AUTHOR_ID = 'a.etherpad-system';
+
+/**
+ * True iff `authorId` is the reserved system author.
+ */
+export const isSystemAuthor = (authorId: string|null|undefined): boolean =>
+  authorId === SYSTEM_AUTHOR_ID;

--- a/src/tests/backend/specs/messages.ts
+++ b/src/tests/backend/specs/messages.ts
@@ -5,6 +5,8 @@ import {MapArrayType} from "../../../node/types/MapType";
 
 const assert = require('assert').strict;
 const common = require('../common');
+const log4js = require('log4js');
+const sinon = require('sinon');
 const padManager = require('../../../node/db/PadManager');
 const plugins = require('../../../static/js/pluginfw/plugin_defs');
 import readOnlyManager from '../../../node/db/ReadOnlyManager';
@@ -334,5 +336,42 @@ describe(__filename, function () {
       assert.equal(pad!.head, rev); // Not incremented.
       assert.equal(pad!.text(), 'hello\n');
     });
+  });
+
+  describe('CLIENT_READY', function () {
+    // Every pad created with non-empty initial text and no authorId — which
+    // includes every pad that gets the default `settings.defaultPadText`
+    // welcome content (#7885) — carries `a.etherpad-system` in its attribute
+    // pool forever. The system author is server-internal bookkeeping, not a
+    // real contributor, so it has no `globalAuthor:` record. Looking it up
+    // like a real author logged an ERROR on every single pad open (#8044).
+    it('does not treat the reserved system author as a missing author',
+        async function () {
+          assert(pad!.getAllAuthors().includes('a.etherpad-system'));
+          // log4js.getLogger() hands out a fresh Logger per call, so spy on the
+          // shared prototype and filter by category to catch the log emitted by
+          // PadMessageHandler's module-scope `messageLogger`.
+          const errorSpy = sinon.spy(log4js.getLogger('message').constructor.prototype, 'error');
+          try {
+            const res = await agent.get(`/p/${padId}`).expect(200);
+            const readySocket = await common.connect(res);
+            try {
+              const {type, data: clientVars} = await common.handshake(readySocket, padId);
+              assert.equal(type, 'CLIENT_VARS');
+              const {historicalAuthorData} = clientVars.collab_client_vars;
+              assert(!('a.etherpad-system' in historicalAuthorData));
+              assert.deepEqual(
+                  errorSpy.getCalls()
+                      .filter((c: any) => c.thisValue.category === 'message')
+                      .map((c: any) => String(c.args[0]))
+                      .filter((m: string) => m.includes('a.etherpad-system')),
+                  []);
+            } finally {
+              readySocket.close();
+            }
+          } finally {
+            errorSpy.restore();
+          }
+        });
   });
 });


### PR DESCRIPTION
Closes #8044.

## The bug

Since 3.1.0, opening *any* pad logs:

```
[ERROR] message - There is no author for authorId: a.etherpad-system. This is possibly related to https://github.com/ether/etherpad-lite/issues/2802
```

Reproduced on a clean `develop` checkout with DirtyDB (log excerpt, pad `TEST8044`):

```
SET - pad:TEST8044:revs:0 - {"changeset":"Z:1>b0*0|6+b0$Welcome to Etherpad!...",
  "meta":{"author":"a.cr21NSDGFIagqk2W",...,"pool":{"numToAttrib":{"0":["author","a.etherpad-system"],"1":["author","a.cr21NSDGFIagqk2W"]}}}}
GET - globalAuthor:a.etherpad-system - undefined
[ERROR] message - There is no author for authorId: a.etherpad-system. ...
```

## Root cause

`a.etherpad-system` is the reserved author Etherpad attributes inserts to when no `authorId` is supplied — the HTTP API `setText`/`appendText`/`setHTML` paths, server-side imports, plugins like `ep_post_data`, and (since #7885) the auto-generated default pad content, which must *not* be coloured as the first visitor's writing.

That means the attribute pool of every pad created with default content permanently contains `['author', 'a.etherpad-system']`. It is changeset bookkeeping, not a contributor, so there is deliberately no `globalAuthor:a.etherpad-system` record.

`CLIENT_READY` builds `historicalAuthorData` from `pad.getAllAuthors()` and treats *every* pool author as a real one, so the system author fails the lookup and hits the "this should never happen" error branch — on every pad open, for new and pre-existing pads alike. The reporter's note that pads "otherwise function normally" is right: the log line is the whole symptom.

## The fix

Filter the system author out of the `historicalAuthorData` lookup, exactly the way `listAuthorsOfPad` already keeps it out of the public API. This is option 2 from the issue. Option 1 (create a real `globalAuthor` record) was rejected: it would give the welcome text a real author colour and surface a phantom user in the author list, undoing the point of #7885.

Client-visible behaviour is unchanged — the id was never in `historicalAuthorData`, because the lookup failed.

While here: the id had been duplicated as a bare literal in five modules, each carrying a comment about `Pad.SYSTEM_AUTHOR_ID` being unimportable due to a circular require. The canonical definition now lives in a leaf module, `src/node/utils/SystemAuthor.ts`; `Pad.SYSTEM_AUTHOR_ID` remains as a re-export for plugin compatibility.

## Tests

New backend regression test in `tests/backend/specs/messages.ts` (`CLIENT_READY`) — asserts the pad's pool does contain the system author, that it is absent from `historicalAuthorData`, and that no `message`-category error mentioning it was logged. It fails on the pre-fix code with exactly the reported message.

- `pnpm test` (backend suite): **1614 passing, 0 failing**, 22 pending
- `tsc --noEmit`: clean (also adds the missing `getAllAuthors` to the `PadType` interface)
- Manual: dev server on a fresh clone, opening a pad created *before* the fix and a brand-new pad — **0** occurrences of the error, pad renders normally, no new browser-console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)