### PR TITLE
fix: unblock the admin build on TypeScript 7

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -37,7 +37,6 @@
     "i18next": "^26.3.6",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.31.0",
-    "openapi-typescript": "^7.13.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-hook-form": "^7.85.0",

--- a/admin/scripts/gen-api.mjs
+++ b/admin/scripts/gen-api.mjs
@@ -37,9 +37,14 @@ try {
     process.exit(dump.status ?? 1);
   }
 
+  // Run openapi-typescript out of @etherpad/openapi-codegen rather than from
+  // admin. It needs the TypeScript compiler API, which TypeScript 7 (the
+  // native port) does not expose; that package is where its TypeScript is
+  // pinned to a version that still has one. See its README.
   const gen = spawnSync(
     'pnpm',
-    ['exec', 'openapi-typescript', specPath, '-o', outFile],
+    ['--filter', '@etherpad/openapi-codegen', 'exec',
+      'openapi-typescript', specPath, '-o', outFile],
     spawnOpts,
   );
   if (gen.status !== 0) {

--- a/admin/tools/openapi-codegen/README.md
+++ b/admin/tools/openapi-codegen/README.md
@@ -1,0 +1,31 @@
+# @etherpad/openapi-codegen
+
+Private, build-time-only package. It exists purely to pin the TypeScript that
+`openapi-typescript` runs against.
+
+`openapi-typescript` builds its output using the TypeScript **compiler API**
+(`ts.factory`, `ts.SyntaxKind`, the printer). TypeScript 7 is the native port,
+and its main export is only `./lib/version.cjs` — the compiler API isn't there
+at all, so the codegen dies with:
+
+```
+TypeError: Cannot read properties of undefined (reading 'createKeywordTypeNode')
+```
+
+Its declared peer range is `typescript: ^5.x`, and 7.13.0 is the newest
+release, so there is nothing to upgrade to yet.
+
+Pinning it from the workspace root doesn't work: `openapi-typescript` takes
+`typescript` as a *peer* dependency, so pnpm satisfies it from whichever
+package depends on it. While `admin` both depended on `openapi-typescript`
+and declared `typescript: ^7.0.2`, the peer always resolved to 7 — neither
+`overrides` nor `packageExtensions` overrides that. Giving the tool its own
+package, whose only TypeScript is 6.x, is what makes the peer resolve to a
+version with a working compiler API.
+
+The tool only runs at build time to emit `admin/src/api/schema.d.ts`, and that
+output is plain text which `tsc` 7 then consumes normally. Nothing here ships.
+
+**Delete this package** once `openapi-typescript` supports the native compiler:
+move `openapi-typescript` back into `admin`'s devDependencies and point
+`admin/scripts/gen-api.mjs` at it directly.

--- a/admin/tools/openapi-codegen/package.json
+++ b/admin/tools/openapi-codegen/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@etherpad/openapi-codegen",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Build-time wrapper that runs openapi-typescript against a TypeScript it can actually use. See README.md.",
+  "devDependencies": {
+    "openapi-typescript": "^7.13.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,6 @@ importers:
       lucide-react:
         specifier: ^1.31.0
         version: 1.31.0(react@19.2.8)
-      openapi-typescript:
-        specifier: ^7.13.0
-        version: 7.13.0(typescript@7.0.2)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -149,6 +146,15 @@ importers:
       zustand:
         specifier: ^5.0.15
         version: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
+
+  admin/tools/openapi-codegen:
+    devDependencies:
+      openapi-typescript:
+        specifier: ^7.13.0
+        version: 7.13.0(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   bin:
     dependencies:
@@ -5392,6 +5398,11 @@ packages:
     resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
     engines: {node: '>= 0.4'}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -10004,14 +10015,14 @@ snapshots:
 
   openapi-typescript-helpers@0.1.0: {}
 
-  openapi-typescript@7.13.0(typescript@7.0.2):
+  openapi-typescript@7.13.0(typescript@6.0.3):
     dependencies:
       '@redocly/openapi-core': 1.34.17(supports-color@10.2.2)
       ansi-colors: 4.1.3
       change-case: 5.4.4
       parse-json: 8.3.0
       supports-color: 10.2.2
-      typescript: 7.0.2
+      typescript: 6.0.3
       yargs-parser: 21.1.1
 
   option@0.2.4: {}
@@ -11065,6 +11076,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,9 @@ packages:
   - bin
   - doc
   - ui
+  # Build-time only: pins the TypeScript that openapi-typescript runs
+  # against, which cannot be TypeScript 7. See its README.
+  - admin/tools/openapi-codegen
 allowBuilds:
   '@scarf/scarf': set this to true or false
   esbuild: set this to true or false


### PR DESCRIPTION
Supersedes #8142, which rolled TypeScript back to 6. This keeps us on 7 and fixes the actual incompatibility instead.

## Problem

`develop` has been red since #8132 bumped `typescript` to `^7.0.2` — **every PR** fails at "Build admin ui":

```
node_modules/.pnpm/openapi-typescript@7.13.0_typescript@7.0.2/node_modules/openapi-typescript/dist/lib/ts.mjs:11
const BOOLEAN = ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
                           ^
TypeError: Cannot read properties of undefined (reading 'createKeywordTypeNode')
```

`openapi-typescript` builds its output with the TypeScript **compiler API** (`ts.factory`, `ts.SyntaxKind`, the printer). TypeScript 7 is the native port, and its main export is only `./lib/version.cjs`:

```json
"exports": {
  ".": "./lib/version.cjs",
  "./unstable/ast": "./dist/ast/index.js",
  ...
}
```

The compiler API isn't there at all. `openapi-typescript`'s declared peer range is `typescript: ^5.x` and 7.13.0 is the newest published release, so there is nothing to upgrade to yet.

## Why the obvious fixes don't work

`openapi-typescript` takes `typescript` as a **peer** dependency, so pnpm satisfies it from whichever package depends on it. While `admin` both depended on `openapi-typescript` and declared `typescript: ^7.0.2`, the peer always resolved to 7.

I tried both root-level mechanisms and verified neither works — pnpm still linked the `_typescript@7.0.2` variant into `admin`:

```yaml
overrides:
  openapi-typescript>typescript: ^6.0.3        # no effect on the peer
packageExtensions:
  openapi-typescript:
    peerDependencies: {typescript: ^6.0.3}     # no effect either
```

## Fix

Isolate the one tool that can't move. `openapi-typescript` goes into a private, build-time-only workspace package — `admin/tools/openapi-codegen` — whose only TypeScript is 6.x. The peer then resolves to a version with a working compiler API, and **`admin` keeps `typescript: ^7.0.2` like every other workspace**. `gen-api.mjs` invokes the tool through that package.

The codegen only runs at build time to emit `admin/src/api/schema.d.ts`, and that output is plain text which `tsc` 7 consumes normally. The regenerated file is byte-identical to the committed one, so there's no downstream churn.

The package's README records the reasoning and says to delete it once `openapi-typescript` supports the native compiler.

## Verified locally

- all four workspaces report `tsc` **7.0.2** and typecheck clean (`src`, `ui`, `bin`, `admin`)
- `admin` `gen:api` succeeds; full `pnpm build` succeeds
- `pnpm install --frozen-lockfile` consistent (CI uses this)
- regenerated `schema.d.ts` byte-identical to the committed file
- backend suite: 1621 passing, 0 failing

## Follow-up

Worth making the admin build a required check, so a dependency bump that breaks it can't land red again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)