### PR TITLE
chore: gitignore var/log/

### DIFF
--- a/var/.gitignore
+++ b/var/.gitignore
@@ -4,3 +4,5 @@ installed_plugins.json
 dirty.db
 rusty.db
 update-state.json
+# Runtime update log, written by src/node/updater (see index.ts logPath()).
+log/


### PR DESCRIPTION
`src/node/updater` writes `var/log/update.log` at runtime:

- `src/node/updater/index.ts:255` — `logPath()`
- `src/node/updater/UpdateExecutor.ts:106`
- `src/node/updater/RollbackHandler.ts:77`

`var/.gitignore` already covers `update-state.json`, `dirty.db`, `rusty.db` and friends, but not the log directory. So running the backend suite leaves an untracked `var/log/update.log` behind, which `git add -A` will happily sweep into a commit.

Found the honest way: I did exactly that on two branches while working on #8134, and had to strip it back out.

One line, `log/`, with a comment pointing at what writes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)