### PR TITLE
Fix home and post-delete redirects behind a proxy URL prefix

### DIFF
--- a/src/static/js/getHomeUrl.ts
+++ b/src/static/js/getHomeUrl.ts
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * Resolve the Etherpad home URL from a pad URL.
+ *
+ * Pad pages live at `{prefix}/p/{padId}`. One `..` segment removes the pad id
+ * and lands on `{prefix}/`, which is correct both for root deployments
+ * (`/p/testpad` -> `/`) and reverse-proxy prefixes (`/etherpad/p/testpad`
+ * -> `/etherpad/`). See issue #8111.
+ */
+export const getHomeUrl = (fromHref: string): string =>
+  new URL('..', fromHref).href;

--- a/src/static/js/pad_editbar.ts
+++ b/src/static/js/pad_editbar.ts
@@ -24,6 +24,7 @@
  */
 
 const hooks = require('./pluginfw/hooks');
+import {getHomeUrl} from './getHomeUrl';
 import padutils from "./pad_utils";
 const padeditor = require('./pad_editor').padeditor;
 const padsavedrevs = require('./pad_savedrevs');
@@ -481,9 +482,9 @@ exports.padeditbar = new class {
     this.registerDropdownCommand('connectivity');
     this.registerDropdownCommand('import_export');
     this.registerDropdownCommand('embed');
-    this.registerCommand('home', ()=>{
-      window.location.href = new URL('../..', window.location.href).href
-    })
+    this.registerCommand('home', () => {
+      window.location.href = getHomeUrl(window.location.href);
+    });
 
     this.registerCommand('settings', () => {
       this.toggleDropDown('settings');

--- a/src/static/js/pad_editor.ts
+++ b/src/static/js/pad_editor.ts
@@ -22,6 +22,7 @@
  * limitations under the License.
  */
 
+import {getHomeUrl} from './getHomeUrl';
 import padutils from "./pad_utils";
 const Ace2Editor = require('./ace').Ace2Editor;
 import html10n from '../js/vendors/html10n'
@@ -176,7 +177,7 @@ const padeditor = (() => {
         pad.socket.on('message', (data: any) => {
           if (data && data.disconnect === 'deleted') {
             handled = true;
-            window.location.href = '/';
+            window.location.href = getHomeUrl(window.location.href);
           }
         });
         pad.socket.on('shout', (data: any) => {
@@ -192,7 +193,7 @@ const padeditor = (() => {
           data: {padId: pad.getPadId(), deletionToken: token},
         });
         setTimeout(() => {
-          if (!handled) window.location.href = '/';
+          if (!handled) window.location.href = getHomeUrl(window.location.href);
         }, 5000);
       });
 
@@ -207,7 +208,7 @@ const padeditor = (() => {
           pad.socket.on('message', (data: any) => {
             if (data && data.disconnect === 'deleted') {
               handled = true;
-              window.location.href = '/';
+              window.location.href = getHomeUrl(window.location.href);
             }
           });
           // If the user is not the pad creator, the server sends a shout
@@ -224,7 +225,7 @@ const padeditor = (() => {
           // Fallback: if the server doesn't respond within 5 seconds
           // (e.g. socket dropped), navigate away anyway.
           setTimeout(() => {
-            if (!handled) window.location.href = '/';
+            if (!handled) window.location.href = getHomeUrl(window.location.href);
           }, 5000);
         }
       })

--- a/src/tests/backend-new/specs/getHomeUrl.test.ts
+++ b/src/tests/backend-new/specs/getHomeUrl.test.ts
@@ -1,0 +1,20 @@
+'use strict';
+
+import {describe, it, expect} from 'vitest';
+import {getHomeUrl} from '../../../static/js/getHomeUrl';
+
+describe('getHomeUrl', () => {
+  it('returns / for a root-deployed pad', () => {
+    expect(getHomeUrl('https://example.com/p/testpad')).toBe('https://example.com/');
+  });
+
+  it('returns the proxy prefix home for a prefixed pad URL', () => {
+    expect(getHomeUrl('https://example.com/etherpad/p/testpad'))
+        .toBe('https://example.com/etherpad/');
+  });
+
+  it('preserves a deep proxy prefix', () => {
+    expect(getHomeUrl('https://example.com/api/hassio_ingress/abc/p/testpad'))
+        .toBe('https://example.com/api/hassio_ingress/abc/');
+  });
+});

--- a/src/tests/frontend-new/specs/editbar.spec.ts
+++ b/src/tests/frontend-new/specs/editbar.spec.ts
@@ -15,4 +15,5 @@ test('should go to home on pad', async ({page}) => {
   await page.waitForURL((url) => !url.pathname.includes('/p/'));
   const url = page.url();
   expect(url).not.toContain('/p/');
-})
+  expect(new URL(url).pathname).toBe('/');
+});


### PR DESCRIPTION
## What

Preserve the public URL prefix when navigating home from a pad and after a pad is deleted.

## Why

When Etherpad is served behind a reverse proxy under a prefix such as `/etherpad`, the Home command resolved `../..` from `/etherpad/p/<padId>` and redirected to the domain root. Post-delete redirects separately hardcoded `/`, causing the same problem.

## Changes

- Resolve the home URL relative to the current pad URL.
- Use the same resolver for Home and all post-delete redirects.
- Add regression coverage for root, single-prefix, and nested-prefix deployments.

Fixes #8111

## Tests

- `vitest run tests/backend-new/specs/getHomeUrl.test.ts`
- Playwright `editbar.spec.ts`

Note: ESLint could not be run locally because of a pre-existing ESLint/package compatibility mismatch.